### PR TITLE
ci: tidy workflows (drop explanatory comments, collapse single-command run blocks)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      id-token: write # keyless Cosign signing of the published chart
+      id-token: write
       packages: write
     env:
       VERSION: ${{ github.event.release.tag_name }}
@@ -89,10 +89,6 @@ jobs:
           install_args: --locked
       - name: Generate manifests and CRDs
         run: mise run helm-crds
-      # Pin the chart's image to the exact digest the build just published, so the
-      # released chart references an immutable image (not a floating tag). The digest
-      # is the manifest-list (index) digest from docker/github-builder; fail closed
-      # rather than ship a chart that silently falls back to the tag.
       - name: Pin the released image digest into the chart
         env:
           DIGEST: ${{ needs.release.outputs.digest }}
@@ -100,10 +96,7 @@ jobs:
           [ -n "${DIGEST}" ] || { echo "build produced no digest"; exit 1; }
           yq -i '.image.digest = strenv(DIGEST)' charts/miroir/values.yaml
       - name: Package Helm chart
-        run: |
-          helm package charts/miroir \
-            --version "${VERSION}" \
-            --app-version "${VERSION}"
+        run: helm package charts/miroir --version "${VERSION}" --app-version "${VERSION}"
       - name: Log in to Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -111,8 +104,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Helm chart to GHCR
-        run: |-
-          helm push "miroir-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+        run: helm push "miroir-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
       - name: Sign the published chart with Cosign
-        run: |-
-          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/miroir:${VERSION}"
+        run: cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/miroir:${VERSION}"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -38,16 +38,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
-        run: |
-          gh run watch \
-            --repo "${{ github.repository_owner }}/.github" \
-            "${RUN_ID}" \
-            --exit-status
+        run: gh run watch --repo "${{ github.repository_owner }}/.github" "${RUN_ID}" --exit-status
       - name: Renovate Output
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
-        run: |-
-          gh run view \
-            --repo "${{ github.repository_owner }}/.github" \
-            --log "${RUN_ID}"
+        run: gh run view --repo "${{ github.repository_owner }}/.github" --log "${RUN_ID}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -94,7 +94,6 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-
-      # lvmthin needs dm_thin_pool on the shared kernel.
       - name: Load kernel modules
         run: sudo modprobe dm_thin_pool loop
       - name: Run e2e (miroir-local / lvmthin / replicas:1)


### PR DESCRIPTION
Workflow tidy matching [echo#26](https://github.com/home-operations/echo/pull/26) and the e2e-repo rollout — the **comment/format cleanup only** (no e2e parallelization in this PR).

## Changes
- Removed explanatory/rationale comments from the workflows.
- Collapsed single-command multi-line `run:` blocks to one-liners (multi-command blocks left as block scalars).

Functional comments preserved: `# yaml-language-server:`, `# renovate:`, `# zizmor:`.

## Verification
Adversarially reviewed and independently cross-checked: no functional comments removed, YAML valid, and **no `uses:` / `with:` / `env:` / `permissions:` / trigger / logic changes** — comment + run-formatting only. Committed with the pre-commit hooks running (zizmor "No findings", format-yaml clean).
