### PR TITLE
feat: auto-place diskless tie-breakers and default quorum to freeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,12 @@ spec:
 
 | Parameter                           | Values                        | Default             |
 | ----------------------------------- | ----------------------------- | ------------------- |
-| `miroir.home-operations.com/quorum` | `last-man-standing`, `freeze` | `last-man-standing` |
+| `miroir.home-operations.com/quorum` | `freeze`, `last-man-standing` | `freeze` |
+
+`freeze` gives 2-replica volumes majority quorum via an automatically
+placed diskless tie-breaker on a spare node (opt out with
+`controller.autoTieBreaker=false`); without a spare node — or with
+`last-man-standing` — the volume runs on the two diskful replicas alone.
 
 ### 4. Snapshot and restore
 
@@ -212,7 +217,6 @@ the exact `drbdsetup` / `lvremove` / `zfs destroy` calls needed.
 
 **Natural extensions**
 
-- [ ] 3-node topology with majority quorum
 - [ ] Online volume migration (node-to-node, backend-to-backend)
 - [ ] Thick LVM volumes
 - [ ] Read-only clones

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -39,6 +39,7 @@ Kubernetes: `>=1.31.0`
 | agent.resources.limits.memory | string | `"128Mi"` |  |
 | agent.resources.requests.cpu | string | `"10m"` |  |
 | agent.resources.requests.memory | string | `"32Mi"` |  |
+| controller.autoTieBreaker | bool | `true` |  |
 | controller.overcommitRatio | int | `2` |  |
 | controller.provisionTimeout | string | `"120s"` |  |
 | controller.resources.limits.memory | string | `"128Mi"` |  |
@@ -70,7 +71,7 @@ Kubernetes: `>=1.31.0`
 | replicatedStorageClass.fsType | string | `"ext4"` |  |
 | replicatedStorageClass.isDefault | bool | `false` |  |
 | replicatedStorageClass.name | string | `"miroir-replicated"` |  |
-| replicatedStorageClass.quorum | string | `"last-man-standing"` |  |
+| replicatedStorageClass.quorum | string | `"freeze"` |  |
 | replicatedStorageClass.reclaimPolicy | string | `"Delete"` |  |
 | sidecars.provisioner.image | string | `"registry.k8s.io/sig-storage/csi-provisioner:v6.3.0"` |  |
 | sidecars.provisioner.timeout | string | `"120s"` |  |

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -35,6 +35,7 @@ spec:
             - --nodes-config=/etc/miroir/nodes.yaml
             - --provision-timeout={{ .Values.controller.provisionTimeout }}
             - --overcommit-ratio={{ .Values.controller.overcommitRatio }}
