### PR TITLE
feat(csi): auto-place diskless tie-breaker for 2-replica quorum

### DIFF
--- a/charts/miroir/templates/storageclass.tpl
+++ b/charts/miroir/templates/storageclass.tpl
@@ -27,10 +27,25 @@ allowVolumeExpansion: true
 reclaimPolicy: {{ .Values.replicatedStorageClass.reclaimPolicy }}
 parameters:
   miroir.home-operations.com/replicas: "2"
-  # last-man-standing: survivor keeps writing on node loss, split-brain
-  # alerts on reconnect; freeze: never diverges, halts on any disconnect.
   miroir.home-operations.com/quorum: {{ .Values.replicatedStorageClass.quorum }}
   csi.storage.k8s.io/fstype: {{ .Values.replicatedStorageClass.fsType }}
+{{- end }}
+{{- if .Values.replicatedStorageClassLMS.create }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.replicatedStorageClassLMS.name }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: {{ .Values.replicatedStorageClassLMS.isDefault | quote }}
+provisioner: {{ include "miroir.csiDriverName" . }}
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: {{ .Values.replicatedStorageClassLMS.reclaimPolicy }}
+parameters:
+  miroir.home-operations.com/replicas: "2"
+  miroir.home-operations.com/quorum: {{ .Values.replicatedStorageClassLMS.quorum }}
+  csi.storage.k8s.io/fstype: {{ .Values.replicatedStorageClassLMS.fsType }}
 {{- end }}
 {{- if .Values.volumeSnapshotClass.create }}
 ---

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -118,7 +118,19 @@ replicatedStorageClass:
   name: miroir-replicated
   isDefault: false
   fsType: ext4
-  quorum: last-man-standing # | freeze
+  # freeze: never diverges; auto-adds a diskless tie-breaker for
+  # 2-replica volumes when a spare node exists. With 2 storage nodes
+  # and no spare, falls back to last-man-standing automatically.
+  quorum: freeze # | last-man-standing
+  reclaimPolicy: Delete
+
+# Explicit last-man-standing opt-out for clusters that prefer availability.
+replicatedStorageClassLMS:
+  create: false
+  name: miroir-replicated-lms
+  isDefault: false
+  fsType: ext4
+  quorum: last-man-standing
   reclaimPolicy: Delete
 
 # Requires the cluster-wide snapshot-controller + CRDs (deployed

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -133,7 +133,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	if err != nil {
 		return nil, err
 	}
-	quorum, err := parseQuorum(req.GetParameters())
+	quorum, quorumExplicit, err := parseQuorum(req.GetParameters())
 	if err != nil {
 		return nil, err
 	}
@@ -177,6 +177,12 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			return nil, err
 		}
 		placed = p
+	}
+	// Auto-tie-breaker: for even-diskful replicated volumes, append a
+	// diskless peer if a spare node exists. Defaulted quorum flips to
+	// freeze when a spare is found, stays LMS otherwise.
+	if replicas > 1 && snapID == "" {
+		placed, quorum = c.maybeAddTieBreaker(ctx, placed, quorum, quorumExplicit, replicas)
 	}
 	vol := &miroirv1alpha1.MiroirVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: req.GetName()},
@@ -440,6 +446,95 @@ func (c *Controller) nodeInternalIP(ctx context.Context, name string) (string, e
 		}
 	}
 	return "", status.Errorf(codes.Internal, "node %s has no InternalIP", name)
