### PR TITLE
fix(backend): typed ErrBusy for retryable teardown failures

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -63,18 +62,6 @@ const drbdPollInterval = 30 * time.Second
 // errSplitBrain gives the split-brain transition log a real error value.
 var errSplitBrain = errors.New("DRBD split-brain detected")
 
-// isDeviceBusy matches failures that resolve themselves once something
-// else goes away: an open device (force-deleted pod), an LVM origin with
-// snapshot children, a ZFS origin with clones.
-func isDeviceBusy(err error) bool {
-	s := err.Error()
-	return strings.Contains(s, "held open") || strings.Contains(s, "busy") ||
-		strings.Contains(s, "in use") ||
-		strings.Contains(s, "snapshot") || // lvremove: origin contains snapshots
-		strings.Contains(s, "has children") || // zfs destroy: snapshots exist
-		strings.Contains(s, "dependent clones") // zfs destroy: restore clones exist
-}
-
 // Reconcile realizes (or tears down) this node's replica of one volume.
 func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -98,9 +85,8 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if !mine && !controllerutil.ContainsFinalizer(vol, constants.FinalizerPrefix+r.NodeName) {
 			return ctrl.Result{}, nil
 		}
-		dropVolumeMetrics(vol.Name)
 		if err := r.teardown(ctx, vol); err != nil {
-			if isDeviceBusy(err) {
+			if errors.Is(err, backend.ErrBusy) {
 				// A force-deleted pod can leave the device open past
 				// NodeUnstage; retry until the mount goes away.
 				log.Info("device busy during teardown, retrying", "volume", vol.Name)
@@ -108,6 +94,9 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 			return ctrl.Result{}, err
 		}
+		// Drop metrics only once the device is gone: a retrying teardown
+		// must not blank a volume that still exists.
+		dropVolumeMetrics(vol.Name)
 		return ctrl.Result{}, r.removeFinalizer(ctx, vol)
 	}
 	if !mine {
@@ -313,9 +302,8 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 		}
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-	dropVolumeMetrics(vol.Name)
 	if err := r.teardown(ctx, vol); err != nil {
-		if isDeviceBusy(err) {
+		if errors.Is(err, backend.ErrBusy) {
 			// A pod still staged here holds the device open; it has to
 			// move off this node before the leg can go.
 			log.Info("device busy during replica removal, retrying", "volume", vol.Name)
@@ -323,6 +311,7 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 		}
 		return ctrl.Result{}, err
 	}
+	dropVolumeMetrics(vol.Name)
 	// Drop this node's status slot — merge-patch null deletes the key.
 	// Best-effort ordering: a crash here leaves a stale slot, which
 	// nothing reads (phase and growth iterate spec.replicas only).

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -96,9 +97,9 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 		}
 		if err := r.Backend.DeleteSnapshot(ctx, vol.Name, snap.Name); err != nil {
-			if isDeviceBusy(err) {
-				// ZFS refuses to destroy an origin with live clones;
-				// retry until restored volumes are gone.
+			if errors.Is(err, backend.ErrBusy) {
+				// The snapshot device is still open (e.g. a restore in
+				// progress); retry until it is released.
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			return ctrl.Result{}, err

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -22,10 +22,17 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 )
+
+// ErrBusy marks a Delete or DeleteSnapshot that cannot finish yet because
+// the resource is still held: an open device, or dependents (snapshots,
+// restore clones) that must be removed first. Callers retry on ErrBusy and
+// treat any other error as permanent.
+var ErrBusy = errors.New("backend resource busy")
 
 // PoolStats reports capacity of the node-local pool backing this Backend.
 type PoolStats struct {
@@ -64,9 +71,11 @@ type Backend interface {
 	CreateFromSnapshot(ctx context.Context, vol, sourceVol, snap string) (devPath string, err error)
 	// Exists reports whether a device for vol is present on this node.
 	Exists(ctx context.Context, vol string) (bool, error)
-	// Delete removes the device. Succeeds if already absent.
+	// Delete removes the device. Succeeds if already absent; returns a
+	// wrapped ErrBusy while the device is still held or has dependents.
 	Delete(ctx context.Context, vol string) error
-	// DeleteSnapshot removes a snapshot. Succeeds if already absent.
+	// DeleteSnapshot removes a snapshot. Succeeds if already absent;
+	// returns a wrapped ErrBusy while the snapshot is still held.
 	DeleteSnapshot(ctx context.Context, vol, snap string) error
 	// DevicePath returns the path the device has (or would have).
 	DevicePath(vol string) string

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -273,6 +273,51 @@ func TestZFSDeleteWithoutClonesDoesNotPromote(t *testing.T) {
 	fe.notCalledWith(t, "zfs get -Hpo value clones")
 }
 
+func TestZFSDeleteBusyWhileSnapshotsPresent(t *testing.T) {
+	// Snapshots (children, not clones) block destroy and cannot be
+	// promoted away: the volume must report ErrBusy so the agent retries
+	// until its snapshots are deleted, not fail teardown permanently.
+	fe := &fakeExec{}
+	fe.respond("zfs destroy tank/miroir/pvc-1",
+		"", errors.New("cannot destroy 'tank/miroir/pvc-1': filesystem has children"))
+	fe.respond("zfs get -Hpo value clones", "-\n", nil) // no clones to promote
+	b := newZFS(cfg, fe.run)
+
+	if err := b.Delete(context.Background(), "pvc-1"); !errors.Is(err, ErrBusy) {
+		t.Fatalf("want ErrBusy while snapshots pin the volume, got %v", err)
+	}
+}
+
+func TestZFSDeleteSnapshotSurfacesPermanentError(t *testing.T) {
+	// Deferred destroy (-d) never blocks on clones, so a DeleteSnapshot
+	// error is permanent and must surface — never ErrBusy, or the agent
+	// would silently retry it forever. The message contains "snapshot",
+	// which the old substring matcher wrongly treated as busy.
+	fe := &fakeExec{}
+	fe.respond("zfs destroy -d tank/miroir/pvc-1@snap-1", "",
+		errors.New("cannot destroy snapshot tank/miroir/pvc-1@snap-1: permission denied"))
+	b := newZFS(cfg, fe.run)
+
+	err := b.DeleteSnapshot(context.Background(), "pvc-1", "snap-1")
+	if err == nil {
+		t.Fatal("a permanent DeleteSnapshot error must surface")
+	}
+	if errors.Is(err, ErrBusy) {
+		t.Fatalf("permanent snapshot error must not be ErrBusy, got %v", err)
+	}
+}
+
+func TestLVMThinDeleteBusyWhenInUse(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lvremove --yes vg-miroir/pvc-1", "",
+		errors.New("Logical volume vg-miroir/pvc-1 in use."))
+	b := newLVMThin(cfg, fe.run)
+
+	if err := b.Delete(context.Background(), "pvc-1"); !errors.Is(err, ErrBusy) {
+		t.Fatalf("want ErrBusy while the LV is open, got %v", err)
+	}
+}
+
 func TestZFSStatsUsesPool(t *testing.T) {
 	fe := &fakeExec{}
 	fe.respond("zpool get", "2000000000000\n500000000000\n", nil)

--- a/internal/backend/exec.go
+++ b/internal/backend/exec.go
@@ -37,3 +37,23 @@ func RealExec(ctx context.Context, name string, args ...string) (string, error) 
 	}
 	return string(out), nil
 }
+
+// busy classifies a delete/destroy failure: it wraps err as ErrBusy when the
+// cause clears on its own — the device is still open, or (zfs) snapshots or
+// restore clones must go first — so the caller retries. Other errors pass
+// through unchanged and are treated as permanent. Returns nil for nil.
+func busy(err error) error {
+	if err == nil {
+		return nil
+	}
+	s := err.Error()
+	switch {
+	case strings.Contains(s, "held open"),
+		strings.Contains(s, "busy"),
+		strings.Contains(s, "in use"),
+		strings.Contains(s, "has children"),     // zfs: snapshots exist
+		strings.Contains(s, "dependent clones"): // zfs: restore clones exist
+		return fmt.Errorf("%w: %v", ErrBusy, err)
+	}
+	return err
+}

--- a/internal/backend/loopfile.go
+++ b/internal/backend/loopfile.go
@@ -243,7 +243,7 @@ func (lf *loopfile) Delete(ctx context.Context, vol string) error {
 	}
 	if dev != "" {
 		if _, err := lf.exec(ctx, "losetup", "-d", dev); err != nil {
-			return fmt.Errorf("detach %s: %w", dev, err)
+			return busy(fmt.Errorf("detach %s: %w", dev, err))
 		}
 	}
 	if _, err := lf.exec(ctx, "rm", "-f", lf.DevicePath(vol)); err != nil {

--- a/internal/backend/loopfile_test.go
+++ b/internal/backend/loopfile_test.go
@@ -142,6 +142,18 @@ func TestLoopfileDeleteDetachesAndRemoves(t *testing.T) {
 	fe.calledWith(t, "rm -f /var/lib/miroir/volumes/pvc-1.img")
 }
 
+func TestLoopfileDeleteBusyWhenAttached(t *testing.T) {
+	fe := &fakeExec{} // stat succeeds → file exists
+	fe.respond("losetup -j", "/dev/loop3\n", nil)
+	fe.respond("losetup -d /dev/loop3", "",
+		errors.New("losetup: /dev/loop3: detach failed: Device or resource busy"))
+	b := newLoopfile(lcfg, fe.run)
+
+	if err := b.Delete(context.Background(), "pvc-1"); !errors.Is(err, ErrBusy) {
+		t.Fatalf("want ErrBusy while the loop device is attached, got %v", err)
+	}
+}
+
 func TestLoopfileDeleteAbsentIsNoop(t *testing.T) {
 	fe := &fakeExec{}
 	fe.respond("stat /var/lib/miroir/volumes/pvc-1.img", "",

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -214,7 +214,7 @@ func (l *lvmThin) Delete(ctx context.Context, vol string) error {
 		return err
 	}
 	if _, err := l.lvm(ctx, "lvremove", "--yes", fmt.Sprintf("%s/%s", l.vg, vol)); err != nil {
-		return fmt.Errorf("lvremove %s: %w", vol, err)
+		return busy(fmt.Errorf("lvremove %s: %w", vol, err))
 	}
 	return nil
 }

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -153,7 +153,7 @@ func (z *zfsBackend) Delete(ctx context.Context, vol string) error {
 	if derr == nil ||
 		(!strings.Contains(derr.Error(), "has children") &&
 			!strings.Contains(derr.Error(), "dependent clones")) {
-		return derr
+		return busy(derr)
 	}
 	// Restore clones pin this volume's snapshot chain — promoting
 	// reparents each clone's origin snapshot onto the clone, freeing the
@@ -163,7 +163,7 @@ func (z *zfsBackend) Delete(ctx context.Context, vol string) error {
 		return err
 	}
 	_, err = z.exec(ctx, "zfs", "destroy", z.name(vol))
-	return err
+	return busy(err)
 }
 
 func (z *zfsBackend) promoteClones(ctx context.Context, vol string) error {


### PR DESCRIPTION
## The bug

The agent classified backend delete failures with a shared `isDeviceBusy()` that substring-matched the CLI error text:

```go
strings.Contains(s, "held open") || strings.Contains(s, "busy") ||
	strings.Contains(s, "in use") ||
	strings.Contains(s, "snapshot") ||        // lvremove: origin contains snapshots
	strings.Contains(s, "has children") ||    // zfs destroy: snapshots exist
	strings.Contains(s, "dependent clones")
```

In the volume-teardown path those matches are correct. But the **same matcher ran on `DeleteSnapshot`**, where the tool output almost always contains the word `snapshot` (e.g. `cannot destroy snapshot tank/x@snap: permission denied`). A genuinely *permanent* snapshot-deletion failure was therefore misread as transient and retried silently on a fixed 30s tick, forever, with nothing logged — instead of surfacing as an error with backoff so an operator can see it.

## The fix

Replace the cross-package string matching with a typed `backend.ErrBusy` sentinel. Each backend is the authority on its own tool's error strings and wraps **only** its genuinely self-clearing conditions:

| backend | Delete wraps `ErrBusy` when |
|---|---|
| zfs | `has children` (snapshots present), device held, or the post-clone-promote retry still blocks |
| lvmthin | `lvremove` reports the LV `in use` |
| loopfile | `losetup -d` reports the device `busy` |

ZFS `DeleteSnapshot` uses **deferred** destroy (`-d`), which never blocks on clones, so it wraps nothing: its failures are permanent and now surface correctly. The agent switches from `isDeviceBusy(err)` to `errors.Is(err, backend.ErrBusy)`, and the classification keyword list lives once, in the backend package.

## Metrics ordering

Also move `dropVolumeMetrics(vol.Name)` to **after** teardown succeeds in both the volume-deletion and replica-removal paths. Previously metrics were dropped before teardown, so a teardown that returns `ErrBusy` and keeps retrying would blank a volume that still exists on the node.

## Tests

- `TestZFSDeleteSnapshotSurfacesPermanentError` — the regression guard: a permanent snapshot error whose text contains `snapshot` is **not** `ErrBusy` (would otherwise silently retry forever).
- `TestZFSDeleteBusyWhileSnapshotsPresent`, `TestLVMThinDeleteBusyWhenInUse`, `TestLoopfileDeleteBusyWhenAttached` — each backend raises `ErrBusy` for its real transient condition.

## Verification

- `go build`, `go vet`, `go test ./internal/backend/... ./internal/agent/...` all green.
- `golangci-lint run` on both packages reports 0 issues.