### PR TITLE
fix(csi): serialize CreateVolume placement with allocation

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -139,9 +139,10 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	}
 
 	var source *miroirv1alpha1.VolumeSource
-	var placed []miroirv1alpha1.Replica
 	var sourceFormatted bool
-	if snapID := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId(); snapID != "" {
+	var srcReplicas []miroirv1alpha1.Replica
+	snapID := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()
+	if snapID != "" {
 		// Restore: clones are local CoW, so replicas must live on the
 		// nodes holding the snapshot — placement follows the source.
 		srcVol, snap, err := c.snapshotSource(ctx, snapID)
@@ -159,18 +160,26 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				replicas, len(srcVol.Spec.Replicas))
 		}
 		source = &miroirv1alpha1.VolumeSource{SnapshotName: snapID}
-		placed = srcVol.Spec.Replicas
-	} else {
-		placed, err = c.place(ctx, req.GetAccessibilityRequirements(), replicas, sizeBytes, req.GetName())
-		if err != nil {
-			return nil, err
-		}
+		srcReplicas = srcVol.Spec.Replicas
 	}
 
+	// Serialise placement, port allocation, and Create as one critical
+	// section: the overcommit guard and the DRBD port scan read fresh
+	// cluster state, and a concurrent CreateVolume that has not committed
+	// yet would otherwise be invisible to both — two RPCs could pass the
+	// guard or claim the same port. waitReady is deliberately left outside.
+	c.allocMu.Lock()
+	placed := srcReplicas
+	if snapID == "" {
+		p, err := c.place(ctx, req.GetAccessibilityRequirements(), replicas, sizeBytes, req.GetName())
+		if err != nil {
+			c.allocMu.Unlock()
+			return nil, err
+		}
+		placed = p
+	}
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: req.GetName(),
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: req.GetName()},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: sizeBytes,
 			Replicas:  placed,
@@ -182,31 +191,22 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	}
 	if replicas > 1 {
 		vol.Spec.QuorumPolicy = quorum
-		c.allocMu.Lock()
 		drbdSpec, err := c.allocateDRBD(ctx)
 		if err != nil {
 			c.allocMu.Unlock()
 			return nil, err
 		}
 		vol.Spec.DRBD = drbdSpec
-		err = c.Client.Create(ctx, vol)
-		c.allocMu.Unlock()
-		sourceSnapshot := ""
-		if source != nil {
-			sourceSnapshot = source.SnapshotName
-		}
-		if err2 := c.handleCreateErr(ctx, err, vol, sizeBytes, replicas, quorum, sourceSnapshot); err2 != nil {
-			return nil, err2
-		}
-	} else {
-		err := c.Client.Create(ctx, vol)
-		sourceSnapshot := ""
-		if source != nil {
-			sourceSnapshot = source.SnapshotName
-		}
-		if err2 := c.handleCreateErr(ctx, err, vol, sizeBytes, replicas, quorum, sourceSnapshot); err2 != nil {
-			return nil, err2
-		}
+	}
+	createErr := c.Client.Create(ctx, vol)
+	c.allocMu.Unlock()
+
+	sourceSnapshot := ""
+	if source != nil {
+		sourceSnapshot = source.SnapshotName
+	}
+	if err := c.handleCreateErr(ctx, createErr, vol, sizeBytes, replicas, quorum, sourceSnapshot); err != nil {
+		return nil, err
 	}
 	// A clone carries the source's filesystem: inherit Formatted before
 	// any pod stages it, so a blank clone is refused instead of mkfs'd.
@@ -406,13 +406,24 @@ func (c *Controller) nodeInternalIP(ctx context.Context, name string) (string, e
 	return "", status.Errorf(codes.Internal, "node %s has no InternalIP", name)
 }
 
