### PR TITLE
fix(csi): grow filesystem on every stage, not only a fresh mount

### DIFF
--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -174,65 +174,67 @@ func (n *Node) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequ
 	} else if err != nil {
 		return nil, status.Errorf(codes.Internal, "inspect staging path: %v", err)
 	}
-	if !notMnt {
+	if notMnt {
+		fsType := req.GetVolumeCapability().GetMount().GetFsType()
+		if fsType == "" {
+			fsType = "ext4"
+		}
+		mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
+
+		// Open-for-write probe: the first open(2) auto-promotes DRBD, and a
+		// refused promotion (peer already Primary) otherwise surfaces as
+		// mkfs "Wrong medium type".
+		f, err := os.OpenFile(dev, os.O_RDWR, 0)
+		if err != nil {
+			return nil, status.Errorf(codes.Unavailable,
+				"device %s not writable (is the volume in use on another node?): %v", dev, err)
+		}
+		_ = f.Close()
+
+		// mkfs-if-blank is allowed exactly once per volume: a blank device on
+		// a volume that ever carried a filesystem is data loss (diverged
+		// replica, torn clone), and reformatting would silently finish it.
+		format, err := n.Mounter.GetDiskFormat(dev)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "probe filesystem on %s: %v", dev, err)
+		}
+		if format == "" && vol.Status.Formatted {
+			return nil, status.Errorf(codes.DataLoss,
+				"volume %s was formatted before but %s reads blank — refusing to reformat", req.GetVolumeId(), dev)
+		}
+		if format != "" {
+			// Record before mounting so a clone that arrived with a
+			// filesystem is protected from then on.
+			if err := n.markFormatted(ctx, vol); err != nil {
+				return nil, status.Errorf(codes.Internal, "record formatted flag: %v", err)
+			}
+		}
+
+		// FormatAndMount formats only when the device has no filesystem —
+		// the mkfs-if-blank step of notes/DESIGN.md §4.5.2.
+		if err := n.Mounter.FormatAndMount(dev, req.GetStagingTargetPath(), fsType, mountFlags); err != nil {
+			return nil, status.Errorf(codes.Internal, "format/mount %s: %v", dev, err)
+		}
+		if format == "" {
+			// First mkfs. A failed patch fails the stage; the retry lands in
+			// the format != "" path above and records it then.
+			if err := n.markFormatted(ctx, vol); err != nil {
+				return nil, status.Errorf(codes.Internal, "record formatted flag: %v", err)
+			}
+		}
+	} else {
 		// Already staged: a mounted device carries a filesystem, so a
 		// missed Formatted patch from an earlier stage heals here.
 		if err := n.markFormatted(ctx, vol); err != nil {
 			return nil, status.Errorf(codes.Internal, "record formatted flag: %v", err)
 		}
-		return &csi.NodeStageVolumeResponse{}, nil // idempotent
 	}
 