+            - --auto-tie-breaker={{ .Values.controller.autoTieBreaker }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -80,6 +80,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--nodes-config=/etc/miroir/nodes.yaml"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--auto-tie-breaker=true"
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false
@@ -110,6 +113,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--provision-timeout=90s"
+
+  - it: controller.autoTieBreaker=false opts out of tie-breaker placement
+    set:
+      controller.autoTieBreaker: false
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--auto-tie-breaker=false"
 
   - it: sidecars pick up their image + the provisioner timeout
     set:

--- a/charts/miroir/tests/storageclass_test.yaml
+++ b/charts/miroir/tests/storageclass_test.yaml
@@ -83,7 +83,7 @@ tests:
           value: "2"
       - equal:
           path: parameters["miroir.home-operations.com/quorum"]
-          value: last-man-standing
+          value: freeze
       - equal:
           path: parameters["csi.storage.k8s.io/fstype"]
           value: ext4
@@ -137,7 +137,7 @@ tests:
       replicatedStorageClass:
         create: true
         name: custom-replicated
-        quorum: freeze
+        quorum: last-man-standing
         fsType: zfs
     documentSelector:
       path: metadata.name
@@ -148,7 +148,7 @@ tests:
           value: StorageClass
       - equal:
           path: parameters["miroir.home-operations.com/quorum"]
-          value: freeze
+          value: last-man-standing
       - equal:
           path: parameters["csi.storage.k8s.io/fstype"]
           value: zfs

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -52,6 +52,12 @@
     },
     "controller": {
       "properties": {
+        "autoTieBreaker": {
+          "default": true,
+          "description": "Add a diskless tie-breaker replica to 2-replica freeze volumes when a\nspare storage node exists, so majority quorum survives a single node\nloss. Also retrofits existing freeze volumes at controller startup.",
+          "title": "autoTieBreaker",
+          "type": "boolean"
+        },
         "overcommitRatio": {
           "default": 2,
           "description": "Thin-provisioning overcommit guardrail: CreateVolume is refused when a\nnode's provisioned total would exceed capacity × this ratio. 2× is the\nclassic CoW headroom; raise it only if you trust your usage to stay\nsparse, lower it toward 1 to provision conservatively.",
@@ -307,7 +313,8 @@
           "type": "string"
         },
         "quorum": {
-          "default": "last-man-standing",
+          "default": "freeze",
+          "description": "freeze (majority quorum + suspend I/O without it) is split-brain-free;\nwith autoTieBreaker a third node keeps volumes writable through a\nsingle node loss. last-man-standing keeps the survivor writable even\nwithout quorum, at the cost of possible divergence.",
           "title": "quorum",
           "type": "string"
         },

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -61,6 +61,10 @@ controller:
   # classic CoW headroom; raise it only if you trust your usage to stay
   # sparse, lower it toward 1 to provision conservatively.
   overcommitRatio: 2
+  # Add a diskless tie-breaker replica to 2-replica freeze volumes when a
+  # spare storage node exists, so majority quorum survives a single node
+  # loss. Also retrofits existing freeze volumes at controller startup.
+  autoTieBreaker: true
   resources:
     requests:
       cpu: 10m
@@ -118,7 +122,11 @@ replicatedStorageClass:
   name: miroir-replicated
   isDefault: false
   fsType: ext4
-  quorum: last-man-standing # | freeze
+  # freeze (majority quorum + suspend I/O without it) is split-brain-free;
+  # with autoTieBreaker a third node keeps volumes writable through a
+  # single node loss. last-man-standing keeps the survivor writable even
+  # without quorum, at the cost of possible divergence.
+  quorum: freeze # | last-man-standing
   reclaimPolicy: Delete
 
 # Requires the cluster-wide snapshot-controller + CRDs (deployed

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,24 @@ func init() {
 	utilruntime.Must(miroirv1alpha1.AddToScheme(scheme))
 }
 
+// setupMembership registers the membership reconciler (completes
+// operator-added replica entries) and, when enabled, the tie-breaker
+// retrofit for pre-existing 2-replica freeze volumes (#70).
+func setupMembership(mgr ctrl.Manager, nodes nodemap.Map, autoTieBreaker bool) error {
+	r := &membership.Reconciler{Client: mgr.GetClient(), Nodes: nodes}
+	if err := r.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("membership reconciler: %w", err)
+	}
+	if !autoTieBreaker {
+		return nil
+	}
+	tb := &membership.TieBreakerReconciler{Client: mgr.GetClient(), Nodes: nodes}
+	if err := tb.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("tie-breaker reconciler: %w", err)
+	}
+	return nil
+}
+
 func main() {
 	var (
 		mode             string
@@ -76,6 +94,7 @@ func main() {
 		nodesConfig      string
 		provisionTimeout time.Duration
 		overcommitRatio  float64
+		autoTieBreaker   bool
 
 		// agent mode
 		nodeName          string
@@ -95,6 +114,8 @@ func main() {
 		"wait for agents to realise a new volume (controller; 0 → default)")
 	flag.Float64Var(&overcommitRatio, "overcommit-ratio", 0,
 		"max provisioned-over-capacity per pool before CreateVolume is refused (controller; 0 → default 2.0)")
+	flag.BoolVar(&autoTieBreaker, "auto-tie-breaker", true,
+		"add a diskless tie-breaker to 2-replica freeze volumes when a spare node exists (controller)")
 	flag.DurationVar(&poolStatsInterval, "pool-stats-interval", 0,
 		"how often the agent republishes pool capacity (agent; 0 → default 60s)")
 	flag.StringVar(&vg, "lvm-vg", "vg-miroir", "LVM volume group (agent, lvmthin)")
@@ -192,15 +213,10 @@ func main() {
 			Nodes:            nodes,
 			ProvisionTimeout: provisionTimeout,
 			OvercommitRatio:  overcommitRatio,
+			AutoTieBreaker:   autoTieBreaker,
 		}
-		// Completes operator-added replica entries on live volumes
-		// (kubectl edit of spec.replicas).
-		membershipReconciler := &membership.Reconciler{
-			Client: mgr.GetClient(),
-			Nodes:  nodes,
-		}
-		if err := membershipReconciler.SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to set up membership reconciler")
+		if err := setupMembership(mgr, nodes, autoTieBreaker); err != nil {
+			setupLog.Error(err, "unable to set up membership reconcilers")
 			os.Exit(1)
 		}
 		serveCSI(mgr, csiSocket, identity, controller, nil)

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -65,6 +65,9 @@ type Controller struct {
 	// refused when a node's provisioned total would exceed
 	// capacity×ratio (notes/DESIGN.md §4.6). Zero → defaultOvercommitRatio.
 	OvercommitRatio float64
+	// AutoTieBreaker adds a diskless tie-breaker replica to new 2-replica
+	// freeze volumes when a spare storage node exists (#70).
+	AutoTieBreaker bool
 
 	// allocMu serialises CreateVolume RPCs that run concurrently within
 	// the single controller pod: two interleaved List→Create spans would
@@ -176,7 +179,11 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			c.allocMu.Unlock()
 			return nil, err
 		}
-		placed = p
+		placed, err = c.withTieBreaker(ctx, p, replicas, quorum)
+		if err != nil {
+			c.allocMu.Unlock()
+			return nil, err
+		}
 	}
 	vol := &miroirv1alpha1.MiroirVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: req.GetName()},
@@ -393,6 +400,30 @@ func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, c
 		replicas = append(replicas, r)
 	}
 	return replicas, nil
