### PR TITLE
fix: serialize snapshot rounds per volume and harden deletion

### DIFF
--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -83,21 +83,29 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	mine := replicaOn(vol, r.NodeName)
-	if !mine {
-		return ctrl.Result{}, nil
-	}
-
 	if !snap.DeletionTimestamp.IsZero() {
-		// A snapshot deleted mid-round must not strand its barrier:
-		// resume before anything that can fail or requeue. Every replica
-		// passes here and resume-io is a no-op when not suspended.
-		if snap.Status.IOSuspended && vol.Spec.DRBD != nil {
-			if err := r.DRBD.ResumeIO(ctx, vol.Name); err != nil {
-				return ctrl.Result{}, err
+		// Deletion runs before the membership gate: a node that left
+		// spec.replicas after the snapshot was cut still holds its
+		// finalizer, and skipping it would wedge the snapshot in
+		// Terminating forever (which also blocks every later replica
+		// removal on the volume).
+		//
+		// A snapshot deleted mid-round must not strand its barrier. The
+		// lift keys on kernel state, not status.ioSuspended: a peer's
+		// barrier can outlive the coordinator's void (status already
+		// false), and a torn-down resource must not error the path
+		// (Status fails → nothing is suspended). Never lift a barrier a
+		// sibling snapshot's live round now owns.
+		if vol.Spec.DRBD != nil {
+			if st, err := r.DRBD.Status(ctx, vol.Name); err == nil && st.Suspended {
+				if err := r.resumeUnlessSiblingRound(ctx, snap, vol); err != nil {
+					return ctrl.Result{}, err
+				}
 			}
 		}
-		// A diskless replica has no backend snapshot to delete.
+		// A diskless replica has no backend snapshot to delete; a
+		// departed node deletes whatever leg it still holds (the
+		// backends succeed when it is already absent).
 		if r.disklessOn(vol) {
 			return ctrl.Result{}, r.removeFinalizer(ctx, snap)
 		}
@@ -112,12 +120,17 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, r.removeFinalizer(ctx, snap)
 	}
 
+	if !replicaOn(vol, r.NodeName) {
+		return ctrl.Result{}, nil
+	}
+
 	if snap.Status.ReadyToUse {
-		// A peer's barrier can outlive the round by a moment; lift it.
+		// A peer's barrier can outlive the round by a moment; lift it —
+		// unless a sibling snapshot's round owns the kernel barrier now.
 		// Best-effort: if DRBD cannot report, nothing holds a barrier.
 		if vol.Spec.DRBD != nil {
 			if st, err := r.DRBD.Status(ctx, vol.Name); err == nil && st.Suspended {
-				return ctrl.Result{}, r.DRBD.ResumeIO(ctx, vol.Name)
+				return ctrl.Result{}, r.resumeUnlessSiblingRound(ctx, snap, vol)
 			}
 		}
 		return ctrl.Result{}, nil
@@ -181,6 +194,12 @@ func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miro
 			time.Since(snap.Status.SuspendedAt.Time) < suspendRetryBackoff {
 			return ctrl.Result{RequeueAfter: suspendRetryBackoff}, nil
 		}
+		// One round per volume: the kernel suspend flag is shared, so a
+		// second snapshot's round would tear the first's barrier down
+		// mid-cut. Wait for the sibling round to close.
+		if active, err := r.otherRoundActive(ctx, snap); err != nil || active {
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, err
+		}
 		return r.raiseBarrier(ctx, snap, vol, true)
 
 	case !coordinator && snap.Status.IOSuspended && !expired && healthy &&
@@ -200,8 +219,9 @@ func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miro
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.DRBD.ResumeIO(ctx, vol.Name)
 
 	case !snap.Status.IOSuspended && st.Suspended:
-		// The round ended (voided) while the local barrier was still up.
-		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.DRBD.ResumeIO(ctx, vol.Name)
+		// The round ended (voided) while the local barrier was still up —
+		// unless a sibling snapshot's round owns the barrier by now.
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.resumeUnlessSiblingRound(ctx, snap, vol)
 	}
 	return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 }
@@ -331,6 +351,35 @@ func allSuspended(vol *miroirv1alpha1.MiroirVolume, snap *miroirv1alpha1.MiroirS
 		}
 	}
 	return true
