### PR TITLE
feat: tune chart defaults for redundancy-restore, integrity, and control-plane resilience

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -41,6 +41,7 @@ Kubernetes: `>=1.31.0`
 | agent.resources.requests.memory | string | `"32Mi"` |  |
 | controller.autoTieBreaker | bool | `true` |  |
 | controller.overcommitRatio | int | `2` |  |
+| controller.priorityClassName | string | `"system-cluster-critical"` |  |
 | controller.provisionTimeout | string | `"120s"` |  |
 | controller.resources.limits.memory | string | `"128Mi"` |  |
 | controller.resources.requests.cpu | string | `"10m"` |  |
@@ -50,10 +51,10 @@ Kubernetes: `>=1.31.0`
 | drbd.resync.fillTarget | string | `""` | c-fill-target, the resync controller's target fill level (e.g. "1M"). |
 | drbd.resync.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864"). |
 | drbd.resync.maxRate | string | `""` | c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. "720M"). |
-| drbd.resync.minRate | string | `""` | c-min-rate, the resync floor guaranteed even under application I/O (e.g. "20M"); keep low on shared links. |
+| drbd.resync.minRate | string | `"10M"` | c-min-rate, the resync floor guaranteed even under application I/O. Defaulted to 10M: DRBD's kernel default (250 KiB/s) leaves a degraded volume resyncing for days under load; 10 MiB/s heals a 100Gi leg in hours while still yielding most of a 1GbE link to applications. Lower on a slow shared link. |
 | drbd.resync.planAhead | string | `""` | c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller. |
 | drbd.resync.rate | string | `""` | resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0). |
-| drbd.verifyAlg | string | `""` | verify-alg enables `drbdadm verify <res>` — the only cross-leg integrity check (zfs scrub validates one leg against itself). Set to a kernel digest (e.g. "crc32c") and run verify from cron/manually during quiet hours; out-of-sync blocks surface in the kernel log and `drbdsetup status`. Empty keeps verification unavailable. |
+| drbd.verifyAlg | string | `"crc32c"` | verify-alg arms `drbdadm verify <res>` — the only cross-leg integrity check (a zfs scrub only validates one leg against itself). Defaulted to crc32c: drbd.ko depends on libcrc32c so it is present on every node, and it costs nothing until a verify runs. Schedule the verify pass yourself (cron, quiet hours); out-of-sync blocks surface in the kernel log and `drbdsetup status`. Empty disables verification. |
 | image.digest | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/home-operations/miroir"` |  |
@@ -80,7 +81,9 @@ Kubernetes: `>=1.31.0`
 | sidecars.provisioner.timeout | string | `"120s"` |  |
 | sidecars.registrar.image | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"` |  |
 | sidecars.resizer.image | string | `"registry.k8s.io/sig-storage/csi-resizer:v2.2.1"` |  |
+| sidecars.resizer.timeout | string | `"120s"` |  |
 | sidecars.snapshotter.image | string | `"registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0"` |  |