+}
+
+// withTieBreaker appends a diskless tie-breaker to a freshly placed
+// 2-replica freeze volume, so majority quorum survives a single node loss
+// (#70). Unchanged when disabled, not applicable, or no spare node exists —
+// the tie-breaker reconciler retrofits skipped volumes once one joins.
+func (c *Controller) withTieBreaker(ctx context.Context, placed []miroirv1alpha1.Replica, replicas int, quorum miroirv1alpha1.QuorumPolicy) ([]miroirv1alpha1.Replica, error) {
+	if !c.AutoTieBreaker || replicas != 2 || quorum != miroirv1alpha1.QuorumFreeze {
+		return placed, nil
+	}
+	tb := c.Nodes.TieBreakerNode(placed)
+	if tb == "" {
+		return placed, nil
+	}
+	addr, err := c.nodeInternalIP(ctx, tb)
+	if err != nil {
+		return nil, err
+	}
+	return append(placed, miroirv1alpha1.Replica{
+		Node:     tb,
+		NodeID:   int32(len(placed)), //nolint:gosec // ≤3 replicas
+		Address:  addr,
+		Diskless: true,
+	}), nil
 }
 
 // spreadByZone selects count nodes from ordered (already ranked by topology
@@ -875,12 +906,14 @@ func parseReplicas(params map[string]string) (int, error) {
 	return n, nil
 }
 
