### PR TITLE
fix: expand retries wait for realization; restores clean replica entries

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -118,7 +118,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if !localDiskless {
 		// Realize: create (or grow) the backing device — a CoW clone when the
 		// volume restores from a snapshot.
-		dev, forceFullSync, err = r.realizeBacking(ctx, vol)
+		dev, forceFullSync, err = r.realizeBacking(ctx, vol, vol.Spec.Replicas[idx].FullSync)
 		if err != nil {
 			return ctrl.Result{}, r.reportError(ctx, vol, err)
 		}
@@ -291,11 +291,14 @@ func (r *VolumeReconciler) wipedBacking(ctx context.Context, vol *miroirv1alpha1
 // the day0 GI seed keeps restored volumes from resyncing. forceFullSync
 // reports the node-wipe signature (wipedBacking): the recreated device
 // must join as a full SyncTarget, never re-seed the day0 GI.
-func (r *VolumeReconciler) realizeBacking(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) (dev string, forceFullSync bool, err error) {
+func (r *VolumeReconciler) realizeBacking(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, fullSync bool) (dev string, forceFullSync bool, err error) {
 	if forceFullSync, err = r.wipedBacking(ctx, vol); err != nil {
 		return "", false, err
 	}
-	if vol.Spec.Source == nil {
+	if vol.Spec.Source == nil || fullSync {
+		// A FullSync joiner never clones, even on a restored volume: its
+		// node holds no source snapshot, and its content arrives over the
+		// wire as a full SyncTarget regardless of what the backing holds.
 		dev, err = r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
 		return dev, forceFullSync, err
 	}

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -734,6 +735,29 @@ func TestReconcileTeardownDeletesDespiteDetachedDiskState(t *testing.T) {
 
 // A diskless tie-breaker joins DRBD for quorum only: no backend device,
 // no metadata seed, DeviceCreated stays false so CSI never stages here.
+// A FullSync joiner on a restored volume must create a fresh backing,
+// not clone: its node holds no source snapshot (the MiroirSnapshot may
+// be gone entirely), and DRBD full-syncs its content anyway.
+func TestRealizeBackingFullSyncJoinerCreatesFresh(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-gone"}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fb := newFakeBackend()
+	r := &VolumeReconciler{Client: c, NodeName: nodeParis, Backend: fb}
+
+	if _, _, err := r.realizeBacking(context.Background(), v, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(fb.fromSnapVol) != 0 {
+		t.Fatalf("joiner must not clone: %v", fb.fromSnapVol)
+	}
+	if !slices.Contains(fb.createVol, volPvc1) {
+		t.Fatalf("joiner must create a fresh backing: %v", fb.createVol)
+	}
+}
+
 // A backing device that vanished after this node had realized it (the
 // status slot still says DeviceCreated) is the node-wipe signature: the
 // recreated device must full-sync, never re-seed the day0 GI and pose as

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -78,7 +78,6 @@ type Controller struct {
 
 const (
 	defaultProvisionTimeout = 120 * time.Second // matches sidecars.provisioner.timeout
-	defaultExpandTimeout    = 10 * time.Minute  // node reboots during grow
 	// defaultOvercommitRatio caps provisioned-over-capacity per pool
 	// (notes/DESIGN.md §4.6); 2× is the documented default.
 	defaultOvercommitRatio = 2.0
@@ -163,7 +162,10 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				replicas, len(srcVol.Spec.DiskfulReplicas()))
 		}
 		source = &miroirv1alpha1.VolumeSource{SnapshotName: snapID}
-		srcReplicas = srcVol.Spec.Replicas
+		srcReplicas, err = c.restoreReplicas(ctx, srcVol)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Serialise placement, port allocation, and Create as one critical
@@ -662,26 +664,24 @@ func (c *Controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		}
 		return nil, status.Errorf(codes.Internal, "get volume: %v", err)
 	}
-	if newSize <= vol.Spec.SizeBytes {
-		// Already at or above the requested size; never shrink, and never
-		// advertise less capacity than exists.
-		return &csi.ControllerExpandVolumeResponse{
-			CapacityBytes:         vol.Spec.SizeBytes,
-			NodeExpansionRequired: nodeExpansion,
-		}, nil
+	if newSize > vol.Spec.SizeBytes {
+		base := vol.DeepCopy()
+		vol.Spec.SizeBytes = newSize
+		if err := c.Client.Patch(ctx, vol, client.MergeFrom(base)); err != nil {
+			return nil, status.Errorf(codes.Internal, "grow volume: %v", err)
+		}
 	}
-	base := vol.DeepCopy()
-	vol.Spec.SizeBytes = newSize
-	if err := c.Client.Patch(ctx, vol, client.MergeFrom(base)); err != nil {
-		return nil, status.Errorf(codes.Internal, "grow volume: %v", err)
-	}
+	// Never shrink, and never advertise less capacity than the spec holds.
+	respBytes := max(newSize, vol.Spec.SizeBytes)
 
-	// Wait for all replicas to realize the size. Use a longer timeout than
-	// provisioning: a boot-time resize blocks until the node comes back up.
-	timeout := c.ProvisionTimeout
-	if timeout == 0 {
-		timeout = defaultExpandTimeout
-	}
+	// Wait for every diskful replica to realize at least this RPC's size —
+	// including idempotent retries whose earlier attempt already patched
+	// the spec but timed out. Returning success before the device grew
+	// would let kubelet run the node expansion against the old size: the
+	// filesystem resize no-ops, the PVC is recorded expanded, and nothing
+	// ever retriggers the grow. The csi-resizer retries this RPC, so a
+	// slow grow (node rebooting) just re-waits each attempt.
+	timeout := cmp.Or(c.ProvisionTimeout, defaultProvisionTimeout)
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	err := wait.PollUntilContextCancel(waitCtx, 500*time.Millisecond, true,
@@ -704,7 +704,7 @@ func (c *Controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		return nil, status.Errorf(codes.DeadlineExceeded, "volume %s not grown yet: %v", req.GetVolumeId(), err)
 	}
 	return &csi.ControllerExpandVolumeResponse{
-		CapacityBytes:         newSize,
+		CapacityBytes:         respBytes,
 		NodeExpansionRequired: nodeExpansion,
 	}, nil
 }
@@ -854,6 +854,27 @@ func csiSnapshot(snap *miroirv1alpha1.MiroirSnapshot, sizeBytes int64) *csi.Snap
 		CreationTime:   timestamppb.New(snap.CreationTimestamp.Time),
 		ReadyToUse:     snap.Status.ReadyToUse,
 	}
+}
+
+// restoreReplicas copies the source volume's replica layout for a clone,
+// cleaned: FullSync is stripped — every leg clones its byte-identical
+// local snapshot, so a carried flag would full-resync one for nothing —
+// and replication addresses are re-resolved from the live Node objects
+// (the source's were captured at its creation and can be stale).
+func (c *Controller) restoreReplicas(ctx context.Context, srcVol *miroirv1alpha1.MiroirVolume) ([]miroirv1alpha1.Replica, error) {
+	reps := slices.Clone(srcVol.Spec.Replicas)
+	for i := range reps {
+		reps[i].FullSync = false
+		if reps[i].Address == "" {
+			continue
+		}
+		addr, err := c.nodeInternalIP(ctx, reps[i].Node)
+		if err != nil {
+			return nil, err
+		}
+		reps[i].Address = addr
+	}
+	return reps, nil
 }
 
 // snapshotSource resolves a ready snapshot and its source volume.

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -446,6 +446,153 @@ func TestCreateVolumeAutoTieBreakerNoSpareNode(t *testing.T) {
 	}
 }
 
+// A retried expand whose earlier attempt already patched the spec but
+// timed out must keep waiting on realized sizes — returning success
+// early lets kubelet no-op the filesystem grow against the old device
+// size and record the PVC expanded while the fs stays small.
+func TestControllerExpandRetryWaitsForRealization(t *testing.T) {
+	s := newScheme(t)
+	v := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 10 << 30, // a prior attempt already grew the spec
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin},
+				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS},
+			},
+		},
+		Status: miroirv1alpha1.MiroirVolumeStatus{
+			PerNode: map[string]miroirv1alpha1.ReplicaStatus{
+				nodeKharkiv: {SizeBytes: 5 << 30},
+				nodeParis:   {SizeBytes: 5 << 30},
+			},
+		},
+	}
+	c := &Controller{
+		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+			WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build(),
+		ProvisionTimeout: time.Second,
+	}
+
+	_, err := c.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		VolumeId:      volPvc1,
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 10 << 30},
+	})
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("retry must wait for realization, got %v", err)
+	}
+}
+
+func TestControllerExpandSucceedsOnceRealized(t *testing.T) {
+	s := newScheme(t)
+	v := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 10 << 30,
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin},
+			},
+		},
+		Status: miroirv1alpha1.MiroirVolumeStatus{
+			PerNode: map[string]miroirv1alpha1.ReplicaStatus{
+				nodeKharkiv: {SizeBytes: 10 << 30},
+			},
+		},
+	}
+	c := &Controller{
+		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+			WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build(),
+		ProvisionTimeout: time.Second,
+	}
+
+	// The idempotent retry (spec already at size, devices realized).
+	resp, err := c.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		VolumeId:      volPvc1,
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 10 << 30},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.CapacityBytes != 10<<30 {
+		t.Fatalf("capacity = %d", resp.CapacityBytes)
+	}
+
+	// A stale smaller request must never shrink and reports the spec size.
+	resp, err = c.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		VolumeId:      volPvc1,
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 5 << 30},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.CapacityBytes != 10<<30 {
+		t.Fatalf("stale request must report the larger spec size, got %d", resp.CapacityBytes)
+	}
+}
+
+// Restore copies the source's replica layout but must clean the entries:
+// FullSync stripped (clones are byte-identical on every leg) and the
+// replication addresses re-resolved from the live Node objects.
+func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
+	s := newScheme(t)
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "10.0.0.1"},
+				// paris joined after creation: FullSync stuck in the spec.
+				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "10.0.0.2", FullSync: true},
+			},
+		},
+	}
+	srcSnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Status:     miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
+	}
+	cl := readyOnGet(s)
+	for _, obj := range []client.Object{srcVol, srcSnap,
+		nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)} {
+		if err := cl.Create(context.Background(), obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := cl.Status().Update(context.Background(), srcSnap); err != nil {
+		t.Fatal(err)
+	}
+	c := &Controller{Client: cl, Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	if _, err := c.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name:               volNew,
+		VolumeCapabilities: volCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapSnap1},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	for _, rep := range got.Spec.Replicas {
+		if rep.FullSync {
+			t.Fatalf("clone must not inherit FullSync: %+v", rep)
+		}
+	}
+	if got.Spec.Replicas[0].Address != addrKharkiv || got.Spec.Replicas[1].Address != addrParis {
+		t.Fatalf("addresses must be re-resolved: %+v", got.Spec.Replicas)
+	}
+}
+
 func TestPickNodeNoStorageNodes(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).Build(), Nodes: nodemap.Map{}}


