### PR TITLE
perf(backend): direct-io loop devices, lz4 on zvols

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -165,8 +165,8 @@ func TestZFSCreate(t *testing.T) {
 	if dev != "/dev/zvol/tank/miroir/pvc-1" {
 		t.Fatalf("unexpected device path %q", dev)
 	}
-	// Sparse + 4k volblocksize per notes/DESIGN.md §4.1a / SPIKE P0-1.
-	fe.calledWith(t, "zfs create -s -b 4096 -V 10737418240 tank/miroir/pvc-1")
+	// Sparse + 4k volblocksize per notes/DESIGN.md §4.1a / SPIKE P0-1, lz4.
+	fe.calledWith(t, "zfs create -s -b 4096 -o compression=lz4 -V 10737418240 tank/miroir/pvc-1")
 }
 
 func TestZFSSnapshotIdempotent(t *testing.T) {

--- a/internal/backend/loopfile.go
+++ b/internal/backend/loopfile.go
@@ -129,6 +129,11 @@ func (lf *loopfile) attach(ctx context.Context, vol, file string) (string, error
 			return "", fmt.Errorf("losetup --find %s: %w", file, aerr)
 		}
 		dev = strings.TrimSpace(out)
+		// Direct I/O drops the host page cache under the loop device: the
+		// filesystem above it already caches, so buffered mode double-caches
+		// (wasted memory, extra copy). Best-effort — a backing filesystem
+		// without O_DIRECT (e.g. some ZFS builds) must not fail the attach.
+		_, _ = lf.exec(ctx, "losetup", "--direct-io=on", dev)
 	}
 	link := lf.DevicePath(vol)
 	if _, err := lf.exec(ctx, "ln", "-sfn", dev, link); err != nil {

--- a/internal/backend/loopfile_test.go
+++ b/internal/backend/loopfile_test.go
@@ -41,6 +41,7 @@ func TestLoopfileCreateAttachesNewFile(t *testing.T) {
 	}
 	fe.calledWith(t, "truncate -s 10737418240 /var/lib/miroir/volumes/pvc-1.img")
 	fe.calledWith(t, "losetup --find --show /var/lib/miroir/volumes/pvc-1.img")
+	fe.calledWith(t, "losetup --direct-io=on /dev/loop0")
 	fe.calledWith(t, "ln -sfn /dev/loop0 /var/lib/miroir/dev/pvc-1")
 }
 

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -86,6 +86,9 @@ func (z *zfsBackend) Create(ctx context.Context, vol string, sizeBytes int64) (s
 		_, err = z.exec(ctx, "zfs", "create",
 			"-s", // sparse: thin semantics, matching the lvm-thin leg
 			"-b", "4096",
+			// lz4 early-aborts on incompressible data (≈free) and cuts
+			// physical I/O; a near-universal default for zvols.
+			"-o", "compression=lz4",
 			"-V", strconv.FormatInt(sizeBytes, 10),
 			z.name(vol))
 		if err != nil {


### PR DESCRIPTION
The two safe performance defaults from the [#70 perf review](https://github.com/home-operations/miroir/issues/70#issuecomment-4920377068). Both are unconditional, low-risk, and standard practice; the workload/hardware-dependent knobs (al-extents, volblocksize, disk-flushes, protocol) stay opt-in and remain tracked on #70.

## loopfile — `losetup --direct-io=on`

`attach()` ran `losetup --find --show` with buffered I/O. The filesystem inside the loop device already caches, so buffered mode **double-caches** the backing file (wasted memory + an extra copy). Now sets direct I/O after attach.

**Best-effort:** applied as a separate `losetup --direct-io=on <dev>` after `--find --show`, with its error ignored, so a backing filesystem without O_DIRECT (e.g. some ZFS builds) can't fail the attach — it just falls back to buffered. miroir's baseDir is required reflink-capable (XFS/btrfs), which do support O_DIRECT, so the common path gets it.

## zfs — `compression=lz4` on zvols

`zfs create -s -b 4096` set no compression, so zvols inherited the pool default (usually off). Now creates with `-o compression=lz4`: it early-aborts on incompressible data (≈free CPU), cuts physical I/O, and is the near-universal zvol default. (Gains are modest at the current 4K volblocksize but still net-positive; they grow if volblocksize becomes tunable — an opt-in item on #70.)

## Tests / verification

- `TestLoopfileCreateAttachesNewFile` asserts `losetup --direct-io=on /dev/loop0` follows the attach.
- `TestZFSCreate*` asserts `zfs create -s -b 4096 -o compression=lz4 …`.
- `go build`/`vet`/`test ./internal/backend/...` green on macOS. (Local `golangci-lint` is skewed against the module's go 1.26.5 — CI's Go Lint runs the pinned toolchain.)

No API/CRD/chart change; both are internal backend create/attach flags.