+| sidecars.snapshotter.timeout | string | `"120s"` |  |
 | storageClass.create | bool | `true` |  |
 | storageClass.fsType | string | `"ext4"` |  |
 | storageClass.isDefault | bool | `false` |  |

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/component: controller
     spec:
       serviceAccountName: {{ include "miroir.controllerName" . }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -73,7 +74,7 @@ spec:
           image: {{ .Values.sidecars.snapshotter.image }}
           args:
             - --csi-address=/csi/csi.sock
-            - --timeout={{ .Values.sidecars.provisioner.timeout }}
+            - --timeout={{ .Values.sidecars.snapshotter.timeout }}
             - --leader-election=false
           resources:
             requests: { cpu: 10m, memory: 32Mi }
@@ -85,7 +86,7 @@ spec:
           image: {{ .Values.sidecars.resizer.image }}
           args:
             - --csi-address=/csi/csi.sock
-            - --timeout={{ .Values.sidecars.provisioner.timeout }}
+            - --timeout={{ .Values.sidecars.resizer.timeout }}
             - --leader-election=false
           resources:
             requests: { cpu: 10m, memory: 32Mi }

--- a/charts/miroir/tests/configmap_test.yaml
+++ b/charts/miroir/tests/configmap_test.yaml
@@ -90,7 +90,7 @@ tests:
       - matchRegex:
           path: data["global_common.conf"]
           pattern: "handlers \\{\\}"
-      # Default emits no resync options — common{} keeps DRBD's built-ins.
+      # Default emits no bandwidth ceiling — the kernel controller adapts.
       - notMatchRegex:
           path: data["global_common.conf"]
           pattern: "c-max-rate"
@@ -99,6 +99,16 @@ tests:
       - matchRegex:
           path: data["global_common.conf"]
           pattern: "on-io-error detach;"
+      # c-min-rate is defaulted so a degraded volume heals in hours, not
+      # days, under application I/O.
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "c-min-rate 10M;"
+      # verify-alg is defaulted (crc32c is always present); free until a
+      # verify runs.
+      - matchRegex:
+          path: data["global_common.conf"]
+          pattern: "verify-alg crc32c;"
 
   - it: renders cluster-wide resync tuning into common{} when set
     set:
@@ -150,7 +160,7 @@ tests:
           path: data["global_common.conf"]
           pattern: "verify-alg crc32c;"
 
-  - it: default emits neither discard granularity nor verify-alg
+  - it: default emits no discard granularity (loopfile-unsafe, opt-in)
     set:
       nodes:
         kharkiv:
@@ -161,9 +171,6 @@ tests:
       - notMatchRegex:
           path: data["global_common.conf"]
           pattern: "rs-discard-granularity"
-      - notMatchRegex:
-          path: data["global_common.conf"]
-          pattern: "verify-alg"
 
   - it: honours a non-default Release namespace for both ConfigMaps
     release:

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -123,11 +123,13 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--auto-tie-breaker=false"
 
-  - it: sidecars pick up their image + the provisioner timeout
+  - it: each sidecar picks up its own image and timeout
     set:
       sidecars.provisioner.timeout: 75s
       sidecars.provisioner.image: registry.k8s.io/sig-storage/csi-provisioner:v9.9.9
+      sidecars.snapshotter.timeout: 76s
       sidecars.snapshotter.image: registry.k8s.io/sig-storage/csi-snapshotter:v9.9.9
+      sidecars.resizer.timeout: 77s
       sidecars.resizer.image: registry.k8s.io/sig-storage/csi-resizer:v9.9.9
     documentIndex: 0
     asserts:
@@ -150,7 +152,7 @@ tests:
             image: registry.k8s.io/sig-storage/csi-snapshotter:v9.9.9
             args:
               - "--csi-address=/csi/csi.sock"
-              - "--timeout=75s"
+              - "--timeout=76s"
               - "--leader-election=false"
       - contains:
           any: true
@@ -160,8 +162,15 @@ tests:
             image: registry.k8s.io/sig-storage/csi-resizer:v9.9.9
             args:
               - "--csi-address=/csi/csi.sock"
-              - "--timeout=75s"
+              - "--timeout=77s"
               - "--leader-election=false"
+
+  - it: the controller pod is cluster-critical by default
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-cluster-critical
 
   - it: respects a custom image repository + tag
     set:

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -64,8 +64,15 @@
           "title": "overcommitRatio",
           "type": "integer"
         },
+        "priorityClassName": {
+          "default": "system-cluster-critical",
+          "description": "system-cluster-critical protects the single controller from eviction\nunder node pressure — while it is down, no volume can be provisioned,\nexpanded, or snapshotted.",
+          "title": "priorityClassName",
+          "type": "string"
+        },
         "provisionTimeout": {
           "default": "120s",
+          "description": "Wait for agents to realise a new volume. Keep sidecars.*.timeout at or\nabove this, or the sidecar RPC deadline fires before this one and the\nknob has no effect.",
           "title": "provisionTimeout",
           "type": "string"
         },
