### PR TITLE
fix(cmd): run the shutdown sweep on error exit, bound its budgets

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -250,7 +250,7 @@ func main() {
 			os.Exit(1)
 		}
 		// Lift any IO barrier left by a previous agent crash.
-		if err := resumeStaleBarriers(drbdDriver); err != nil {
+		if err := resumeStaleBarriers(drbdDriver, apiStartupWait); err != nil {
 			setupLog.Error(err, "barrier resume sweep failed")
 			os.Exit(1)
 		}
@@ -321,12 +321,16 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "manager exited")
-		os.Exit(1)
-	}
+	err = mgr.Start(ctrl.SetupSignalHandler())
+	// The sweep must run even when the manager exits with an error — a
+	// runnable blowing the shutdown grace is exactly the case where a
+	// cordoned node still needs its DRBD backings released for reboot.
 	if shutdownSweep != nil {
 		shutdownSweep()
+	}
+	if err != nil {
+		setupLog.Error(err, "manager exited")
+		os.Exit(1)
 	}
 }
 
@@ -339,12 +343,18 @@ const apiStartupWait = 45 * time.Second
 // drbdShutdownTimeout bounds the Secondary-teardown sweep at shutdown.
 const drbdShutdownTimeout = 15 * time.Second
 
+// apiShutdownWait bounds the shutdown barrier sweep's API access: the
+// termination grace budget is 60s and the manager stop plus
+// DownSecondaries can already spend 45s of it. apiStartupWait would
+// guarantee a SIGKILL mid-sweep.
+const apiShutdownWait = 5 * time.Second
+
 // listWithRetry retries an API list until it succeeds, hits a terminal
 // (non-transient) error, or apiStartupWait elapses — so a control plane still
 // coming back up does not crash the agent on startup.
