### PR TITLE
feat: consolidate on a single operational port per workload (org standard)

### DIFF
--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -56,7 +56,6 @@ spec:
             - --csi-socket=/csi/csi.sock
             - --nodes-config=/etc/miroir/nodes.yaml
             - --metrics-bind-address=:9810
-            - --health-probe-bind-address=:9811
             - --pool-stats-interval={{ .Values.agent.poolStatsInterval }}
           env:
             - name: NODE_NAME
@@ -66,16 +65,18 @@ spec:
           securityContext:
             privileged: true
           ports:
-            - name: healthz
-              containerPort: 9811
+            # Serves /metrics plus the /healthz and /readyz probes (single
+            # operational port; see cmd/main.go). Stays in the agent's 98xx
+            # host-port range: hostNetwork means this binds on the node, and
+            # :8081 is the org-standard pod port other workloads use.
             - name: metrics
               containerPort: 9810
           livenessProbe:
-            httpGet: { path: /healthz, port: healthz }
+            httpGet: { path: /healthz, port: metrics }
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
-            httpGet: { path: /readyz, port: healthz }
+            httpGet: { path: /readyz, port: metrics }
             initialDelaySeconds: 5
             periodSeconds: 10
           resources: {{- toYaml .Values.agent.resources | nindent 12 }}

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -39,15 +39,15 @@ spec:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
           ports:
-            - name: healthz
-              containerPort: 8081
+            # Serves /metrics plus the /healthz and /readyz probes (single
+            # operational port; see cmd/main.go).
             - name: metrics
-              containerPort: 8080
+              containerPort: 8081
           livenessProbe:
-            httpGet: { path: /healthz, port: healthz }
+            httpGet: { path: /healthz, port: metrics }
             initialDelaySeconds: 10
           readinessProbe:
-            httpGet: { path: /readyz, port: healthz }
+            httpGet: { path: /readyz, port: metrics }
           resources: {{- toYaml .Values.controller.resources | nindent 12 }}
           volumeMounts:
             - name: socket-dir

--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -67,19 +67,19 @@ tests:
           value: true
       - lengthEqual:
           path: spec.template.spec.containers[0].ports
-          count: 2
+          count: 1
       - equal:
           path: spec.template.spec.containers[0].ports[0].name
-          value: healthz
-      - equal:
-          path: spec.template.spec.containers[0].ports[0].containerPort
-          value: 9811
-      - equal:
-          path: spec.template.spec.containers[0].ports[1].name
           value: metrics
       - equal:
-          path: spec.template.spec.containers[0].ports[1].containerPort
+          path: spec.template.spec.containers[0].ports[0].containerPort
           value: 9810
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: metrics
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: metrics
 
   - it: pod runs with hostNetwork, hostPID and ClusterFirstWithHostNet
     set:

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -88,19 +88,19 @@ tests:
           value: ALL
       - lengthEqual:
           path: spec.template.spec.containers[0].ports
-          count: 2
+          count: 1
       - equal:
           path: spec.template.spec.containers[0].ports[0].name
-          value: healthz
+          value: metrics
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8081
       - equal:
-          path: spec.template.spec.containers[0].ports[1].name
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
           value: metrics
       - equal:
-          path: spec.template.spec.containers[0].ports[1].containerPort
-          value: 8080
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: metrics
 
   - it: flows controller.provisionTimeout into the controller args
     set:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,7 +73,6 @@ func main() {
 		mode             string
 		csiSocket        string
 		metricsAddr      string
-		probeAddr        string
 		nodesConfig      string
 		provisionTimeout time.Duration
 		overcommitRatio  float64
@@ -87,8 +86,8 @@ func main() {
 	)
 	flag.StringVar(&mode, "mode", "", "controller | agent")
 	flag.StringVar(&csiSocket, "csi-socket", "/csi/csi.sock", "CSI gRPC unix socket path")
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "metrics endpoint (0 to disable)")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "health probe endpoint")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8081",
+		"single operational endpoint: /metrics plus the /healthz and /readyz probes (org port standard)")
 	flag.StringVar(&nodeName, "node-name", os.Getenv("NODE_NAME"), "this node's name (agent)")
 	flag.StringVar(&nodesConfig, "nodes-config", "/etc/miroir/nodes.yaml",
 		"per-node storage topology (rendered from Helm values)")
@@ -110,9 +109,13 @@ func main() {
 	setupLog.Info("starting miroir", "mode", mode, "version", version, "commit", commit)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
-		HealthProbeBindAddress: probeAddr,
+		Scheme:  scheme,
+		Metrics: metricsserver.Options{BindAddress: metricsAddr},
+		// The dedicated health-probe server is disabled; the probes are
+		// co-hosted on the (plain HTTP) metrics listener so each workload
+		// exposes a single operational port — the agent runs hostNetwork,
+		// so every listener occupies a real node port.
+		HealthProbeBindAddress: "0",
 		// No leader election: the controller is a 1-replica Deployment and
 		// agents are per-node singletons (notes/DESIGN.md §4.2).
 	})
@@ -120,11 +123,13 @@ func main() {
 		setupLog.Error(err, "unable to create manager")
 		os.Exit(1)
 	}
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	// healthz.CheckHandler returns 200 when the checker passes and 500
+	// otherwise — the contract a kubelet HTTP probe expects.
+	if err := mgr.AddMetricsServerExtraHandler("/healthz", healthz.CheckHandler{Checker: healthz.Ping}); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddMetricsServerExtraHandler("/readyz", healthz.CheckHandler{Checker: healthz.Ping}); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
@@ -324,7 +329,7 @@ func main() {
 // apiStartupWait bounds how long the startup sweeps wait for the API server,
 // so a reboot that races control-plane recovery does not exit on the first
 // dial error and churn through CrashLoopBackOff. Kept under the liveness
-// kill window: the probe server is not up until the manager starts.
+// kill window: the probe endpoints are not up until the manager starts.
 const apiStartupWait = 45 * time.Second
 
 // drbdShutdownTimeout bounds the Secondary-teardown sweep at shutdown.


### PR DESCRIPTION
Applies the org port standard for non-HTTP services (rule 2): **one plain-HTTP operational listener per workload** serving `/metrics` plus the `/healthz` and `/readyz` probes. The dedicated health-probe server and `--health-probe-bind-address` are gone; probes are registered as metrics-server ExtraHandlers.

## Port layout

| Workload | Before | After |
|---|---|---|
| controller (Deployment) | metrics `:8080` + health `:8081` | **`:8081`** (org standard) |
| agent (DaemonSet, hostNetwork) | metrics `:9810` + health `:9811` | **`:9810`** |

**Why the agent doesn't move to 8081:** it runs `hostNetwork` (DRBD peers dial node IPs), so its listener occupies a real port on every node. The 98xx range was deliberately chosen to be host-unique; putting the org-standard pod port 8081 into the host namespace would invite collisions with anything else that binds it. The agent still gets the standard's substance — one port, co-hosted probes — just in its reserved host range. Happy to move it to 8081 if you'd rather have full uniformity.

Net effect on each node: the agent frees one host port (9811).

## Verification
- `GOOS=linux` build, vet, and golangci-lint: clean (darwin can't compile `internal/drbd` — pre-existing `Stat_t.Rdev` platform difference, unrelated)
- helm lint + unittest: 47/47
- helm-docs current, go.mod tidy
- CI's kind e2e (lvmthin, ubuntu) exercises the new probe wiring since pods must go Ready

Same change shape as tuppr#369 and litellm-operator#30.