+// parseQuorum defaults to freeze: with the auto-added tie-breaker a
+// 2-replica volume gets majority quorum without split-brain exposure (#70).
 func parseQuorum(params map[string]string) (miroirv1alpha1.QuorumPolicy, error) {
 	switch raw := params[constants.ParamQuorum]; raw {
-	case "", string(miroirv1alpha1.QuorumLastManStanding):
-		return miroirv1alpha1.QuorumLastManStanding, nil
-	case string(miroirv1alpha1.QuorumFreeze):
+	case "", string(miroirv1alpha1.QuorumFreeze):
 		return miroirv1alpha1.QuorumFreeze, nil
+	case string(miroirv1alpha1.QuorumLastManStanding):
+		return miroirv1alpha1.QuorumLastManStanding, nil
 	default:
 		return "", status.Errorf(codes.InvalidArgument,
 			"invalid %s=%q (want last-man-standing | freeze)", constants.ParamQuorum, raw)

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -43,6 +43,8 @@ const (
 	nodeParis   = "paris"
 	nodeOslo    = "oslo"
 	addrKharkiv = "192.168.1.41"
+	addrParis   = "192.168.1.42"
+	addrOslo    = "192.168.1.43"
 	volPvc1     = "pvc-1"
 	volSrc      = "pvc-src"
 	volNew      = "pvc-new"
@@ -254,7 +256,7 @@ func TestCreateVolumeReplicated(t *testing.T) {
 		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
 		Parameters: map[string]string{
 			constants.ParamReplicas: "2",
-			constants.ParamQuorum:   "last-man-standing",
+			constants.ParamQuorum:   string(miroirv1alpha1.QuorumLastManStanding),
 		},
 		AccessibilityRequirements: &csi.TopologyRequirement{
 			Preferred: []*csi.Topology{
@@ -308,6 +310,139 @@ func TestCreateVolumeReplicated(t *testing.T) {
 	}
 	if vol2.Spec.DRBD.Port != 7001 {
 		t.Fatalf("allocator must advance: %+v", vol2.Spec.DRBD)
+	}
+}
+
+// tieBreakerController is a 3-node controller whose fake client flips
+// created volumes to Ready, for exercising the auto-tie-breaker path.
+func tieBreakerController(t *testing.T, autoTieBreaker bool) *Controller {
+	t.Helper()
+	return &Controller{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).
+			WithObjects(nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis), nodeObj(nodeOslo, addrOslo)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if err := cl.Get(ctx, key, obj, opts...); err != nil {
+						return err
+					}
+					if vol, ok := obj.(*miroirv1alpha1.MiroirVolume); ok {
+						vol.Status.Phase = miroirv1alpha1.VolumeReady
+					}
+					return nil
+				},
+			}).Build(),
+		Nodes: nodemap.Map{
+			nodeKharkiv: {Backend: miroirv1alpha1.BackendLVMThin},
+			nodeParis:   {Backend: miroirv1alpha1.BackendZFS, ZFSDataset: "data-pool/miroir"},
+			nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin},
+		},
+		ProvisionTimeout: 2 * time.Second,
+		AutoTieBreaker:   autoTieBreaker,
+	}
+}
+
+// A 2-replica volume with the default quorum (now freeze) gets a diskless
+// tie-breaker on the spare node (#70).
+func TestCreateVolumeAutoTieBreaker(t *testing.T) {
+	c := tieBreakerController(t, true)
+
+	resp, err := c.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name:               "pvc-tb",
+		VolumeCapabilities: volCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Preferred: []*csi.Topology{
+				{Segments: map[string]string{constants.TopologyKey: nodeKharkiv}},
+				{Segments: map[string]string{constants.TopologyKey: nodeParis}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Volume.AccessibleTopology) != 2 {
+		t.Fatalf("topology must cover only diskful nodes: %+v", resp.Volume.AccessibleTopology)
+	}
+
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(context.Background(), types.NamespacedName{Name: "pvc-tb"}, vol); err != nil {
+		t.Fatal(err)
+	}
+	if vol.Spec.QuorumPolicy != miroirv1alpha1.QuorumFreeze {
+		t.Fatalf("default quorum must be freeze, got %s", vol.Spec.QuorumPolicy)
+	}
+	if len(vol.Spec.Replicas) != 3 {
+		t.Fatalf("want 2 diskful + 1 tie-breaker, got %+v", vol.Spec.Replicas)
+	}
+	tb := vol.Spec.Replicas[2]
+	if tb.Node != nodeOslo || !tb.Diskless || tb.NodeID != 2 || tb.Address != addrOslo {
+		t.Fatalf("unexpected tie-breaker %+v", tb)
+	}
+	if tb.Backend != "" {
+		t.Fatalf("tie-breaker must carry no backend: %+v", tb)
+	}
+	if len(vol.Finalizers) != 3 {
+		t.Fatalf("tie-breaker node needs a teardown finalizer: %v", vol.Finalizers)
+	}
+}
+
+func TestCreateVolumeAutoTieBreakerSkips(t *testing.T) {
+	cases := map[string]struct {
+		controller *Controller
+		params     map[string]string
+	}{
+		"opted out": {
+			controller: tieBreakerController(t, false),
+			params:     map[string]string{constants.ParamReplicas: "2"},
+		},
+		"last-man-standing": {
+			controller: tieBreakerController(t, true),
+			params: map[string]string{
+				constants.ParamReplicas: "2",
+				constants.ParamQuorum:   string(miroirv1alpha1.QuorumLastManStanding),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := tc.controller.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+				Name:               "pvc-plain",
+				VolumeCapabilities: volCaps(),
+				Parameters:         tc.params,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			vol := &miroirv1alpha1.MiroirVolume{}
+			if err := tc.controller.Client.Get(context.Background(), types.NamespacedName{Name: "pvc-plain"}, vol); err != nil {
+				t.Fatal(err)
+			}
+			if len(vol.Spec.Replicas) != 2 {
+				t.Fatalf("no tie-breaker expected: %+v", vol.Spec.Replicas)
+			}
+		})
+	}
+}
+
+// With every storage node holding a replica there is nothing to place the
+// tie-breaker on — the volume is created without one.
+func TestCreateVolumeAutoTieBreakerNoSpareNode(t *testing.T) {
+	c := tieBreakerController(t, true)
+	c.Nodes = testNodes // kharkiv + paris only
+
+	if _, err := c.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name:               "pvc-nospare",
+		VolumeCapabilities: volCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(context.Background(), types.NamespacedName{Name: "pvc-nospare"}, vol); err != nil {
+		t.Fatal(err)
+	}
+	if len(vol.Spec.Replicas) != 2 || vol.Spec.QuorumPolicy != miroirv1alpha1.QuorumFreeze {
+		t.Fatalf("want 2 diskful freeze replicas, got %+v (quorum %s)",
+			vol.Spec.Replicas, vol.Spec.QuorumPolicy)
 	}
 }
 

--- a/internal/membership/tiebreaker.go
+++ b/internal/membership/tiebreaker.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package membership
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/nodemap"
+)
+
+// TieBreakerReconciler retrofits a diskless tie-breaker onto 2-replica
+// freeze volumes that lack one (#70) — volumes created before a spare
+// node existed, or switched to freeze later. It appends a bare
+// {node, diskless} entry; the membership Reconciler completes it exactly
+// like an operator-added replica. The node map is fixed per controller
+// process (a node-map change is a Helm upgrade, hence a restart), so the
+// startup reconcile pass covers node additions — no Node watch needed.
+type TieBreakerReconciler struct {
+	client.Client
+	// Nodes is the storage topology — the same map CreateVolume places from.
+	Nodes nodemap.Map
+}
+
+// Reconcile appends a tie-breaker entry when the volume is a 2-replica
+// freeze volume, its entries are complete, and a spare node exists.
+func (r *TieBreakerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(ctx, req.NamespacedName, vol); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if !vol.DeletionTimestamp.IsZero() || vol.Spec.DRBD == nil ||
+		vol.Spec.QuorumPolicy != miroirv1alpha1.QuorumFreeze {
+		return ctrl.Result{}, nil
+	}
+	if len(vol.Spec.Replicas) != 2 || len(vol.Spec.DiskfulReplicas()) != 2 {
+		// Already has a tie-breaker, or a membership edit is in flight.
+		return ctrl.Result{}, nil
+	}
+	for _, rep := range vol.Spec.Replicas {
+		if rep.Address == "" {
+			// Incomplete entry: membership's completion edit re-triggers us.
+			return ctrl.Result{}, nil
+		}
+	}
+	tb := r.Nodes.TieBreakerNode(vol.Spec.Replicas)
+	if tb == "" {
+		// No spare node; the startup pass after the next node-map change
+		// (Helm upgrade → restart) revisits this volume.
+		return ctrl.Result{}, nil
+	}
+
+	vol.Spec.Replicas = append(vol.Spec.Replicas, miroirv1alpha1.Replica{Node: tb, Diskless: true})
+	if err := r.Update(ctx, vol); err != nil {
+		return ctrl.Result{}, err
+	}
+	ctrl.LoggerFrom(ctx).Info("added diskless tie-breaker", "volume", vol.Name, "node", tb)
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the reconciler. Generation-filtered like the
+// membership Reconciler; the initial list delivers every volume once at
+// startup, which is the retrofit pass.
+func (r *TieBreakerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&miroirv1alpha1.MiroirVolume{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Named("tiebreaker").
+		Complete(r)
+}

--- a/internal/membership/tiebreaker_test.go
+++ b/internal/membership/tiebreaker_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package membership
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/constants"
+	"github.com/home-operations/miroir/internal/nodemap"
+)
+
+const (
+	nodeKharkiv = "kharkiv"
+	nodeParis   = "paris"
+	addrOslo    = "192.168.1.43"
+	volTB       = "pvc-tb"
+)
+
+// freezeVol is a complete 2-replica freeze volume on kharkiv+paris — the
+// shape the tie-breaker reconciler retrofits.
+func freezeVol() *miroirv1alpha1.MiroirVolume {
+	return &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volTB,
+			Finalizers: []string{
+				constants.FinalizerPrefix + nodeKharkiv,
+				constants.FinalizerPrefix + nodeParis,
+			},
+		},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    1 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendZFS, NodeID: 0, Address: "192.168.1.41"},
+				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "192.168.1.42"},
+			},
+		},
+	}
+}
+
+func tbReconcile(t *testing.T, r *TieBreakerReconciler) {
+	t.Helper()
+	if _, err := r.Reconcile(context.Background(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volTB}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The retrofit appends a bare diskless entry, and the membership
+// Reconciler completes it exactly like an operator-added replica.
+func TestTieBreakerRetrofitsAndMembershipCompletes(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(freezeVol(), node(nodeOslo, addrOslo)).
+		Build()
+	nodes := nodemap.Map{
+		nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},
+		nodeParis:   {Backend: miroirv1alpha1.BackendZFS},
+		nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin},
+	}
+	tb := &TieBreakerReconciler{Client: c, Nodes: nodes}
+
+	tbReconcile(t, tb)
+
+	mr := &Reconciler{Client: c, Nodes: nodes}
+	got := get(t, mr, volTB)
+	if len(got.Spec.Replicas) != 3 {
+		t.Fatalf("tie-breaker not added: %+v", got.Spec.Replicas)
+	}
+	if rep := got.Spec.Replicas[2]; rep.Node != nodeOslo || !rep.Diskless || rep.Address != "" {
+		t.Fatalf("want a bare diskless oslo entry, got %+v", rep)
+	}
+
+	reconcile(t, mr, volTB)
+	got = get(t, mr, volTB)
+	rep := got.Spec.Replicas[2]
+	if rep.NodeID != 2 || rep.Address != addrOslo || !rep.Diskless {
+		t.Fatalf("membership must complete the tie-breaker: %+v", rep)
+	}
+	if rep.FullSync || rep.Backend != "" {
+		t.Fatalf("diskless entry must carry no backend or FullSync: %+v", rep)
+	}
+	if !slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeOslo) {
+		t.Fatalf("tie-breaker node needs a teardown finalizer: %v", got.Finalizers)
+	}
+
+	// A second pass sees the tie-breaker in place and changes nothing.
+	tbReconcile(t, tb)
+	if got = get(t, mr, volTB); len(got.Spec.Replicas) != 3 {
+		t.Fatalf("retrofit must be idempotent: %+v", got.Spec.Replicas)
+	}
+}
+
+func TestTieBreakerSkips(t *testing.T) {
+	spare := nodemap.Map{
+		nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},
+		nodeParis:   {Backend: miroirv1alpha1.BackendZFS},
+		nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin},
+	}
+	cases := map[string]struct {
+		mutate func(*miroirv1alpha1.MiroirVolume)
+		nodes  nodemap.Map
+	}{
+		"last-man-standing keeps its policy": {
+			mutate: func(v *miroirv1alpha1.MiroirVolume) {
+				v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
+			},
+			nodes: spare,
+		},
+		"tie-breaker already present": {
+			mutate: func(v *miroirv1alpha1.MiroirVolume) {
+				v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
+					Node: nodeOslo, NodeID: 2, Address: addrOslo, Diskless: true,
+				})
+			},
+			nodes: spare,
+		},
+		"membership completion in flight": {
+			mutate: func(v *miroirv1alpha1.MiroirVolume) {
+				v.Spec.Replicas[1].Address = ""
+			},
+			nodes: spare,
+		},
+		"no spare node": {
+			mutate: func(*miroirv1alpha1.MiroirVolume) {},
+			nodes: nodemap.Map{
+				nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},
+				nodeParis:   {Backend: miroirv1alpha1.BackendZFS},
+			},
+		},
+		"unreplicated volume": {
+			mutate: func(v *miroirv1alpha1.MiroirVolume) { v.Spec.DRBD = nil },
+			nodes:  spare,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			vol := freezeVol()
+			tc.mutate(vol)
+			want := len(vol.Spec.Replicas)
+			c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+				WithObjects(vol, node(nodeOslo, addrOslo)).Build()
+			tb := &TieBreakerReconciler{Client: c, Nodes: tc.nodes}
+
+			tbReconcile(t, tb)
+
+			got := get(t, &Reconciler{Client: c}, volTB)
+			if len(got.Spec.Replicas) != want {
+				t.Fatalf("replicas must stay unchanged: %+v", got.Spec.Replicas)
+			}
+		})
+	}
+}

