### PR TITLE
feat: explain a detached backing disk in volume status

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -223,6 +223,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		Connected:     connected,
 		SplitBrain:    st.SplitBrain,
 		Diskless:      localDiskless,
+		Message:       detachedDiskMessage(vol, r.NodeName, st, localDiskless),
 	}); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -516,6 +517,22 @@ func (r *VolumeReconciler) assignMinor(_ context.Context, vol *miroirv1alpha1.Mi
 
 // computePhase aggregates per-node states into the volume phase the CSI
 // controller waits on (notes/DESIGN.md §4.5.1).
+// detachedDiskMessage explains a diskful leg DRBD dropped to Diskless
+// after a backing-device I/O error (on-io-error detach): the volume keeps
+// serving via the peer, but the operator otherwise sees only
+// "DiskState: Diskless" with no cause. Gated on the leg having previously
+// been attached so a normal bring-up (briefly Diskless) does not cry wolf.
+func detachedDiskMessage(vol *miroirv1alpha1.MiroirVolume, self string, st drbd.Status, localDiskless bool) string {
+	if localDiskless || st.DiskState != drbd.DiskDiskless {
+		return ""
+	}
+	if prev := vol.Status.PerNode[self].DiskState; prev == "" || prev == drbd.DiskDiskless {
+		return ""
+	}
+	return "backing device detached after an I/O error; serving via the peer — " +
+		"replace the disk, then remove and re-add this replica"
+}
+
 func computePhase(vol *miroirv1alpha1.MiroirVolume) miroirv1alpha1.VolumePhase {
 	diskfulReplicas := vol.Spec.DiskfulReplicas()
 	ready := 0

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -773,6 +773,46 @@ func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 	}
 }
 
+// A diskful leg DRBD detached after an I/O error reads Diskless while the
+// volume serves via the peer. The reconcile must explain it (actionable
+// Message) and keep the leg DeviceCreated=true so the volume stays
+// Degraded, not hard-Failed.
+func TestReconcileDetachedDiskGetsActionableMessage(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	// The leg was UpToDate before the disk errored.
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+	}
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	// DRBD reports the local leg detached (Diskless).
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"Diskless"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
+	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+
+	reconcile(t, r, volPvc1)
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	st := got.Status.PerNode[nodeKharkiv]
+	if !strings.Contains(st.Message, "detached") {
+		t.Fatalf("detached leg must carry an actionable message: %q", st.Message)
+	}
+	if !st.DeviceCreated {
+		t.Fatalf("detached leg must stay DeviceCreated (Degraded, not Failed): %+v", st)
+	}
+}
+
 // A diskless tie-breaker joins DRBD for quorum only: no backend device,
 // no metadata seed, DeviceCreated stays false so CSI never stages here.
 // A FullSync joiner on a restored volume must create a fresh backing,

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -645,6 +645,13 @@ func (d *Driver) Down(ctx context.Context, name string) error {
 // DiskUpToDate is the disk state of a replica holding current data.
 const DiskUpToDate = "UpToDate"
 
+// DiskDiskless is the disk state of a replica with no attached backing
+// device — a quorum-only tie-breaker, or a diskful leg DRBD detached
+// after an I/O error (on-io-error detach). Do NOT use it to infer
+// tie-breaker-ness (that is spec-driven, see Replica.Diskless); it is
+// only meaningful for observing a detach on a leg the spec says is diskful.
+const DiskDiskless = "Diskless"
+
 // rolePrimary is the DRBD role of a node that holds the device open.
 const rolePrimary = "Primary"
 


### PR DESCRIPTION
PR ③ of the performance/resiliency review — scoped to the safe, unambiguously-correct half of the failed-disk finding.

## What this does

With `on-io-error detach` (the default since #88), a backing-device I/O error drops the diskful leg to `Diskless` and the volume keeps serving via the peer. The volume already goes **Degraded** and `miroir_volume_up_to_date` already reads 0 for that node — but the per-node status showed only `DiskState: Diskless` with **no cause**, so an operator can't tell a dying disk from a tie-breaker or a mid-sync leg.

This sets an actionable `Message` on the detached leg — "backing device detached after an I/O error; serving via the peer — replace the disk, then remove and re-add this replica" — gated on the leg having **previously been attached** (persisted `DiskState` was a real state, now `Diskless`), so a normal bring-up doesn't cry wolf. `DeviceCreated` stays true, so `computePhase` keeps the volume **Degraded** (its hard-`Failed` path requires `!DeviceCreated`), never flipping a serving volume to Failed.

Added `drbd.DiskDiskless` const with a doc warning it must not be used to infer tie-breaker-ness (that's spec-driven) — only to observe a detach on a spec-diskful leg.

## What this defers (and why)

The review's candidate #1 was the full **SkipDisk latch**: stop `drbdadm adjust` from re-attaching a persistently-failing disk (LINSTOR sets `--skip-disk` on detected failure; blockstor detaches + stamps a prop). I'm not shipping that speculatively:

1. Its value hinges on DRBD re-attaching a detached leg on the next `adjust` — a **kernel behavior I can't verify without real hardware** (and I was burned by an unverified premise in the `WaitDelay` change #90).
2. Even if the flap is real, it's **noise, not corruption** — the peer's data stays authoritative and the bad leg never serves reads.
3. A correct latch needs a deliberate **transient-vs-persistent** policy and clear semantics (LINSTOR clears via operator; blockstor via read-probe) — a design decision, not a quick fix.

Filed as a design issue (link in a follow-up comment). This PR is the correct increment that stands regardless of how that resolves.

## Tests

`TestReconcileDetachedDiskGetsActionableMessage`: a previously-UpToDate leg now `Diskless` gets the message and stays `DeviceCreated` (Degraded, not Failed). Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean (helper extracted to keep `Reconcile` under gocyclo).

```
gh pr merge 100 --squash --repo home-operations/miroir
```