### PR TITLE
feat(chart): expose cluster-wide DRBD resync tuning

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -44,6 +44,12 @@ Kubernetes: `>=1.31.0`
 | controller.resources.limits.memory | string | `"128Mi"` |  |
 | controller.resources.requests.cpu | string | `"10m"` |  |
 | controller.resources.requests.memory | string | `"32Mi"` |  |
+| drbd.resync.fillTarget | string | `""` | c-fill-target, the resync controller's target fill level (e.g. "1M"). |
+| drbd.resync.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864"). |
+| drbd.resync.maxRate | string | `""` | c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. "720M"). |
+| drbd.resync.minRate | string | `""` | c-min-rate, the resync floor guaranteed even under application I/O (e.g. "20M"); keep low on shared links. |
+| drbd.resync.planAhead | string | `""` | c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller. |
+| drbd.resync.rate | string | `""` | resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0). |
 | image.digest | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/home-operations/miroir"` |  |

--- a/charts/miroir/templates/configmap.tpl
+++ b/charts/miroir/templates/configmap.tpl
@@ -12,8 +12,9 @@ data:
   nodes.yaml: |
     {{- .Values.nodes | toYaml | nindent 4 }}
 ---
-# Minimal drbd-utils global config: the drbd.d hostPath bind shadows the
-# image-baked copy. Per-resource settings live in rendered .res files.
+# drbd-utils global config: the drbd.d hostPath bind shadows the image-baked
+# copy. Cluster-wide resync tuning goes in common{} (inherited by every
+# resource); per-resource settings live in the rendered .res files.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,6 +32,30 @@ data:
         handlers {}
         startup {}
         options {}
-        disk {}
-        net {}
+        disk {
+        {{- with .Values.drbd.resync }}
+        {{- if .planAhead }}
+            c-plan-ahead {{ .planAhead }};
+        {{- end }}
+        {{- if .fillTarget }}
+            c-fill-target {{ .fillTarget }};
+        {{- end }}
+        {{- if .maxRate }}
+            c-max-rate {{ .maxRate }};
+        {{- end }}
+        {{- if .minRate }}
+            c-min-rate {{ .minRate }};
+        {{- end }}
+        {{- if .rate }}
+            resync-rate {{ .rate }};
+        {{- end }}
+        {{- end }}
+        }
+        net {
+        {{- with .Values.drbd.resync }}
+        {{- if .maxBuffers }}
+            max-buffers {{ .maxBuffers }};
+        {{- end }}
+        {{- end }}
+        }
     }

--- a/charts/miroir/tests/configmap_test.yaml
+++ b/charts/miroir/tests/configmap_test.yaml
@@ -90,6 +90,37 @@ tests:
       - matchRegex:
           path: data["global_common.conf"]
           pattern: "handlers \\{\\}"
+      # Default emits no resync options — common{} keeps DRBD's built-ins.
+      - notMatchRegex:
+          path: data["global_common.conf"]
+          pattern: "c-max-rate"
+
+  - it: renders cluster-wide resync tuning into common{} when set
+    set:
+      nodes:
+        kharkiv:
+          backend: lvmthin
+          device: /dev/disk/by-partlabel/r-miroir
+      drbd:
+        resync:
+          planAhead: "20"
+          maxRate: 720M
+          minRate: 20M
+          maxBuffers: "36864"
+    documentIndex: 1
+    asserts:
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "c-plan-ahead 20;"
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "c-max-rate 720M;"
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "c-min-rate 20M;"
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "max-buffers 36864;"
 
   - it: honours a non-default Release namespace for both ConfigMaps
     release:

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -104,6 +104,57 @@
       "title": "controller",
       "type": "object"
     },
