### PR TITLE
fix(agent): scope volume status apply to this node's slot

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -134,7 +135,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
 			DeviceCreated: true,
 			DevicePath:    dev,
-		}); err != nil && !apierrors.IsConflict(err) {
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 		vol.Status.PerNode[r.NodeName] = miroirv1alpha1.ReplicaStatus{
@@ -209,7 +210,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		splitBrain: st.SplitBrain,
 		suspended:  st.Suspended,
 	})
-	err = r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
+	if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
 		DeviceCreated: true,
 		DevicePath:    drbd.DevicePath(minor),
 		DRBDMinor:     minor,
@@ -217,14 +218,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		DiskState:     st.DiskState,
 		Connected:     st.Connected,
 		SplitBrain:    st.SplitBrain,
-	})
-	if apierrors.IsConflict(err) {
-		// Both agents poll the same volume; a lost optimistic-lock race
-		// is routine. A fixed requeue keeps the poll interval bounded
-		// instead of growing exponential backoff (and stale DiskState).
-		return ctrl.Result{RequeueAfter: requeue}, nil
-	}
-	if err != nil {
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: requeue}, nil
@@ -314,7 +308,7 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 		log.Info("replica removal blocked", "volume", vol.Name, "reason", reason)
 		st := vol.Status.PerNode[r.NodeName]
 		st.Message = "replica removal blocked: " + reason
