### PR TITLE
fix: guard the day0 re-seed after a node wipe; default on-io-error detach

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -45,6 +45,7 @@ Kubernetes: `>=1.31.0`
 | controller.resources.limits.memory | string | `"128Mi"` |  |
 | controller.resources.requests.cpu | string | `"10m"` |  |
 | controller.resources.requests.memory | string | `"32Mi"` |  |
+| drbd.onIoError | string | `"detach"` |  |
 | drbd.resync.fillTarget | string | `""` | c-fill-target, the resync controller's target fill level (e.g. "1M"). |
 | drbd.resync.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864"). |
 | drbd.resync.maxRate | string | `""` | c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. "720M"). |

--- a/charts/miroir/templates/configmap.tpl
+++ b/charts/miroir/templates/configmap.tpl
@@ -33,6 +33,9 @@ data:
         startup {}
         options {}
         disk {
+        {{- with .Values.drbd.onIoError }}
+            on-io-error {{ . }};
+        {{- end }}
         {{- with .Values.drbd.resync }}
         {{- if .planAhead }}
             c-plan-ahead {{ .planAhead }};

--- a/charts/miroir/tests/configmap_test.yaml
+++ b/charts/miroir/tests/configmap_test.yaml
@@ -94,6 +94,11 @@ tests:
       - notMatchRegex:
           path: data["global_common.conf"]
           pattern: "c-max-rate"
+      # on-io-error detach is the default: a dying disk degrades the leg
+      # to Diskless instead of surfacing EIO into the pod.
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "on-io-error detach;"
 
   - it: renders cluster-wide resync tuning into common{} when set
     set:
@@ -102,6 +107,7 @@ tests:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       drbd:
+        onIoError: pass_on
         resync:
           planAhead: "20"
           maxRate: 720M
@@ -121,6 +127,9 @@ tests:
       - matchRegex:
           path: data["global_common.conf"]
           pattern: "max-buffers 36864;"
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "on-io-error pass_on;"
 
   - it: honours a non-default Release namespace for both ConfigMaps
     release:

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -113,6 +113,12 @@
     "drbd": {
       "description": "DRBD replication tuning applied cluster-wide through the common{} section of\nglobal_common.conf; every resource inherits it. Leave a value empty to use\nDRBD's built-in default. Tune to your replication network — see the LINBIT\n\"Tuning the DRBD Resync Controller\" guide.",
       "properties": {
+        "onIoError": {
+          "default": "detach",
+          "description": "How a diskful replica reacts to a backing-device I/O error. detach\n(the LINSTOR/DRBD-recommended default) drops the failing leg to\nDiskless and serves reads/writes via the peer instead of surfacing\nEIO into the pod. Set to pass_on to propagate errors instead.",
+          "title": "onIoError",
+          "type": "string"
+        },
         "resync": {
           "properties": {
             "fillTarget": {

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -94,6 +94,11 @@ agent:
 # DRBD's built-in default. Tune to your replication network — see the LINBIT
 # "Tuning the DRBD Resync Controller" guide.
 drbd:
+  # How a diskful replica reacts to a backing-device I/O error. detach
+  # (the LINSTOR/DRBD-recommended default) drops the failing leg to
+  # Diskless and serves reads/writes via the peer instead of surfacing
+  # EIO into the pod. Set to pass_on to propagate errors instead.
+  onIoError: detach
   resync:
     # -- c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller.
     planAhead: ""

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -113,11 +113,12 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	var dev string
+	var forceFullSync bool
 	var err error
 	if !localDiskless {
 		// Realize: create (or grow) the backing device — a CoW clone when the
 		// volume restores from a snapshot.
-		dev, err = r.realizeBacking(ctx, vol)
+		dev, forceFullSync, err = r.realizeBacking(ctx, vol)
 		if err != nil {
 			return ctrl.Result{}, r.reportError(ctx, vol, err)
 		}
@@ -162,7 +163,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
-	if err := r.DRBD.Apply(ctx, drbdResource(vol, r.NodeName, dev, minor, localDiskless)); err != nil {
+	if err := r.DRBD.Apply(ctx, drbdResource(vol, r.NodeName, dev, minor, localDiskless, forceFullSync)); err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
 	// Online growth: once every peer's backing device is at the new size
@@ -265,40 +266,68 @@ func peerBackingsGrown(vol *miroirv1alpha1.MiroirVolume, self string) bool {
 	return true
 }
 
+// wipedBacking reports the node-wipe signature: this node's status slot
+// says the backing was realized, but the device is gone and so is the
+// local seed marker (a reinstall takes both). Re-seeding the day0 GI
+// would pose the empty recreated device as the peers' identical twin and
+// the partial resync would miss every write since creation — the caller
+// forces the just-created-metadata path so the first handshake
+// full-syncs this leg instead. Cheap steady-state: the marker check
+// short-circuits once Apply has seeded.
+func (r *VolumeReconciler) wipedBacking(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) (bool, error) {
+	if vol.Spec.DRBD == nil || r.DRBD.Seeded(vol.Name) ||
+		!vol.Status.PerNode[r.NodeName].DeviceCreated {
+		return false, nil
+	}
+	exists, err := r.Backend.Exists(ctx, vol.Name)
+	if err != nil {
+		return false, err
+	}
+	return !exists, nil
+}
+
 // realizeBacking creates the backing device: fresh, or cloned from a
 // snapshot for restores. Clones are byte-identical on every replica, so
-// the day0 GI seed keeps restored volumes from resyncing.
-func (r *VolumeReconciler) realizeBacking(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) (string, error) {
+// the day0 GI seed keeps restored volumes from resyncing. forceFullSync
+// reports the node-wipe signature (wipedBacking): the recreated device
+// must join as a full SyncTarget, never re-seed the day0 GI.
+func (r *VolumeReconciler) realizeBacking(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) (dev string, forceFullSync bool, err error) {
+	if forceFullSync, err = r.wipedBacking(ctx, vol); err != nil {
+		return "", false, err
+	}
 	if vol.Spec.Source == nil {
-		return r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
+		dev, err = r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
+		return dev, forceFullSync, err
 	}
 	// The backing is cloned once and survives reboots; the source snapshot
 	// may be gone by then, so recover an existing device without it.
 	if exists, err := r.Backend.Exists(ctx, vol.Name); err != nil {
-		return "", err
+		return "", false, err
 	} else if exists {
-		return r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
+		dev, err = r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
+		return dev, forceFullSync, err
 	}
 	snap := &miroirv1alpha1.MiroirSnapshot{}
 	if err := r.Get(ctx, types.NamespacedName{Name: vol.Spec.Source.SnapshotName}, snap); err != nil {
-		return "", err
+		return "", false, err
 	}
-	return r.Backend.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name)
+	dev, err = r.Backend.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name)
+	return dev, forceFullSync, err
 }
 
 // drbdResource maps the CRD desired state to a render input. Entries the
 // membership reconciler has not completed yet (no address) are left out:
 // rendering them would produce a config DRBD cannot parse, and the peer
 // cannot connect before completion anyway.
-func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string, minor int32, localDiskless bool) drbd.Resource {
+func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string, minor int32, localDiskless, forceFullSync bool) drbd.Resource {
 	peers := make([]drbd.Peer, 0, len(vol.Spec.Replicas))
-	skipSeed := false
+	skipSeed := forceFullSync
 	for _, rep := range vol.Spec.Replicas {
 		if rep.Address == "" {
 			continue
 		}
-		if rep.Node == localNode {
-			skipSeed = rep.FullSync
+		if rep.Node == localNode && rep.FullSync {
+			skipSeed = true
 		}
 		peers = append(peers, drbd.Peer{
 			Node:     rep.Node,

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -734,6 +734,46 @@ func TestReconcileTeardownDeletesDespiteDetachedDiskState(t *testing.T) {
 
 // A diskless tie-breaker joins DRBD for quorum only: no backend device,
 // no metadata seed, DeviceCreated stays false so CSI never stages here.
+// A backing device that vanished after this node had realized it (the
+// status slot still says DeviceCreated) is the node-wipe signature: the
+// recreated device must full-sync, never re-seed the day0 GI and pose as
+// the peers' identical twin.
+func TestReconcileWipedNodeForcesFullSync(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = "192.168.1.42"
+	// The pre-wipe agent had realized the backing and said so in status.
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DevicePath: "/dev/mapper/x"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	// The kernel probe fails (fresh boot, resource never configured);
+	// the post-Apply --json status still answers.
+	fe := &fakeDRBDExec{
+		statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"Inconsistent"}],"connections":[]}]`,
+		errOn: map[string]error{"drbdsetup status " + volPvc1: errors.New("no such resource")},
+	}
+	fb := newFakeBackend() // Exists() == false: the wipe took the device
+	r := &VolumeReconciler{
+		Client:   c,
+		NodeName: nodeKharkiv,
+		Backend:  fb,
+		DRBD:     &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+	reconcile(t, r, volPvc1)
+
+	fe.calledWith(t, "create-md")
+	fe.notCalledWith(t, "set-gi") // just-created metadata → full SyncTarget
+}
+
 func TestReconcileDisklessTieBreaker(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -47,6 +47,15 @@ type Driver struct {
 	Mknod func(path string, mode uint32, dev int) error
 }
 
+// Seeded reports whether Apply has completed the create-md + GI phase for
+// the resource on this node (the .md-created marker). Absent marker with
+// a previously realized volume is the node-wipe signature the agent keys
+// its re-seed guard on.
+func (d *Driver) Seeded(name string) bool {
+	_, err := os.Stat(d.path(name + ".md-created"))
+	return err == nil
+}
+
 // Apply converges the kernel state for one resource: write config when it
 // changed, create and GI-seed metadata once (see seedGI for how fresh
 // volumes skip the initial sync), bring the resource up / adjust.


### PR DESCRIPTION
PR D of the review cycle — the two alignment red flags where miroir contradicted both blockstor and LINSTOR.

## 1. Node-wipe re-seed guard (data-integrity)

The skip-initial-sync authority was entirely node-local: hostPath seed markers + on-disk GI probing. A full node wipe (Talos reinstall — the canonical homelab rebuild) destroys the backing device **and** the markers together. On rejoin, a creation-time replica recreates a fresh backing, finds no metadata, and re-seeds the day0 GI — posing the empty device as the identical twin of a volume with months of writes. DRBD then does a bitmap-based partial resync (or none), silently missing everything since creation. blockstor persists this decision cluster-side (`RD.Spec.Initialized` latch) for exactly this failure; the CR outliving the node gives miroir the same signal for free.

**Fix:** `realizeBacking` now reports the wipe signature via `wipedBacking` — `status.perNode[self].deviceCreated` true, backing absent, local seed marker (`drbd.Seeded`, the `.md-created` stat) absent — and the render forces the just-created-metadata path (`SkipSeed`), so the first handshake makes the recreated leg a **full SyncTarget**, the only safe outcome. Steady-state cost is one `os.Stat` (the marker short-circuits after Apply seeds); the backend `Exists` exec only runs in the suspect window.

## 2. `on-io-error detach` (availability)

miroir rendered no `on-io-error`, leaving the kernel default `pass_on`: a dying disk surfaces EIO straight into the pod's filesystem despite a healthy peer. LINSTOR's controller default and blockstor's option catalogue are both `detach` — and miroir's own teardown comment already reasons about "a diskful replica reads Diskless after an I/O-error detach", i.e. the code assumed semantics that were never configured.

**Fix:** the global DRBD config now renders `on-io-error` in `common { disk { } }` from a new `drbd.onIoError` chart value, **default `detach`** (a failing leg degrades to Diskless and serves via the peer; the agent already reports the per-node DiskState). `pass_on` remains available as the override.

## Tests

`TestReconcileWipedNodeForcesFullSync` (status says DeviceCreated, device+marker gone → `create-md` runs, `set-gi` never does); chart tests for the `detach` default and the `pass_on` override; README/schema regenerated. Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean (Reconcile's gocyclo kept under the limit by folding the guard into `realizeBacking`).

```
gh pr merge 88 --squash --repo home-operations/miroir
```