@@ -146,8 +153,8 @@
               "type": "string"
             },
             "minRate": {
-              "default": "",
-              "description": "c-min-rate, the resync floor guaranteed even under application I/O (e.g. \"20M\"); keep low on shared links.",
+              "default": "10M",
+              "description": "c-min-rate, the resync floor guaranteed even under application I/O.\nDefaulted to 10M: DRBD's kernel default (250 KiB/s) leaves a degraded\nvolume resyncing for days under load; 10 MiB/s heals a 100Gi leg in\nhours while still yielding most of a 1GbE link to applications. Lower\non a slow shared link.",
               "title": "minRate",
               "type": "string"
             },
@@ -169,8 +176,8 @@
           "type": "object"
         },
         "verifyAlg": {
-          "default": "",
-          "description": "verify-alg enables `drbdadm verify \u003cres\u003e` — the only cross-leg\nintegrity check (zfs scrub validates one leg against itself). Set to a\nkernel digest (e.g. \"crc32c\") and run verify from cron/manually during\nquiet hours; out-of-sync blocks surface in the kernel log and\n`drbdsetup status`. Empty keeps verification unavailable.",
+          "default": "crc32c",
+          "description": "verify-alg arms `drbdadm verify \u003cres\u003e` — the only cross-leg\nintegrity check (a zfs scrub only validates one leg against itself).\nDefaulted to crc32c: drbd.ko depends on libcrc32c so it is present on\nevery node, and it costs nothing until a verify runs. Schedule the\nverify pass yourself (cron, quiet hours); out-of-sync blocks surface\nin the kernel log and `drbdsetup status`. Empty disables verification.",
           "title": "verifyAlg",
           "type": "string"
         }
@@ -384,6 +391,12 @@
               "default": "registry.k8s.io/sig-storage/csi-resizer:v2.2.1",
               "title": "image",
               "type": "string"
+            },
+            "timeout": {
+              "default": "120s",
+              "description": "Online grow can block on a rebooting node; keep \u003e= controller.provisionTimeout.",
+              "title": "timeout",
+              "type": "string"
             }
           },
           "required": [],
@@ -395,6 +408,12 @@
             "image": {
               "default": "registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0",
               "title": "image",
+              "type": "string"
+            },
+            "timeout": {
+              "default": "120s",
+              "description": "CreateSnapshot returns fast (readiness is polled), so the default\nsuffices; raise if snapshot RPCs are slow.",
+              "title": "timeout",
               "type": "string"
             }
           },

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -19,8 +19,13 @@ sidecars:
     image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
   snapshotter:
     image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
+    # CreateSnapshot returns fast (readiness is polled), so the default
+    # suffices; raise if snapshot RPCs are slow.
+    timeout: 120s
   resizer:
     image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
+    # Online grow can block on a rebooting node; keep >= controller.provisionTimeout.
+    timeout: 120s
 
 # Pre-delete hook Job: deletes miroirsnapshots/miroirvolumes (so the agent
 # tears down DRBD/LVM) before the CRDs are released. Needs only `kubectl`.
@@ -55,6 +60,13 @@ kubeletDir: /var/lib/kubelet
 nodes: {}
 
 controller:
+  # system-cluster-critical protects the single controller from eviction
+  # under node pressure — while it is down, no volume can be provisioned,
+  # expanded, or snapshotted.
+  priorityClassName: system-cluster-critical
+  # Wait for agents to realise a new volume. Keep sidecars.*.timeout at or
+  # above this, or the sidecar RPC deadline fires before this one and the
+  # knob has no effect.
   provisionTimeout: 120s
   # Thin-provisioning overcommit guardrail: CreateVolume is refused when a
   # node's provisioned total would exceed capacity × this ratio. 2× is the
@@ -106,8 +118,12 @@ drbd:
     fillTarget: ""
     # -- c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. "720M").
     maxRate: ""
