### PR TITLE
fix(agent): scope a snapshot peer's barrier write to its own slot

### DIFF
--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -205,12 +206,15 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 	if err := r.DRBD.SuspendIO(ctx, vol.Name); err != nil {
 		return ctrl.Result{}, err
 	}
-	now := metav1.Now()
-	err := r.patchSnap(ctx, snap, func(s *miroirv1alpha1.MiroirSnapshot) {
-		if s.Status.PerNode == nil {
-			s.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{}
-		}
-		if opensRound {
+	var err error
+	if opensRound {
+		// The coordinator owns the round: it sets the barrier fields and
+		// resets peers, so it applies the whole status.
+		now := metav1.Now()
+		err = r.patchSnap(ctx, snap, func(s *miroirv1alpha1.MiroirSnapshot) {
+			if s.Status.PerNode == nil {
+				s.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{}
+			}
 			s.Status.IOSuspended = true
 			s.Status.SuspendedAt = &now
 			// Reset peers: a slow peer's Done from the voided round can
@@ -221,9 +225,14 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 					s.Status.PerNode[rep.Node] = miroirv1alpha1.SnapshotPending
 				}
 			}
-		}
-		s.Status.PerNode[r.NodeName] = miroirv1alpha1.SnapshotSuspended
-	})
+			s.Status.PerNode[r.NodeName] = miroirv1alpha1.SnapshotSuspended
+		})
+	} else {
+		// A peer records only its own slot. A full-status apply would
+		// force-own the coordinator's barrier fields (ioSuspended,
+		// suspendedAt) and revert a resume or void it raced.
+		err = r.patchOwnState(ctx, snap, miroirv1alpha1.SnapshotSuspended)
+	}
 	if err != nil {
 		// The barrier is only real once recorded; a failed patch must
 		// not leave IO frozen until the retry.
@@ -259,9 +268,7 @@ func (r *SnapshotReconciler) cutLeg(ctx context.Context, snap *miroirv1alpha1.Mi
 	if err := r.Backend.Snapshot(ctx, vol.Name, snap.Name); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{RequeueAfter: time.Second}, r.patchSnap(ctx, snap, func(s *miroirv1alpha1.MiroirSnapshot) {
-		s.Status.PerNode[r.NodeName] = miroirv1alpha1.SnapshotDone
-	})
+	return ctrl.Result{RequeueAfter: time.Second}, r.patchOwnState(ctx, snap, miroirv1alpha1.SnapshotDone)
 }
 
 // collectLegs is the coordinator's last phase: all legs Done → resume and
@@ -340,6 +347,15 @@ func replicaOn(vol *miroirv1alpha1.MiroirVolume, node string) bool {
 		}
 	}
 	return false