-		if err := r.patchStatus(ctx, vol, st); err != nil && !apierrors.IsConflict(err) {
+		if err := r.patchStatus(ctx, vol, st); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -404,16 +398,21 @@ func (r *VolumeReconciler) reportError(ctx context.Context, vol *miroirv1alpha1.
 	return cause // requeue with backoff
 }
 
-// patchStatus updates this node's slot in status and recomputes the phase.
+// patchStatus applies only this node's slot and the derived phase. A
+// full-status apply would force-own peers' slots and Formatted (a CSI
+// field) and revert them to this agent's stale read.
 func (r *VolumeReconciler) patchStatus(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, mine miroirv1alpha1.ReplicaStatus) error {
 	if vol.Status.PerNode == nil {
 		vol.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{}
 	}
 	vol.Status.PerNode[r.NodeName] = mine
 	vol.Status.Phase = computePhase(vol)
-	vol.SetGroupVersionKind(miroirv1alpha1.GroupVersion.WithKind("MiroirVolume"))
-	vol.ManagedFields = nil
-	return r.Status().Patch(ctx, vol, client.Apply, //nolint:staticcheck
+
+	patch := &miroirv1alpha1.MiroirVolume{ObjectMeta: metav1.ObjectMeta{Name: vol.Name}}
+	patch.SetGroupVersionKind(miroirv1alpha1.GroupVersion.WithKind("MiroirVolume"))
+	patch.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{r.NodeName: mine}
+	patch.Status.Phase = vol.Status.Phase
+	return r.Status().Patch(ctx, patch, client.Apply, //nolint:staticcheck
 		client.FieldOwner("agent-volume-"+r.NodeName),
 		client.ForceOwnership)
 }

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 	"github.com/home-operations/miroir/internal/backend"
@@ -385,6 +386,78 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 	}
 	if got.Status.Phase != miroirv1alpha1.VolumeReady {
 		t.Fatalf("phase = %s, want Ready with both legs UpToDate", got.Status.Phase)
+	}
+}
+
+// Every status apply must name only this node's slot and the phase — never a
+// peer's slot or Formatted (a CSI-owned field). A full-status apply would
+// force-own those and revert them to this agent's stale read, hot-looping the
+// agents against each other; reverting Formatted risks re-mkfs of live data.
+// Asserting on the wire payload proves the scope regardless of how faithfully
+// the fake client models server-side apply ownership.
+func TestReconcile_StatusApplyScopedToOwnSlot(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = addrParis
+	// A peer slot and a CSI-owned Formatted flag this agent must not touch.
+	v.Status.Formatted = true
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeParis: {DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true},
+	}
+
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
+		"resource \"pvc-1\" {\n    on \"kharkiv\" {\n        device minor 1000;\n    }\n}\n",
+	), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+
+	var applies []miroirv1alpha1.MiroirVolumeStatus
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, cl client.Client, sub string,
+				obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if patch.Type() == types.ApplyPatchType {
+					applies = append(applies, obj.(*miroirv1alpha1.MiroirVolume).Status)
+				}
+				return cl.Status().Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	if _, err := r.Reconcile(context.Background(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(applies) == 0 {
+		t.Fatal("expected at least one server-side apply of status")
+	}
+	for i, st := range applies {
+		if _, ok := st.PerNode[nodeKharkiv]; !ok {
+			t.Errorf("apply %d omits this node's slot: %+v", i, st.PerNode)
+		}
+		if _, ok := st.PerNode[nodeParis]; ok {
+			t.Errorf("apply %d names the peer's slot (would force-own it): %+v", i, st.PerNode)
+		}
+		if st.Formatted {
+			t.Errorf("apply %d sets Formatted (would force-own a CSI field)", i)
+		}
 	}
 }
 


### PR DESCRIPTION
## The bug

`patchStatus` force-applied the **whole** `MiroirVolume` status with a per-node field owner (`agent-volume-<node>`) and `client.ForceOwnership`:

```go
vol.Status.PerNode[r.NodeName] = mine
vol.Status.Phase = computePhase(vol)
vol.ManagedFields = nil
r.Status().Patch(ctx, vol, client.Apply, client.FieldOwner("agent-volume-"+r.NodeName), client.ForceOwnership)
```

The applied object carried **every peer's `PerNode` slot** and **`Formatted`** as this agent last read them. With `ForceOwnership`, the apply claims ownership of those fields too and writes them back at the agent's (possibly stale) values. Two agents polling the same volume then transfer ownership of each other's slots back and forth on every reconcile — and the volume agent-volume controller has no predicate, so each write re-triggers the peer: a status **hot loop**.

Worse: `Formatted` is owned by **CSI** (`node.go` / `controller.go` set it once after `mkfs` via a `MergeFrom` patch). The agent force-owning it and reverting it to a stale `false` is exactly the *"a blank device on a formatted volume is data loss"* case the field's own doc warns about — a subsequent stage could re-`mkfs` and wipe live data.

## The fix

Build the apply from a **fresh object containing only this node's slot and the derived phase**:

```go
patch := &miroirv1alpha1.MiroirVolume{ObjectMeta: metav1.ObjectMeta{Name: vol.Name}}
patch.SetGroupVersionKind(...)
patch.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{r.NodeName: mine}
patch.Status.Phase = vol.Status.Phase
r.Status().Patch(ctx, patch, client.Apply, client.FieldOwner("agent-volume-"+r.NodeName), client.ForceOwnership)
```

Server-side apply merges this into peers' slots without ever naming them, so no agent owns or reverts another's status, and `Formatted` stays CSI's. `Message` (an `omitempty` field that `computePhase` reads to decide `VolumeFailed`) still clears correctly, because SSA removes owned-but-omitted fields — a plain merge patch could not clear it.

### Design note: Phase stays co-written

The review suggested making `Phase` single-writer. I kept it co-written because `computePhase` is deterministic over the shared `PerNode` map: once the map converges, every agent applies the same phase value and SSA shares ownership with no churn. Making it single-writer (only `replicas[0]`) would remove the transient during a state change but also means the volume could not report `Degraded` while `replicas[0]`'s node is down — a resilience regression during provisioning. Happy to switch if you'd rather have the single writer.

## Dead code removed

With `ForceOwnership` retained the apply never returns a conflict, so the three `apierrors.IsConflict(err)` branches guarding these calls were unreachable. Dropped them (behavior is identical — a real error still backs off, and the success path keeps its bounded `requeue`).

## Test

`TestReconcile_StatusApplyScopedToOwnSlot` seeds a volume with a peer slot and `Formatted=true`, intercepts the `SubResourcePatch`, and asserts every apply payload names only this node's slot (no peer slot, `Formatted` unset). Asserting on the wire payload proves the scoping regardless of how faithfully the fake client models SSA field ownership.

## Verification

- `go build ./internal/agent/...`, `go vet`, `go test ./internal/agent/...` all green.
- `golangci-lint run ./internal/agent/...` reports 0 issues.

## Scope

This is the volume half of the status-ownership finding. The snapshot reconciler's `patchSnap` has the same full-object shape but is **not** a simple scope-to-self: its coordinator intentionally writes peers' slots as part of the write-barrier protocol (`raiseBarrier` resets peers to Pending, `collectLegs` voids the round). That needs a role-aware fix and its own tests, so it stays in a follow-up.