### PR TITLE
fix(backend): crash-safe reflink clones, locale-stable exec

### DIFF
--- a/internal/backend/exec.go
+++ b/internal/backend/exec.go
@@ -19,6 +19,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -30,7 +31,11 @@ type Exec func(ctx context.Context, name string, args ...string) (string, error)
 // RealExec executes commands on the host. The agent container runs with the
 // host namespaces, so lvm/zfs act on the node's devices directly.
 func RealExec(ctx context.Context, name string, args ...string) (string, error) {
-	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	cmd := exec.CommandContext(ctx, name, args...)
+	// Force the C locale: the delete/exists classifiers match lvm/zfs error
+	// text ("in use", "Failed to find", …), which the tools localise.
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(out), fmt.Errorf("%s %s: %w: %s",
 			name, strings.Join(args, " "), err, strings.TrimSpace(string(out)))

--- a/internal/backend/loopfile.go
+++ b/internal/backend/loopfile.go
@@ -204,12 +204,27 @@ func (lf *loopfile) Sync(_ context.Context, vol string) error {
 	return nil
 }
 
+// reflinkAtomic clones src to dst through a temp path and an atomic rename,
+// so a crash mid-copy never leaves a short image at dst that exists() would
+// accept as complete. Reflink keeps it an instant per-extent CoW copy.
+func (lf *loopfile) reflinkAtomic(ctx context.Context, src, dst string) error {
+	tmp := dst + ".tmp"
+	if _, err := lf.exec(ctx, "cp", "--reflink=always", src, tmp); err != nil {
+		return err
+	}
+	// Same directory, same filesystem: mv is a rename(2), atomic.
+	if _, err := lf.exec(ctx, "mv", tmp, dst); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (lf *loopfile) Snapshot(ctx context.Context, vol, snap string) error {
 	ok, err := lf.exists(ctx, lf.snapPath(snap))
 	if err != nil || ok {
 		return err
 	}
-	if _, err := lf.exec(ctx, "cp", "--reflink=always", lf.imgPath(vol), lf.snapPath(snap)); err != nil {
+	if err := lf.reflinkAtomic(ctx, lf.imgPath(vol), lf.snapPath(snap)); err != nil {
 		return fmt.Errorf("reflink snapshot %s of %s: %w", snap, vol, err)
 	}
 	return nil
@@ -224,7 +239,7 @@ func (lf *loopfile) CreateFromSnapshot(ctx context.Context, vol, _ /* sourceVol 
 	if !ok {
 		// A reflink copy of the snapshot is the clone: instant CoW within
 		// the same filesystem, writes break sharing per-extent.
-		if _, err := lf.exec(ctx, "cp", "--reflink=always", lf.snapPath(snap), file); err != nil {
+		if err := lf.reflinkAtomic(ctx, lf.snapPath(snap), file); err != nil {
 			return "", fmt.Errorf("reflink clone %s from %s: %w", vol, snap, err)
 		}
 	}

--- a/internal/backend/loopfile_test.go
+++ b/internal/backend/loopfile_test.go
@@ -98,7 +98,8 @@ func TestLoopfileSnapshotReflinks(t *testing.T) {
 	if err := b.Snapshot(context.Background(), "pvc-1", "snap-1"); err != nil {
 		t.Fatal(err)
 	}
-	fe.calledWith(t, "cp --reflink=always /var/lib/miroir/volumes/pvc-1.img /var/lib/miroir/snapshots/snap-1.img")
+	fe.calledWith(t, "cp --reflink=always /var/lib/miroir/volumes/pvc-1.img /var/lib/miroir/snapshots/snap-1.img.tmp")
+	fe.calledWith(t, "mv /var/lib/miroir/snapshots/snap-1.img.tmp /var/lib/miroir/snapshots/snap-1.img")
 }
 
 func TestLoopfileSnapshotIdempotent(t *testing.T) {
@@ -126,7 +127,8 @@ func TestLoopfileCreateFromSnapshot(t *testing.T) {
 	if dev != "/var/lib/miroir/dev/pvc-2" {
 		t.Fatalf("unexpected device path %q", dev)
 	}
-	fe.calledWith(t, "cp --reflink=always /var/lib/miroir/snapshots/snap-1.img /var/lib/miroir/volumes/pvc-2.img")
+	fe.calledWith(t, "cp --reflink=always /var/lib/miroir/snapshots/snap-1.img /var/lib/miroir/volumes/pvc-2.img.tmp")
+	fe.calledWith(t, "mv /var/lib/miroir/volumes/pvc-2.img.tmp /var/lib/miroir/volumes/pvc-2.img")
 }
 
 func TestLoopfileDeleteDetachesAndRemoves(t *testing.T) {

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -94,8 +94,13 @@ func (l *lvmThin) DevicePath(vol string) string {
 	return fmt.Sprintf("/dev/%s/%s", l.vg, vol)
 }
 
+// ref is the "vg/lv" reference lvm commands take for a logical volume.
+func (l *lvmThin) ref(lv string) string {
+	return fmt.Sprintf("%s/%s", l.vg, lv)
+}
+
 func (l *lvmThin) exists(ctx context.Context, lv string) (bool, error) {
-	_, err := l.lvm(ctx, "lvs", fmt.Sprintf("%s/%s", l.vg, lv))
+	_, err := l.lvm(ctx, "lvs", l.ref(lv))
 	if err != nil {
 		if strings.Contains(err.Error(), "Failed to find") ||
 			strings.Contains(err.Error(), "not found") {
@@ -132,7 +137,7 @@ func (l *lvmThin) Create(ctx context.Context, vol string, sizeBytes int64) (stri
 	// node reboot exists in metadata but has no device node until
 	// activated. Idempotent on an already-active LV.
 	if _, err := l.lvm(ctx, "lvchange", "--activate", "y",
-		fmt.Sprintf("%s/%s", l.vg, vol)); err != nil {
+		l.ref(vol)); err != nil {
 		return "", fmt.Errorf("activate %s: %w", vol, err)
 	}
 	return l.DevicePath(vol), nil
@@ -148,7 +153,7 @@ func (l *lvmThin) Resize(ctx context.Context, vol string, sizeBytes int64) error
 	}
 	if _, err := l.lvm(ctx, "lvextend",
 		"--size", fmt.Sprintf("%db", sizeBytes),
-		fmt.Sprintf("%s/%s", l.vg, vol)); err != nil {
+		l.ref(vol)); err != nil {
 		return fmt.Errorf("lvextend %s to %d: %w", vol, sizeBytes, err)
 	}
 	return nil
@@ -174,7 +179,7 @@ func (l *lvmThin) Snapshot(ctx context.Context, vol, snap string) error {
 		"--snapshot",
 		"--name", snapLV(snap),
 		"--setactivationskip", "n",
-		fmt.Sprintf("%s/%s", l.vg, vol))
+		l.ref(vol))
 	if err != nil {
 		return fmt.Errorf("snapshot %s of %s: %w", snap, vol, err)
 	}
@@ -193,7 +198,7 @@ func (l *lvmThin) CreateFromSnapshot(ctx context.Context, vol, _ /* sourceVol */
 			"--snapshot",
 			"--name", vol,
 			"--setactivationskip", "n",
-			fmt.Sprintf("%s/%s", l.vg, snapLV(snap)))
+			l.ref(snapLV(snap)))
 		if err != nil {
 			return "", err
 		}
@@ -202,7 +207,7 @@ func (l *lvmThin) CreateFromSnapshot(ctx context.Context, vol, _ /* sourceVol */
 	// Same reboot gap as Create: the clone survives in LVM metadata but
 	// inactive, with no device node until activated.
 	if _, err := l.lvm(ctx, "lvchange", "--activate", "y",
-		fmt.Sprintf("%s/%s", l.vg, vol)); err != nil {
+		l.ref(vol)); err != nil {
 		return "", fmt.Errorf("activate %s: %w", vol, err)
 	}
 	return l.DevicePath(vol), nil
@@ -213,7 +218,7 @@ func (l *lvmThin) Delete(ctx context.Context, vol string) error {
 	if err != nil || !ok {
 		return err
 	}
-	if _, err := l.lvm(ctx, "lvremove", "--yes", fmt.Sprintf("%s/%s", l.vg, vol)); err != nil {
+	if _, err := l.lvm(ctx, "lvremove", "--yes", l.ref(vol)); err != nil {
 		return busy(fmt.Errorf("lvremove %s: %w", vol, err))
 	}
 	return nil
@@ -225,7 +230,7 @@ func (l *lvmThin) DeleteSnapshot(ctx context.Context, _ /* vol */, snap string) 
 
 func (l *lvmThin) sizeOf(ctx context.Context, lv string) (int64, error) {
 	out, err := l.lvm(ctx, "lvs", "--noheadings", "--units", "b", "--nosuffix",
-		"-o", "lv_size", fmt.Sprintf("%s/%s", l.vg, lv))
+		"-o", "lv_size", l.ref(lv))
 	if err != nil {
 		return 0, err
 	}
@@ -236,7 +241,7 @@ func (l *lvmThin) Stats(ctx context.Context) (PoolStats, error) {
 	out, err := l.lvm(ctx, "lvs", "--noheadings", "--units", "b", "--nosuffix",
 		"--separator", "|",
 		"-o", "lv_size,data_percent,metadata_percent",
-		fmt.Sprintf("%s/%s", l.vg, l.pool))
+		l.ref(l.pool))
 	if err != nil {
 		return PoolStats{}, err
 	}

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -51,6 +51,13 @@ func (z *zfsBackend) name(vol string) string {
 	return z.dataset + "/" + vol
 }
 
+// pool is the top-level zpool of the dataset (tank/miroir → tank): the scope
+// whose capacity the overcommit guard reads, since it is shared with OpenEBS.
+func (z *zfsBackend) pool() string {
+	p, _, _ := strings.Cut(z.dataset, "/")
+	return p
+}
+
 func (z *zfsBackend) DevicePath(vol string) string {
 	return "/dev/zvol/" + z.name(vol)
 }
@@ -111,7 +118,7 @@ func (z *zfsBackend) Sync(ctx context.Context, vol string) error {
 		return fmt.Errorf("flush %s: %w", vol, err)
 	}
 	// Commit pending transaction groups before the snapshot dataset is cut.
-	pool := strings.SplitN(z.dataset, "/", 2)[0]
+	pool := z.pool()
 	if _, err := z.exec(ctx, "zpool", "sync", pool); err != nil {
 		return fmt.Errorf("zpool sync: %w", err)
 	}
@@ -207,7 +214,7 @@ func (z *zfsBackend) volSize(ctx context.Context, vol string) (int64, error) {
 func (z *zfsBackend) Stats(ctx context.Context) (PoolStats, error) {
 	// Pool-level stats: the pool is shared with OpenEBS, so headroom must
 	// account for everything in it, not only miroir zvols (notes/DESIGN.md §4.6).
-	pool := strings.SplitN(z.dataset, "/", 2)[0]
+	pool := z.pool()
 	out, err := z.exec(ctx, "zpool", "get", "-Hpo", "value", "size,allocated", pool)
 	if err != nil {
 		return PoolStats{}, err


### PR DESCRIPTION
Two robustness fixes for the backend layer, plus small DRY.

## 1. Crash-safe reflink clones (loopfile)

`Snapshot` and `CreateFromSnapshot` reflinked straight to the final image path:

```go
lf.exec(ctx, "cp", "--reflink=always", src, finalPath)
```

A crash (power loss, OOM-kill) mid-copy leaves a short file at `finalPath`. The next reconcile calls `exists(finalPath)` → present → skips the copy and attaches the **truncated** image: a silently corrupt snapshot or clone.

Fixed with a shared `reflinkAtomic` helper that copies to `dst + ".tmp"` and `mv`s it into place — `mv` within one filesystem is `rename(2)`, atomic. A crash leaves only the temp (invisible to `exists`, which checks the final path), and a retry overwrites it. The callers already guard on `exists(dst)`, so the rename never clobbers a complete image.

## 2. Locale-stable exec (RealExec)

The delete classifier (`backend.ErrBusy`, added in #61) and the `exists()` probes match lvm/zfs/losetup **error text** — `"in use"`, `"Failed to find"`, `"No such file"`, `"has children"`. Those strings are localised by the tools, so on a node with a non-English locale every one of these classifiers silently fails (a busy device read as a permanent error, a missing LV read as an unexpected error). `RealExec` now sets `LC_ALL=C` so the output the classifiers parse is always the C-locale English.

## 3. DRY

- lvmthin: the nine `fmt.Sprintf("%s/%s", l.vg, …)` become `l.ref(…)`.
- zfs: the two `strings.SplitN(z.dataset, "/", 2)[0]` dataset→pool splits become `z.pool()` via `strings.Cut`.

## Verification

- `go build`/`vet`/`test ./internal/backend/...` green on macOS; `GOOS=linux go build ./...` clean.
- `golangci-lint run ./internal/backend/...` → 0 issues.
- `TestLoopfileSnapshotReflinks` / `TestLoopfileCreateFromSnapshot` updated to assert the `cp → .tmp` + `mv` sequence; `TestLoopfileSnapshotIdempotent` still asserts no copy when the snapshot already exists.