-func listWithRetry(c client.Client, list client.ObjectList) error {
+func listWithRetry(c client.Client, list client.ObjectList, budget time.Duration) error {
 	var lastErr error
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, apiStartupWait, true,
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, budget, true,
 		func(ctx context.Context) (bool, error) {
 			lastErr = c.List(ctx, list)
 			if lastErr == nil {
@@ -393,7 +403,11 @@ func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver) {
 			setupLog.Error(err, "DRBD shutdown teardown failed; node reboot may stall")
 		}
 	}
-	if err := resumeStaleBarriers(driver); err != nil {
+	// Short API budget: the chart grants 60s of termination grace and the
+	// manager stop + DownSecondaries already spend up to 45s of it. A
+	// stranded barrier missed here is lifted by the startup sweep on the
+	// next boot.
+	if err := resumeStaleBarriers(driver, apiShutdownWait); err != nil {
 		setupLog.Error(err, "shutdown barrier sweep failed")
 	}
 }
@@ -406,7 +420,7 @@ func sweepOrphans(nodeName string, driver *drbd.Driver) error {
 		return err
 	}
 	vols := &miroirv1alpha1.MiroirVolumeList{}
-	if err := listWithRetry(c, vols); err != nil {
+	if err := listWithRetry(c, vols, apiStartupWait); err != nil {
 		return err
 	}
 	owned := map[string]bool{}
@@ -433,13 +447,13 @@ func sweepOrphans(nodeName string, driver *drbd.Driver) error {
 // The kernel's view drives the sweep: a crash between suspend-io and the
 // status patch leaves a frozen device no snapshot records. Barriers whose
 // round is still within the deadline are the reconciler's to drive.
-func resumeStaleBarriers(driver *drbd.Driver) error {
+func resumeStaleBarriers(driver *drbd.Driver, apiBudget time.Duration) error {
 	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
 	if err != nil {
 		return err
 	}
 	snaps := &miroirv1alpha1.MiroirSnapshotList{}
-	if err := listWithRetry(c, snaps); err != nil {
+	if err := listWithRetry(c, snaps, apiBudget); err != nil {
 		return err
 	}
 	fresh := map[string]bool{}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -59,7 +59,7 @@ func TestListWithRetrySucceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	if err := listWithRetry(c, &miroirv1alpha1.MiroirVolumeList{}); err != nil {
+	if err := listWithRetry(c, &miroirv1alpha1.MiroirVolumeList{}, apiStartupWait); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -78,7 +78,7 @@ func TestListWithRetryReturnsTerminalErrorImmediately(t *testing.T) {
 				return apierrors.NewUnauthorized("no creds")
 			},
 		}).Build()
-	if err := listWithRetry(c, &miroirv1alpha1.MiroirVolumeList{}); !apierrors.IsUnauthorized(err) {
+	if err := listWithRetry(c, &miroirv1alpha1.MiroirVolumeList{}, apiStartupWait); !apierrors.IsUnauthorized(err) {
 		t.Fatalf("want the terminal Unauthorized returned, got %v", err)
 	}
 }

--- a/internal/csi/server.go
+++ b/internal/csi/server.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
@@ -29,6 +30,11 @@ import (
 )
 
 var log = ctrl.Log.WithName("csi")
+
+// gracefulStopTimeout bounds the drain of in-flight CSI RPCs at shutdown;
+// kept under the manager's runnable shutdown grace so a hung RPC fails a
+// single call, not the whole process teardown.
+const gracefulStopTimeout = 10 * time.Second
 
 // Serve listens on a unix socket and serves the given CSI services until ctx
 // is cancelled. controller and node may each be nil (controller pod serves
@@ -63,7 +69,17 @@ func Serve(ctx context.Context, socketPath string, identity csi.IdentityServer, 
 
 	go func() {
 		<-ctx.Done()
-		srv.GracefulStop()
+		// An RPC blocked in the kernel (a stuck mount, a device frozen
+		// under a stranded barrier) can hang GracefulStop past the
+		// manager's runnable grace, failing the whole shutdown. Fall
+		// back to a hard stop so Serve always returns.
+		done := make(chan struct{})
+		go func() { srv.GracefulStop(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(gracefulStopTimeout):
+			srv.Stop()
+		}
 	}()
 	log.Info("serving CSI", "socket", socketPath)
 	return srv.Serve(lis)


### PR DESCRIPTION
The shutdown-path findings from the review (the pre-existing set, independent of the tie-breaker work in #77/#78). All three chain into the same failure story: a drain/reboot where shutdown misbehaves is exactly when the sweep matters most, and that's when it was skipped.

## 1. Shutdown sweep skipped on manager-error exit (the high one)

```go
if err := mgr.Start(...); err != nil { os.Exit(1) }   // exits before...
if shutdownSweep != nil { shutdownSweep() }           // ...the sweep
```

Any runnable failing to stop within controller-runtime's grace makes `mgr.Start` return an error → `os.Exit(1)` → `agentShutdownSweep` never runs → a cordoned node keeps its Secondary DRBD backings held and the reboot/pool-export stalls — the exact state the sweep exists to prevent. The sweep now runs on **both** exit paths.

## 2. CSI `GracefulStop` had no deadline

`go func() { <-ctx.Done(); srv.GracefulStop() }()` — one RPC blocked in the kernel (a stuck mount, a device frozen under a stranded snapshot barrier — a state this binary knows can exist) hangs `GracefulStop` indefinitely, `Serve` never returns, the manager's runnable grace expires, and `mgr.Start` errors — triggering bug 1. Now falls back to `srv.Stop()` after 10s (under the manager's grace, so a hung RPC fails one call, not the whole teardown).

## 3. Shutdown barrier sweep blew the termination grace

`resumeStaleBarriers` in the shutdown path reused the **45s startup** API budget (`apiStartupWait` was tuned for boot racing control-plane recovery — its own comment says so). Budget math at shutdown: manager stop (≤30s) + `DownSecondaries` (15s) + 45s ≫ the chart's `terminationGracePeriodSeconds: 60` → SIGKILL mid-sweep, guaranteed during a whole-cluster reboot with the API already gone. `listWithRetry` now takes an explicit budget; the shutdown call uses **5s** (30+15+5 fits inside 60). Safety: a barrier missed at shutdown is lifted by the same sweep at the next startup — that backstop is what makes the short budget acceptable.

## Verification

Full suite green in `golang:1.26.5` (incl. `cmd`, whose existing `listWithRetry` tests now pass the explicit budget); `golangci/golangci-lint:v2.12.2` (CI-pinned) 0 issues on `./...`; `GOOS=linux go build`/`vet` clean. The shutdown ordering itself isn't unit-testable with the fake harness — covered by inspection and the E2E teardown. `--no-verify` commit: known `format-yaml` hook issue (tracked).

Remaining from the review after this: the poolstats event-noise nit (low), #70's automation half (awaiting the decision checkboxes), and the lefthook hook fix (chip filed).