### PR TITLE
fix(drbd): crash-safe minor allocation, atomic config writes, robust event scan

### DIFF
--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -309,44 +309,41 @@ const drbdMajor = 147
 const minorBase int32 = 1000
 
 // AllocateMinor assigns a DRBD minor to a volume, returning the same
-// minor on future calls. Thread-safe via lock file + atomic rename.
+// minor on future calls. Serialised by an advisory flock the kernel
+// releases on close or process death, then persisted via atomic rename.
 func (d *Driver) AllocateMinor(volume string) (int32, error) {
-	lockPath := d.path("minor.lock")
-	for tries := 0; tries < 10; tries++ {
-		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o640)
-		if err != nil {
-			if os.IsExist(err) {
-				continue
-			}
-			return 0, err
-		}
-		assigned, err := d.readAssignments()
-		if err != nil {
-			_ = f.Close()
-			_ = os.Remove(lockPath)
-			return 0, err
-		}
-		if m, ok := assigned[volume]; ok {
-			_ = f.Close()
-			_ = os.Remove(lockPath)
-			return m, nil
-		}
-		used := d.scanUsedMinors(assigned)
-		m := minorBase
-		for used[m] {
-			m++
-		}
-		assigned[volume] = m
-		if err := d.writeAssignments(assigned); err != nil {
-			_ = f.Close()
-			_ = os.Remove(lockPath)
-			return 0, err
-		}
-		_ = f.Close()
-		_ = os.Remove(lockPath)
+	// flock, not an O_EXCL sentinel: a sentinel orphaned by a crash between
+	// create and remove would deadlock every future allocation (nothing
+	// sweeps minor.lock). LOCK_EX blocks until acquired and the kernel drops
+	// it when the fd closes — including on SIGKILL/OOM — so a crash cannot
+	// wedge allocation. The file is intentionally left on disk as the stable
+	// lock target.
+	f, err := os.OpenFile(d.path("minor.lock"), os.O_CREATE|os.O_RDWR, 0o640)
+	if err != nil {
+		return 0, fmt.Errorf("open minor lock: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		return 0, fmt.Errorf("lock minor allocation: %w", err)
+	}
+
+	assigned, err := d.readAssignments()
+	if err != nil {
+		return 0, err
+	}
+	if m, ok := assigned[volume]; ok {
 		return m, nil
 	}
-	return 0, fmt.Errorf("minor lock held after 10 retries")
+	used := d.scanUsedMinors(assigned)
+	m := minorBase
+	for used[m] {
+		m++
+	}
+	assigned[volume] = m
+	if err := d.writeAssignments(assigned); err != nil {
+		return 0, err
+	}
+	return m, nil
 }
 
 func (d *Driver) readAssignments() (map[string]int32, error) {
@@ -433,7 +430,10 @@ func (d *Driver) ensureDeviceNode(minor int32) error {
 	var st unix.Stat_t
 	err := unix.Stat(path, &st)
 	if err == nil {
-		if st.Mode&unix.S_IFMT == unix.S_IFBLK && st.Rdev == want {
+		// unix.Stat_t.Rdev is uint64 on linux but int32 on darwin; the cast is a
+		// no-op on linux (hence the nolint) but required for the package to build
+		// on a macOS dev host.
+		if st.Mode&unix.S_IFMT == unix.S_IFBLK && uint64(st.Rdev) == want { //nolint:unconvert
 			return nil
 		}
 		// Wrong rdev or a leftover regular file (e.g. a pre-mknod open
@@ -710,7 +710,32 @@ func (d *Driver) writeConfig(r Resource) (bool, error) {
 	if err := os.MkdirAll(d.StateDir, 0o750); err != nil {
 		return false, err
 	}
-	return true, os.WriteFile(path, rendered, 0o640)
+	// Atomic write: StateDir is drbdadm's include directory, and a crash
+	// mid-write would leave a truncated .res that makes drbdadm adjust fail
+	// for EVERY resource on the node, not just this one. Same tmp+sync+rename
+	// as writeAssignments.
+	return true, writeFileAtomic(path, rendered, 0o640)
+}
+
+// writeFileAtomic writes data to path via a temp file, fsync, and rename, so a
+// crash never leaves a partially-written file at path.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }() // no-op after the explicit Close below; guards early returns
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 func (d *Driver) path(file string) string {

--- a/internal/drbd/events.go
+++ b/internal/drbd/events.go
@@ -55,8 +55,10 @@ func (w *EventWatcher) Start(ctx context.Context) error {
 			}
 		}
 		if err == nil {
-			w.scan(ctx, out)
-			err = cmd.Wait()
+			err = w.scan(ctx, out)
+			if werr := cmd.Wait(); err == nil {
+				err = werr
+			}
 		}
 		if ctx.Err() != nil {
 			return nil
@@ -71,13 +73,19 @@ func (w *EventWatcher) Start(ctx context.Context) error {
 	return nil
 }
 
-func (w *EventWatcher) scan(ctx context.Context, r io.Reader) {
+// scan reads events2 lines until EOF and returns the scanner error, if any.
+// The 1 MiB buffer lifts bufio.Scanner's 64 KiB default token cap so an
+// unusually long line cannot silently end the stream; a surfaced error lets
+// Start log it and respawn rather than the pipe filling and wedging Wait.
+func (w *EventWatcher) scan(ctx context.Context, r io.Reader) error {
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		if name := parseEvent2(scanner.Text()); name != "" {
 			w.Notify(ctx, name)
 		}
 	}
+	return scanner.Err()
 }
 
 // parseEvent2 extracts the resource name from one events2 line, or ""

--- a/internal/drbd/minor_test.go
+++ b/internal/drbd/minor_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drbd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// AllocateMinor hands out the base minor first, increments for new volumes,
+// returns the same minor on repeat (idempotent), and survives a fresh Driver
+// over the same StateDir (the assignment is persisted).
+func TestAllocateMinorStableSequentialPersistent(t *testing.T) {
+	dir := t.TempDir()
+	d := &Driver{StateDir: dir}
+
+	a, err := d.AllocateMinor("pvc-a")
+	if err != nil {
+		t.Fatalf("allocate pvc-a: %v", err)
+	}
+	if a != minorBase {
+		t.Errorf("first minor = %d, want %d", a, minorBase)
+	}
+
+	b, err := d.AllocateMinor("pvc-b")
+	if err != nil {
+		t.Fatalf("allocate pvc-b: %v", err)
+	}
+	if b != minorBase+1 {
+		t.Errorf("second minor = %d, want %d", b, minorBase+1)
+	}
+
+	// Repeat call is stable, not a new allocation.
+	if again, _ := d.AllocateMinor("pvc-a"); again != a {
+		t.Errorf("repeat pvc-a = %d, want stable %d", again, a)
+	}
+
+	// A fresh Driver over the same StateDir reads the persisted assignment.
+	fresh := &Driver{StateDir: dir}
+	if got, _ := fresh.AllocateMinor("pvc-a"); got != a {
+		t.Errorf("after reload pvc-a = %d, want persisted %d", got, a)
+	}
+	if got, _ := fresh.AllocateMinor("pvc-c"); got != minorBase+2 {
+		t.Errorf("new volume after reload = %d, want %d", got, minorBase+2)
+	}
+}
+
+// A minor already claimed by a .res file on disk (a resource created out of
+// band, or a partially-recorded assignment) must be skipped so two resources
+// never collide on /dev/drbd<minor>.
+func TestAllocateMinorSkipsMinorsUsedInResFiles(t *testing.T) {
+	dir := t.TempDir()
+	d := &Driver{StateDir: dir}
+
+	// A .res claiming minorBase and minorBase+1, with no matching assignment.
+	res := "resource legacy {\n" +
+		"  device drbd0 minor 1000;\n" +
+		"  device drbd1 minor 1001;\n" +
+		"}\n"
+	if err := os.WriteFile(filepath.Join(dir, "legacy.res"), []byte(res), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := d.AllocateMinor("pvc-new")
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	if got != minorBase+2 {
+		t.Errorf("minor = %d, want %d (must skip 1000/1001 held by legacy.res)", got, minorBase+2)
+	}
+}


### PR DESCRIPTION
First of a series splitting the recent miroir review into focused PRs. This one is the **DRBD-layer robustness** cluster; it changes no external behavior on the happy path and adds test coverage for the previously-untested minor allocator.

## Changes

**1. `AllocateMinor`: `flock` instead of an `O_EXCL` sentinel.** The old lock was an `O_CREATE|O_EXCL` file removed only on the success/error paths. A process killed (SIGKILL/OOM/power loss) between create and remove orphaned `minor.lock` — nothing sweeps it — so every later allocation failed after a 10-try busy-spin (`"minor lock held after 10 retries"`) and **no new volume could be provisioned on that node until an operator `rm`'d the file**. Switched to `unix.Flock(LOCK_EX)`, which the kernel releases on fd close *and on process death*, so a crash can't wedge allocation; also removes the busy-spin (it blocks instead of failing instantly).

**2. `writeConfig`: atomic `.res` write.** `os.WriteFile` truncates in place; a crash mid-write leaves a partial `.res` in `StateDir`, which is drbdadm's include directory — one malformed file makes `drbdadm adjust` fail for **every** resource on the node, not just this one. Now writes via temp + `fsync` + `rename` (the same pattern `writeAssignments` already uses), extracted into a small `writeFileAtomic` helper.

**3. `events.go` scan: surface `scanner.Err()` + lift the 64 KiB token cap to 1 MiB.** The scan loop discarded the scanner error and used `bufio.Scanner`'s default cap; a read error (or an unusually long line) ended the stream silently while `drbdsetup` kept writing, filling the pipe and blocking `cmd.Wait()` forever — the event stream died with no log and never restarted. Now the error propagates so `Start` logs and respawns.

**4. Portability: `uint64(st.Rdev)` cast in `ensureDeviceNode`.** `unix.Stat_t.Rdev` is `uint64` on linux but `int32` on darwin, so the package (and its whole test suite) failed to compile on a macOS dev host. The cast is a no-op on the linux target (with a scoped `//nolint:unconvert`) and lets `go test ./internal/drbd/...` run locally.

## Tests

New `minor_test.go` covers the allocator (previously 0% there): base-minor-first, sequential increment, stable repeat (idempotent), persistence across a fresh `Driver`, and skipping minors already claimed by on-disk `.res` files. Full `internal/drbd` suite green; `golangci-lint` clean on both linux and darwin.

Part of the review follow-up; subsequent PRs cover agent status-write convergence, CSI correctness, and the backends.