### PR TITLE
fix: pin spec.drbd presence with a CEL transition rule

### DIFF
--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -127,6 +127,7 @@ func (s MiroirVolumeSpec) FirstDiskfulReplica() *Replica {
 // +kubebuilder:validation:XValidation:rule="!has(self.drbd) ? !self.replicas.exists(r, has(r.diskless) && r.diskless) : true",message="diskless replicas are only valid on replicated volumes"
 // +kubebuilder:validation:XValidation:rule="size(self.replicas) > 0 ? !has(self.replicas[0].diskless) || !self.replicas[0].diskless : true",message="the first replica must be diskful (not a diskless tie-breaker)"
 // +kubebuilder:validation:XValidation:rule="self.replicas.all(r, oldSelf.replicas.all(o, o.node != r.node || (has(o.diskless) && o.diskless) == (has(r.diskless) && r.diskless)))",message="a replica's diskless flag is immutable; remove the replica and re-add it instead"
+// +kubebuilder:validation:XValidation:rule="has(self.drbd) == has(oldSelf.drbd)",message="a volume cannot gain or lose its replication layer in place"
 type MiroirVolumeSpec struct {
 	// SizeBytes is the provisioned (virtual, thin) size of the volume.
 	// +kubebuilder:validation:Minimum=1

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -183,6 +183,8 @@ spec:
                 and re-add it instead
               rule: self.replicas.all(r, oldSelf.replicas.all(o, o.node != r.node
                 || (has(o.diskless) && o.diskless) == (has(r.diskless) && r.diskless)))
+            - message: a volume cannot gain or lose its replication layer in place
+              rule: has(self.drbd) == has(oldSelf.drbd)
           status:
             description: MiroirVolumeStatus is the observed state aggregated from
               node agents.

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -183,6 +183,8 @@ spec:
                 and re-add it instead
               rule: self.replicas.all(r, oldSelf.replicas.all(o, o.node != r.node
                 || (has(o.diskless) && o.diskless) == (has(r.diskless) && r.diskless)))
+            - message: a volume cannot gain or lose its replication layer in place
+              rule: has(self.drbd) == has(oldSelf.drbd)
           status:
             description: MiroirVolumeStatus is the observed state aggregated from
               node agents.


### PR DESCRIPTION
PR C of the review cycle.

## The gap

The spec doc-comment — and a membership-reconciler comment ("the CRD validation rule already blocks such edits") — promise that an unreplicated volume cannot grow a replication layer in place. No rule enforced it: a single `kubectl edit` adding `spec.drbd` **and** a second replica satisfies every existing check (`has(self.drbd) ? 2-3 replicas : exactly 1` is a per-state rule, not a transition rule).

The consequence of that edit is data loss: the agent finds no `.md-created` marker and no on-disk metadata, runs `drbdadm create-md --force` on a device fully occupied by a live filesystem, and DRBD's internal metadata overwrites the device tail while shrinking the usable size below the filesystem's. The reverse edit (dropping `drbd` + shrinking to 1 replica) was equally unguarded.

## The fix

One transition rule: `has(self.drbd) == has(oldSelf.drbd)`. `oldSelf` rules run only on UPDATE, so CreateVolume is unaffected; every legitimate flow (membership add/remove, tie-breaker retrofit, expand) leaves `drbd` presence untouched. O(1) CEL cost — no budget concern. CRDs regenerated (`config/crd/bases` + `charts/miroir/crds`); the previously-aspirational comments are now true.

E2E applies the regenerated CRD, which validates schema acceptance.

```
gh pr merge 87 --squash --repo home-operations/miroir
```