+// reader returns the API-server reader for read-your-writes, falling back
+// to the cached client (in tests, or before the manager wires APIReader).
+// The overcommit guard and DRBD port scan run under allocMu and must see a
+// concurrent CreateVolume's just-committed object, which the cache can lag.
+func (c *Controller) reader() client.Reader {
+	if c.APIReader != nil {
+		return c.APIReader
+	}
+	return c.Client
+}
+
 // poolStats returns the fresh pool capacity each storage node's agent
 // published (notes/DESIGN.md §4.6). Stale or never-published nodes are
 // omitted — placement treats them as unknown (eligible, no free-space
 // signal) so a cold cluster still provisions.
 func (c *Controller) poolStats(ctx context.Context) (map[string]miroirv1alpha1.MiroirNodeStatus, error) {
 	list := &miroirv1alpha1.MiroirNodeList{}
-	if err := c.Client.List(ctx, list); err != nil {
+	if err := c.reader().List(ctx, list); err != nil {
 		return nil, status.Errorf(codes.Internal, "list MiroirNodes: %v", err)
 	}
 	out := make(map[string]miroirv1alpha1.MiroirNodeStatus, len(list.Items))
@@ -431,7 +442,7 @@ func (c *Controller) poolStats(ctx context.Context) (map[string]miroirv1alpha1.M
 // backing on disk but are counted in full — a conservative overcommit guard.
 func (c *Controller) provisionedPerNode(ctx context.Context, exclude string) (map[string]int64, error) {
 	list := &miroirv1alpha1.MiroirVolumeList{}
-	if err := c.Client.List(ctx, list); err != nil {
+	if err := c.reader().List(ctx, list); err != nil {
 		return nil, status.Errorf(codes.Internal, "list MiroirVolumes: %v", err)
 	}
 	out := map[string]int64{}
@@ -718,9 +729,11 @@ func (c *Controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 
 	start := 0
 	if req.GetStartingToken() != "" {
-		if _, err := fmt.Sscanf(req.GetStartingToken(), "%d", &start); err != nil || start < 0 || start >= len(vols.Items) {
+		n, err := strconv.Atoi(req.GetStartingToken())
+		if err != nil || n < 0 || n >= len(vols.Items) {
 			return nil, status.Errorf(codes.Aborted, "invalid starting_token: %s", req.GetStartingToken())
 		}
+		start = n
 	}
 
 	maxEntries := int(req.GetMaxEntries())


### PR DESCRIPTION
## The bug

`CreateVolume` protected its DRBD **port** allocation against concurrent RPCs: `allocateDRBD` runs under `allocMu` and reads volumes through the fresh `APIReader` (read-your-writes). The **overcommit guard** got neither protection — `place()` ran *before* the lock and read pool stats + per-node provisioned totals through the **cached** client:

```go
placed, err = c.place(...)          // capacity check: cached reads, no lock
...
c.allocMu.Lock()                    // lock starts here, after the guard
drbdSpec, _ := c.allocateDRBD(ctx)  // fresh reads, locked
c.Client.Create(ctx, vol)
c.allocMu.Unlock()
```

Two `CreateVolume` RPCs racing on the same pool could each read stale state that omits the other's in-flight volume, both pass the guard, and both create — pushing the pool past its overcommit ratio (notes/DESIGN.md §4.6).

## The fix

Widen the critical section to span **placement → port allocation → Create** as one unit, and route the capacity reads through the same API-server reader the port scan uses:

- Extract `reader()` (fresh `APIReader`, falling back to the cached client in tests / before the manager wires it) and use it in `poolStats` and `provisionedPerNode`.
- Hold `allocMu` from `place()` through `Create`. Under the lock with fresh reads, the second RPC sees the first's committed volume and is bounded by the guard.
- `waitReady` stays **outside** the lock — holding `allocMu` across a multi-second provisioning wait would serialize every create.

The two duplicated `Create`/`handleCreateErr` arms (replicated vs single-replica) fold into one.

## Also

`ListVolumes` parsed its `starting_token` with `fmt.Sscanf(tok, "%d", &start)`, which silently accepts trailing garbage (`"5x"` → `5`). Replaced with `strconv.Atoi`, which rejects it.

## Verification

The `csi` package is linux-only, so verified by cross-compile + container run:

- `GOOS=linux go build`/`vet` clean; `GOOS=linux golangci-lint run ./internal/csi/...` → 0 issues.
- `docker run golang:1.26.5 go test ./internal/csi/...` — all pass, including the existing placement/overcommit tests (which seed a pre-existing volume and assert `ResourceExhausted`, exercising the fresh-read counting path) and the CreateVolume idempotency/restore tests (which validate the restructure preserves behavior).

The lock ordering itself is not unit-testable deterministically; it is covered by inspection and the behavior-preserving suite. This completes the CSI-correctness pair with #62 (node-side grow-to-fill).