+    "drbd": {
+      "description": "DRBD replication tuning applied cluster-wide through the common{} section of\nglobal_common.conf; every resource inherits it. Leave a value empty to use\nDRBD's built-in default. Tune to your replication network — see the LINBIT\n\"Tuning the DRBD Resync Controller\" guide.",
+      "properties": {
+        "resync": {
+          "properties": {
+            "fillTarget": {
+              "default": "",
+              "description": "c-fill-target, the resync controller's target fill level (e.g. \"1M\").",
+              "title": "fillTarget",
+              "type": "string"
+            },
+            "maxBuffers": {
+              "default": "",
+              "description": "max-buffers, the DRBD receive-buffer count in the net{} section (e.g. \"36864\").",
+              "title": "maxBuffers",
+              "type": "string"
+            },
+            "maxRate": {
+              "default": "",
+              "description": "c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. \"720M\").",
+              "title": "maxRate",
+              "type": "string"
+            },
+            "minRate": {
+              "default": "",
+              "description": "c-min-rate, the resync floor guaranteed even under application I/O (e.g. \"20M\"); keep low on shared links.",
+              "title": "minRate",
+              "type": "string"
+            },
+            "planAhead": {
+              "default": "",
+              "description": "c-plan-ahead in 0.1s units; a value \u003e 0 enables DRBD's variable-rate resync controller.",
+              "title": "planAhead",
+              "type": "string"
+            },
+            "rate": {
+              "default": "",
+              "description": "resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0).",
+              "title": "rate",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "resync",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "drbd",
+      "type": "object"
+    },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
       "required": [],

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -81,6 +81,25 @@ agent:
     limits:
       memory: 128Mi
 
+# DRBD replication tuning applied cluster-wide through the common{} section of
+# global_common.conf; every resource inherits it. Leave a value empty to use
+# DRBD's built-in default. Tune to your replication network — see the LINBIT
+# "Tuning the DRBD Resync Controller" guide.
+drbd:
+  resync:
+    # -- c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller.
+    planAhead: ""
+    # -- c-fill-target, the resync controller's target fill level (e.g. "1M").
+    fillTarget: ""
+    # -- c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. "720M").
+    maxRate: ""
+    # -- c-min-rate, the resync floor guaranteed even under application I/O (e.g. "20M"); keep low on shared links.
+    minRate: ""
+    # -- resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0).
+    rate: ""
+    # -- max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864").
+    maxBuffers: ""
+
 storageClass:
   create: true
   name: miroir-local


### PR DESCRIPTION
First of the blockstor-inspired follow-ups (PR 1 of 4: resync tuning). Chart-only — no Go or data-path change.

## Why

A fresh replica full-syncs at DRBD's built-in resync rate, which miroir gave operators no way to tune for their replication network — the gap LINSTOR/blockstor close with the resync controller. On a slow/shared link the default can either crawl or starve application I/O; on a fast link it leaves bandwidth on the table.

## What

A new `drbd.resync` values block exposes the resync-controller knobs and the net buffer:

| value | DRBD option | section |
|---|---|---|
| `planAhead` | `c-plan-ahead` (>0 enables the variable-rate controller) | disk |
| `fillTarget` | `c-fill-target` | disk |
| `maxRate` | `c-max-rate` (idle-link ceiling) | disk |
| `minRate` | `c-min-rate` (floor under app I/O) | disk |
| `rate` | `resync-rate` (fixed, controller-off) | disk |
| `maxBuffers` | `max-buffers` | net |

They render into the **`common {}`** section of `global_common.conf`, which every DRBD resource inherits. That's deliberate: resync rate is a property of the replication *link*, uniform across volumes — so it belongs in the cluster-wide common config, not in the per-volume CRD (`DRBDSpec`) or the per-resource `.res`. No Go change, nothing on the data path.

## Safety

- Every knob defaults **empty** and is omitted from the render, so an untuned install produces byte-for-byte the same `common { disk {} net {} }` as today.
- `values.schema.json` types them as strings (DRBD-native syntax like `"720M"`, `"20"`), which also rejects mistyped non-string values at `helm install` time.

## Tests / verification

- `helm-unittest`: added a case asserting the default emits **no** resync options, and one asserting a tuned `drbd.resync` renders `c-plan-ahead`/`c-max-rate`/`c-min-rate`/`max-buffers` into `common {}`. Full suite 55/55.
- `helm lint` clean; `helm template` renders correctly with and without values; README + `values.schema.json` regenerated (idempotent).

Follow-ups from the same review, per the agreed sequence: PR 2 zone-aware placement, then the diskless-tiebreaker feature (design issue first) as PR 3/4.