+}
+
+// otherRoundActive reports whether a different MiroirSnapshot of the same
+// volume is mid-round (its coordinator holds status.ioSuspended). The
+// kernel suspend-io flag is per-resource, not per-snapshot: concurrent
+// rounds would lift each other's barrier and cut non-identical legs, so
+// every barrier touch outside a round defers to a live sibling.
+func (r *SnapshotReconciler) otherRoundActive(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot) (bool, error) {
+	list := &miroirv1alpha1.MiroirSnapshotList{}
+	if err := r.List(ctx, list); err != nil {
+		return false, err
+	}
+	for i := range list.Items {
+		s := &list.Items[i]
+		if s.Name != snap.Name && s.Spec.VolumeName == snap.Spec.VolumeName && s.Status.IOSuspended {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// resumeUnlessSiblingRound lifts the local barrier unless a sibling
+// snapshot's live round owns it (that round's protocol lifts it).
+func (r *SnapshotReconciler) resumeUnlessSiblingRound(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume) error {
+	active, err := r.otherRoundActive(ctx, snap)
+	if err != nil || active {
+		return err
+	}
+	return r.DRBD.ResumeIO(ctx, vol.Name)
 }
 
 // isCoordinator: the Primary owns the barrier (suspend-io only blocks

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -18,11 +18,13 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -513,7 +515,9 @@ func TestSnapshotWaitsForHealthyReplication(t *testing.T) {
 }
 
 // Regression: a snapshot deleted while its barrier is up must resume IO
-// on the way out — nothing else ever would.
+// on the way out — nothing else ever would. The lift keys on the kernel
+// suspend flag, so it fires even when status.ioSuspended is already false
+// (a peer's barrier outliving the coordinator's void).
 func TestSnapshotDeleteResumesStrandedBarrier(t *testing.T) {
 	s := newScheme(t)
 	v := vol(volPvc1, nodeKharkiv, nodeParis)
@@ -521,19 +525,173 @@ func TestSnapshotDeleteResumesStrandedBarrier(t *testing.T) {
 	snap := snapObj("snap-del", volPvc1, nodeKharkiv)
 	now := metav1.NewTime(time.Now())
 	snap.DeletionTimestamp = &now
-	snap.Status.IOSuspended = true
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snap).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
-	fe := &fakeDRBDExec{}
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}]}]`}
 	fb := newFakeBackend()
 	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, "snap-del")
 
 	fe.calledWith(t, "drbdadm resume-io pvc-1")
+}
+
+// assertFinalizerReleased passes when the node's finalizer is gone —
+// including when releasing the last finalizer let the fake client delete
+// the object outright.
+func assertFinalizerReleased(t *testing.T, c client.Client, name, node string) {
+	t.Helper()
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	err := c.Get(context.Background(), types.NamespacedName{Name: name}, got)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(got.Finalizers, constants.FinalizerPrefix+node) {
+		t.Fatalf("finalizer must be released: %v", got.Finalizers)
+	}
+}
+
+// A snapshot deleted after this node's volume teardown already ran Down
+// must not wedge on the barrier lift: Status fails on the torn-down
+// resource, so nothing is suspended and deletion proceeds — the volume
+// teardown's ErrBusy retry then completes. (Deadlock regression.)
+func TestSnapshotDeleteToleratesDownedResource(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	snap := snapObj("snap-del", volPvc1, nodeKharkiv)
+	now := metav1.NewTime(time.Now())
+	snap.DeletionTimestamp = &now
+	snap.Status.IOSuspended = true // stranded by the dead round
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snap).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{errOn: map[string]error{"status": errors.New("no such resource")}}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend(),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	reconcileSnap(t, r, "snap-del")
+
+	fe.notCalledWith(t, "resume-io")
+	assertFinalizerReleased(t, c, "snap-del", nodeKharkiv)
+}
+
+// A node that left spec.replicas after the snapshot was cut still holds
+// its finalizer; deletion must release it or the snapshot wedges in
+// Terminating and blocks every later replica removal on the volume.
+func TestSnapshotDeleteReleasesDepartedNode(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis) // oslo already removed
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	snap := snapObj("snap-del", volPvc1, nodeKharkiv, nodeParis, nodeOslo)
+	now := metav1.NewTime(time.Now())
+	snap.DeletionTimestamp = &now
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snap).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{errOn: map[string]error{"status": errors.New("no such resource")}}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeOslo, Backend: newFakeBackend(),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	reconcileSnap(t, r, "snap-del")
+
+	assertFinalizerReleased(t, c, "snap-del", nodeOslo)
+}
+
+// The kernel suspend flag is shared per resource: while a sibling
+// snapshot's round is live, a deleting snapshot must not lift the
+// barrier out from under it — but it still deletes its leg and departs.
+func TestSnapshotDeleteSkipsSiblingRoundBarrier(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	snap := snapObj("snap-del", volPvc1, nodeKharkiv)
+	now := metav1.NewTime(time.Now())
+	snap.DeletionTimestamp = &now
+	sibling := snapObj("snap-live", volPvc1, nodeKharkiv, nodeParis)
+	sibling.Status.IOSuspended = true
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snap, sibling).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}]}]`}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend(),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	reconcileSnap(t, r, "snap-del")
+
+	fe.notCalledWith(t, "resume-io")
+	assertFinalizerReleased(t, c, "snap-del", nodeKharkiv)
+}
+
+// One round per volume: a coordinator must not open a round while a
+// sibling snapshot of the same volume is mid-round.
+func TestSnapshotRoundWaitsForSibling(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	fresh := snapObj("snap-b", volPvc1, nodeKharkiv, nodeParis)
+	sibling := snapObj("snap-a", volPvc1, nodeKharkiv, nodeParis)
+	sibling.Status.IOSuspended = true
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, fresh, sibling).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend(),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	res := reconcileSnap(t, r, "snap-b")
+
+	fe.notCalledWith(t, "suspend-io")
+	if res.RequeueAfter == 0 {
+		t.Fatal("must requeue to wait for the sibling round to close")
+	}
+}
+
+// A voided round's leftover barrier must stay up while a sibling round
+// owns it — the sibling's own protocol lifts it.
+func TestSnapshotVoidedResumeDefersToSiblingRound(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	voided := snapObj("snap-a", volPvc1, nodeKharkiv, nodeParis) // round voided
+	sibling := snapObj("snap-b", volPvc1, nodeKharkiv, nodeParis)
+	sibling.Status.IOSuspended = true
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, voided, sibling).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	// paris: Secondary, not replicas[0] → not coordinator; barrier up.
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	reconcileSnap(t, r, "snap-a")
+
+	fe.notCalledWith(t, "resume-io")
 }
 
 func TestSnapshotPeerWaitsForBarrier(t *testing.T) {


### PR DESCRIPTION
PR A of the review cycle — the snapshot write-barrier protocol fixes (3 confirmed bugs, one file).

## Bug 1 — concurrent snapshots of one volume corrupt each other's rounds

The kernel `suspend-io` flag is per **resource**; the barrier protocol tracked it per **snapshot**. Two MiroirSnapshots of the same PVC in flight (overlapping scheduled backups):

- Snapshot B's "stray barrier" case (`!snap.Status.IOSuspended && st.Suspended → ResumeIO`) lifts snapshot A's **live** barrier mid-round.
- B's coordinator opens its own round under A's barrier (`healthy` stays true under suspend).

Either way legs get cut while writes are flowing on some nodes — non-byte-identical legs reported `ReadyToUse`, which a restore then day0-seeds as identical twins: silent divergence DRBD never resyncs.

**Fix:** new `otherRoundActive` (List snapshots of the volume with `status.ioSuspended`) serializes rounds — the coordinator waits for a sibling round to close, and every barrier lift outside a round (`voided-round resume`, `ReadyToUse` lift, deletion) defers to a live sibling via a shared `resumeUnlessSiblingRound` helper.

## Bug 2 — departed node wedges snapshot deletion forever

The `mine` membership gate ran **before** the deletion branch, so a node that left `spec.replicas` after the snapshot was cut (tie-breaker removal, replica removal) never released its snapshot finalizer: the MiroirSnapshot sticks in Terminating forever, external-snapshotter retries forever, and — worse — `removalBlocked` keeps seeing the Terminating snapshot, permanently blocking any further replica removal on the volume.

**Fix:** deletion runs first, for every node holding the finalizer; a departed node deletes whatever backend leg it still holds (backends succeed when absent) and releases.

## Bug 3 — deletion barrier lift keyed on stale status

`if snap.Status.IOSuspended → ResumeIO` had two failure modes: a peer's kernel barrier outliving the coordinator's void (status already false → never lifted → volume frozen until the next agent restart), and a stranded `ioSuspended=true` on a node whose volume teardown already ran `drbdadm down` (`resume-io` errors on the unconfigured resource → snapshot finalizer never released → volume teardown ErrBusy forever: mutual deadlock).

**Fix:** the lift keys on kernel state (`Status().Suspended`), best-effort — a failed `Status` means no resource, hence nothing suspended — and skips a sibling round's barrier.

## Tests

Six new/updated cases: kernel-keyed stranded-barrier lift, downed-resource deletion (deadlock regression), departed-node finalizer release, sibling-round barrier protection during deletion, coordinator waiting for a sibling round, and voided-round resume deferring to a sibling. Full suite green in `golang:1.26.5`; golangci-lint v2.12.2 clean.

```
gh pr merge 85 --squash --repo home-operations/miroir
```