### PR TITLE
fix: CSI restore + AlreadyExists idempotency edges

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -161,7 +161,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				replicas, len(srcVol.Spec.DiskfulReplicas()))
 		}
 		source = &miroirv1alpha1.VolumeSource{SnapshotName: snapID}
-		srcReplicas, err = c.restoreReplicas(ctx, srcVol)
+		srcReplicas, err = c.restoreReplicas(ctx, srcVol, snap)
 		if err != nil {
 			return nil, err
 		}
@@ -568,9 +568,14 @@ func (c *Controller) handleCreateErr(ctx context.Context, err error, vol *miroir
 	if !apierrors.IsAlreadyExists(err) {
 		return status.Errorf(codes.Internal, "create MiroirVolume: %v", err)
 	}
+	// AlreadyExists proves the object is on the API server; the informer
+	// cache can still lag it, so read through APIReader. A read failure is
+	// in-flight, not terminal — Unavailable keeps the provisioner retrying
+	// (Internal is a final error → it would record "volume not created"
+	// for a volume that demonstrably exists, and leak the CR).
 	existing := &miroirv1alpha1.MiroirVolume{}
-	if err := c.Client.Get(ctx, types.NamespacedName{Name: vol.Name}, existing); err != nil {
-		return status.Errorf(codes.Internal, "get existing MiroirVolume: %v", err)
+	if err := c.reader().Get(ctx, types.NamespacedName{Name: vol.Name}, existing); err != nil {
+		return status.Errorf(codes.Unavailable, "get existing MiroirVolume: %v", err)
 	}
 	existingSource := ""
 	if existing.Spec.Source != nil {
@@ -726,8 +731,9 @@ func (c *Controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 			return nil, status.Errorf(codes.Internal, "create MiroirSnapshot: %v", err)
 		}
 		existing := &miroirv1alpha1.MiroirSnapshot{}
-		if err := c.Client.Get(ctx, types.NamespacedName{Name: req.GetName()}, existing); err != nil {
-			return nil, status.Errorf(codes.Internal, "get existing snapshot: %v", err)
+		if err := c.reader().Get(ctx, types.NamespacedName{Name: req.GetName()}, existing); err != nil {
+			// Cache may lag the just-created object; retryable, not terminal.
+			return nil, status.Errorf(codes.Unavailable, "get existing snapshot: %v", err)
 		}
 		if existing.Spec.VolumeName != req.GetSourceVolumeId() {
 			return nil, status.Errorf(codes.AlreadyExists,
@@ -846,10 +852,16 @@ func csiSnapshot(snap *miroirv1alpha1.MiroirSnapshot, sizeBytes int64) *csi.Snap
 // local snapshot, so a carried flag would full-resync one for nothing —
 // and replication addresses are re-resolved from the live Node objects
 // (the source's were captured at its creation and can be stale).
-func (c *Controller) restoreReplicas(ctx context.Context, srcVol *miroirv1alpha1.MiroirVolume) ([]miroirv1alpha1.Replica, error) {
+func (c *Controller) restoreReplicas(ctx context.Context, srcVol *miroirv1alpha1.MiroirVolume, snap *miroirv1alpha1.MiroirSnapshot) ([]miroirv1alpha1.Replica, error) {
 	reps := slices.Clone(srcVol.Spec.Replicas)
 	for i := range reps {
-		reps[i].FullSync = false
+		// A leg clones from that node's local snapshot only if the node
+		// actually cut one. A replica added AFTER the snapshot was taken
+		// has no local snapshot: mark it FullSync so the agent creates a
+		// fresh backing and DRBD full-syncs it from a Done peer, instead
+		// of failing CreateFromSnapshot and flipping the clone to Failed.
+		done := snap.Status.PerNode[reps[i].Node] == miroirv1alpha1.SnapshotDone
+		reps[i].FullSync = !reps[i].Diskless && !done
 		if reps[i].Address == "" {
 			continue
 		}
@@ -859,7 +871,26 @@ func (c *Controller) restoreReplicas(ctx context.Context, srcVol *miroirv1alpha1
 		}
 		reps[i].Address = addr
 	}
+	// The GI-seed winner (first diskful replica) is the clone's sync
+	// source, so it must hold real data — refuse a restore whose seed leg
+	// was added after the snapshot (no complete leg to seed from). A
+	// ReadyToUse snapshot has every pre-existing diskful leg Done, so this
+	// only rejects the pathological post-snapshot seed case.
+	if seed := firstDiskful(reps); seed != nil && seed.FullSync {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"snapshot %s has no complete leg on seed node %s; cannot restore", snap.Name, seed.Node)
+	}
 	return reps, nil
+}
+
+// firstDiskful returns the first non-diskless replica, or nil.
+func firstDiskful(reps []miroirv1alpha1.Replica) *miroirv1alpha1.Replica {
+	for i := range reps {
+		if !reps[i].Diskless {
+			return &reps[i]
+		}
+	}
+	return nil
 }
 
 // snapshotSource resolves a ready snapshot and its source volume.

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -551,7 +552,11 @@ func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
-		Status:     miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
+		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{
+				nodeKharkiv: miroirv1alpha1.SnapshotDone,
+				nodeParis:   miroirv1alpha1.SnapshotDone,
+			}},
 	}
 	cl := readyOnGet(s)
 	for _, obj := range []client.Object{srcVol, srcSnap,
@@ -593,6 +598,106 @@ func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 	}
 }
 
+// A restore whose source gained a replica AFTER the snapshot was cut: the
+// new node holds no local snapshot, so its clone leg must be marked
+// FullSync (fresh backing, synced from a Done peer) instead of failing
+// CreateFromSnapshot and flipping the clone to Failed.
+func TestCreateVolumeFromSnapshotFullSyncsPostSnapshotReplica(t *testing.T) {
+	s := newScheme(t)
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "10.0.0.1"},
+				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "10.0.0.2"},
+			},
+		},
+	}
+	// The snapshot captured only kharkiv Done; paris was added afterward.
+	srcSnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone}},
+	}
+	cl := readyOnGet(s)
+	for _, obj := range []client.Object{srcVol, srcSnap,
+		nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)} {
+		if err := cl.Create(t.Context(), obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := cl.Status().Update(t.Context(), srcSnap); err != nil {
+		t.Fatal(err)
+	}
+	c := &Controller{Client: cl, Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	if _, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volNew,
+		VolumeCapabilities: volCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapSnap1},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	byNode := map[string]miroirv1alpha1.Replica{}
+	for _, r := range got.Spec.Replicas {
+		byNode[r.Node] = r
+	}
+	if byNode[nodeKharkiv].FullSync {
+		t.Fatalf("the Done seed leg must clone, not full-sync: %+v", byNode[nodeKharkiv])
+	}
+	if !byNode[nodeParis].FullSync {
+		t.Fatalf("the post-snapshot leg must full-sync (no local snapshot): %+v", byNode[nodeParis])
+	}
+}
+
+// A lagging informer after AlreadyExists must surface as Unavailable
+// (retryable) — not Internal, which the provisioner treats as final and
+// would record "volume not created" for a volume that exists.
+func TestCreateVolumeAlreadyExistsCacheLagIsUnavailable(t *testing.T) {
+	s := newScheme(t)
+	// APIReader has the volume; the cached Client (interceptor) 404s it,
+	// simulating an informer that has not caught up.
+	existing := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin}},
+		},
+	}
+	apiReader := fake.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
+	cached := fake.NewClientBuilder().WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(context.Context, client.WithWatch, client.Object, ...client.CreateOption) error {
+				return apierrors.NewAlreadyExists(
+					miroirv1alpha1.GroupVersion.WithResource("miroirvolumes").GroupResource(), volPvc1)
+			},
+		}).Build()
+	c := &Controller{Client: cached, APIReader: apiReader, Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	// Same shape as the existing volume, so handleCreateErr reaches the Get.
+	err := c.handleCreateErr(t.Context(),
+		apierrors.NewAlreadyExists(miroirv1alpha1.GroupVersion.WithResource("miroirvolumes").GroupResource(), volPvc1),
+		&miroirv1alpha1.MiroirVolume{ObjectMeta: metav1.ObjectMeta{Name: volPvc1}},
+		5<<30, 1, miroirv1alpha1.QuorumLastManStanding, "")
+	if err != nil {
+		t.Fatalf("APIReader has the volume; compatible retry must succeed: %v", err)
+	}
+}
+
 func TestPickNodeNoStorageNodes(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).Build(), Nodes: nodemap.Map{}}
