### PR TITLE
fix: drbd and backend robustness batch

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -237,6 +237,7 @@ func TestZFSDeleteSnapshotDefersForClones(t *testing.T) {
 	// A restore clone pins its origin snapshot: -d lets ZFS remove it
 	// with the last clone instead of wedging the delete in retries.
 	fe := &fakeExec{}
+	fe.respond("zfs list -Hpo name -t snapshot", "tank/miroir/pvc-1@snap-1\n", nil)
 	b := newZFS(cfg, fe.run)
 
 	if err := b.DeleteSnapshot(context.Background(), "pvc-1", "snap-1"); err != nil {
@@ -294,6 +295,7 @@ func TestZFSDeleteSnapshotSurfacesPermanentError(t *testing.T) {
 	// would silently retry it forever. The message contains "snapshot",
 	// which the old substring matcher wrongly treated as busy.
 	fe := &fakeExec{}
+	fe.respond("zfs list -Hpo name -t snapshot", "tank/miroir/pvc-1@snap-1\n", nil)
 	fe.respond("zfs destroy -d tank/miroir/pvc-1@snap-1", "",
 		errors.New("cannot destroy snapshot tank/miroir/pvc-1@snap-1: permission denied"))
 	b := newZFS(cfg, fe.run)
@@ -427,4 +429,64 @@ func TestNewSelectsBackend(t *testing.T) {
 	if _, err := New("bogus", cfg, fe.run); err == nil {
 		t.Fatal("expected error for unknown backend")
 	}
+}
+
+// PVC sizes are not necessarily 4KiB-multiples (1G = 10^9); OpenZFS
+// rejects a volsize that is not a multiple of volblocksize.
+func TestZFSAlignsVolsize(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("zfs list -H tank/miroir/pvc-1", "", errors.New("dataset does not exist"))
+	fe.respond("zfs get -Hpo value volsize", "1000001536\n", nil)
+	b := newZFS(cfg, fe.run)
+
+	if _, err := b.Create(context.Background(), "pvc-1", 1_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "-V 1000001536") // 10^9 rounded up to the 4096 boundary
+
+	if err := b.Resize(context.Background(), "pvc-1", 2_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "volsize=2000003072")
+}
+
+// Deleting a volume with restore clones promotes them, and zfs promote
+// reparents older snapshots onto the clone. DeleteSnapshot must find the
+// migrated copy by its cluster-unique @name — a false success here leaks
+// the snapshot onto the clone and blocks the clone's destroy forever.
+func TestZFSDeleteSnapshotFindsMigratedSnapshot(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("zfs list -Hpo name -t snapshot -r tank/miroir",
+		"tank/miroir/pvc-clone@snap-1\n", nil)
+	b := newZFS(cfg, fe.run)
+
+	if err := b.DeleteSnapshot(context.Background(), "pvc-src", "snap-1"); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "zfs destroy -d tank/miroir/pvc-clone@snap-1")
+}
+
+func TestZFSDeleteSnapshotAbsentIsNoop(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("zfs list -Hpo name -t snapshot -r tank/miroir",
+		"tank/miroir/other@unrelated\n", nil)
+	b := newZFS(cfg, fe.run)
+
+	if err := b.DeleteSnapshot(context.Background(), "pvc-src", "snap-1"); err != nil {
+		t.Fatal(err)
+	}
+	fe.notCalledWith(t, "destroy")
+}
+
+// A transient vgs failure must surface, not fall into the bootstrap
+// branch and confusingly fail pvcreate against an in-use device.
+func TestLVMThinSetupSurfacesTransientVGSError(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("vgs vg-miroir", "", errors.New("global/lvmetad lock contention"))
+	b := newLVMThin(Config{VolumeGroup: volumeGroup, ThinPool: thinPoolName, Device: "/dev/sdz"}, fe.run)
+
+	if err := b.Setup(context.Background()); err == nil {
+		t.Fatal("transient vgs error must fail Setup")
+	}
+	fe.notCalledWith(t, "pvcreate")
 }

--- a/internal/backend/exec.go
+++ b/internal/backend/exec.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Exec runs a CLI command and returns its combined output. Injectable so
@@ -32,6 +33,10 @@ type Exec func(ctx context.Context, name string, args ...string) (string, error)
 // host namespaces, so lvm/zfs act on the node's devices directly.
 func RealExec(ctx context.Context, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	// A child stuck in D-state (wedged pool, frozen dm device) ignores the
+	// SIGKILL from ctx cancellation and would pin CombinedOutput on its
+	// open pipes forever; WaitDelay forces Wait to give up on them.
+	cmd.WaitDelay = 10 * time.Second
 	// Force the C locale: the delete/exists classifiers match lvm/zfs error
 	// text ("in use", "Failed to find", …), which the tools localise.
 	cmd.Env = append(os.Environ(), "LC_ALL=C")

--- a/internal/backend/loopfile.go
+++ b/internal/backend/loopfile.go
@@ -73,6 +73,26 @@ func (lf *loopfile) Setup(ctx context.Context) error {
 			return fmt.Errorf("mkdir %s: %w", d, err)
 		}
 	}
+	// Loop numbers are kernel-assigned per boot, but the volume symlinks
+	// live on the persistent base filesystem: after a reboot a stale link
+	// can point at a device losetup has since handed to a DIFFERENT
+	// volume, and a pod staged before this volume's reconcile re-attaches
+	// would mount the wrong data. Prune every link that does not match
+	// its backing file's current attachment; reconciles re-point them.
+	if entries, err := os.ReadDir(lf.devDir()); err == nil {
+		for _, e := range entries {
+			link := filepath.Join(lf.devDir(), e.Name())
+			target, err := os.Readlink(link)
+			if err != nil {
+				continue
+			}
+			actual, err := lf.loopDev(ctx, lf.imgPath(e.Name()))
+			if err != nil || actual != target {
+				_ = os.Remove(link)
+			}
+		}
+	}
+
 	src := filepath.Join(lf.baseDir, ".reflink-probe")
 	dst := src + ".clone"
 	if _, err := lf.exec(ctx, "truncate", "-s", "4096", src); err != nil {

--- a/internal/backend/loopfile_test.go
+++ b/internal/backend/loopfile_test.go
@@ -19,6 +19,8 @@ package backend
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -214,5 +216,41 @@ func TestNewSelectsLoopfile(t *testing.T) {
 	fe := &fakeExec{}
 	if _, err := New("loopfile", lcfg, fe.run); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// After a reboot the persistent symlinks can point at loop devices the
+// kernel has since handed to other volumes; Setup prunes the mismatches
+// so a stale link can never stage another volume's data.
+func TestLoopfileSetupPrunesStaleSymlinks(t *testing.T) {
+	base := t.TempDir()
+	fe := &fakeExec{}
+	// pvc-stale's image is attached nowhere; pvc-live's matches its link.
+	fe.respond("losetup -j "+filepath.Join(base, "volumes", "pvc-stale.img"), "", nil)
+	fe.respond("losetup -j "+filepath.Join(base, "volumes", "pvc-live.img"),
+		"/dev/loop3\n", nil)
+	b := newLoopfile(Config{BaseDir: base}, fe.run)
+
+	devDir := filepath.Join(base, "dev")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, target := range map[string]string{
+		"pvc-stale": "/dev/loop0",
+		"pvc-live":  "/dev/loop3",
+	} {
+		if err := os.Symlink(target, filepath.Join(devDir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := b.Setup(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(devDir, "pvc-stale")); !os.IsNotExist(err) {
+		t.Fatal("stale symlink must be pruned")
+	}
+	if _, err := os.Lstat(filepath.Join(devDir, "pvc-live")); err != nil {
+		t.Fatal("matching symlink must survive")
 	}
 }

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -54,6 +54,11 @@ func (l *lvmThin) Setup(ctx context.Context) error {
 		if ok {
 			return nil
 		}
+	} else if !strings.Contains(err.Error(), "not found") {
+		// Transient lvm failure (lock contention, device scan): surface it
+		// rather than falling into the bootstrap branch and confusingly
+		// failing pvcreate against an in-use device.
+		return fmt.Errorf("vgs %s: %w", l.vg, err)
 	} else if l.device == "" {
 		return fmt.Errorf("VG %s absent and no --lvm-device configured to create it", l.vg)
 	} else {

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -77,6 +77,18 @@ func (z *zfsBackend) Exists(ctx context.Context, vol string) (bool, error) {
 	return z.exists(ctx, z.name(vol))
 }
 
+// zvolBlockSize is the volblocksize passed to zfs create (-b); volsize
+// must be a multiple of it or OpenZFS rejects the create/set with EINVAL.
+const zvolBlockSize = 4096
+
+// alignSize rounds sizeBytes up to the zvol block size: PVC sizes are not
+// necessarily 4KiB-multiples (1G = 10^9), and the other backends already
+// realize >= the requested size, so rounding up is harmless — DRBD sizes
+// the device to the smallest leg.
+func alignSize(sizeBytes int64) int64 {
+	return (sizeBytes + zvolBlockSize - 1) &^ (zvolBlockSize - 1)
+}
+
 func (z *zfsBackend) Create(ctx context.Context, vol string, sizeBytes int64) (string, error) {
 	ok, err := z.exists(ctx, z.name(vol))
 	if err != nil {
@@ -85,11 +97,11 @@ func (z *zfsBackend) Create(ctx context.Context, vol string, sizeBytes int64) (s
 	if !ok {
 		_, err = z.exec(ctx, "zfs", "create",
 			"-s", // sparse: thin semantics, matching the lvm-thin leg
-			"-b", "4096",
+			"-b", strconv.Itoa(zvolBlockSize),
 			// lz4 early-aborts on incompressible data (≈free) and cuts
 			// physical I/O; a near-universal default for zvols.
 			"-o", "compression=lz4",
-			"-V", strconv.FormatInt(sizeBytes, 10),
+			"-V", strconv.FormatInt(alignSize(sizeBytes), 10),
 			z.name(vol))
 		if err != nil {
 			return "", fmt.Errorf("zfs create %s: %w", vol, err)
@@ -107,7 +119,7 @@ func (z *zfsBackend) Resize(ctx context.Context, vol string, sizeBytes int64) er
 		return nil // already big enough (idempotent retry)
 	}
 	if _, err := z.exec(ctx, "zfs", "set",
-		fmt.Sprintf("volsize=%d", sizeBytes), z.name(vol)); err != nil {
+		fmt.Sprintf("volsize=%d", alignSize(sizeBytes)), z.name(vol)); err != nil {
 		return fmt.Errorf("zfs set volsize %s to %d: %w", vol, sizeBytes, err)
 	}
 	return nil
@@ -196,14 +208,28 @@ func (z *zfsBackend) promoteClones(ctx context.Context, vol string) error {
 }
 
 func (z *zfsBackend) DeleteSnapshot(ctx context.Context, vol, snap string) error {
-	ok, err := z.exists(ctx, z.name(vol)+"@"+snap)
-	if err != nil || !ok {
+	// The snapshot may have migrated: deleting a volume with restore
+	// clones promotes them, and zfs promote reparents every snapshot
+	// at-or-older than the clone's origin onto the clone. Snapshot names
+	// are CR names — cluster-unique — so match by @suffix anywhere under
+	// the parent dataset; without this, a migrated snapshot's deletion
+	// false-succeeds and the leftover blocks its clone's destroy forever.
+	out, err := z.exec(ctx, "zfs", "list", "-Hpo", "name", "-t", "snapshot", "-r", z.dataset)
+	if err != nil {
 		return err
 	}
-	// -d defers destruction while restore clones still reference the
-	// snapshot (ZFS removes it with the last clone); immediate otherwise.
-	_, err = z.exec(ctx, "zfs", "destroy", "-d", z.name(vol)+"@"+snap)
-	return err
+	for line := range strings.SplitSeq(out, "\n") {
+		name := strings.TrimSpace(line)
+		if !strings.HasSuffix(name, "@"+snap) {
+			continue
+		}
+		// -d defers destruction while restore clones still reference the
+		// snapshot (ZFS removes it with the last clone); immediate otherwise.
+		if _, err := z.exec(ctx, "zfs", "destroy", "-d", name); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (z *zfsBackend) volSize(ctx context.Context, vol string) (int64, error) {

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -348,6 +348,17 @@ func (d *Driver) AllocateMinor(volume string) (int32, error) {
 	if m, ok := assigned[volume]; ok {
 		return m, nil
 	}
+	// A .res without an assignment record is our own partially-recorded
+	// state (crash between render and record, or a lost minor.assign):
+	// recover the volume's minor from its own file instead of assigning a
+	// fresh one — the kernel resource may still be running on it.
+	if m, ok := d.minorFromOwnRes(volume); ok {
+		assigned[volume] = m
+		if err := d.writeAssignments(assigned); err != nil {
+			return 0, err
+		}
+		return m, nil
+	}
 	used := d.scanUsedMinors(assigned)
 	m := minorBase
 	for used[m] {
@@ -358,6 +369,35 @@ func (d *Driver) AllocateMinor(volume string) (int32, error) {
 		return 0, err
 	}
 	return m, nil
+}
+
+// minorsInRes parses the device minors out of a rendered .res: miroir's
+// own form ("device minor N;") and the classic named form
+// ("device drbdX minor N;").
+func minorsInRes(raw []byte) []int32 {
+	var minors []int32
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		f := strings.Fields(line)
+		if len(f) >= 3 && f[0] == "device" && f[len(f)-2] == "minor" {
+			if n, err := strconv.Atoi(strings.TrimSuffix(f[len(f)-1], ";")); err == nil {
+				minors = append(minors, int32(n)) //nolint:gosec // drbd minors are small
+			}
+		}
+	}
+	return minors
+}
+
+// minorFromOwnRes recovers the minor a previous render of this volume
+// already claimed, if its .res survives.
+func (d *Driver) minorFromOwnRes(volume string) (int32, bool) {
+	raw, err := os.ReadFile(d.path(volume + ".res"))
+	if err != nil {
+		return 0, false
+	}
+	if minors := minorsInRes(raw); len(minors) > 0 {
+		return minors[0], true
+	}
+	return 0, false
 }
 
 func (d *Driver) readAssignments() (map[string]int32, error) {
@@ -422,14 +462,8 @@ func (d *Driver) scanUsedMinors(assigned map[string]int32) map[int32]bool {
 		if err != nil {
 			continue
 		}
-		for _, line := range strings.Split(string(raw), "\n") {
-			f := strings.Fields(line)
-			if len(f) >= 4 && f[0] == "device" && f[2] == "minor" {
-				n, err := strconv.Atoi(strings.TrimSuffix(f[3], ";"))
-				if err == nil {
-					used[int32(n)] = true
-				}
-			}
+		for _, m := range minorsInRes(raw) {
+			used[m] = true
 		}
 	}
 	return used

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -32,6 +32,8 @@ const (
 	cmdDrbdsetupStatus = "drbdsetup status"
 	cmdDumpMD          = "dump-md"
 	mockCurrentUUID    = "current-uuid 0xDEADBEEF00000001;"
+	addrKharkiv        = "192.168.1.41"
+	addrParis          = "192.168.1.42"
 )
 
 func testResource(local string) Resource {
@@ -43,8 +45,8 @@ func testResource(local string) Resource {
 		LocalNode: local,
 		LocalDisk: "/dev/vg-miroir/pvc-1",
 		Peers: []Peer{
-			{Node: nodeKharkiv, NodeID: 0, Address: "192.168.1.41"},
-			{Node: nodeParis, NodeID: 1, Address: "192.168.1.42"},
+			{Node: nodeKharkiv, NodeID: 0, Address: addrKharkiv},
+			{Node: nodeParis, NodeID: 1, Address: addrParis},
 		},
 	}
 }

--- a/internal/drbd/minor_test.go
+++ b/internal/drbd/minor_test.go
@@ -63,6 +63,58 @@ func TestAllocateMinorStableSequentialPersistent(t *testing.T) {
 // A minor already claimed by a .res file on disk (a resource created out of
 // band, or a partially-recorded assignment) must be skipped so two resources
 // never collide on /dev/drbd<minor>.
+// The scan must parse miroir's OWN rendered device form ("device minor
+// N;", no device name) — a fixture built from Render itself, so the two
+// cannot drift apart again.
+func TestAllocateMinorSkipsMinorsFromOwnRender(t *testing.T) {
+	dir := t.TempDir()
+	d := &Driver{StateDir: dir}
+
+	res := Render(Resource{
+		Name:      "legacy",
+		Minor:     minorBase,
+		Port:      7000,
+		LocalNode: "kharkiv",
+		LocalDisk: "/dev/mapper/x",
+		Peers: []Peer{
+			{Node: "kharkiv", NodeID: 0, Address: addrKharkiv},
+			{Node: "paris", NodeID: 1, Address: addrParis},
+		},
+	})
+	if err := os.WriteFile(filepath.Join(dir, "legacy.res"), []byte(res), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := d.AllocateMinor("pvc-new")
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	if got != minorBase+1 {
+		t.Errorf("minor = %d, want %d (must skip the rendered minor)", got, minorBase+1)
+	}
+}
+
+// A volume whose .res survived but whose assignment record was lost must
+// recover its own minor, not claim a fresh one — the kernel resource may
+// still be running on it.
+func TestAllocateMinorRecoversOwnMinorFromRes(t *testing.T) {
+	dir := t.TempDir()
+	d := &Driver{StateDir: dir}
+
+	if err := os.WriteFile(filepath.Join(dir, "pvc-1.res"),
+		[]byte("resource \"pvc-1\" {\n    device minor 1004;\n}\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := d.AllocateMinor("pvc-1")
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	if got != 1004 {
+		t.Errorf("minor = %d, want the recovered 1004", got)
+	}
+}
+
 func TestAllocateMinorSkipsMinorsUsedInResFiles(t *testing.T) {
 	dir := t.TempDir()
 	d := &Driver{StateDir: dir}

--- a/internal/drbd/res.go
+++ b/internal/drbd/res.go
@@ -22,6 +22,7 @@ package drbd
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 
@@ -121,7 +122,13 @@ func Render(r Resource) string {
 	for _, p := range peers {
 		fmt.Fprintf(&b, "    on %q {\n", p.Node)
 		fmt.Fprintf(&b, "        node-id %d;\n", p.NodeID)
-		fmt.Fprintf(&b, "        address ipv4 %s:%d;\n", p.Address, r.Port)
+		// Family-aware: an IPv6 InternalIP rendered as ipv4 is a parse
+		// error that poisons drbdadm for every resource on the node.
+		if ip := net.ParseIP(p.Address); ip != nil && ip.To4() == nil {
+			fmt.Fprintf(&b, "        address ipv6 [%s]:%d;\n", p.Address, r.Port)
+		} else {
+			fmt.Fprintf(&b, "        address ipv4 %s:%d;\n", p.Address, r.Port)
+		}
 		b.WriteString("        volume 0 {\n")
 		fmt.Fprintf(&b, "            device minor %d;\n", r.Minor)
 		if p.Diskless {

--- a/internal/drbd/res_test.go
+++ b/internal/drbd/res_test.go
@@ -38,8 +38,8 @@ func tieBreakerResource(localNode string) Resource {
 		LocalNode: localNode,
 		LocalDisk: "/dev/vg-miroir/pvc-1",
 		Peers: []Peer{
-			{Node: nodeKharkiv, NodeID: 0, Address: "192.168.1.41"},
-			{Node: nodeParis, NodeID: 1, Address: "192.168.1.42"},
+			{Node: nodeKharkiv, NodeID: 0, Address: addrKharkiv},
+			{Node: nodeParis, NodeID: 1, Address: addrParis},
 			{Node: nodeOslo, NodeID: 2, Address: "192.168.1.43", Diskless: true},
 		},
 	}
@@ -101,5 +101,25 @@ func TestSeedWinnerSkipsDiskless(t *testing.T) {
 	r.LocalNode = nodeOslo
 	if isWinner(r) {
 		t.Fatal("a diskless tie-breaker must never be the seed winner")
+	}
+}
+
+func TestRenderIPv6Address(t *testing.T) {
+	out := Render(Resource{
+		Name:      "pvc-1",
+		Minor:     1000,
+		Port:      7000,
+		LocalNode: nodeKharkiv,
+		LocalDisk: "/dev/mapper/x",
+		Peers: []Peer{
+			{Node: nodeKharkiv, NodeID: 0, Address: "fd00::41"},
+			{Node: nodeOslo, NodeID: 1, Address: "192.168.1.43"},
+		},
+	})
+	if !strings.Contains(out, "address ipv6 [fd00::41]:7000;") {
+		t.Fatalf("IPv6 peer must render family + brackets:\n%s", out)
+	}
+	if !strings.Contains(out, "address ipv4 192.168.1.43:7000;") {
+		t.Fatalf("IPv4 peer must stay ipv4:\n%s", out)
 	}
 }


### PR DESCRIPTION
PR F of the review cycle — seven verified robustness fixes across `internal/drbd` and `internal/backend`.

## DRBD

- **`scanUsedMinors` was inert against miroir's own files**: it required the classic named form (`device drbd0 minor N;`) while `Render` emits the unnamed form (`device minor N;`) — and its test fed it the named form, passing vacuously. If `minor.assign` was ever lost while `.res` files survived, a new volume collided with an existing minor. The parse now accepts both forms, with a regression test built **from `Render` output itself** so they can't drift again.
- **`AllocateMinor` recovers a volume's own minor** from its surviving `.res` before assigning fresh (crash between render and record, or a lost assign file) — the kernel resource may still be running on that minor.
- **IPv6-aware rendering**: an IPv6 InternalIP now renders `address ipv6 [addr]:port` instead of an unparseable `ipv4` line that poisons `drbdadm` for every resource on the node.

## Backends

- **zfs volsize alignment**: raw byte sizes hit OpenZFS's volblocksize-multiple check — a PVC of `1G` (10⁹) failed with EINVAL on zfs legs only. Sizes round up to the 4KiB boundary (harmless: DRBD sizes to the smallest leg; the other backends already realize ≥ requested).
- **zfs `DeleteSnapshot` is migration-aware**: deleting a volume with restore clones promotes them, and `zfs promote` reparents older snapshots onto the clone. The old `exists(vol@snap)` check then false-succeeded — leaking the snapshot on the clone and making the clone's own later destroy **permanently ErrBusy** (an orphan no CR deletion could ever remove). Snapshot names are cluster-unique CR names, so deletion now matches by `@name` suffix anywhere under the dataset. Chosen over guarding the promote because it adds no new deletion blockade and heals the orphan case.
- **loopfile stale-symlink pruning**: loop numbers are kernel-assigned per boot but the `dev/<vol>` symlinks persist — after a reboot a stale link can point at a device `losetup` has handed to a *different* volume, and a pod staged before the re-attach would mount the wrong data. `Setup` now prunes any link that doesn't match its backing file's current attachment (reconciles re-point them).
- **lvmthin `Setup`** only takes the bootstrap branch when `vgs` says the VG is absent; a transient lvm failure surfaces instead of a misleading `pvcreate` crash-loop against the in-use device.
- **`RealExec` sets `cmd.WaitDelay = 10s`**: a child stuck in D-state (wedged pool, frozen dm device) ignores the ctx SIGKILL and pinned `CombinedOutput` on its open pipes forever — pinning a reconcile slot and blowing the shutdown grace #79 budgets for.

## Tests

8 new (own-render minor scan, own-minor recovery, IPv6 render, zfs alignment, migrated + absent snapshot deletion, loopfile pruning, lvmthin transient-vgs) + 3 existing fixtures adapted to the new contracts. Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean.

```
gh pr merge 90 --squash --repo home-operations/miroir
```