### PR TITLE
fix(agent): release DRBD backings on node shutdown to unblock reboots

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ synchronous 2-node replication via DRBD9.
       for `baseDir` (XFS `reflink=1`, e.g. Talos `/var`, or btrfs).
 - For DRBD9 replication: `drbd` and `drbd_transport_tcp` kernel
   modules, plus `drbd-utils` (`drbdadm`, `drbdsetup`, `drbdmeta`).
+- Kubelet [graceful node shutdown][gns] so the agent (a
+  `system-node-critical` pod) is stopped _after_ workloads on reboot
+  and can release DRBD backings before the backend pool exports —
+  otherwise a node reboot can wedge unmounting the pool. On Talos it
+  is on by default; give critical pods enough of the window via
+  `machine.kubelet.extraConfig.shutdownGracePeriodCriticalPods` (≥ the
+  agent's `terminationGracePeriodSeconds`, default 60s).
+
+[gns]: https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown
 
 Talos Linux is the primary target because it ships these modules
 ready to go, but nothing in the controller or agent is

--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -37,10 +37,14 @@ spec:
       # drbdadm/drbdsetup need the host PID namespace for /proc access
       # to the kernel module's worker threads.
       hostPID: true
-      # No teardown hooks: kernel-side storage state is host-scoped and
-      # survives the pod; reconcile converges on next start. A short
-      # grace period keeps DaemonSet rollouts unblocked.
-      terminationGracePeriodSeconds: 10
+      # system-node-critical so kubelet graceful shutdown stops the agent
+      # after workloads — their DRBD legs are then Secondary and safe to
+      # release (see agentShutdownSweep). Needs Talos
+      # shutdownGracePeriodCriticalPods >= the grace period below (see README).
+      priorityClassName: system-node-critical
+      # Longer grace lets the cordon-gated DRBD teardown finish before SIGKILL;
+      # routine restarts stay schedulable and skip it.
+      terminationGracePeriodSeconds: 60
       tolerations:
         - operator: Exists # CSI node service must run on every schedulable node
       containers:

--- a/charts/miroir/templates/rbac.tpl
+++ b/charts/miroir/templates/rbac.tpl
@@ -116,6 +116,11 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  # reads its own Node's cordon state to distinguish a node shutdown
+  # (release DRBD backings so the pool can export) from a routine pod restart
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -100,7 +100,10 @@ tests:
           value: ClusterFirstWithHostNet
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 10
+          value: 60
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-node-critical
       - lengthEqual:
           path: spec.template.spec.tolerations
           count: 1

--- a/charts/miroir/tests/rbac_test.yaml
+++ b/charts/miroir/tests/rbac_test.yaml
@@ -96,6 +96,14 @@ tests:
             apiGroups: ["miroir.home-operations.com"]
             resources: ["miroirvolumes/status", "miroirsnapshots/status"]
             verbs: ["get", "patch"]
+      # reads its own Node's cordon state to gate DRBD shutdown teardown
+      - contains:
+          any: true
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["get", "list", "watch"]
 
   - it: controller ClusterRoleBinding binds to miroir-controller ServiceAccount
     documentIndex: 3

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,9 +28,11 @@ import (
 	"os"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -129,10 +131,10 @@ func main() {
 
 	identity := &csi.Identity{Version: version, WithController: mode == "controller"}
 
-	// Agent mode only, run after the manager stops: a write barrier is
-	// kernel state and outlives the process — never leave one behind for
-	// the successor.
-	var shutdownSweep func() error
+	// Agent mode only, run after the manager stops (SIGTERM): release DRBD
+	// backings when the node is going down and lift any leftover write
+	// barrier — both are kernel state that outlives the process.
+	var shutdownSweep func()
 
 	switch mode {
 	case "setup":
@@ -243,7 +245,14 @@ func main() {
 			setupLog.Error(err, "barrier resume sweep failed")
 			os.Exit(1)
 		}
-		shutdownSweep = func() error { return resumeStaleBarriers(drbdDriver) }
+		// Tracks this node's cordon state so shutdownSweep can tell a node
+		// reboot/upgrade (drained, so cordoned) from a routine pod restart.
+		cordon := &agent.CordonWatcher{Client: mgr.GetClient(), NodeName: nodeName}
+		if err := cordon.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to set up cordon watcher")
+			os.Exit(1)
+		}
+		shutdownSweep = func() { agentShutdownSweep(cordon, drbdDriver) }
 		// events2 turns kernel state changes into immediate reconciles;
 		// the 30s poll remains as the safety net.
 		drbdEvents := make(chan event.GenericEvent, 64)
@@ -308,9 +317,75 @@ func main() {
 		os.Exit(1)
 	}
 	if shutdownSweep != nil {
-		if err := shutdownSweep(); err != nil {
-			setupLog.Error(err, "shutdown barrier sweep failed")
+		shutdownSweep()
+	}
+}
+
+// apiStartupWait bounds how long the startup sweeps wait for the API server,
+// so a reboot that races control-plane recovery does not exit on the first
+// dial error and churn through CrashLoopBackOff. Kept under the liveness
+// kill window: the probe server is not up until the manager starts.
+const apiStartupWait = 45 * time.Second
+
+// drbdShutdownTimeout bounds the Secondary-teardown sweep at shutdown.
+const drbdShutdownTimeout = 15 * time.Second
+
+// listWithRetry retries an API list until it succeeds, hits a terminal
+// (non-transient) error, or apiStartupWait elapses — so a control plane still
+// coming back up does not crash the agent on startup.
+func listWithRetry(c client.Client, list client.ObjectList) error {
+	var lastErr error
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, apiStartupWait, true,
+		func(ctx context.Context) (bool, error) {
+			lastErr = c.List(ctx, list)
+			if lastErr == nil {
+				return true, nil
+			}
+			if !transientAPIError(lastErr) {
+				return false, lastErr
+			}
+			setupLog.Info("API server not ready; retrying", "error", lastErr.Error())
+			return false, nil
+		})
+	if waitErr != nil && lastErr != nil {
+		return lastErr
+	}
+	return waitErr
+}
+
+// transientAPIError reports whether an API error is worth retrying. Dial
+// failures during control-plane recovery (connection refused, no route to
+// host) arrive as non-APIStatus errors; only explicit terminal statuses
+// (auth, not-found, invalid) are treated as permanent.
+func transientAPIError(err error) bool {
+	switch {
+	case err == nil:
+		return false
+	case apierrors.IsUnauthorized(err), apierrors.IsForbidden(err),
+		apierrors.IsNotFound(err), apierrors.IsInvalid(err):
+		return false
+	default:
+		return true
+	}
+}
+
+// agentShutdownSweep runs after the agent's manager stops (SIGTERM). A
+// cordoned node is being drained for a reboot or upgrade: release Secondary
+// backings so the backend pool can export. Gated on cordon because an
+// ungated teardown would disconnect idle replicas on every pod rollout. A
+// leftover write barrier is also kernel state that must not outlive the
+// process.
+func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver) {
+	if cordon.Cordoned() {
+		ctx, cancel := context.WithTimeout(context.Background(), drbdShutdownTimeout)
+		defer cancel()
+		setupLog.Info("node cordoned; releasing Secondary DRBD backings for shutdown")
+		if err := driver.DownSecondaries(ctx); err != nil {
+			setupLog.Error(err, "DRBD shutdown teardown failed; node reboot may stall")
 		}
+	}
+	if err := resumeStaleBarriers(driver); err != nil {
+		setupLog.Error(err, "shutdown barrier sweep failed")
 	}
 }
 
@@ -322,7 +397,7 @@ func sweepOrphans(nodeName string, driver *drbd.Driver) error {
 		return err
 	}
 	vols := &miroirv1alpha1.MiroirVolumeList{}
-	if err := c.List(context.Background(), vols); err != nil {
+	if err := listWithRetry(c, vols); err != nil {
 		return err
 	}
 	owned := map[string]bool{}
@@ -355,7 +430,7 @@ func resumeStaleBarriers(driver *drbd.Driver) error {
 		return err
 	}
 	snaps := &miroirv1alpha1.MiroirSnapshotList{}
-	if err := c.List(context.Background(), snaps); err != nil {
+	if err := listWithRetry(c, snaps); err != nil {
 		return err
 	}
 	fresh := map[string]bool{}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+func TestTransientAPIError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unauthorized", apierrors.NewUnauthorized("no creds"), false},
+		{"forbidden", apierrors.NewForbidden(schema.GroupResource{}, "x", errors.New("rbac")), false},
+		{"notfound", apierrors.NewNotFound(schema.GroupResource{}, "x"), false},
+		// The failure that crashed the agent on startup: a dial error while
+		// the control plane is still recovering — must be retried.
+		{"dial error", errors.New("dial tcp 10.43.0.1:443: connect: no route to host"), true},
+		{"service unavailable", apierrors.NewServiceUnavailable("starting"), true},
+	}
+	for _, tc := range cases {
+		if got := transientAPIError(tc.err); got != tc.want {
+			t.Errorf("%s: transientAPIError = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestListWithRetrySucceeds(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := miroirv1alpha1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if err := listWithRetry(c, &miroirv1alpha1.MiroirVolumeList{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListWithRetryReturnsTerminalErrorImmediately(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := miroirv1alpha1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	// A terminal (non-transient) error must abort the wait at once rather
+	// than block for apiStartupWait — otherwise a misconfiguration would
+	// look like a slow startup.
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+				return apierrors.NewUnauthorized("no creds")
+			},
+		}).Build()
+	if err := listWithRetry(c, &miroirv1alpha1.MiroirVolumeList{}); !apierrors.IsUnauthorized(err) {
+		t.Fatalf("want the terminal Unauthorized returned, got %v", err)
+	}
+}

--- a/internal/agent/cordon.go
+++ b/internal/agent/cordon.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// CordonWatcher caches whether this node is cordoned (unschedulable), read by
+// the agent at shutdown. Cached from a watch, not fetched on demand: by
+// shutdown the API server may be gone (a whole-cluster reboot takes etcd with
+// it), but the cordon was observed earlier while it was still up.
+type CordonWatcher struct {
+	client.Client
+	NodeName string
+	cordoned atomic.Bool
+}
+
+// Cordoned reports this node's last observed unschedulable state.
+func (w *CordonWatcher) Cordoned() bool {
+	return w.cordoned.Load()
+}
+
+// Reconcile refreshes the cached cordon state from the node object.
+func (w *CordonWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	node := &corev1.Node{}
+	if err := w.Get(ctx, req.NamespacedName, node); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	w.cordoned.Store(node.Spec.Unschedulable)
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the watch, filtered to this node's own object.
+func (w *CordonWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	thisNode := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == w.NodeName
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}, builder.WithPredicates(thisNode)).
+		Named("agent-cordon").
+		Complete(w)
+}