+}
+
+// maybeAddTieBreaker appends a diskless replica when the diskful count
+// is even and a spare node exists. Defaulted quorum flips to freeze
+// (safe+available) when a spare is found; falls back to the existing
+// policy when no spare is available. Explicit freeze keeps the policy
+// and adds the tie-breaker opportunistically. Explicit LMS is never
+// overridden.
+func (c *Controller) maybeAddTieBreaker(
+	ctx context.Context,
+	placed []miroirv1alpha1.Replica,
+	quorum miroirv1alpha1.QuorumPolicy,
+	explicit bool,
+	replicas int,
+) ([]miroirv1alpha1.Replica, miroirv1alpha1.QuorumPolicy) {
+	diskful := 0
+	for _, r := range placed {
+		if !r.Diskless {
+			diskful++
+		}
+	}
+	if diskful < 2 || diskful%2 != 0 {
+		return placed, quorum
+	}
+
+	// Try freeze+tie-breaker when explicitly freeze, or when defaulted
+	// and replicas==2 (would flip to freeze if a spare exists).
+	tryFreeze := quorum == miroirv1alpha1.QuorumFreeze ||
+		(!explicit && replicas == 2)
+	if !tryFreeze {
+		return placed, quorum
+	}
+
+	spare := c.findTieBreakerNode(placed)
+	if spare == "" {
+		// No spare: explicit freeze keeps the policy; defaulted stays
+		// LMS (freeze without a tie-breaker is strictly worse).
+		return placed, quorum
+	}
+
+	addr, err := c.nodeInternalIP(ctx, spare)
+	if err != nil {
+		return placed, quorum
+	}
+	rep := miroirv1alpha1.Replica{
+		Node:     spare,
+		Backend:  c.Nodes[spare].Backend,
+		NodeID:   int32(len(placed)), //nolint:gosec // count <= 3
+		Address:  addr,
+		Diskless: true,
+	}
+	return append(placed, rep), miroirv1alpha1.QuorumFreeze
+}
+
+// findTieBreakerNode returns a spare node from the node map not already
+// a diskful replica of this volume, preferring a zone not used by any
+// diskful replica. Returns "" if no spare exists.
+func (c *Controller) findTieBreakerNode(placed []miroirv1alpha1.Replica) string {
+	used := make(map[string]bool, len(placed))
+	usedZones := make(map[string]bool)
+	for _, r := range placed {
+		used[r.Node] = true
+		if n, ok := c.Nodes[r.Node]; ok && n.Zone != "" {
+			usedZones[n.Zone] = true
+		}
+	}
+	type candidate struct{ node string }
+	var zoneDistinct, fallback []candidate
+	for n := range c.Nodes {
+		if used[n] {
+			continue
+		}
+		zone := c.Nodes[n].Zone
+		if zone == "" || !usedZones[zone] {
+			zoneDistinct = append(zoneDistinct, candidate{n})
+		} else {
+			fallback = append(fallback, candidate{n})
+		}
+	}
+	// Sort for determinism (tests; placement is otherwise node-map order).
+	pool := zoneDistinct
+	if len(pool) == 0 {
+		pool = fallback
+	}
+	if len(pool) == 0 {
+		return ""
+	}
+	slices.SortFunc(pool, func(a, b candidate) int { return cmp.Compare(a.node, b.node) })
+	return pool[0].node
 }
 
 // reader returns the API-server reader for read-your-writes, falling back
@@ -875,14 +970,15 @@ func parseReplicas(params map[string]string) (int, error) {
 	return n, nil
 }
 
