### PR TITLE
feat: opt-in rs-discard-granularity and verify-alg chart knobs

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -46,12 +46,14 @@ Kubernetes: `>=1.31.0`
 | controller.resources.requests.cpu | string | `"10m"` |  |
 | controller.resources.requests.memory | string | `"32Mi"` |  |
 | drbd.onIoError | string | `"detach"` |  |
+| drbd.resync.discardGranularity | string | `""` | rs-discard-granularity: during a full resync, runs of zeroes are sent as discards of this size instead of written out (e.g. "65536"), keeping a re-added thin leg thin. lvmthin/zfs only — leave empty on clusters with loopfile-backed replicated volumes (loop devices mishandle it) or entirely to keep DRBD's default (off). |
 | drbd.resync.fillTarget | string | `""` | c-fill-target, the resync controller's target fill level (e.g. "1M"). |
 | drbd.resync.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864"). |
 | drbd.resync.maxRate | string | `""` | c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. "720M"). |
 | drbd.resync.minRate | string | `""` | c-min-rate, the resync floor guaranteed even under application I/O (e.g. "20M"); keep low on shared links. |
 | drbd.resync.planAhead | string | `""` | c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller. |
 | drbd.resync.rate | string | `""` | resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0). |
+| drbd.verifyAlg | string | `""` | verify-alg enables `drbdadm verify <res>` — the only cross-leg integrity check (zfs scrub validates one leg against itself). Set to a kernel digest (e.g. "crc32c") and run verify from cron/manually during quiet hours; out-of-sync blocks surface in the kernel log and `drbdsetup status`. Empty keeps verification unavailable. |
 | image.digest | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/home-operations/miroir"` |  |

--- a/charts/miroir/templates/configmap.tpl
+++ b/charts/miroir/templates/configmap.tpl
@@ -52,6 +52,9 @@ data:
         {{- if .rate }}
             resync-rate {{ .rate }};
         {{- end }}
+        {{- if .discardGranularity }}
+            rs-discard-granularity {{ .discardGranularity }};
+        {{- end }}
         {{- end }}
         }
         net {
@@ -59,6 +62,9 @@ data:
         {{- if .maxBuffers }}
             max-buffers {{ .maxBuffers }};
         {{- end }}
+        {{- end }}
+        {{- with .Values.drbd.verifyAlg }}
+            verify-alg {{ . }};
         {{- end }}
         }
     }

--- a/charts/miroir/tests/configmap_test.yaml
+++ b/charts/miroir/tests/configmap_test.yaml
@@ -131,6 +131,40 @@ tests:
           path: data["global_common.conf"]
           pattern: "on-io-error pass_on;"
 
+  - it: renders discard granularity and verify-alg when set
+    set:
+      nodes:
+        kharkiv:
+          backend: lvmthin
+          device: /dev/disk/by-partlabel/r-miroir
+      drbd:
+        verifyAlg: crc32c
+        resync:
+          discardGranularity: "65536"
+    documentIndex: 1
+    asserts:
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "rs-discard-granularity 65536;"
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "verify-alg crc32c;"
+
+  - it: default emits neither discard granularity nor verify-alg
+    set:
+      nodes:
+        kharkiv:
+          backend: lvmthin
+          device: /dev/disk/by-partlabel/r-miroir
+    documentIndex: 1
+    asserts:
+      - notMatchRegex:
+          path: data["global_common.conf"]
+          pattern: "rs-discard-granularity"
+      - notMatchRegex:
+          path: data["global_common.conf"]
+          pattern: "verify-alg"
+
   - it: honours a non-default Release namespace for both ConfigMaps
     release:
       name: miroir

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -121,6 +121,12 @@
         },
         "resync": {
           "properties": {
+            "discardGranularity": {
+              "default": "",
+              "description": "rs-discard-granularity: during a full resync, runs of zeroes are\nsent as discards of this size instead of written out (e.g. \"65536\"),\nkeeping a re-added thin leg thin. lvmthin/zfs only — leave empty on\nclusters with loopfile-backed replicated volumes (loop devices\nmishandle it) or entirely to keep DRBD's default (off).",
+              "title": "discardGranularity",
+              "type": "string"
+            },
             "fillTarget": {
               "default": "",
               "description": "c-fill-target, the resync controller's target fill level (e.g. \"1M\").",
@@ -161,6 +167,12 @@
           "required": [],
           "title": "resync",
           "type": "object"
+        },
+        "verifyAlg": {
+          "default": "",
+          "description": "verify-alg enables `drbdadm verify \u003cres\u003e` — the only cross-leg\nintegrity check (zfs scrub validates one leg against itself). Set to a\nkernel digest (e.g. \"crc32c\") and run verify from cron/manually during\nquiet hours; out-of-sync blocks surface in the kernel log and\n`drbdsetup status`. Empty keeps verification unavailable.",
+          "title": "verifyAlg",
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -112,6 +112,18 @@ drbd:
     rate: ""
     # -- max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864").
     maxBuffers: ""
+    # -- rs-discard-granularity: during a full resync, runs of zeroes are
+    # sent as discards of this size instead of written out (e.g. "65536"),
+    # keeping a re-added thin leg thin. lvmthin/zfs only — leave empty on
+    # clusters with loopfile-backed replicated volumes (loop devices
+    # mishandle it) or entirely to keep DRBD's default (off).
+    discardGranularity: ""
+  # -- verify-alg enables `drbdadm verify <res>` — the only cross-leg
+  # integrity check (zfs scrub validates one leg against itself). Set to a
+  # kernel digest (e.g. "crc32c") and run verify from cron/manually during
+  # quiet hours; out-of-sync blocks surface in the kernel log and
+  # `drbdsetup status`. Empty keeps verification unavailable.
+  verifyAlg: ""
 
 storageClass:
   create: true


### PR DESCRIPTION
PR H — the final PR of the review cycle: the two adopted blockstor/LINSTOR alignment knobs. Both default **empty**, so the rendered global DRBD config is byte-identical until an operator opts in.

## `drbd.resync.discardGranularity` → `rs-discard-granularity` (disk{})

Keeps a full-sync **target** thin: during resync, runs of zeroes are sent as discards of this size instead of written out. Re-adding a replica of a 200Gi volume with 15Gi used costs ~15Gi of pool on the new leg instead of ballooning to the full virtual size. Documented as lvmthin/zfs only — blockstor hit a real regression combining it with loop devices, so clusters with loopfile-backed replicated volumes leave it unset (it's cluster-wide common config, hence a doc caveat rather than per-backend gating).

## `drbd.verifyAlg` → `verify-alg` (net{})

Arms `drbdadm verify <res>` — the only **cross-leg** integrity check available (zfs scrub validates one leg against itself; lvmthin/loopfile have nothing). Costs nothing until a verify pass runs; scheduling stays with the operator (cron during quiet hours), matching the DRBD user guide's guidance. Out-of-sync blocks surface in the kernel log and `drbdsetup status`. An agent-side scheduled-verify feature (jittered ticker + out-of-sync metric) would exceed what blockstor offers and is left as future work.

Also filed in this cycle: #92 (auto-evict design issue — deliberately design-first, not code).

Chart tests: both knobs rendered when set, absent by default (58/58); README/schema regenerated; helm lint clean.

```
gh pr merge 93 --squash --repo home-operations/miroir
```