### PR TITLE
fix: bound host commands, classify held-open teardown, self-heal stale metadata marker

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -435,7 +435,10 @@ func (r *VolumeReconciler) removalBlocked(ctx context.Context, vol *miroirv1alph
 func (r *VolumeReconciler) teardown(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) error {
 	if vol.Spec.DRBD != nil {
 		if err := r.DRBD.Down(ctx, vol.Name); err != nil {
-			return err
+			// A still-staged device answers "held open"; classify it as
+			// ErrBusy so teardown takes the 10s retry, not the workqueue's
+			// minutes-long backoff (NodeUnstage releases it shortly).
+			return backend.Busy(err)
 		}
 	}
 	// Backend.Delete succeeds when the device is already absent, so a

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -733,6 +733,46 @@ func TestReconcileTeardownDeletesDespiteDetachedDiskState(t *testing.T) {
 	}
 }
 
+// Teardown behind a still-staged device: drbdsetup down answers "held
+// open"; the error must classify as ErrBusy so teardown takes the 10s
+// retry, not the workqueue's minutes-long backoff, and the finalizer
+// stays until NodeUnstage releases the device.
+func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	now := metav1.NewTime(time.Now())
+	v.DeletionTimestamp = &now
+	stateDir := t.TempDir()
+	// A .res must exist or Down short-circuits as never-configured.
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte("resource \"pvc-1\" {}\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{errOn: map[string]error{
+		"drbdsetup down pvc-1": errors.New("pvc-1: State change failed: Device is held open by someone"),
+	}}
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	res, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+	if err != nil {
+		t.Fatalf("held-open must be a requeue, not an error: %v", err)
+	}
+	if res.RequeueAfter != 10*time.Second {
+		t.Fatalf("want 10s busy-retry, got %v", res.RequeueAfter)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal("finalizer must be retained while the device is held open")
+	}
+}
+
 // A diskless tie-breaker joins DRBD for quorum only: no backend device,
 // no metadata seed, DeviceCreated stays false so CSI never stages here.
 // A FullSync joiner on a restored volume must create a fresh backing,

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -490,3 +490,23 @@ func TestLVMThinSetupSurfacesTransientVGSError(t *testing.T) {
 	}
 	fe.notCalledWith(t, "pvcreate")
 }
+
+func TestBusyClassifiesHeldOpen(t *testing.T) {
+	cases := map[string]bool{
+		"Device is held open by someone": true,
+		"volume group is in use":         true,
+		"has children":                   true,
+		"dependent clones":               true,
+		"No such file or directory":      false,
+		"":                               false, // nil in, nil out handled separately
+	}
+	for msg, wantBusy := range cases {
+		got := Busy(errors.New(msg))
+		if errors.Is(got, ErrBusy) != wantBusy {
+			t.Errorf("Busy(%q): ErrBusy=%v, want %v", msg, errors.Is(got, ErrBusy), wantBusy)
+		}
+	}
+	if Busy(nil) != nil {
+		t.Error("Busy(nil) must be nil")
+	}
+}

--- a/internal/backend/exec.go
+++ b/internal/backend/exec.go
@@ -29,13 +29,26 @@ import (
 // backends are unit-testable without lvm/zfs installed.
 type Exec func(ctx context.Context, name string, args ...string) (string, error)
 
+// execTimeout bounds a single host command. Every miroir CLI call (lvm,
+// zfs, drbdadm, drbdsetup, losetup, blockdev) is a metadata operation
+// that completes in well under a second on healthy hardware; the only way
+// to exceed this is a genuinely wedged device or pool. Reconcile contexts
+// have no deadline of their own, so without this bound a child stuck in
+// D-state pins the single reconcile worker forever and head-of-line-blocks
+// every other volume on the node.
+const execTimeout = 2 * time.Minute
+
 // RealExec executes commands on the host. The agent container runs with the
 // host namespaces, so lvm/zfs act on the node's devices directly.
 func RealExec(ctx context.Context, name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...)
 	// A child stuck in D-state (wedged pool, frozen dm device) ignores the
-	// SIGKILL from ctx cancellation and would pin CombinedOutput on its
-	// open pipes forever; WaitDelay forces Wait to give up on them.
+	// SIGKILL ctx cancellation sends and would pin CombinedOutput on its
+	// open pipes forever; WaitDelay makes Wait give up on them. It only
+	// arms once ctx is done, which is why the timeout above is required —
+	// the reconcile context is otherwise never cancelled.
 	cmd.WaitDelay = 10 * time.Second
 	// Force the C locale: the delete/exists classifiers match lvm/zfs error
 	// text ("in use", "Failed to find", …), which the tools localise.
@@ -48,11 +61,13 @@ func RealExec(ctx context.Context, name string, args ...string) (string, error) 
 	return string(out), nil
 }
 