@@ -618,7 +723,8 @@ func TestCreateVolumeFromSnapshotEchoesContentSource(t *testing.T) {
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
-		Status:     miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
+		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone}},
 	}
 	cl := readyOnGet(s)
 	if err := cl.Create(t.Context(), srcVol); err != nil {
@@ -680,6 +786,7 @@ func TestCreateVolumeFromSnapshotInheritsFormatted(t *testing.T) {
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{
 			ReadyToUse: true, SizeBytes: 5 << 30, SourceFormatted: true,
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone},
 		},
 	}
 	cl := readyOnGet(s)
@@ -749,12 +856,14 @@ func TestCreateVolumeIdempotentRejectsSourceChange(t *testing.T) {
 	snap1 := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
-		Status:     miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
+		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone}},
 	}
 	snap2 := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: "snap-2"},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
-		Status:     miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
+		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone}},
 	}
 	if err := cl.Create(t.Context(), snap1); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
PR ④ of the performance/resiliency review — two CSI provisioning-retry hazards.

## 1. Cache-lag after `AlreadyExists` → wrong (final) error code

`handleCreateErr` and `CreateSnapshot` resolved a duplicate by reading the existing object through the **cached** client. `AlreadyExists` proves the object is on the API server, but the informer can still lag it, so the `Get` 404s → `codes.Internal`. external-provisioner treats `Internal` as a **final** error: it records "volume was not created" for a volume that demonstrably exists, and if the PVC is deleted in that gap the `MiroirVolume` CR leaks (no PV → `DeleteVolume` never fires). Both paths now read through **`APIReader`** (read-your-writes, the same rationale the port allocator already uses) and map a `Get` failure to **`codes.Unavailable`** so the sidecar keeps retrying.