-	fsType := req.GetVolumeCapability().GetMount().GetFsType()
-	if fsType == "" {
-		fsType = "ext4"
-	}
-	mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
-
-	// Open-for-write probe: the first open(2) auto-promotes DRBD, and a
-	// refused promotion (peer already Primary) otherwise surfaces as
-	// mkfs "Wrong medium type".
-	f, err := os.OpenFile(dev, os.O_RDWR, 0)
-	if err != nil {
-		return nil, status.Errorf(codes.Unavailable,
-			"device %s not writable (is the volume in use on another node?): %v", dev, err)
-	}
-	_ = f.Close()
-
-	// mkfs-if-blank is allowed exactly once per volume: a blank device on
-	// a volume that ever carried a filesystem is data loss (diverged
-	// replica, torn clone), and reformatting would silently finish it.
-	format, err := n.Mounter.GetDiskFormat(dev)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "probe filesystem on %s: %v", dev, err)
-	}
-	if format == "" && vol.Status.Formatted {
-		return nil, status.Errorf(codes.DataLoss,
-			"volume %s was formatted before but %s reads blank — refusing to reformat", req.GetVolumeId(), dev)
-	}
-	if format != "" {
-		// Record before mounting so a clone that arrived with a
-		// filesystem is protected from then on.
-		if err := n.markFormatted(ctx, vol); err != nil {
-			return nil, status.Errorf(codes.Internal, "record formatted flag: %v", err)
-		}
-	}
-
-	// FormatAndMount formats only when the device has no filesystem —
-	// the mkfs-if-blank step of notes/DESIGN.md §4.5.2.
-	if err := n.Mounter.FormatAndMount(dev, req.GetStagingTargetPath(), fsType, mountFlags); err != nil {
-		return nil, status.Errorf(codes.Internal, "format/mount %s: %v", dev, err)
-	}
-	if format == "" {
-		// First mkfs. A failed patch fails the stage; the retry lands in
-		// the format != "" path above and records it then.
-		if err := n.markFormatted(ctx, vol); err != nil {
-			return nil, status.Errorf(codes.Internal, "record formatted flag: %v", err)
-		}
-	}
-
-	// A restored clone carries the snapshot's filesystem, which is smaller
-	// than the device when the new PVC asked for more — grow it to fill.
+	// Grow-to-fill runs on every stage, not only a fresh mount: a restored
+	// clone carries the snapshot's smaller filesystem, and a resize that
+	// failed after the mount already succeeded must be retried on the next
+	// stage, not skipped by the already-staged fast path. NeedResize is a
+	// no-op once the filesystem fills the device.
 	resizer := mount.NewResizeFs(n.Mounter.Exec)
 	need, err := resizer.NeedResize(dev, req.GetStagingTargetPath())
 	if err != nil {

--- a/internal/csi/node_test.go
+++ b/internal/csi/node_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/drbd"
+)
+
+type fakeDRBDStatus struct {
+	st  drbd.Status
+	err error
+}
+
+func (f fakeDRBDStatus) Status(context.Context, string) (drbd.Status, error) {
+	return f.st, f.err
+}
+
+// stagedVolume is a single-replica-on-kharkiv replicated volume whose agent
+// has already created the local DRBD device.
+func stagedVolume() *miroirv1alpha1.MiroirVolume {
+	v := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 1 << 30,
+			DRBD:      &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Address: "192.168.1.41"}},
+		},
+	}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DevicePath: "/dev/drbd1000"},
+	}
+	return v
+}
+
+func newNode(t *testing.T, vol *miroirv1alpha1.MiroirVolume, d DRBDStatus) *Node {
+	t.Helper()
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		WithObjects(vol).Build()
+	return &Node{Client: c, NodeName: nodeKharkiv, DRBD: d}
+}
+
+// A split-brain leg must never be staged: mkfs/mount on divergent data
+// would finalize the loser's copy. The kernel's live view decides, not the
+// lagging CRD status.
+func TestDevicePathRefusesSplitBrain(t *testing.T) {
+	n := newNode(t, stagedVolume(), fakeDRBDStatus{
+		st: drbd.Status{DiskState: drbd.DiskUpToDate, Connected: true, SplitBrain: true},
+	})
+	if _, _, err := n.devicePath(context.Background(), volPvc1); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("split-brain must be FailedPrecondition, got %v", err)
+	}
+}
+
+// A leg that is not UpToDate is still resyncing or diverged; staging it
+// could mount stale data or race the initial handshake.
+func TestDevicePathRefusesNotUpToDate(t *testing.T) {
+	n := newNode(t, stagedVolume(), fakeDRBDStatus{
+		st: drbd.Status{DiskState: "Inconsistent", Connected: true},
+	})
+	if _, _, err := n.devicePath(context.Background(), volPvc1); status.Code(err) != codes.Unavailable {
+		t.Fatalf("a non-UpToDate leg must be Unavailable, got %v", err)
+	}
+}
+
+// The gate reads the kernel, not the CRD: an unreadable DRBD state must not
+// fall through to staging.
+func TestDevicePathRefusesUnreadableDRBD(t *testing.T) {
+	n := newNode(t, stagedVolume(), fakeDRBDStatus{err: context.DeadlineExceeded})
+	if _, _, err := n.devicePath(context.Background(), volPvc1); status.Code(err) != codes.Unavailable {
+		t.Fatalf("unreadable DRBD state must be Unavailable, got %v", err)
+	}
+}
+
+func TestDevicePathHealthyReturnsDevice(t *testing.T) {
+	n := newNode(t, stagedVolume(), fakeDRBDStatus{
+		st: drbd.Status{DiskState: drbd.DiskUpToDate, Connected: true},
+	})
+	dev, _, err := n.devicePath(context.Background(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dev != "/dev/drbd1000" {
+		t.Fatalf("dev = %q, want /dev/drbd1000", dev)
+	}
+}
+
+// A node holding no replica of the volume must be refused before any DRBD
+// or device lookup.
+func TestDevicePathRefusesForeignNode(t *testing.T) {
+	v := stagedVolume()
+	v.Spec.Replicas[0].Node = nodeParis
+	n := newNode(t, v, fakeDRBDStatus{st: drbd.Status{DiskState: drbd.DiskUpToDate}})
+	if _, _, err := n.devicePath(context.Background(), volPvc1); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("a node without a replica must be FailedPrecondition, got %v", err)
+	}
+}


### PR DESCRIPTION
## The bug

`NodeStageVolume` grows a restored clone's filesystem to fill the device (a clone carries the snapshot's *smaller* filesystem). But that grow-to-fill step only ran on the path that formatted-and-mounted a **fresh** staging point:

