### PR TITLE
fix: snapshot coordinator fails over from a dead replicas[0]

### DIFF
--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -38,6 +38,11 @@ import (
 // snapshots must not freeze the volume forever. Exported so the agent's
 // startup sweep can apply the same deadline when lifting barriers left
 // raised by a previous crash.
+//
+// Peers compare the coordinator's SuspendedAt (its wall clock) against
+// their own, so this deadline doubles as the cross-node clock-skew
+// budget: nodes must run NTP. Skew approaching 60s can prematurely expire
+// (or over-extend) a round; homelab nodes are expected well under a second.
 const SuspendDeadline = 60 * time.Second
 
 // suspendRetryBackoff spaces barrier retries after a failed round.
@@ -394,8 +399,32 @@ func (r *SnapshotReconciler) isCoordinator(vol *miroirv1alpha1.MiroirVolume, st 
 	if st.PeerPrimary {
 		return false
 	}
-	rep := vol.Spec.FirstDiskfulReplica()
-	return rep != nil && rep.Node == r.NodeName
+	// No Primary anywhere: the lowest-ordered diskful replica coordinates,
+	// but a dead replicas[0] must not orphan the round (no survivor would
+	// ever become coordinator, so it never voids and every sibling snapshot
+	// queues behind it forever). Walk diskful replicas in spec order and
+	// take the first REACHABLE one: self → we coordinate; a connected peer
+	// → it does; a down or not-yet-completed peer → skip to the next. A
+	// dead node is in no survivor's connected set, so every mutually
+	// connected survivor elects the same present node; a partitioned
+	// minority may self-elect, but a degraded volume fails the healthy gate
+	// and cannot raise a barrier anyway.
+	for _, rep := range vol.Spec.Replicas {
+		if rep.Diskless {
+			continue
+		}
+		if rep.Node == r.NodeName {
+			return true
+		}
+		// A diskful peer earlier in spec order coordinates unless it is
+		// provably down — addressed but its connection is not established.
+		// An address-less (not-yet-completed) peer is treated as present so
+		// coordination stays deterministic during a membership change.
+		if rep.Address == "" || st.PeerConnected[rep.NodeID] {
+			return false
+		}
+	}
+	return false
 }
 
 func replicaOn(vol *miroirv1alpha1.MiroirVolume, node string) bool {

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -86,6 +86,51 @@ func TestSnapshotUnreplicatedReadyImmediately(t *testing.T) {
 	}
 }
 
+// Regression: replicas[0] (the default coordinator) is dead mid-round. A
+// surviving diskful replica must take over as coordinator and void the
+// expired round — otherwise status.IOSuspended stays true forever and
+// every future snapshot of the volume queues behind it.
+func TestSnapshotCoordinatorFailsOverFromDeadReplica0(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis) // kharkiv = replicas[0]
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	snap := snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)
+	expired := metav1.NewTime(time.Now().Add(-2 * SuspendDeadline))
+	snap.Status.IOSuspended = true
+	snap.Status.SuspendedAt = &expired
+	snap.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{
+		nodeParis: miroirv1alpha1.SnapshotSuspended,
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snap).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	// paris: Secondary, no Primary anywhere, and its link to kharkiv
+	// (node-id 0) is down — paris is now the lowest reachable diskful leg.
+	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":0,"connection-state":"Connecting"}]}]`}
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
+	reconcileSnap(t, rP, snapSnap1)
+
+	feP.calledWith(t, "drbdadm resume-io pvc-1")
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.IOSuspended {
+		t.Fatalf("survivor coordinator must void the dead round: %+v", got.Status)
+	}
+}
+
 func TestSnapshotReplicatedBarrier(t *testing.T) {
 	s := newScheme(t)
 	v := vol(volPvc1, nodeKharkiv, nodeParis)


### PR DESCRIPTION
PR ② of the performance/resiliency review — the second non-self-healing wedge.

## The bug

The snapshot barrier picks a coordinator: the Primary if one exists, else `replicas[0]`. When **no node is Primary** (all Secondary — the common case for an idle replicated volume) and `replicas[0]` is **dead**, every survivor computes `FirstDiskfulReplica().Node == replicas[0] != self` → **nobody coordinates**. The round opened by the now-dead coordinator never voids: `status.IOSuspended` stays true forever, and because `otherRoundActive` serializes rounds per volume (#85), **every future snapshot of that volume queues behind the dead round indefinitely**. Survivors self-expire their kernel barriers at the 60s deadline so there's no I/O outage — but snapshots silently stop working until the node returns or a pod failover promotes a survivor.

## The fix

`isCoordinator` now walks diskful replicas in spec order and takes the first **reachable** one:
- self → we coordinate;
- an earlier diskful peer that is present (address set + connection established, **or** not-yet-completed) → it coordinates, we defer;
- an earlier diskful peer that is **provably down** (addressed but disconnected) → skip to the next.

A dead node is in no survivor's connected set, so every mutually-connected survivor elects the same present node. A partitioned minority may self-elect, but a degraded volume fails the `healthy` gate and can't raise a barrier anyway. The "treat address-less as present" rule keeps coordination deterministic mid-membership-change and preserves the existing behaviour exactly (the conservative form deviates from `replicas[0]` *only* when it's addressed-and-disconnected).

## Clock skew

While here, documented on `SuspendDeadline` that the 60s barrier deadline doubles as the cross-node clock-skew budget — peers compare the coordinator's wall-clock `SuspendedAt` against their own, so nodes must run NTP (homelab skew is normally sub-second; skew approaching 60s is the failure mode). No code change — measuring from local first-observation would need per-round in-memory state that resets on restart, not worth it at this scale.

## Tests

`TestSnapshotCoordinatorFailsOverFromDeadReplica0`: `replicas[0]` down mid-round, surviving `replicas[1]` becomes coordinator and voids the expired round (resume-io + `IOSuspended` cleared). All existing snapshot tests pass unchanged — the conservative rule required zero fixture edits. Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean.

```
gh pr merge 99 --squash --repo home-operations/miroir
```