### PR TITLE
fix: release a volume's DRBD minor on teardown

### DIFF
--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -352,21 +352,51 @@ const minorBase int32 = 1000
 // AllocateMinor assigns a DRBD minor to a volume, returning the same
 // minor on future calls. Serialised by an advisory flock the kernel
 // releases on close or process death, then persisted via atomic rename.
-func (d *Driver) AllocateMinor(volume string) (int32, error) {
-	// flock, not an O_EXCL sentinel: a sentinel orphaned by a crash between
-	// create and remove would deadlock every future allocation (nothing
-	// sweeps minor.lock). LOCK_EX blocks until acquired and the kernel drops
-	// it when the fd closes — including on SIGKILL/OOM — so a crash cannot
-	// wedge allocation. The file is intentionally left on disk as the stable
-	// lock target.
+// lockMinors serialises minor.assign access. flock, not an O_EXCL
+// sentinel: a sentinel orphaned by a crash between create and remove would
+// deadlock every future allocation (nothing sweeps minor.lock). LOCK_EX
+// blocks until acquired and the kernel drops it when the fd closes —
+// including on SIGKILL/OOM — so a crash cannot wedge allocation. The file
+// is intentionally left on disk as the stable lock target.
+func (d *Driver) lockMinors() (func(), error) {
 	f, err := os.OpenFile(d.path("minor.lock"), os.O_CREATE|os.O_RDWR, 0o640)
 	if err != nil {
-		return 0, fmt.Errorf("open minor lock: %w", err)
+		return nil, fmt.Errorf("open minor lock: %w", err)
 	}
-	defer func() { _ = f.Close() }()
 	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
-		return 0, fmt.Errorf("lock minor allocation: %w", err)
+		_ = f.Close()
+		return nil, fmt.Errorf("lock minor allocation: %w", err)
 	}
+	return func() { _ = f.Close() }, nil
+}
+
+// releaseMinor drops a volume's minor.assign entry so the minor can be
+// reused. Called on teardown; without it the map grows for the lifetime of
+// the StateDir. Absent entry (unreplicated volume, or already released) is
+// a no-op.
+func (d *Driver) releaseMinor(volume string) error {
+	unlock, err := d.lockMinors()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	assigned, err := d.readAssignments()
+	if err != nil {
+		return err
+	}
+	if _, ok := assigned[volume]; !ok {
+		return nil
+	}
+	delete(assigned, volume)
+	return d.writeAssignments(assigned)
+}
+
+func (d *Driver) AllocateMinor(volume string) (int32, error) {
+	unlock, err := d.lockMinors()
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
 
 	assigned, err := d.readAssignments()
 	if err != nil {
@@ -639,7 +669,9 @@ func (d *Driver) Down(ctx context.Context, name string) error {
 			return err
 		}
 	}
-	return nil
+	// Free the minor for reuse — the .res is gone, so scanUsedMinors no
+	// longer covers it, and the assignment would otherwise leak forever.
+	return d.releaseMinor(name)
 }
 
 // DiskUpToDate is the disk state of a replica holding current data.

--- a/internal/drbd/minor_test.go
+++ b/internal/drbd/minor_test.go
@@ -97,6 +97,34 @@ func TestAllocateMinorSkipsMinorsFromOwnRender(t *testing.T) {
 // A volume whose .res survived but whose assignment record was lost must
 // recover its own minor, not claim a fresh one — the kernel resource may
 // still be running on it.
+// Down releases the volume's minor.assign entry so the minor is reused,
+// not leaked for the lifetime of the StateDir.
+func TestDownReleasesMinorAssignment(t *testing.T) {
+	dir := t.TempDir()
+	fe := &fakeExec{}
+	d := &Driver{StateDir: dir, Exec: fe.run, Mknod: fakeMknod}
+
+	first, err := d.AllocateMinor("pvc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A .res must exist or Down short-circuits as never-configured.
+	if err := os.WriteFile(filepath.Join(dir, "pvc-1.res"), []byte("resource \"pvc-1\" {}\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Down(t.Context(), "pvc-1"); err != nil {
+		t.Fatal(err)
+	}
+	// A fresh volume reclaims the freed minor instead of advancing past it.
+	reused, err := d.AllocateMinor("pvc-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused != first {
+		t.Fatalf("freed minor %d must be reused, got %d", first, reused)
+	}
+}
+
 func TestAllocateMinorRecoversOwnMinorFromRes(t *testing.T) {
 	dir := t.TempDir()
 	d := &Driver{StateDir: dir}


### PR DESCRIPTION
PR ⑧ (final) of the performance/resiliency review — the last residue teardown left behind.

`Down` removed the rendered `.res` and the metadata markers (`stateSuffixes`), but never the volume's `minor.assign` entry. So the assignment map grew monotonically for the lifetime of the agent's `StateDir`, and freed minors were never reused (`scanUsedMinors` seeds from the map). The review flagged it as "the one true permanent residue" — cosmetic (exhaustion needs ~1M volume lifetimes) but real.

`Down` now releases the entry under the same flock `AllocateMinor` takes (extracted into a shared `lockMinors`). Once the `.res` is gone `scanUsedMinors` no longer covers the minor, so dropping the assignment is what actually makes it reusable.

## Deferred from this PR

The resync-progress gauge (`percent-in-sync`) was the other half of the planned batch — deferred to #108. It's pure observability with a `drbdsetup --json` field path I can't confirm without a real DRBD kernel; if the path is wrong the gauge silently reads 0, and unlike everything else this cycle it isn't code-verifiable here. Filed with the on-hardware confirmation step.

## Tests

`TestDownReleasesMinorAssignment`: allocate → Down → a fresh volume reclaims the freed minor instead of advancing past it. Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean.

```
gh pr merge 109 --squash --repo home-operations/miroir
```