### PR TITLE
fix(membership): requeue transient replica-completion failures

### DIFF
--- a/internal/membership/reconciler.go
+++ b/internal/membership/reconciler.go
@@ -25,6 +25,7 @@ package membership
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -73,11 +74,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			continue
 		}
 		if err := r.complete(ctx, vol, rep); err != nil {
-			// Misplacement (unknown node, duplicate) only resolves by
-			// another spec edit — surface it and stop without requeueing.
-			log.Error(err, "cannot complete added replica",
-				"volume", vol.Name, "node", rep.Node)
-			return ctrl.Result{}, nil
+			if errors.Is(err, errBadPlacement) {
+				// Unknown node or duplicate: no Node update or poll
+				// re-triggers this generation-filtered controller, but only
+				// a spec edit could fix it anyway, so stop without requeue.
+				log.Error(err, "cannot complete added replica",
+					"volume", vol.Name, "node", rep.Node)
+				return ctrl.Result{}, nil
+			}
+			// Transient (Node not registered yet, InternalIP not posted):
+			// requeue with backoff — nothing else wakes this controller.
+			return ctrl.Result{}, err
 		}
 		changed = true
 	}
@@ -96,6 +103,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
+// errBadPlacement marks a completion failure that only a spec edit can fix
+// (unknown node, duplicate), as opposed to a transient one (Node not
+// registered yet) that must be retried.
+var errBadPlacement = errors.New("replica placement is invalid")
+
 // complete fills one added entry in place. NodeID takes the lowest id not
 // used by the other entries — freed ids may be reused; the joiner's
 // just-created metadata forces a full sync either way, so a stale bitmap
@@ -103,7 +115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) complete(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, rep *miroirv1alpha1.Replica) error {
 	entry, ok := r.Nodes[rep.Node]
 	if !ok {
-		return fmt.Errorf("node %s is not in the storage node map", rep.Node)
+		return fmt.Errorf("%w: node %s is not in the storage node map", errBadPlacement, rep.Node)
 	}
 	dup := 0
 	for _, other := range vol.Spec.Replicas {
@@ -112,7 +124,7 @@ func (r *Reconciler) complete(ctx context.Context, vol *miroirv1alpha1.MiroirVol
 		}
 	}
 	if dup > 1 {
-		return fmt.Errorf("node %s appears %d times in spec.replicas", rep.Node, dup)
+		return fmt.Errorf("%w: node %s appears %d times in spec.replicas", errBadPlacement, rep.Node, dup)
 	}
 	node := &corev1.Node{}
 	if err := r.Get(ctx, types.NamespacedName{Name: rep.Node}, node); err != nil {

--- a/internal/membership/reconciler_test.go
+++ b/internal/membership/reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
@@ -153,6 +154,39 @@ func TestUnknownNodeLeavesSpecUntouched(t *testing.T) {
 
 	if got := get(t, r, "pvc-1").Spec.Replicas[2]; got.Address != "" {
 		t.Fatalf("must not complete an entry for a non-storage node: %+v", got)
+	}
+}
+
+// A replica on a real storage node whose Node object is not ready yet
+// (unregistered, or InternalIP not posted) is transient: Reconcile must
+// return an error so it requeues. A Node gaining its InternalIP does not
+// wake this generation-filtered controller, so swallowing the error would
+// wedge the entry at Address="" until the next spec edit.
+func TestRequeuesWhenNodeNotReady(t *testing.T) {
+	cases := map[string]*corev1.Node{
+		"node not registered":     nil,
+		"node without InternalIP": {ObjectMeta: metav1.ObjectMeta{Name: nodeOslo}},
+	}
+	for name, n := range cases {
+		t.Run(name, func(t *testing.T) {
+			objs := []client.Object{replicatedVol()}
+			if n != nil {
+				objs = append(objs, n)
+			}
+			c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+				WithObjects(objs...).Build()
+			r := &Reconciler{Client: c, Nodes: nodemap.Map{
+				nodeOslo: {Backend: miroirv1alpha1.BackendZFS},
+			}}
+
+			if _, err := r.Reconcile(context.Background(),
+				ctrl.Request{NamespacedName: types.NamespacedName{Name: "pvc-1"}}); err == nil {
+				t.Fatal("transient completion failure must return an error to requeue")
+			}
+			if got := get(t, r, "pvc-1").Spec.Replicas[2]; got.Address != "" {
+				t.Fatalf("entry must stay incomplete: %+v", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

When an operator adds a replica to a live volume, the membership controller completes the entry (DRBD node id, replication address, teardown finalizer, FullSync marker). `complete()` could fail for two unrelated reasons, and `Reconcile` treated them identically by returning `(ctrl.Result{}, nil)` for both:

- **Permanent** placement errors: the node is not in the storage node map, or it appears twice in `spec.replicas`. Only a spec edit can fix these.
- **Transient** not-ready conditions: the target node's `Node` object is not registered yet, or it has not posted an `InternalIP` yet.

The controller is `GenerationChangedPredicate`-filtered, so a no-requeue return on a transient failure wedges the entry: a `Node` later gaining its `InternalIP` is not a `MiroirVolume` generation change, and the per-poll status patches from agents are filtered out. Nothing wakes the controller again, so the replica stays at `Address=""` until the next manual spec edit, while its agent sits at a 5s requeue waiting on that address.

## Fix

Tag the two permanent causes with an `errBadPlacement` sentinel. `Reconcile` keeps the no-requeue path for those (a requeue would just spin on an error only a human can resolve), and returns the error for everything else so controller-runtime requeues with backoff and retries once the `Node` is ready.

## Test

`TestRequeuesWhenNodeNotReady` covers both transient shapes (node object absent, and present-but-no-InternalIP): `Reconcile` now returns an error and the entry stays incomplete. `TestUnknownNodeLeavesSpecUntouched` continues to assert the permanent case returns without error.

## Verification

- `go build ./internal/membership/...`, `go vet`, `go test` all green.
- `golangci-lint run ./internal/membership/...` reports 0 issues.

## Scope note

This is the first of the review's status-convergence findings, split out on its own because it is a self-contained, unambiguously-correct fix. The larger server-side-apply ownership change (scoping each agent's status write to its own `PerNode` slot) is deferred to a separate PR: on inspection the snapshot reconciler's `patchSnap` intentionally writes peers' slots as part of the barrier protocol, so that change is protocol-sensitive and deserves isolated review rather than being bundled here. The "RequeueAfter-vs-error" finding was dropped after verification: `return Result{RequeueAfter: X}, someCall()` already behaves correctly (requeue-after on success, logged backoff on error).