### PR TITLE
chore: skip the manager in setup mode; nodemap tests; errors.AsType

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,6 +108,44 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog.Info("starting miroir", "mode", mode, "version", version, "commit", commit)
 
+	// Setup mode provisions the node-local pool and exits. It reads the node
+	// map from a file and drives lvm/zfs directly, so it needs neither the
+	// controller-runtime manager nor an API connection — build neither.
+	if mode == "setup" {
+		if nodeName == "" {
+			setupLog.Error(nil, "--node-name (or NODE_NAME) is required in setup mode")
+			os.Exit(1)
+		}
+		nodes, err := nodemap.Load(nodesConfig)
+		if err != nil {
+			setupLog.Error(err, "unable to load node map")
+			os.Exit(1)
+		}
+		entry, ok := nodes[nodeName]
+		if !ok {
+			setupLog.Error(nil, "node absent from the node map", "node", nodeName)
+			os.Exit(1)
+		}
+		be, err := backend.New(entry.Backend, backend.Config{
+			VolumeGroup: vg,
+			ThinPool:    thinPool,
+			Device:      entry.Device,
+			Dataset:     entry.ZFSDataset,
+			PoolSize:    entry.ThinPoolSize,
+			BaseDir:     entry.BaseDir,
+		}, backend.RealExec)
+		if err != nil {
+			setupLog.Error(err, "invalid backend for node", "node", nodeName)
+			os.Exit(1)
+		}
+		if err := be.Setup(context.Background()); err != nil {
+			setupLog.Error(err, "backend pool setup failed", "node", nodeName)
+			os.Exit(1)
+		}
+		setupLog.Info("pool ready", "node", nodeName)
+		return
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: metricsAddr},
@@ -142,40 +180,6 @@ func main() {
 	var shutdownSweep func()
 
 	switch mode {
-	case "setup":
-		if nodeName == "" {
-			setupLog.Error(nil, "--node-name (or NODE_NAME) is required in setup mode")
-			os.Exit(1)
-		}
-		nodes, err := nodemap.Load(nodesConfig)
-		if err != nil {
-			setupLog.Error(err, "unable to load node map")
-			os.Exit(1)
-		}
-		entry, ok := nodes[nodeName]
-		if !ok {
-			setupLog.Error(nil, "node absent from the node map", "node", nodeName)
-			os.Exit(1)
-		}
-		be, err := backend.New(entry.Backend, backend.Config{
-			VolumeGroup: vg,
-			ThinPool:    thinPool,
-			Device:      entry.Device,
-			Dataset:     entry.ZFSDataset,
-			PoolSize:    entry.ThinPoolSize,
-			BaseDir:     entry.BaseDir,
-		}, backend.RealExec)
-		if err != nil {
-			setupLog.Error(err, "invalid backend for node", "node", nodeName)
-			os.Exit(1)
-		}
-		if err := be.Setup(context.Background()); err != nil {
-			setupLog.Error(err, "backend pool setup failed", "node", nodeName)
-			os.Exit(1)
-		}
-		setupLog.Info("pool ready", "node", nodeName)
-		return
-
 	case "controller":
 		nodes, err := nodemap.Load(nodesConfig)
 		if err != nil {

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -562,8 +562,7 @@ func (c *Controller) waitReady(ctx context.Context, name string) error {
 	if err == nil {
 		return nil
 	}
-	failed := &errVolumeFailed{}
-	if errors.As(err, &failed) {
+	if failed, ok := errors.AsType[*errVolumeFailed](err); ok {
 		// Hard agent failure (e.g. pool out of space). DeadlineExceeded
 		// would make the provisioner retry forever.
 		return status.Errorf(codes.ResourceExhausted, "volume %s failed: %s", name, failed.detail)

--- a/internal/nodemap/nodemap_test.go
+++ b/internal/nodemap/nodemap_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodemap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+func writeMap(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "nodes.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadValid(t *testing.T) {
+	m, err := Load(writeMap(t, `
+kharkiv:
+  backend: lvmthin
+  device: /dev/disk/by-partlabel/r-miroir
+  thinPoolSize: 400g
+paris:
+  backend: zfs
+  zfsDataset: tank/miroir
+oslo:
+  backend: loopfile
+  baseDir: /var/lib/miroir
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m) != 3 {
+		t.Fatalf("want 3 nodes, got %d", len(m))
+	}
+	if m["kharkiv"].Backend != miroirv1alpha1.BackendLVMThin || m["kharkiv"].ThinPoolSize != "400g" {
+		t.Fatalf("kharkiv parsed wrong: %+v", m["kharkiv"])
+	}
+	if m["paris"].ZFSDataset != "tank/miroir" {
+		t.Fatalf("paris dataset wrong: %+v", m["paris"])
+	}
+	if m["oslo"].BaseDir != "/var/lib/miroir" {
+		t.Fatalf("oslo baseDir wrong: %+v", m["oslo"])
+	}
+}
+
+func TestLoadErrors(t *testing.T) {
+	cases := map[string]string{
+		"unknown backend":          "kharkiv:\n  backend: btrfs\n",
+		"zfs without dataset":      "paris:\n  backend: zfs\n",
+		"loopfile without baseDir": "oslo:\n  backend: loopfile\n",
+		"unknown field":            "kharkiv:\n  backend: lvmthin\n  bogus: x\n",
+		"malformed yaml":           "kharkiv: : :\n",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Load(writeMap(t, body)); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	if _, err := Load(filepath.Join(t.TempDir(), "absent.yaml")); err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+}


### PR DESCRIPTION
Idiom/wiring polish — no behavior change outside setup mode.

## 1. Setup mode no longer builds the manager (cmd)

`main()` built the controller-runtime manager (`ctrl.GetConfigOrDie()` + `ctrl.NewManager`, which dials the API server) **before** the mode switch. But `setup` mode only loads the node map from a file and runs `backend.Setup` on node-local storage — it never touches `mgr`. So the setup Job pulled a kubeconfig and stood up a manager just to `truncate`/`vgcreate`/`zfs create` a pool.

Provision the pool and `return` **before** building the manager. Setup mode now needs no API connection or manager; `controller`/`agent` are unchanged.

## 2. nodemap.Load tests (nodemap)

The package had no tests. Added `TestLoad*` covering the valid three-backend parse and every validation error: unknown backend, zfs without `zfsDataset`, loopfile without `baseDir`, an unknown field (`UnmarshalStrict`), malformed YAML, and a missing file.

## 3. errors.AsType (csi)

`waitReady`'s hard-failure check becomes `errors.AsType[*errVolumeFailed](err)` (go 1.26) instead of `errors.As` with a pre-declared pointer.

## Verification

- `GOOS=linux go build ./...`, `vet`, `golangci-lint run` (cmd + csi + nodemap) all clean.
- `go test ./internal/nodemap/...` on macOS; `docker run golang:1.26.5` builds `./cmd/...` and runs the csi + nodemap suites — all green.

## Deliberately skipped

The review also flagged deduping the `InternalIP`-from-`Node.Status.Addresses` loop shared by `csi.nodeInternalIP` and `membership.complete`. It is ~4 lines, and the two call sites wrap it in different error types (gRPC `status` vs `fmt`); the only shared package that could host it (`nodemap`) is about the topology map, not `Node` objects. Not worth a new package or an awkward home, so left as-is.