### PR TITLE
fix: tie-breaker retrofit must not re-add a node mid-removal

### DIFF
--- a/internal/membership/tiebreaker.go
+++ b/internal/membership/tiebreaker.go
@@ -18,6 +18,9 @@ package membership
 
 import (
 	"context"
+	"slices"
+	"strings"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -25,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/constants"
 	"github.com/home-operations/miroir/internal/nodemap"
 )
 
@@ -60,6 +64,23 @@ func (r *TieBreakerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if rep.Address == "" {
 			// Incomplete entry: membership's completion edit re-triggers us.
 			return ctrl.Result{}, nil
+		}
+	}
+	for _, f := range vol.Finalizers {
+		node, ok := strings.CutPrefix(f, constants.FinalizerPrefix)
+		if !ok {
+			continue
+		}
+		if !slices.ContainsFunc(vol.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
+			return rep.Node == node
+		}) {
+			// A removed replica's teardown is still in flight: its agent
+			// holds the finalizer until the leg is safely gone. Picking
+			// that node now would cancel the teardown, leaking its backing
+			// device and stale DRBD metadata that a later diskful re-add
+			// would adopt. Releasing the finalizer does not bump the
+			// generation, so poll instead of waiting on a watch event.
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 	}
 	tb := r.Nodes.TieBreakerNode(vol.Spec.Replicas)

--- a/internal/membership/tiebreaker_test.go
+++ b/internal/membership/tiebreaker_test.go
@@ -113,6 +113,37 @@ func TestTieBreakerRetrofitsAndMembershipCompletes(t *testing.T) {
 	}
 }
 
+// A removed replica's node must not be picked as the tie-breaker while
+// its teardown finalizer is still held — re-adding it would cancel the
+// teardown, leaking the backing device and stale DRBD metadata that a
+// later diskful re-add would adopt (partial resync missing writes).
+func TestTieBreakerWaitsForInFlightRemoval(t *testing.T) {
+	vol := freezeVol()
+	// oslo was just removed from spec.replicas; its agent still holds the
+	// teardown finalizer while it waits for the remaining legs to be safe.
+	vol.Finalizers = append(vol.Finalizers, constants.FinalizerPrefix+nodeOslo)
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(vol, node(nodeOslo, addrOslo)).Build()
+	tb := &TieBreakerReconciler{Client: c, Nodes: nodemap.Map{
+		nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},
+		nodeParis:   {Backend: miroirv1alpha1.BackendZFS},
+		nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin},
+	}}
+
+	res, err := tb.Reconcile(context.Background(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volTB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatal("must requeue: the finalizer release does not bump the generation")
+	}
+	got := get(t, &Reconciler{Client: c}, volTB)
+	if len(got.Spec.Replicas) != 2 {
+		t.Fatalf("no tie-breaker may be added mid-removal: %+v", got.Spec.Replicas)
+	}
+}
+
 func TestTieBreakerSkips(t *testing.T) {
 	spare := nodemap.Map{
 		nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},


### PR DESCRIPTION
PR B of the review cycle — the race in #81's retrofit reconciler.

## The race

Removing a replica from a 3-node freeze volume leaves the volume at exactly the retrofit shape (2 complete diskful replicas), and the removed node is by definition "spare" — so `TieBreakerReconciler` re-adds **the node being removed** as the diskless tie-breaker, usually within milliseconds of the spec edit. Meanwhile that node's agent is parked in `reconcileRemoval` behind the health/snapshot gate (30s requeues, arbitrarily long).

Once membership completes the tie-breaker entry, the agent sees itself back in `spec.replicas` and abandons the removal path entirely:

- the backing device (LV/zvol/loopfile) is never torn down — permanent leak;
- the `.md-created` marker survives, so if the node is later re-added **diskful**, `drbd.Apply` skips `ensureMetadata` and attaches the pre-removal DRBD metadata — peers stopped tracking its bitmap slot after the removal, so a GI-based partial resync silently misses writes.

## The fix

Before picking a tie-breaker, treat any held teardown finalizer whose node is no longer in `spec.replicas` as "removal in flight" and requeue (30s): releasing a finalizer doesn't bump `metadata.generation`, so the generation-filtered watch would never re-fire — polling is the only wake-up. Once the removal completes the node is a legitimate candidate again (its state was fully torn down, and a diskless tie-breaker creates no metadata).

CreateVolume's auto-add path is unaffected — a fresh volume has no finalizers for departed nodes.

## Tests

`TestTieBreakerWaitsForInFlightRemoval`: oslo removed from spec but still holding its finalizer, oslo is the only spare → no entry added, non-zero requeue. Full suite green in `golang:1.26.5`; golangci-lint v2.12.2 clean.

```
gh pr merge 86 --squash --repo home-operations/miroir
```