--- a/internal/nodemap/nodemap.go
+++ b/internal/nodemap/nodemap.go
@@ -23,6 +23,7 @@ package nodemap
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"sigs.k8s.io/yaml"
 
@@ -54,6 +55,36 @@ type Node struct {
 // Map is node name → storage config. Nodes absent from the map hold no
 // replicas.
 type Map map[string]Node
+
+// TieBreakerNode picks a storage node to host a diskless tie-breaker for
+// the given replicas: one not already holding a replica, preferring a zone
+// none of them occupy, ties by name. Empty when no spare node exists.
+func (m Map) TieBreakerNode(replicas []miroirv1alpha1.Replica) string {
+	usedNode := make(map[string]bool, len(replicas))
+	usedZone := make(map[string]bool, len(replicas))
+	for _, r := range replicas {
+		usedNode[r.Node] = true
+		if z := m[r.Node].Zone; z != "" {
+			usedZone[z] = true
+		}
+	}
+	spare := make([]string, 0, len(m))
+	for n := range m {
+		if !usedNode[n] {
+			spare = append(spare, n)
+		}
+	}
+	slices.Sort(spare)
+	for _, n := range spare {
+		if z := m[n].Zone; z == "" || !usedZone[z] {
+			return n
+		}
+	}
+	if len(spare) > 0 {
+		return spare[0]
+	}
+	return ""
+}
 
 // Load reads and validates the node map from a YAML file.
 func Load(path string) (Map, error) {

--- a/internal/nodemap/nodemap_test.go
+++ b/internal/nodemap/nodemap_test.go
@@ -24,6 +24,13 @@ import (
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 )
 
+const (
+	nodeKharkiv = "kharkiv"
+	nodeParis   = "paris"
+	nodeOslo    = "oslo"
+	nodeBergen  = "bergen"
+)
+
 func writeMap(t *testing.T, body string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "nodes.yaml")
@@ -87,5 +94,44 @@ func TestLoadErrors(t *testing.T) {
 func TestLoadMissingFile(t *testing.T) {
 	if _, err := Load(filepath.Join(t.TempDir(), "absent.yaml")); err == nil {
 		t.Fatal("expected an error for a missing file")
+	}
+}
+
+func TestTieBreakerNode(t *testing.T) {
+	replicas := []miroirv1alpha1.Replica{{Node: nodeKharkiv}, {Node: nodeParis}}
+	cases := map[string]struct {
+		m    Map
+		want string
+	}{
+		"prefers a zone no replica occupies": {
+			m: Map{
+				nodeKharkiv: {Zone: "a"}, nodeParis: {Zone: "b"},
+				nodeOslo: {Zone: "a"}, nodeBergen: {Zone: "c"},
+			},
+			want: nodeBergen,
+		},
+		"zoneless spare is unconstrained": {
+			m:    Map{nodeKharkiv: {Zone: "a"}, nodeParis: {Zone: "b"}, nodeOslo: {}},
+			want: nodeOslo,
+		},
+		"falls back to an occupied zone when none is free": {
+			m:    Map{nodeKharkiv: {Zone: "a"}, nodeParis: {Zone: "b"}, nodeOslo: {Zone: "a"}},
+			want: nodeOslo,
+		},
+		"name order breaks ties": {
+			m:    Map{nodeKharkiv: {}, nodeParis: {}, nodeOslo: {}, nodeBergen: {}},
+			want: nodeBergen,
+		},
+		"no spare node": {
+			m:    Map{nodeKharkiv: {}, nodeParis: {}},
+			want: "",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.m.TieBreakerNode(replicas); got != tc.want {
+				t.Fatalf("TieBreakerNode = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Implements the four decisions recorded on #70 ([decisions comment](https://github.com/home-operations/miroir/issues/70#issuecomment-4926578346)). Builds on the tie-breaker mechanism from #74 and its hardening in #77/#78.

## What changed

**1. Default quorum flips to `freeze`** (`parseQuorum`, chart `replicatedStorageClass.quorum`)
New 2-replica volumes without an explicit `quorum` parameter get majority quorum with `on-no-quorum io-error` instead of `quorum off`. `last-man-standing` remains the explicit opt-out for availability-over-consistency clusters. Existing volumes keep their stored `quorumPolicy` — nothing is rewritten.

**2. CreateVolume auto-adds a diskless tie-breaker** (`Controller.withTieBreaker`)
For a fresh 2-replica freeze volume, the controller picks a spare storage node via `nodemap.Map.TieBreakerNode` — preferring a zone the diskful replicas don't occupy (complements #69), ties by name — and appends a complete `{node, nodeID: 2, address, diskless: true}` entry inside the same `allocMu` critical section. The tie-breaker node gets a teardown finalizer like any replica; CSI topology and the overcommit guard continue to ignore diskless entries. Skipped on restores (placement follows the snapshot source) and when no spare node exists.

**3. Retrofit reconciler** (`membership.TieBreakerReconciler`)
Watches MiroirVolumes (generation-filtered) and appends a **bare** `{node, diskless: true}` entry to 2-replica freeze volumes that lack one; the existing membership reconciler completes it (NodeID, address, finalizer) exactly like an operator-added replica. Because the node map is fixed per controller process, a node-map change is a Helm upgrade → restart → the startup reconcile pass is the retrofit pass; no Node watch needed. Also covers volumes an operator flips from `last-man-standing` to `freeze`.

**4. Opt-out knob**: `--auto-tie-breaker` flag (default `true`) → chart value `controller.autoTieBreaker`. Disabling skips both the CreateVolume auto-add and the retrofit reconciler.

## Accepted consequence (per #70)

On a 2-node cluster with no spare node, a freeze volume runs majority quorum with only 2 votes: losing either node suspends I/O until it returns. That is the deliberate trade — always split-brain-safe, availability grows automatically when a third node joins (the retrofit adds the tie-breaker without operator action).

## Upgrade note

A PVC that was **mid-provisioning** (created, not yet bound) across this upgrade and whose StorageClass omits `quorum` will fail its idempotent CreateVolume retry with `AlreadyExists` (stored `last-man-standing` vs new default `freeze`). Bound volumes are unaffected. Recreate the pending PVC, or set `quorum: last-man-standing` explicitly.

## Verification

- `go test ./...` in `golang:1.26.5` (linux) — all packages pass; new tests cover the picker (zone preference/fallback/no-spare), CreateVolume (tie-breaker added / opt-out / LMS / no-spare / default-freeze), and the retrofit→membership completion pipeline incl. all skip guards
- `golangci-lint run` (CI-pinned v2.12.2) — 0 issues
- helm-unittest 56/56, helm lint clean, chart README/schema regenerated

```
gh pr merge 81 --squash --repo home-operations/miroir
```