--- a/internal/agent/cordon_test.go
+++ b/internal/agent/cordon_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCordonWatcherTracksUnschedulable(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeKharkiv},
+		Spec:       corev1.NodeSpec{Unschedulable: true},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(node).Build()
+	w := &CordonWatcher{Client: c, NodeName: nodeKharkiv}
+
+	if w.Cordoned() {
+		t.Fatal("must default to not cordoned before any observation")
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: nodeKharkiv}}
+	if _, err := w.Reconcile(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if !w.Cordoned() {
+		t.Fatal("must observe the node cordoned")
+	}
+
+	// Uncordon: the cached state follows the node back to schedulable.
+	node.Spec.Unschedulable = false
+	if err := c.Update(context.Background(), node); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Reconcile(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if w.Cordoned() {
+		t.Fatal("must follow the node back to schedulable")
+	}
+}

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -179,11 +179,18 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if vol.Spec.Replicas[0].Node == r.NodeName {
 		// drbdadm resize is refused mid-resync, so withhold the size and
 		// retry on the next poll instead of failing the reconcile.
-		if peerBackingsGrown(vol, r.NodeName) && !st.Resyncing {
+		switch {
+		case peerBackingsGrown(vol, r.NodeName) && !st.Resyncing:
 			if err := r.DRBD.Resize(ctx, vol.Name); err != nil {
-				return ctrl.Result{}, r.reportError(ctx, vol, err)
+				if !drbd.IsResizeDuringResync(err) {
+					return ctrl.Result{}, r.reportError(ctx, vol, err)
+				}
+				// A resync started between the status read and the resize:
+				// withhold and retry, same as the pre-checked branch below.
+				reportSize = vol.Status.PerNode[r.NodeName].SizeBytes
+				requeue = 5 * time.Second
 			}
-		} else {
+		default:
 			reportSize = vol.Status.PerNode[r.NodeName].SizeBytes
 			requeue = 5 * time.Second
 		}

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -461,14 +461,86 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 	}
 }
 
+func TestReconcile_ResizeRaceWithResyncIsTransient(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := vol(volPvc1, nodeKharkiv, "paris")
+	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = addrParis
+
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
+		"resource \"pvc-1\" {\n    on \"kharkiv\" {\n        device minor 1000;\n    }\n}\n",
+	), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-check sees no resync (Established), but the resize itself races one
+	// and DRBD refuses it — must be a transient withhold, not a hard error.
+	fe := &fakeDRBDExec{
+		statusJSON: `[{"name":"` + volPvc1 + `",
+			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+			"connections":[{"connection-state":"Connected","replication-state":"Established"}]}]`,
+		errOn: map[string]error{
+			"drbdadm resize": errors.New("exit status 10: Resize not allowed during resync."),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	base := got.DeepCopy()
+	got.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		"paris": {DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true},
+	}
+	if err := c.Status().Patch(context.Background(), got, client.MergeFrom(base)); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := r.Reconcile(context.Background(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+	if err != nil {
+		t.Fatalf("a resize that raced a resync must not fail the reconcile: %v", err)
+	}
+	fe.calledWith(t, "drbdadm resize pvc-1") // it was attempted
+	if res.RequeueAfter != 5*time.Second {
+		t.Fatalf("must requeue soon to retry the resize, got %v", res.RequeueAfter)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.PerNode[nodeKharkiv].SizeBytes != 0 {
+		t.Fatalf("size must be withheld until the resize succeeds, got %d", got.Status.PerNode[nodeKharkiv].SizeBytes)
+	}
+}
+
 type fakeDRBDExec struct {
 	calls      []string
 	statusJSON string
+	errOn      map[string]error
 }
 
 func (f *fakeDRBDExec) run(_ context.Context, name string, args ...string) (string, error) {
 	line := name + " " + strings.Join(args, " ")
 	f.calls = append(f.calls, line)
+	for key, err := range f.errOn {
+		if strings.Contains(line, key) {
+			return "", err
+		}
+	}
 	if strings.HasPrefix(line, "drbdsetup status") {
 		return f.statusJSON, nil
 	}

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -272,6 +273,34 @@ func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool)
 	return nil
 }
 
+// DownSecondaries brings down every resource this node holds Secondary,
+// releasing its backing device so the backend pool can export on shutdown.
+// Primary (open) resources are skipped: drbdsetup down refuses an open
+// device, and downing a leg a workload still holds — here, or on a peer this
+// node feeds as SyncSource — would drop live redundancy. Rendered config
+// stays so the successor re-ups. Best effort: errors are joined so one stuck
+// resource cannot strand the rest.
+func (d *Driver) DownSecondaries(ctx context.Context) error {
+	out, err := d.Exec(ctx, "drbdsetup", "status", "--json")
+	if err != nil {
+		return fmt.Errorf("status: %w", err)
+	}
+	var parsed []jsonStatus
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		return fmt.Errorf("parse status: %w", err)
+	}
+	var errs []error
+	for _, res := range parsed {
+		if res.Role == rolePrimary {
+			continue
+		}
+		if _, err := d.Exec(ctx, "drbdsetup", "down", res.Name); err != nil {
+			errs = append(errs, fmt.Errorf("down %s: %w", res.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // drbdMajor is DRBD's fixed block-device major number.
 const drbdMajor = 147
 
@@ -516,6 +545,9 @@ func (d *Driver) Down(ctx context.Context, name string) error {
 // DiskUpToDate is the disk state of a replica holding current data.
 const DiskUpToDate = "UpToDate"
 
+// rolePrimary is the DRBD role of a node that holds the device open.
+const rolePrimary = "Primary"
+
 // Status reports this node's view of one resource.
 type Status struct {
 	// DiskState: UpToDate, Inconsistent, Outdated, Consistent, Diskless…
@@ -634,6 +666,13 @@ func (d *Driver) ResumeIO(ctx context.Context, name string) error {
 func (d *Driver) Resize(ctx context.Context, name string) error {
 	_, err := d.adm(ctx, "resize", name)
 	return err
+}
+
+// IsResizeDuringResync reports whether a Resize failed only because a resync
+// was in flight — DRBD refuses resize then, and the caller retries instead
+// of failing the reconcile.
+func IsResizeDuringResync(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Resize not allowed during resync")
 }
 
 func (d *Driver) writeConfig(r Resource) (bool, error) {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -503,6 +503,53 @@ func TestStatusParsing(t *testing.T) {
 	}
 }
 
+func TestDownSecondariesSkipsPrimary(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[
+			{"name":"pvc-1","role":"Primary"},
+			{"name":"pvc-2","role":"Secondary"}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.DownSecondaries(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Primary legs are still open — skipped.
+	fe.notCalledWith(t, "drbdsetup down pvc-1")
+	fe.calledWith(t, "drbdsetup down pvc-2")
+}
+
+func TestDownSecondariesContinuesOnError(t *testing.T) {
+	fe := &fakeExec{
+		responses: map[string]string{
+			cmdDrbdsetupStatus: `[
+				{"name":"pvc-2","role":"Secondary"},
+				{"name":"pvc-3","role":"Secondary"}]`,
+		},
+		errOn: map[string]error{"down pvc-2": errors.New("Device is held open by someone")},
+	}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	err := d.DownSecondaries(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "pvc-2") {
+		t.Fatalf("want a joined error naming pvc-2, got %v", err)
+	}
+	// One stuck resource must not strand the rest of the sweep.
+	fe.calledWith(t, "drbdsetup down pvc-3")
+}
+
+func TestIsResizeDuringResync(t *testing.T) {
+	if !IsResizeDuringResync(errors.New("exit status 10: Resize not allowed during resync.")) {
+		t.Fatal("must match DRBD's resync refusal")
+	}
+	if IsResizeDuringResync(errors.New("some other drbd failure")) {
+		t.Fatal("must not match unrelated errors")
+	}
+	if IsResizeDuringResync(nil) {
+		t.Fatal("nil is not a resync refusal")
+	}
+}
+
 func TestUserSuspendedListsFrozenResources(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{
 		cmdDrbdsetupStatus: `[


### PR DESCRIPTION
## Problem

A Talos upgrade of a node wedged its reboot for hours. Root cause: miroir never ran `drbdadm down` on node shutdown, so DRBD kept the ZFS zvols open. `ext-zfs-service` could not `zpool export` (the unmount blocked in uninterruptible I/O, immune to SIGKILL) and the reboot stalled. It only cleared via the destructive path — ZFS pulled the backing out from under live DRBD, which took EIO and force-detached to Diskless. The peer held the only UpToDate copy throughout, so no data was lost, but every reboot risked the same wedge.

The recovery also exposed two adjacent fragilities: the agent crashlooped during the control-plane outage, and resize reconciles spammed errors while the returning node resynced.

## Fixes

**1. Graceful DRBD teardown on node shutdown** (the deadlock)
- `drbd.DownSecondaries` brings down only **Secondary** resources at shutdown, releasing their backing so the pool can export. Primary/mounted legs are skipped — `drbdsetup down` refuses an open device, and downing a peer-mounted leg would drop live redundancy.
- `agent.CordonWatcher` caches the node's `unschedulable` state from a Node watch. The teardown is **gated on the node being cordoned**, which distinguishes an orchestrated reboot/upgrade (drains, so cordons, first) from a routine pod restart — preserving the existing "kernel state survives the pod" behavior. Reading from cache means it still works when the API server is gone (the whole-cluster-reboot case).
- Chart: `priorityClassName: system-node-critical` (kubelet graceful shutdown stops the agent after workloads, so their legs are Secondary by then), `terminationGracePeriodSeconds: 60`, and `nodes` get/list/watch RBAC. README documents the Talos `shutdownGracePeriodCriticalPods` requirement.

**2. Survive transient API unavailability at startup**
- `SweepOrphans`/`resumeStaleBarriers` no longer `os.Exit(1)` on a dial error. `listWithRetry` retries transient failures (bounded, under the liveness window); only terminal statuses (auth/not-found/invalid) are fatal.

**3. Tolerate resize racing a resync**
- The `!st.Resyncing` pre-check TOCTOUs. `drbd.IsResizeDuringResync` now absorbs the refusal as a soft size-withhold + requeue instead of a hard reconcile error.

## Tests
- New: `DownSecondaries` (skips Primary / continues past a stuck resource), `IsResizeDuringResync`, `CordonWatcher` tracking, transient-API classification + retry, resize-resync-race-is-transient.
- `go build`, `go vet`, `golangci-lint` (0 issues), 120 Go tests, 47 Helm unit tests all green.

## Operator note
Effective node-shutdown teardown needs kubelet graceful node shutdown with `shutdownGracePeriodCriticalPods` ≥ the agent grace period; without it the agent may not be stopped after workloads.