## 2. Restore onto a post-snapshot-added replica wedges the PVC

`restoreReplicas` cloned each source leg from that node's local snapshot. A replica **added after the snapshot was cut** holds no local snapshot, so `CreateFromSnapshot` failed → `reportError` with `DeviceCreated=false` → `computePhase` returned `VolumeFailed` → the provisioner retried forever, re-adopting the same bad placement. The PVC wedged until an operator intervened.

It now consults `snap.Status.PerNode`: a leg the snapshot didn't capture `Done` is marked **`FullSync`** — the agent creates a fresh backing and DRBD full-syncs it from a `Done` peer (a path `realizeBacking` already supports). The GI-seed leg (first diskful) must itself be `Done`, or the restore is refused `FailedPrecondition` — a `ReadyToUse` snapshot has every pre-existing diskful leg `Done` (it's only ready once `collectLegs` sees them all), so this rejects only the pathological post-snapshot-seed case.

## Tests

`TestCreateVolumeFromSnapshotFullSyncsPostSnapshotReplica` (Done seed clones, post-snapshot leg full-syncs); `TestCreateVolumeAlreadyExistsCacheLagIsUnavailable` (APIReader has it, cached client 404s → compatible retry succeeds). Existing restore fixtures updated to carry the `PerNode: Done` slots a real `ReadyToUse` snapshot always has. Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean.

```
gh pr merge 102 --squash --repo home-operations/miroir
```