### PR DESCRIPTION
PR E of the review cycle — three confirmed correctness bugs around expand and restore.

## 1. Expand-retry short-circuit → filesystem wedged at the old size

`ControllerExpandVolume` returned success immediately when `newSize <= spec.sizeBytes`. On the realistic path — expand while a replica node reboots: attempt 1 patches the spec, times out waiting; csi-resizer retries; attempt 2 hits the short-circuit and reports success with the DRBD device still small. Kubelet then runs `NodeExpandVolume`, whose `resize2fs` grows the fs *to the current device size* (a no-op) and reports the requested capacity — the PVC is recorded expanded while the filesystem stays at the old size, and nothing ever retriggers the grow.

**Fix:** the spec patch is skipped when already at size, but **every** attempt waits for all diskful `status.perNode` sizes to reach the requested size. A genuinely realized volume passes the first poll; a stale smaller retry never shrinks and reports the spec size. The unreachable `defaultExpandTimeout` (10 min — the chart always sets `--provision-timeout`) and its misleading "longer timeout" comment are deleted; the resizer's retry loop is the actual long-wait mechanism.

## 2. Restores inherited `FullSync` and stale addresses

`FullSync` is set by the membership reconciler and never cleared, so a source volume that ever had a replica added carries it forever — and restore copied `spec.replicas` verbatim. The clone's leg then renders `SkipSeed` and full-resyncs data that is byte-identical by construction (every leg clones its own snapshot), sitting Degraded for the whole sync. Addresses were also creation-time copies. New `restoreReplicas` helper strips `FullSync` and re-resolves every address from the live Node objects (a gone node now fails the restore RPC with a clear error instead of producing a volume that can never realize).

## 3. `realizeBacking` ignored `FullSync` (found independently by two reviewers)

Adding a replica to a **restored** volume made the new node try `CreateFromSnapshot` for a snapshot it never held (or a 404 on a deleted MiroirSnapshot) — `computePhase` then flipped the healthy, serving volume to hard `Failed`. A `FullSync` joiner now creates a fresh backing: its content arrives over the wire as a full SyncTarget regardless.

## Tests

Expand: retry-waits (DeadlineExceeded while `PerNode` lags), realized-retry success, stale-smaller-request no-shrink. Restore: `FullSync` stripped + addresses re-resolved. Agent: `FullSync` joiner creates fresh, never clones. Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean.

```
gh pr merge 89 --squash --repo home-operations/miroir
```