### PR TITLE
ci: adopt the org workflow layout and style

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: E2E
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E (kind, local backend)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Cache Go modules and build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Load kernel modules
+        run: sudo modprobe dm_thin_pool loop
+
+      # Cluster boot and image build are independent — overlap them.
+      - name: Create kind cluster
+        id: kind
+        background: true
+        run: mise run e2e-cluster
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Resolve toolchain versions
+        id: tools
+        run: echo "go=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
+
+      - name: Build image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          load: true
+          tags: miroir:e2e
+          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - wait: kind
+
+      - name: Load image into kind
+        run: kind load docker-image miroir:e2e --name miroir-test-e2e
+
+      - name: Provision (loop device, snapshot stack, helm install)
+        run: mise run e2e-provision
+
+      - name: Run e2e specs (miroir-local / lvmthin / replicas:1)
+        run: mise run e2e-run
+
+      - name: Diagnostics
+        if: failure()
+        run: mise run e2e-diagnostics

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,7 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Lint
+
 on:
   push:
     branches:
@@ -12,11 +14,14 @@ on:
     paths-ignore:
       - "**.md"
   workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 permissions:
   contents: read
+
 jobs:
   golangci-lint:
     name: Go Lint
@@ -28,11 +33,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Setup Mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           experimental: true
           install_args: --locked
+
       - name: Cache Go modules and build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -41,14 +48,17 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-
+
       - name: Cache golangci-lint
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/golangci-lint
           key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
           restore-keys: ${{ runner.os }}-golangci-lint-
+
       - name: Run linter
         run: mise run lint
+
   helm-lint:
     name: Helm Lint
     runs-on: ubuntu-24.04
@@ -59,10 +69,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Setup Mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           experimental: true
           install_args: --locked
+
       - name: Run helm lint
         run: mise run helm-lint
+
+      - name: Check generated chart files are current
+        run: mise run helm-docs-check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,7 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Release
+
 on:
   push:
     branches:
@@ -9,9 +11,11 @@ on:
   release:
     types:
       - published
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name != 'release' }}
+
 jobs:
   versions:
     name: Versions
@@ -21,19 +25,23 @@ jobs:
     outputs:
       go-version: ${{ steps.versions.outputs.go-version }}
     steps:
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Setup Mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           cache: false
           experimental: true
           install: false
+
       - name: Resolve versions
         id: versions
         run: echo "go-version=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
+
   release:
     name: Release
     needs: versions
@@ -65,6 +73,7 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
   helm:
     name: Helm
     needs: release
@@ -77,33 +86,41 @@ jobs:
     env:
       VERSION: ${{ github.event.release.tag_name }}
     steps:
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Setup Mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           cache: false
           experimental: true
           install_args: --locked
+
       - name: Generate manifests and CRDs
         run: mise run helm-crds
+
       - name: Pin the released image digest into the chart
         env:
           DIGEST: ${{ needs.release.outputs.digest }}
         run: |
-          [ -n "${DIGEST}" ] || { echo "build produced no digest"; exit 1; }
+          [ -n "${DIGEST}" ] || { echo "::error::empty image digest from build job"; exit 1; }
           yq -i '.image.digest = strenv(DIGEST)' charts/miroir/values.yaml
+
       - name: Package Helm chart
         run: helm package charts/miroir --version "${VERSION}" --app-version "${VERSION}"
+
       - name: Log in to Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish Helm chart to GHCR
+
+      - name: Publish Helm chart to GHCR (OCI)
         run: helm push "miroir-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+
       - name: Sign the published chart with Cosign
         run: cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/miroir:${VERSION}"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,5 +1,7 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Renovate
+
 on:
   push:
     branches:
@@ -8,7 +10,9 @@ on:
       - .renovaterc.json5
       - .renovate/**.json5
   workflow_dispatch:
+
 permissions: {}
+
 jobs:
   renovate:
     name: Renovate
@@ -23,6 +27,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ".github"
           permission-actions: write
+
       - name: Run Renovate
         id: dispatch
         env:
@@ -34,11 +39,13 @@ jobs:
             --ref main \
             --field "autodiscoverFilter=${REPO_NAME}")
           echo "run_id=${RUN_URL##*/}" >> "$GITHUB_OUTPUT"
+
       - name: Await Renovate Completion
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
         run: gh run watch --repo "${{ github.repository_owner }}/.github" "${RUN_ID}" --exit-status
+
       - name: Renovate Output
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,7 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Tests
+
 on:
   push:
     branches:
@@ -12,14 +14,18 @@ on:
     paths-ignore:
       - "**.md"
   workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 permissions:
   contents: read
+
 env:
   # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
   HELM_UNITTEST_VERSION: "v1.1.1"
+
 jobs:
   test:
     name: Go Tests
@@ -31,11 +37,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Setup Mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           experimental: true
           install_args: --locked
+
       - name: Cache Go modules and build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -44,13 +52,16 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-
+
       - name: Check go.mod tidiness
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
+
       - name: Running Unit Tests
         run: mise run test
-  helm-test:
+
+  helm-unittest:
     name: Helm Unit Tests
     runs-on: ubuntu-24.04
     permissions:
@@ -60,69 +71,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install Mise and required tools
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-        with:
-          experimental: true
-          install_args: --locked
-      - name: Run helm unit tests
-        run: |-
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
-          mise run helm-test
-      - name: Check chart docs are current
-        run: mise run helm-docs-check
-  e2e:
-    name: E2E (kind, local backend)
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
+
       - name: Setup Mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           experimental: true
           install_args: --locked
-      - name: Cache Go modules and build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-      - name: Load kernel modules
-        run: sudo modprobe dm_thin_pool loop
-      # Cluster boot and image build are independent — overlap them.
-      - name: Create kind cluster
-        id: kind
-        background: true
-        run: mise run e2e-cluster
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Resolve toolchain versions
-        id: tools
-        run: echo "go=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
-      - name: Build image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          load: true
-          tags: miroir:e2e
-          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - wait: kind
-      - name: Load image into kind
-        run: kind load docker-image miroir:e2e --name miroir-test-e2e
-      - name: Provision (loop device, snapshot stack, helm install)
-        run: mise run e2e-provision
-      - name: Run e2e specs (miroir-local / lvmthin / replicas:1)
-        run: mise run e2e-run
-      - name: Diagnostics
-        if: failure()
-        run: mise run e2e-diagnostics
+
+      - name: Run helm unit tests
+        run: |-
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
+          mise run helm-test


### PR DESCRIPTION
Aligns miroir's workflows with the layout every other org repo (konflate, tuppr, kromgo, chaski, echo, gatus-sidecar) already follows.

## Organization

- **`e2e.yaml` split out of `tests.yaml`** — the org rule everywhere else. Practical win beyond consistency: E2E gets its own concurrency group, so re-running a flaky e2e no longer re-runs (or queues behind) unit tests, and the Tests workflow finishes fast. The check name stays `E2E (kind, local backend)`.
- **`helm-docs-check` moves from the Helm Unit Tests job to Helm Lint** ("Check generated chart files are current") — where konflate/kromgo gate generated files.
- `helm-test` job id → `helm-unittest` (matches the template; the displayed check name `Helm Unit Tests` is unchanged).

## Style

- `---` document-start + `# yaml-language-server` schema header on every file (three files were missing the marker).
- Blank-line separation between top-level blocks and between steps, matching the shared template exactly.
- `renovate.yaml` is now **byte-identical** to the org copy; `stale.yaml` and `release-please.yaml` already were.
- `release.yaml`: `::error::` annotation on an empty build digest (surfaces in the run summary instead of a plain log line).

No step logic changes anywhere — the e2e steps are the same parallel kind∥build pipeline that shipped in #84.

```
gh pr merge 94 --squash --repo home-operations/miroir
```