```go
if !notMnt {
    // already staged
    markFormatted(...)
    return &NodeStageVolumeResponse{}, nil   // <-- returns before grow-to-fill
}
... mkfs-if-blank + FormatAndMount ...
... NeedResize / Resize ...                  // only reached on a fresh mount
```

So if a first stage **mounted** the device but its resize then **failed** (a transient error → the RPC returns an error), kubelet retries `NodeStageVolume`, sees the device already mounted, takes the fast path, and returns — never growing the filesystem. The clone stays stuck at the snapshot's smaller size permanently, even though the PVC asked for more.

## The fix

Restructure so `mkfs-if-blank` + `FormatAndMount` runs only for a fresh mount, but the grow-to-fill (`NeedResize`/`Resize`) runs on **every** stage:

```go
if notMnt {
    // fresh: open-probe, mkfs-if-blank guard, FormatAndMount
} else {
    // already staged: heal a missed Formatted patch
}
// grow-to-fill — idempotent, runs either way
if need, _ := resizer.NeedResize(dev, staging); need { resizer.Resize(...) }
```

`NeedResize` is a no-op once the filesystem already fills the device, so a steady-state re-stage of a normal volume just pays one cheap probe.

## Tests

`internal/csi/node.go` had no unit tests. Added `node_test.go` covering `devicePath`'s staging gates, which need no mounter and enforce the rule that a divergent/resyncing replica is never mkfs'd or mounted:

- split-brain leg → `FailedPrecondition`
- non-`UpToDate` leg → `Unavailable`
- unreadable DRBD state → `Unavailable` (the gate trusts the kernel, not the lagging CRD)
- node holding no replica → `FailedPrecondition`
- healthy `UpToDate` leg → returns the device path

## Verification

The `csi` package is linux-only (mount-utils / statfs), so it does not build on macOS. Verified by cross-compiling and by running the suite in a `golang:1.26.5` container:

- `GOOS=linux go build ./internal/csi/...`, `GOOS=linux go vet`, `GOOS=linux go test -c` all clean.
- `docker run golang:1.26.5 go test ./internal/csi/... ./internal/agent/... ./internal/backend/...` — all pass, including the 5 new gate tests.
- `GOOS=linux golangci-lint run ./internal/csi/...` reports 0 issues.

## Scope

This is the node-side CSI correctness fix. The controller-side finding from the same review — `CreateVolume`'s overcommit guard runs its capacity check via the cached client and outside `allocMu`, so concurrent creates can both pass it — is a concurrency-sensitive `place()`/lock restructure and lands in its own follow-up PR.