### PR TITLE
perf: stop per-poll drbdadm resize and dedup CreateVolume's volume List

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -176,29 +176,9 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
-	reportSize := vol.Spec.SizeBytes
-	requeue := drbdPollInterval
-	if coord := vol.Spec.FirstDiskfulReplica(); coord != nil && coord.Node == r.NodeName {
-		// drbdadm resize is refused mid-resync, so withhold the size and
-		// retry on the next poll instead of failing the reconcile.
-		switch {
-		case peerBackingsGrown(vol, r.NodeName) && !st.Resyncing:
-			// assumeClean=true: all miroir backends are thin/sparse, so
-			// the grown region is zeroed on every replica and a resync
-			// of the new extents is unnecessary.
-			if err := r.DRBD.Resize(ctx, vol.Name, true); err != nil {
-				if !drbd.IsResizeDuringResync(err) {
-					return ctrl.Result{}, r.reportError(ctx, vol, err)
-				}
-				// A resync started between the status read and the resize:
-				// withhold and retry, same as the pre-checked branch below.
-				reportSize = vol.Status.PerNode[r.NodeName].SizeBytes
-				requeue = 5 * time.Second
-			}
-		default:
-			reportSize = vol.Status.PerNode[r.NodeName].SizeBytes
-			requeue = 5 * time.Second
-		}
+	reportSize, requeue, err := r.growIfCoordinator(ctx, vol, st)
+	if err != nil {
+		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
 	if st.SplitBrain && !vol.Status.PerNode[r.NodeName].SplitBrain {
 		log.Error(errSplitBrain,
@@ -517,7 +497,38 @@ func (r *VolumeReconciler) assignMinor(_ context.Context, vol *miroirv1alpha1.Mi
 
 // computePhase aggregates per-node states into the volume phase the CSI
 // controller waits on (notes/DESIGN.md §4.5.1).
-// detachedDiskMessage explains a diskful leg DRBD dropped to Diskless
+// growIfCoordinator runs drbdadm resize when this node is the resize
+// coordinator (first diskful replica) and its realized size still trails
+// the spec — first bring-up and expansion. Once its status reaches spec
+// the device is grown, so the steady state does nothing (no resize exec
+// every poll). Returns the size to report and the requeue interval;
+// resize is withheld (short requeue) while a resync is in flight.
+func (r *VolumeReconciler) growIfCoordinator(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, st drbd.Status) (int64, time.Duration, error) {
+	reportSize := vol.Spec.SizeBytes
+	coord := vol.Spec.FirstDiskfulReplica()
+	behind := vol.Status.PerNode[r.NodeName].SizeBytes < vol.Spec.SizeBytes
+	if !behind || coord == nil || coord.Node != r.NodeName {
+		return reportSize, drbdPollInterval, nil
+	}
+	// drbdadm resize is refused mid-resync, so withhold the size and retry
+	// on the next poll instead of failing the reconcile.
+	if !peerBackingsGrown(vol, r.NodeName) || st.Resyncing {
+		return vol.Status.PerNode[r.NodeName].SizeBytes, 5 * time.Second, nil
+	}
+	// assumeClean=true: all miroir backends are thin/sparse, so the grown
+	// region is zeroed on every replica and a resync of the new extents is
+	// unnecessary.
+	if err := r.DRBD.Resize(ctx, vol.Name, true); err != nil {
+		if !drbd.IsResizeDuringResync(err) {
+			return 0, 0, err
+		}
+		// A resync started between the status read and the resize: withhold.
+		return vol.Status.PerNode[r.NodeName].SizeBytes, 5 * time.Second, nil
+	}
+	return reportSize, drbdPollInterval, nil
+}
+
+// detachedDiskMessage explains a diskful leg DRBD dropped to Diskless// detachedDiskMessage explains a diskful leg DRBD dropped to Diskless
 // after a backing-device I/O error (on-io-error detach): the volume keeps
 // serving via the peer, but the operator otherwise sees only
 // "DiskState: Diskless" with no cause. Gated on the leg having previously

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -813,6 +813,33 @@ func TestReconcileDetachedDiskGetsActionableMessage(t *testing.T) {
 	}
 }
 
+// The resize coordinator must not run drbdadm resize once its realized
+// size already matches the spec — the steady state, every poll.
+func TestReconcileResizeCoordinatorSkipsWhenAtSize(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	// kharkiv is replicas[0] (the coordinator) and already at spec size.
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+	}
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
+	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdadm resize")
+}
+
 // A diskless tie-breaker joins DRBD for quorum only: no backend device,
 // no metadata seed, DeviceCreated stays false so CSI never stages here.
 // A FullSync joiner on a restored volume must create a fresh backing,

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -139,32 +139,10 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 
-	var source *miroirv1alpha1.VolumeSource
-	var sourceFormatted bool
-	var srcReplicas []miroirv1alpha1.Replica
 	snapID := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()
-	if snapID != "" {
-		// Restore: clones are local CoW, so replicas must live on the
-		// nodes holding the snapshot — placement follows the source.
-		srcVol, snap, err := c.snapshotSource(ctx, snapID)
-		if err != nil {
-			return nil, err
-		}
-		sourceFormatted = snap.Status.SourceFormatted
-		if sizeBytes < snap.Status.SizeBytes {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"requested %d below snapshot size %d", sizeBytes, snap.Status.SizeBytes)
-		}
-		if len(srcVol.Spec.DiskfulReplicas()) != replicas {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"restore replica count %d must match source diskful replicas %d",
-				replicas, len(srcVol.Spec.DiskfulReplicas()))
-		}
-		source = &miroirv1alpha1.VolumeSource{SnapshotName: snapID}
-		srcReplicas, err = c.restoreReplicas(ctx, srcVol, snap)
-		if err != nil {
-			return nil, err
-		}
+	source, srcReplicas, sourceFormatted, err := c.resolveSource(ctx, snapID, sizeBytes, replicas)
+	if err != nil {
+		return nil, err
 	}
 
 	// Serialise placement, port allocation, and Create as one critical
@@ -173,9 +151,18 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	// yet would otherwise be invisible to both — two RPCs could pass the
 	// guard or claim the same port. waitReady is deliberately left outside.
 	c.allocMu.Lock()
+	// One volume List serves both the overcommit guard (place) and the
+	// DRBD port scan (allocateDRBD); they need identical data and both run
+	// under the lock. Fetched only when a placing or replicated path needs
+	// it, so a 1-replica restore still does zero volume Lists.
+	vols, err := c.allocVolumes(ctx, snapID == "" || replicas > 1)
+	if err != nil {
+		c.allocMu.Unlock()
+		return nil, err
+	}
 	placed := srcReplicas
 	if snapID == "" {
-		p, err := c.place(ctx, req.GetAccessibilityRequirements(), replicas, sizeBytes, req.GetName())
+		p, err := c.place(ctx, req.GetAccessibilityRequirements(), replicas, sizeBytes, req.GetName(), vols)
 		if err != nil {
 			c.allocMu.Unlock()
 			return nil, err
@@ -199,7 +186,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	}
 	if replicas > 1 {
 		vol.Spec.QuorumPolicy = quorum
-		drbdSpec, err := c.allocateDRBD(ctx)
+		drbdSpec, err := c.allocateDRBD(vols)
 		if err != nil {
 			c.allocMu.Unlock()
 			return nil, err
@@ -293,7 +280,51 @@ func (c *Controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	}, nil
 }
 
-// place selects count replica nodes: the scheduler's preference first
+// resolveSource resolves a restore's source: on a clone (snapID set) it
+// validates the snapshot and size, and returns the placement replicas
+// (following the source, FullSyncing post-snapshot legs). Returns zero
+// values for a fresh volume (no content source).
+func (c *Controller) resolveSource(ctx context.Context, snapID string, sizeBytes int64, replicas int) (*miroirv1alpha1.VolumeSource, []miroirv1alpha1.Replica, bool, error) {
+	if snapID == "" {
+		return nil, nil, false, nil
+	}
+	// Clones are local CoW, so replicas must live on the nodes holding the
+	// snapshot — placement follows the source.
+	srcVol, snap, err := c.snapshotSource(ctx, snapID)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if sizeBytes < snap.Status.SizeBytes {
+		return nil, nil, false, status.Errorf(codes.InvalidArgument,
+			"requested %d below snapshot size %d", sizeBytes, snap.Status.SizeBytes)
+	}
+	if len(srcVol.Spec.DiskfulReplicas()) != replicas {
+		return nil, nil, false, status.Errorf(codes.InvalidArgument,
+			"restore replica count %d must match source diskful replicas %d",
+			replicas, len(srcVol.Spec.DiskfulReplicas()))
+	}
+	srcReplicas, err := c.restoreReplicas(ctx, srcVol, snap)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return &miroirv1alpha1.VolumeSource{SnapshotName: snapID}, srcReplicas, snap.Status.SourceFormatted, nil
+}
+
+// allocVolumes lists every volume once// allocVolumes lists every volume once for the allocMu critical section
+// (the overcommit guard and the DRBD port scan share it). Skipped when
+// unneeded — a 1-replica restore does zero volume Lists.
+func (c *Controller) allocVolumes(ctx context.Context, needed bool) ([]miroirv1alpha1.MiroirVolume, error) {
+	if !needed {
+		return nil, nil
+	}
+	list := &miroirv1alpha1.MiroirVolumeList{}
+	if err := c.reader().List(ctx, list); err != nil {
+		return nil, status.Errorf(codes.Internal, "list MiroirVolumes: %v", err)
+	}
+	return list.Items, nil
+}
+
+// place selects count replica nodes:// place selects count replica nodes: the scheduler's preference first
 // (WaitForFirstConsumer), then the remaining eligible storage nodes by
 // free space — capacity-aware spread (notes/DESIGN.md §4.6). Nodes whose
 // projected provisioned total would breach the overcommit ratio are
@@ -303,7 +334,7 @@ func (c *Controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 // provisions. For replicated volumes it resolves each node's InternalIP
 // and assigns DRBD node ids by slice position — replicas[0] is the GI-seed
 // winner (internal/drbd).
-func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, count int, sizeBytes int64, name string) ([]miroirv1alpha1.Replica, error) {
+func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, count int, sizeBytes int64, name string, vols []miroirv1alpha1.MiroirVolume) ([]miroirv1alpha1.Replica, error) {
 	if len(c.Nodes) < count {
 		return nil, status.Errorf(codes.ResourceExhausted,
 			"need %d storage nodes, have %d (Helm values: nodes)", count, len(c.Nodes))
@@ -313,10 +344,7 @@ func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, c
 	if err != nil {
 		return nil, err
 	}
-	provisioned, err := c.provisionedPerNode(ctx, name)
-	if err != nil {
-		return nil, err
-	}
+	provisioned := provisionedPerNode(vols, name)
 	ratio := c.OvercommitRatio
 	if ratio <= 0 {
 		ratio = defaultOvercommitRatio
@@ -508,13 +536,12 @@ func (c *Controller) poolStats(ctx context.Context) (map[string]miroirv1alpha1.M
 // with a replica on each node, excluding exclude (the volume being
 // (re)created, so an idempotent retry does not count itself). Clones share
 // backing on disk but are counted in full — a conservative overcommit guard.
-func (c *Controller) provisionedPerNode(ctx context.Context, exclude string) (map[string]int64, error) {
-	list := &miroirv1alpha1.MiroirVolumeList{}
-	if err := c.reader().List(ctx, list); err != nil {
-		return nil, status.Errorf(codes.Internal, "list MiroirVolumes: %v", err)
-	}
+// provisionedPerNode sums the provisioned (virtual) bytes per node from a
+// pre-fetched volume list, excluding the named volume (the one being
+// (re)created, so an idempotent retry does not count itself).
+func provisionedPerNode(vols []miroirv1alpha1.MiroirVolume, exclude string) map[string]int64 {
 	out := map[string]int64{}
-	for _, v := range list.Items {
+	for _, v := range vols {
 		if v.Name == exclude {
 			continue
 		}
@@ -525,7 +552,7 @@ func (c *Controller) provisionedPerNode(ctx context.Context, exclude string) (ma
 			out[r.Node] += v.Spec.SizeBytes
 		}
 	}
-	return out, nil
+	return out
 }
 
 // allocateDRBD picks the lowest free TCP port by scanning existing
@@ -533,14 +560,10 @@ func (c *Controller) provisionedPerNode(ctx context.Context, exclude string) (ma
 // allocMu across allocate+Create — CreateVolume RPCs run concurrently
 // within the pod. The minor is per-node and allocated locally by each
 // agent.
-func (c *Controller) allocateDRBD(ctx context.Context) (*miroirv1alpha1.DRBDSpec, error) {
+func (c *Controller) allocateDRBD(vols []miroirv1alpha1.MiroirVolume) (*miroirv1alpha1.DRBDSpec, error) {
 	const portBase = 7000
-	vols := &miroirv1alpha1.MiroirVolumeList{}
-	if err := c.reader().List(ctx, vols); err != nil {
-		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
-	}
 	usedPort := map[int32]bool{}
-	for _, v := range vols.Items {
+	for _, v := range vols {
 		if v.Spec.DRBD != nil {
 			usedPort[v.Spec.DRBD.Port] = true
 		}

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -64,6 +64,17 @@ func placementClient(s *runtime.Scheme, objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
 }
 
+// placementVols lists the seeded volumes the way CreateVolume does, to
+// feed place()'s overcommit accounting.
+func placementVols(t *testing.T, c client.Client) []miroirv1alpha1.MiroirVolume {
+	t.Helper()
+	list := &miroirv1alpha1.MiroirVolumeList{}
+	if err := c.List(t.Context(), list); err != nil {
+		t.Fatal(err)
+	}
+	return list.Items
+}
+
 func topologyPref(node string) *csi.TopologyRequirement {
 	return &csi.TopologyRequirement{
 		Preferred: []*csi.Topology{{Segments: map[string]string{constants.TopologyKey: node}}},
@@ -80,7 +91,7 @@ func TestPlaceWeightsByFreeSpace(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	got, err := c.place(t.Context(), nil, 1, 5*gib, volNew)
+	got, err := c.place(t.Context(), nil, 1, 5*gib, volNew, placementVols(t, c.Client))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +113,7 @@ func TestPlaceRefusesOvercommit(t *testing.T) {
 	}
 
 	// Default 2× ratio: 15 + 10 = 25 GiB provisioned > 20 GiB cap on both.
-	_, err := c.place(t.Context(), nil, 1, 10*gib, volNew)
+	_, err := c.place(t.Context(), nil, 1, 10*gib, volNew, placementVols(t, c.Client))
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("overcommit must be ResourceExhausted, got %v", err)
 	}
@@ -119,7 +130,7 @@ func TestPlaceTopologyPinnedRefusedWhenOvercommitted(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	_, err := c.place(t.Context(), topologyPref(nodeKharkiv), 1, 10*gib, volNew)
+	_, err := c.place(t.Context(), topologyPref(nodeKharkiv), 1, 10*gib, volNew, placementVols(t, c.Client))
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("pinned overcommitted node must be ResourceExhausted, got %v", err)
 	}
@@ -129,7 +140,7 @@ func TestPlaceFallsBackWithoutStats(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: placementClient(s), Nodes: testNodes}
 
-	got, err := c.place(t.Context(), nil, 1, 5*gib, volNew)
+	got, err := c.place(t.Context(), nil, 1, 5*gib, volNew, placementVols(t, c.Client))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +161,7 @@ func TestPlaceHonoursConfiguredRatio(t *testing.T) {
 	}
 
 	// 11 GiB on a 10 GiB pool breaches a 1× ratio on every node.
-	_, err := c.place(t.Context(), nil, 1, 11*gib, volNew)
+	_, err := c.place(t.Context(), nil, 1, 11*gib, volNew, placementVols(t, c.Client))
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("1x ratio must refuse an over-capacity volume, got %v", err)
 	}
@@ -228,7 +239,7 @@ func TestPlaceSpreadsAcrossZones(t *testing.T) {
 		},
 	}
 
-	got, err := c.place(t.Context(), nil, 2, 5*gib, volNew)
+	got, err := c.place(t.Context(), nil, 2, 5*gib, volNew, placementVols(t, c.Client))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes: https://github.com/home-operations/miroir/issues/102

PR ⑤ of the performance/resiliency review — the two behavior-preserving performance wins that need no new process state.

## 1. Resize coordinator no longer runs `drbdadm resize` every poll

The first-diskful replica (resize coordinator) ran `drbdadm resize --assume-clean` on **every 30s reconcile** whenever peers were grown and not resyncing — there was no "already at size" latch, so the steady state re-issued a no-op resize (forking drbdadm, which re-parses every `.res` file on the node) forever. The review measured this concentrated on one node (placement skews coordinators to `replicas[0]`): ~1.7 extra forks/s at 100 volumes, ~144k wasted invocations/day.

Now gated on the coordinator's own realized size trailing the spec (`status.PerNode[self].SizeBytes < spec.SizeBytes`) — true on first bring-up (status 0) and during an expansion, false once the device is grown. Steady state does nothing. Extracted to `growIfCoordinator`; first-bring-up and expansion convergence are unchanged (verified against the existing expand tests).

## 2. CreateVolume lists volumes once, not twice

Under `allocMu`, `place()` → `provisionedPerNode` and `allocateDRBD` each did a full **uncached** (APIReader) `MiroirVolume` List of identical data — the entire critical-section cost. At a 50-PVC StatefulSet scale-up with 100 existing volumes that's 100 full etcd range reads, half of them pure duplication. Now one List per RPC, threaded through both (`provisionedPerNode`/`allocateDRBD` are pure functions over the slice). A 1-replica restore still does **zero** volume Lists (neither path runs).

## Deferred

The bigger steady-state fork win — caching realized state to skip the per-poll backend `Create`/`Resize` (`lvchange --activate`) — needs new per-process state with careful reboot-reactivation semantics, so it gets its own PR with dedicated tests. The no-op status-patch skip is marginal (already a server-side no-op) and deferred with it.

## Tests

`TestReconcileResizeCoordinatorSkipsWhenAtSize` (at-size coordinator issues no `drbdadm resize`); placement tests updated to pass the shared volume slice (new `placementVols` helper mirrors how CreateVolume lists). Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean.

```
gh pr merge 104 --squash --repo home-operations/miroir
```