-// busy classifies a delete/destroy failure: it wraps err as ErrBusy when the
-// cause clears on its own — the device is still open, or (zfs) snapshots or
-// restore clones must go first — so the caller retries. Other errors pass
-// through unchanged and are treated as permanent. Returns nil for nil.
-func busy(err error) error {
+// Busy classifies a delete/destroy/down failure: it wraps err as ErrBusy
+// when the cause clears on its own — the device is still open, or (zfs)
+// snapshots or restore clones must go first — so the caller retries. Other
+// errors pass through unchanged and are treated as permanent. Returns nil
+// for nil. Exported so the agent can classify drbdsetup down failures the
+// same way (a still-staged device answers "held open").
+func Busy(err error) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/backend/loopfile.go
+++ b/internal/backend/loopfile.go
@@ -283,7 +283,7 @@ func (lf *loopfile) Delete(ctx context.Context, vol string) error {
 	}
 	if dev != "" {
 		if _, err := lf.exec(ctx, "losetup", "-d", dev); err != nil {
-			return busy(fmt.Errorf("detach %s: %w", dev, err))
+			return Busy(fmt.Errorf("detach %s: %w", dev, err))
 		}
 	}
 	if _, err := lf.exec(ctx, "rm", "-f", lf.DevicePath(vol)); err != nil {

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -224,7 +224,7 @@ func (l *lvmThin) Delete(ctx context.Context, vol string) error {
 		return err
 	}
 	if _, err := l.lvm(ctx, "lvremove", "--yes", l.ref(vol)); err != nil {
-		return busy(fmt.Errorf("lvremove %s: %w", vol, err))
+		return Busy(fmt.Errorf("lvremove %s: %w", vol, err))
 	}
 	return nil
 }

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -175,7 +175,7 @@ func (z *zfsBackend) Delete(ctx context.Context, vol string) error {
 	if derr == nil ||
 		(!strings.Contains(derr.Error(), "has children") &&
 			!strings.Contains(derr.Error(), "dependent clones")) {
-		return busy(derr)
+		return Busy(derr)
 	}
 	// Restore clones pin this volume's snapshot chain — promoting
 	// reparents each clone's origin snapshot onto the clone, freeing the
@@ -185,7 +185,7 @@ func (z *zfsBackend) Delete(ctx context.Context, vol string) error {
 		return err
 	}
 	_, err = z.exec(ctx, "zfs", "destroy", z.name(vol))
-	return busy(err)
+	return Busy(err)
 }
 
 func (z *zfsBackend) promoteClones(ctx context.Context, vol string) error {

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -57,6 +57,37 @@ func (d *Driver) Seeded(name string) bool {
 }
 
 // Apply converges the kernel state for one resource: write config when it
+// isMissingMetadata matches drbdadm's complaint when a backing device
+// carries no DRBD metadata (attach against a blank/replaced disk).
+func isMissingMetadata(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "no valid meta") || strings.Contains(s, "No valid meta")
+}
+
+// ensureMarkedMetadata creates + GI-seeds metadata once per backing device,
+// gated on the .md-created marker: the marker lands only after a fully
+// successful seed, so a retry never adopts half-seeded metadata (which
+// deadlocks the first handshake — both sides Inconsistent, no sync source).
+func (d *Driver) ensureMarkedMetadata(ctx context.Context, r Resource) error {
+	marker := d.path(r.Name + ".md-created")
+	if _, err := os.Stat(marker); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := d.ensureMetadata(ctx, r); err != nil {
+			return err
+		}
+	}
+	// A sentinel must never outlive a completed seed — left stale, it
+	// would authorize re-seeding live metadata the moment the marker is
+	// lost. Removed before the marker lands so a crash in between leaves
+	// "no markers" (re-probed, re-seeded only if virgin).
+	if err := os.Remove(d.path(r.Name + ".md-seeding")); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.WriteFile(marker, nil, 0o640)
+}
+
 // changed, create and GI-seed metadata once (see seedGI for how fresh
 // volumes skip the initial sync), bring the resource up / adjust.
 func (d *Driver) Apply(ctx context.Context, r Resource) error {
@@ -68,27 +99,7 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 	// device-node, no marker. It only needs the .res rendered (writeConfig
 	// above) and drbdadm up/adjust so DRBD joins the resource for quorum.
 	if !r.LocalDiskless {
-		// create-md + seed exactly once per backing device: the .md-created
-		// marker lands only after a fully successful seed, so a retry never
-		// adopts half-seeded metadata (which deadlocks the first handshake:
-		// both sides Inconsistent, no sync source).
-		marker := d.path(r.Name + ".md-created")
-		if _, err := os.Stat(marker); err != nil {
-			if !os.IsNotExist(err) {
-				return err
-			}
-			if err := d.ensureMetadata(ctx, r); err != nil {
-				return err
-			}
-		}
-		// A sentinel must never outlive a completed seed — left stale, it
-		// would authorize re-seeding live metadata the moment the marker is
-		// lost. Removed before the marker lands so a crash in between leaves
-		// "no markers" (re-probed, re-seeded only if virgin).
-		if err := os.Remove(d.path(r.Name + ".md-seeding")); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		if err := os.WriteFile(marker, nil, 0o640); err != nil {
+		if err := d.ensureMarkedMetadata(ctx, r); err != nil {
 			return err
 		}
 	}
@@ -97,6 +108,22 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 	// otherwise. A half-torn kernel slot can answer "Unknown resource"
 	// to adjust but accept a plain up — fall back rather than loop.
 	if _, err := d.adm(ctx, "adjust", r.Name); err != nil {
+		// A stale .md-created marker surviving a backing-disk replacement
+		// (data disk swapped, /etc/drbd.d intact) makes ensureMarkedMetadata
+		// skip create-md, so adjust attaches a blank device and fails "no
+		// valid meta-data". Drop the marker and re-run: probeMetadata sees
+		// no metadata and create-md + SkipSeed makes this a full SyncTarget.
+		if !r.LocalDiskless && isMissingMetadata(err) {
+			if rmErr := os.Remove(d.path(r.Name + ".md-created")); rmErr != nil && !os.IsNotExist(rmErr) {
+				return rmErr
+			}
+			if mdErr := d.ensureMarkedMetadata(ctx, r); mdErr != nil {
+				return mdErr
+			}
+			if _, err = d.adm(ctx, "adjust", r.Name); err == nil {
+				return d.ensureDeviceNode(r.Minor)
+			}
+		}
 		if !strings.Contains(err.Error(), "Unknown resource") {
 			return fmt.Errorf("adjust %s: %w", r.Name, err)
 		}

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -258,6 +258,39 @@ func TestApplySkipSeedLeavesJustCreatedMetadata(t *testing.T) {
 	}
 }
 
+// A backing disk replaced under a surviving .md-created marker makes the
+// first adjust fail "no valid meta-data"; Apply drops the stale marker,
+// recreates metadata (SkipSeed → full SyncTarget), and retries adjust.
+func TestApplyReseedsOnMissingMetadata(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-existing marker from the pre-replacement life of the volume.
+	if err := os.WriteFile(filepath.Join(dir, "pvc-1.md-created"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	fe := &fakeExec{errOnce: map[string]error{
+		"adjust pvc-1": errors.New("drbdadm: no valid meta-data found"),
+	}}
+	d := &Driver{StateDir: dir, Exec: fe.run, Mknod: fakeMknod}
+	r := testResource(nodeKharkiv)
+	r.SkipSeed = true // the recreated leg must full-sync, never re-seed day0
+
+	if err := d.Apply(t.Context(), r); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
+	fe.notCalledWith(t, "set-gi")
+	// adjust attempted twice: the failing first, the succeeding retry.
+	var adjusts int
+	for _, c := range fe.calls {
+		if strings.Contains(c, "adjust pvc-1") {
+			adjusts++
+		}
+	}
+	if adjusts != 2 {
+		t.Fatalf("want 2 adjust attempts (fail + retry), got %d: %v", adjusts, fe.calls)
+	}
+}
+
 func TestApplyIdempotent(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}


### PR DESCRIPTION
PR ① of the performance/resiliency review — the three highest-blast-radius resiliency fixes. All three are "failure at the wrong moment" cases where the system wedged instead of degrading.

## 1. Host commands are now bounded (the big one)

`RealExec` set `WaitDelay = 10s` (added in #90) believing it capped a hung child — but `WaitDelay` only arms **after** the context is cancelled, and agent reconcile contexts carry no deadline (verified: no `WithTimeout`/`WithDeadline` anywhere in agent/drbd/backend paths). So a child stuck in D-state — a wedged ZFS pool, a frozen dm device — blocked `CombinedOutput` **forever**. With the controller-runtime default of one reconcile worker, that one hung exec head-of-line-blocked **every volume on the node**, silently (health probes stay green, no status breadcrumb). Both blockstor and LINSTOR bound per-operation processing time; miroir didn't.

Fix: `RealExec` wraps each command in a 2-minute context (every miroir CLI call is a sub-second metadata op; only a genuinely wedged device exceeds it), so ctx expiry arms `WaitDelay` → SIGKILL + pipe-drain in 10s → the reconcile errors and backs off instead of hanging. The long-lived `events2` stream doesn't use `RealExec`, so it's unaffected.

## 2. `down` "held open" → ErrBusy fast-retry

Teardown runs `drbdsetup down` before `Backend.Delete`; on a still-staged device that fails "held open by someone". This error bypassed the `ErrBusy` fast path that `Backend.Delete` already used, so a force-deleted pod's teardown rode the workqueue's exponential backoff to **~17 min** (with no status message) instead of the intended 10s retry. Exported `backend.Busy` (was unexported `busy`) and teardown now classifies the `Down` error through it.

## 3. Stale metadata marker self-heals

The `wipedBacking` guard (#88) handles a full node wipe. The inverse — **data disk replaced but `/etc/drbd.d` markers survive** (swap a failed SSD, OS disk intact) — short-circuited on the marker, so `Apply` skipped `create-md` and `adjust` attached a blank device, failing "no valid meta-data" **forever**. Fix: on that error `Apply` drops the `.md-created` marker and re-runs metadata creation; `probeMetadata` sees no metadata and `create-md` + `SkipSeed` makes the recreated leg a full SyncTarget (never re-seeds day0). Extracted `ensureMarkedMetadata` so the create and the self-heal share one path.

## Tests

`TestApplyReseedsOnMissingMetadata` (fail-once adjust → marker dropped → create-md, no set-gi, two adjust attempts), `TestBusyClassifiesHeldOpen`, `TestReconcileTeardownDownHeldOpenRetries` (10s requeue + finalizer retained). Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean.

```
gh pr merge 96 --squash --repo home-operations/miroir
```