-func parseQuorum(params map[string]string) (miroirv1alpha1.QuorumPolicy, error) {
-	switch raw := params[constants.ParamQuorum]; raw {
+func parseQuorum(params map[string]string) (miroirv1alpha1.QuorumPolicy, bool, error) {
+	raw, explicit := params[constants.ParamQuorum]
+	switch raw {
 	case "", string(miroirv1alpha1.QuorumLastManStanding):
-		return miroirv1alpha1.QuorumLastManStanding, nil
+		return miroirv1alpha1.QuorumLastManStanding, explicit, nil
 	case string(miroirv1alpha1.QuorumFreeze):
-		return miroirv1alpha1.QuorumFreeze, nil
+		return miroirv1alpha1.QuorumFreeze, true, nil
 	default:
-		return "", status.Errorf(codes.InvalidArgument,
+		return "", false, status.Errorf(codes.InvalidArgument,
 			"invalid %s=%q (want last-man-standing | freeze)", constants.ParamQuorum, raw)
 	}
 }

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -239,3 +239,160 @@ func TestPlaceSpreadsAcrossZones(t *testing.T) {
 		t.Fatalf("replicas must span zones a and b (kharkiv+oslo), got %v", nodes)
 	}
 }
+
+// threeNodeController builds a controller with kharkiv+paris in zone a
+// and oslo in zone b. All have fresh pool stats and node IP objects.
+func threeNodeController(s *runtime.Scheme) *Controller {
+	return &Controller{
+		Client: placementClient(s,
+			miroirNodeObj(nodeKharkiv, 100*gib, 10*gib),
+			miroirNodeObj(nodeParis, 100*gib, 20*gib),
+			miroirNodeObj("oslo", 100*gib, 90*gib),
+			nodeObj(nodeKharkiv, "192.168.1.41"),
+			nodeObj(nodeParis, "192.168.1.42"),
+			nodeObj("oslo", "192.168.1.43"),
+		),
+		Nodes: nodemap.Map{
+			nodeKharkiv: {Backend: miroirv1alpha1.BackendLVMThin, Zone: "a", Device: "/dev/x"},
+			nodeParis:   {Backend: miroirv1alpha1.BackendZFS, Zone: "a", ZFSDataset: "p/m"},
+			"oslo":      {Backend: miroirv1alpha1.BackendLVMThin, Zone: "b", Device: "/dev/y"},
+		},
+	}
+}
+
+func TestMaybeAddTieBreaker_freezeWithSpare(t *testing.T) {
+	s := newScheme(t)
+	c := threeNodeController(s)
+
+	placed, err := c.place(context.Background(), nil, 2, 5*gib, volNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 2 diskful placed; defaulted LMS should flip to freeze + tie-breaker.
+	// place() zone-spreads onto kharkiv(zone a)+oslo(zone b), so paris is spare.
+	got, q := c.maybeAddTieBreaker(context.Background(), placed, miroirv1alpha1.QuorumLastManStanding, false, 2)
+	if q != miroirv1alpha1.QuorumFreeze {
+		t.Fatalf("quorum should flip to freeze, got %s", q)
+	}
+	if len(got) != 3 || !got[2].Diskless {
+		t.Fatalf("expected 3rd diskless replica, got %+v", got)
+	}
+	if got[2].Node != nodeParis {
+		t.Fatalf("tie-breaker should be paris (spare), got %s", got[2].Node)
+	}
+}
+
+func TestMaybeAddTieBreaker_explicitLMS(t *testing.T) {
+	s := newScheme(t)
+	c := threeNodeController(s)
+
+	placed, err := c.place(context.Background(), nil, 2, 5*gib, volNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Explicitly LMS: no tie-breaker.
+	got, q := c.maybeAddTieBreaker(context.Background(), placed, miroirv1alpha1.QuorumLastManStanding, true, 2)
+	if q != miroirv1alpha1.QuorumLastManStanding {
+		t.Fatalf("explicit LMS must stay, got %s", q)
+	}
+	if len(got) != 2 {
+		t.Fatalf("explicit LMS must not add tie-breaker, got %d replicas", len(got))
+	}
+}
+
+func TestMaybeAddTieBreaker_explicitFreezeNoSpare(t *testing.T) {
+	s := newScheme(t)
+	// Only 2 nodes — no spare for a tie-breaker.
+	c := &Controller{
+		Client: placementClient(s,
+			miroirNodeObj(nodeKharkiv, 10*gib, 0),
+			miroirNodeObj(nodeParis, 10*gib, 0),
+			nodeObj(nodeKharkiv, "192.168.1.41"),
+			nodeObj(nodeParis, "192.168.1.42"),
+		),
+		Nodes: testNodes,
+	}
+	placed, err := c.place(context.Background(), nil, 2, 5*gib, volNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, q := c.maybeAddTieBreaker(context.Background(), placed, miroirv1alpha1.QuorumFreeze, true, 2)
+	if q != miroirv1alpha1.QuorumFreeze {
+		t.Fatalf("explicit freeze must stay, got %s", q)
+	}
+	if len(got) != 2 {
+		t.Fatalf("no spare → no tie-breaker, got %d replicas", len(got))
+	}
+}
+
+func TestMaybeAddTieBreaker_defaultLMSNoSpareFallsBack(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{
+		Client: placementClient(s,
+			miroirNodeObj(nodeKharkiv, 10*gib, 0),
+			miroirNodeObj(nodeParis, 10*gib, 0),
+			nodeObj(nodeKharkiv, "192.168.1.41"),
+			nodeObj(nodeParis, "192.168.1.42"),
+		),
+		Nodes: testNodes,
+	}
+	placed, err := c.place(context.Background(), nil, 2, 5*gib, volNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Defaulted LMS, no spare: stays LMS.
+	got, q := c.maybeAddTieBreaker(context.Background(), placed, miroirv1alpha1.QuorumLastManStanding, false, 2)
+	if q != miroirv1alpha1.QuorumLastManStanding {
+		t.Fatalf("no spare → stay LMS, got %s", q)
+	}
+	if len(got) != 2 {
+		t.Fatalf("no spare → no tie-breaker, got %d replicas", len(got))
+	}
+}
+
+func TestMaybeAddTieBreaker_oddDiskfulNoop(t *testing.T) {
+	// 3 diskful replicas (odd count) → no tie-breaker needed.
+	placed := []miroirv1alpha1.Replica{
+		{Node: nodeKharkiv, NodeID: 0, Address: "10.0.0.1"},
+		{Node: nodeParis, NodeID: 1, Address: "10.0.0.2"},
+		{Node: "oslo", NodeID: 2, Address: "10.0.0.3"},
+	}
+	s := newScheme(t)
+	c := threeNodeController(s)
+	got, q := c.maybeAddTieBreaker(context.Background(), placed, miroirv1alpha1.QuorumFreeze, true, 3)
+	if q != miroirv1alpha1.QuorumFreeze || len(got) != 3 {
+		t.Fatalf("odd diskful → no tie-breaker, got %d replicas quorum=%s", len(got), q)
+	}
+}
+
+func TestFindTieBreakerNode_prefersZoneDistinct(t *testing.T) {
+	c := &Controller{
+		Nodes: nodemap.Map{
+			"a1": {Backend: miroirv1alpha1.BackendLVMThin, Zone: "z1"},
+			"a2": {Backend: miroirv1alpha1.BackendLVMThin, Zone: "z1"},
+			"b1": {Backend: miroirv1alpha1.BackendLVMThin, Zone: "z2"},
+		},
+	}
+	// Both diskful in z1: must pick b1 (z2).
+	got := c.findTieBreakerNode([]miroirv1alpha1.Replica{
+		{Node: "a1"}, {Node: "a2"},
+	})
+	if got != "b1" {
+		t.Fatalf("expected zone-distinct b1, got %s", got)
+	}
+}
+
+func TestFindTieBreakerNode_noSpare(t *testing.T) {
+	c := &Controller{
+		Nodes: nodemap.Map{
+			"a": {Backend: miroirv1alpha1.BackendLVMThin, Zone: "z1"},
+			"b": {Backend: miroirv1alpha1.BackendLVMThin, Zone: "z2"},
+		},
+	}
+	got := c.findTieBreakerNode([]miroirv1alpha1.Replica{
+		{Node: "a"}, {Node: "b"},
+	})
+	if got != "" {
+		t.Fatalf("expected no spare, got %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

After placing diskful replicas, if the diskful count is even and a spare zone-distinct node exists, the controller appends a diskless tie-breaker replica and sets quorum to `freeze`. This makes 2-replica volumes both available (survivor keeps serving through single-node loss) and split-brain-free without operator intervention.

Built on top of #73 (PR 3 — mechanism).

## Behavior

| Quorum param | Replicas | Spare node? | Result |
|---|---|---|---|
| unset (default) | 2 | yes | flips to `freeze` + appends diskless tie-breaker |
| unset (default) | 2 | no | stays `last-man-standing` (safer than freeze without tie-breaker) |
| `freeze` (explicit) | 2 | yes | keeps `freeze` + appends diskless tie-breaker |
| `freeze` (explicit) | 2 | no | keeps `freeze`, no tie-breaker (operator chose it) |
| `last-man-standing` (explicit) | 2 | * | never overridden, no tie-breaker |
| any | 3 (odd) | * | no tie-breaker (odd count already has natural majority) |

## Changes

- **`internal/csi/controller.go`**: `maybeAddTieBreaker()` + `findTieBreakerNode()`; `parseQuorum()` now returns an `explicit` flag driving the conditional default flip
- **`charts/miroir/values.yaml`**: default replicated StorageClass flipped from `last-man-standing` to `freeze`; new opt-out `replicatedStorageClassLMS` (disabled by default)
- **`charts/miroir/templates/storageclass.tpl`**: LMS StorageClass template
- **`internal/csi/placement_test.go`**: 7 new test cases

## Test plan

- [x] `go test ./...` — all pass (7 new tie-breaker tests + all existing)
- [ ] e2e: 3-node kind cluster, create a PVC with `replicas=2`, verify 3rd diskless replica appears
- [ ] e2e: 2-node cluster, verify default falls back to LMS (no tie-breaker)
- [ ] e2e: explicit `freeze` on 2-node cluster, verify no tie-breaker but policy kept

Refs: #70