+}
+
+// patchOwnState records only this node's slot in the snapshot barrier via a
+// merge patch. A peer must not apply the whole status: that would force-own
+// the coordinator's round fields (ioSuspended, suspendedAt) and could revert
+// a resume or void it raced. The merge patch touches nothing else.
+func (r *SnapshotReconciler) patchOwnState(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, state miroirv1alpha1.SnapshotNodeState) error {
+	patch := fmt.Appendf(nil, `{"status":{"perNode":{%q:%q}}}`, r.NodeName, state)
+	return r.Status().Patch(ctx, snap, client.RawPatch(types.MergePatchType, patch))
 }
 
 func (r *SnapshotReconciler) patchSnap(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, mutate func(*miroirv1alpha1.MiroirSnapshot)) error {

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -18,13 +18,16 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 	"github.com/home-operations/miroir/internal/constants"
@@ -147,6 +150,80 @@ func TestSnapshotReplicatedBarrier(t *testing.T) {
 	// The peer's device is still suspended; readyToUse lifts it.
 	reconcileSnap(t, rP, snapSnap1)
 	feP.calledWith(t, "drbdadm resume-io pvc-1")
+}
+
+// A peer raising its barrier must record only its own slot, never the
+// coordinator's round fields: a full-status apply could revert a resume or
+// void the coordinator raced, re-freezing IO or resurrecting a stale leg.
+func TestSnapshotPeerRecordsOnlyOwnSlot(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	// The coordinator has opened the round; paris has not raised its barrier.
+	snap := snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)
+	now := metav1.Now()
+	snap.Status.IOSuspended = true
+	snap.Status.SuspendedAt = &now
+	snap.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{
+		nodeKharkiv: miroirv1alpha1.SnapshotSuspended,
+		nodeParis:   miroirv1alpha1.SnapshotPending,
+	}
+
+	var patchTypes []types.PatchType
+	var patchData []string
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snap).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, cl client.Client, sub string,
+				obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				data, _ := patch.Data(obj)
+				patchTypes = append(patchTypes, patch.Type())
+				patchData = append(patchData, string(data))
+				return cl.Status().Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
+
+	reconcileSnap(t, rP, snapSnap1)
+	feP.calledWith(t, "drbdadm suspend-io pvc-1")
+
+	if len(patchData) == 0 {
+		t.Fatal("expected a status patch from the peer")
+	}
+	for i, data := range patchData {
+		if patchTypes[i] != types.MergePatchType {
+			t.Errorf("patch %d is %q, want a merge patch (a peer must not apply the whole status)", i, patchTypes[i])
+		}
+		if strings.Contains(data, "ioSuspended") || strings.Contains(data, "suspendedAt") {
+			t.Errorf("patch %d touches the coordinator's barrier fields: %s", i, data)
+		}
+		if !strings.Contains(data, nodeParis) {
+			t.Errorf("patch %d does not record this node's slot: %s", i, data)
+		}
+	}
+
+	// The coordinator's barrier survives the peer's write.
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: snapSnap1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.IOSuspended {
+		t.Fatal("peer must not clear the coordinator's barrier")
+	}
+	if got.Status.PerNode[nodeParis] != miroirv1alpha1.SnapshotSuspended {
+		t.Fatalf("peer's own slot not recorded: %+v", got.Status.PerNode)
+	}
 }
 
 // Regression: a Secondary that is replicas[0] must defer to a peer


### PR DESCRIPTION
The snapshot half of the status-ownership finding (the volume half shipped in #60). Completes the review's `patchSnap`/`patchStatus` item.

## The bug

`patchSnap` force-applied the **whole** `MiroirSnapshot` status under a per-node field owner. For the **coordinator** that's correct: it owns the round (`ioSuspended`, `suspendedAt`) and only patches at round boundaries (open, all-Done success, void), where it deliberately resets peers or writes a terminal result.

But a **peer** patches *mid-round* — `raiseBarrier` records `Suspended`, `cutLeg` records `Done` — and its full-status apply re-sent `ioSuspended`/`suspendedAt` from the peer's stale read. A peer whose write lands after the coordinator resumed or voided the round reverts the barrier:

- re-freezing IO after a resume, or
- resurrecting a `Done` leg from a voided round, which then pairs with the *next* round's cuts (exactly the hazard `raiseBarrier`'s peer-reset comment guards against).

It's bounded and self-heals via the deadline, but it's real churn on a data-consistency-critical path.

## The fix

Peers record **only their own `PerNode` slot** via a merge patch — the same idiom the volume removal path already uses — so they can never touch the coordinator's round fields. The coordinator keeps its full apply (it patches only at boundaries, where its peer-slot writes are intentional or an accurate all-Done).

```go
func (r *SnapshotReconciler) patchOwnState(ctx, snap, state) error {
    patch := fmt.Appendf(nil, `{"status":{"perNode":{%q:%q}}}`, r.NodeName, state)
    return r.Status().Patch(ctx, snap, client.RawPatch(types.MergePatchType, patch))
}
```

### Why not a full role-partitioned SSA rewrite

The review floated scoping *every* write by role. I deliberately did **not**: `ioSuspended`/`readyToUse` are non-`omitempty` bools, so marshalling a partial status for a merge patch would serialise them as `false` and **silently drop the barrier** — a torn-snapshot corruption risk. The own-slot merge patch writes only the `PerNode` string and sidesteps that trap; the coordinator's authoritative full apply is left intact rather than reworked.

## Tests

- `TestSnapshotPeerRecordsOnlyOwnSlot`: seeds an open round, runs a peer's reconcile, and asserts its status write is a **merge patch** naming its own slot and **never** `ioSuspended`/`suspendedAt`, and that the coordinator's barrier survives.
- The existing full-round `TestSnapshotReplicatedBarrier` and expired-round reset tests still pass — the protocol is unchanged.

## Verification

- `go build`/`vet`/`test ./internal/agent/...` green on macOS; `golangci-lint run ./internal/agent/...` → 0 issues.