-    # -- c-min-rate, the resync floor guaranteed even under application I/O (e.g. "20M"); keep low on shared links.
-    minRate: ""
+    # -- c-min-rate, the resync floor guaranteed even under application I/O.
+    # Defaulted to 10M: DRBD's kernel default (250 KiB/s) leaves a degraded
+    # volume resyncing for days under load; 10 MiB/s heals a 100Gi leg in
+    # hours while still yielding most of a 1GbE link to applications. Lower
+    # on a slow shared link.
+    minRate: 10M
     # -- resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0).
     rate: ""
     # -- max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864").
@@ -118,12 +134,13 @@ drbd:
     # clusters with loopfile-backed replicated volumes (loop devices
     # mishandle it) or entirely to keep DRBD's default (off).
     discardGranularity: ""
-  # -- verify-alg enables `drbdadm verify <res>` — the only cross-leg
-  # integrity check (zfs scrub validates one leg against itself). Set to a
-  # kernel digest (e.g. "crc32c") and run verify from cron/manually during
-  # quiet hours; out-of-sync blocks surface in the kernel log and
-  # `drbdsetup status`. Empty keeps verification unavailable.
-  verifyAlg: ""
+  # -- verify-alg arms `drbdadm verify <res>` — the only cross-leg
+  # integrity check (a zfs scrub only validates one leg against itself).
+  # Defaulted to crc32c: drbd.ko depends on libcrc32c so it is present on
+  # every node, and it costs nothing until a verify runs. Schedule the
+  # verify pass yourself (cron, quiet hours); out-of-sync blocks surface
+  # in the kernel log and `drbdsetup status`. Empty disables verification.
+  verifyAlg: crc32c
 
 storageClass:
   create: true


### PR DESCRIPTION
PR ⑥ of the performance/resiliency review — four Helm-default changes. All are values-level and trivially overridable.

## `drbd.resync.minRate: 10M` (the impactful one)

DRBD's kernel `c-min-rate` default is **250 KiB/s** — the floor a resync is guaranteed under application I/O. That leaves a degraded 100Gi volume resyncing for **~5 days** under load, which is the opposite of what a replicated driver is for (minimizing time-at-reduced-redundancy). `10M` heals a 100Gi leg in ~2.8 hours while still yielding most of a 1GbE link to applications. The kernel resync controller (`c-plan-ahead`, on by default) is left alone — this is the one floor worth raising.

Note: neither LINSTOR nor blockstor ships a non-kernel default here — this is a deliberate divergence flagged by the data-path review because the kernel default is genuinely harmful, and it's one value to override.

## `drbd.verifyAlg: crc32c`

Arms `drbdadm verify` — the only **cross-leg** integrity check (a ZFS scrub only validates one leg against itself). `drbd.ko` depends on `libcrc32c`, so `crc32c` is present on every node that can run miroir; arming it costs nothing until you run a (self-scheduled, cron) verify pass. This achieves LINSTOR's auto-`verify-alg` outcome with zero cross-node negotiation machinery.

## `controller.priorityClassName: system-cluster-critical`

While the single controller is down, nothing provisions, expands, or snapshots — so it shouldn't be an ordinary eviction candidate under node pressure. The agent is already `system-node-critical`; this brings the controller to the standard CSI-control-plane priority.

## Per-sidecar timeouts

`csi-snapshotter` and `csi-resizer` `--timeout` were both silently wired to `sidecars.provisioner.timeout` — their own values did nothing. Each now has its own `timeout` (default 120s), and `provisionTimeout` is documented to require `sidecars.*.timeout >= controller.provisionTimeout` or the controller's own timeout never fires (the sidecar deadline preempts it).

## Tests

helm-unittest 59/59: default now renders `c-min-rate 10M` + `verify-alg crc32c`; `priorityClassName` asserted; each sidecar asserted to take its own distinct timeout. README/schema regenerated; helm lint clean.

```
gh pr merge 105 --squash --repo home-operations/miroir
```