### PR TITLE
fix: parse replication-state from peer_devices; expose resync percent

### DIFF
--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -42,10 +42,14 @@ var (
 		Name: "miroir_volume_suspended",
 		Help: "1 while suspend-io holds this node's write barrier; sustained means a stranded barrier (snapshot rounds last seconds).",
 	}, []string{volumeLabel})
+	metricResyncPercent = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "miroir_volume_resync_percent",
+		Help: "Percent in sync of the least-synced peer while resyncing; 100 when fully in sync.",
+	}, []string{volumeLabel})
 )
 
 func init() {
-	metrics.Registry.MustRegister(metricUpToDate, metricConnected, metricSplitBrain, metricSuspended)
+	metrics.Registry.MustRegister(metricUpToDate, metricConnected, metricSplitBrain, metricSuspended, metricResyncPercent)
 }
 
 func recordVolumeMetrics(volume string, st miroirReplicaView) {
@@ -53,6 +57,7 @@ func recordVolumeMetrics(volume string, st miroirReplicaView) {
 	metricConnected.WithLabelValues(volume).Set(boolGauge(st.connected))
 	metricSplitBrain.WithLabelValues(volume).Set(boolGauge(st.splitBrain))
 	metricSuspended.WithLabelValues(volume).Set(boolGauge(st.suspended))
+	metricResyncPercent.WithLabelValues(volume).Set(st.resyncPercent)
 }
 
 func dropVolumeMetrics(volume string) {
@@ -60,13 +65,15 @@ func dropVolumeMetrics(volume string) {
 	metricConnected.DeleteLabelValues(volume)
 	metricSplitBrain.DeleteLabelValues(volume)
 	metricSuspended.DeleteLabelValues(volume)
+	metricResyncPercent.DeleteLabelValues(volume)
 }
 
 type miroirReplicaView struct {
-	upToDate   bool
-	connected  bool
-	splitBrain bool
-	suspended  bool
+	upToDate      bool
+	connected     bool
+	splitBrain    bool
+	suspended     bool
+	resyncPercent float64
 }
 
 func boolGauge(b bool) float64 {

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -188,10 +188,11 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	connected := diskfulPeersConnected(st, vol, r.NodeName)
 	if !localDiskless {
 		recordVolumeMetrics(vol.Name, miroirReplicaView{
-			upToDate:   st.DiskState == drbd.DiskUpToDate,
-			connected:  connected,
-			splitBrain: st.SplitBrain,
-			suspended:  st.Suspended,
+			upToDate:      st.DiskState == drbd.DiskUpToDate,
+			connected:     connected,
+			splitBrain:    st.SplitBrain,
+			suspended:     st.Suspended,
+			resyncPercent: st.ResyncPercent,
 		})
 	}
 	if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -487,7 +487,7 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 	// sync should withhold the resize.
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
-		"connections":[{"peer-node-id":1,"connection-state":"Connected","replication-state":"SyncSource"}]}]`}
+		"connections":[{"peer-node-id":1,"connection-state":"Connected","peer_devices":[{"replication-state":"SyncSource"}]}]}]`}
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
@@ -524,7 +524,7 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 	// Resync completes: the next pass grows DRBD and publishes the size.
 	fe.statusJSON = `[{"name":"` + volPvc1 + `",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
-		"connections":[{"peer-node-id":1,"connection-state":"Connected","replication-state":"Established"}]}]`
+		"connections":[{"peer-node-id":1,"connection-state":"Connected","peer_devices":[{"replication-state":"Established"}]}]}]`
 	if _, err := r.Reconcile(t.Context(),
 		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
 		t.Fatal(err)
@@ -561,7 +561,7 @@ func TestReconcile_ResizeRaceWithResyncIsTransient(t *testing.T) {
 	fe := &fakeDRBDExec{
 		statusJSON: `[{"name":"` + volPvc1 + `",
 			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
-			"connections":[{"peer-node-id":1,"connection-state":"Connected","replication-state":"Established"}]}]`,
+			"connections":[{"peer-node-id":1,"connection-state":"Connected","peer_devices":[{"replication-state":"Established"}]}]}]`,
 		errOn: map[string]error{
 			"drbdadm resize": errors.New("exit status 10: Resize not allowed during resync."),
 		},

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -711,6 +711,9 @@ type Status struct {
 	// Resyncing is true while a peer connection is mid-resync; drbdadm
 	// resize is refused in this window.
 	Resyncing bool
+	// ResyncPercent is the least-synced diskful peer's percent-in-sync
+	// while resyncing; 100 when fully in sync (nothing to catch up).
+	ResyncPercent float64
 }
 
 // drbdsetup status --json shapes (the fields miroir reads).
@@ -722,10 +725,16 @@ type jsonStatus struct {
 		DiskState string `json:"disk-state"`
 	} `json:"devices"`
 	Connections []struct {
-		PeerNodeID       int32  `json:"peer-node-id"`
-		ConnectionState  string `json:"connection-state"`
-		PeerRole         string `json:"peer-role"`
-		ReplicationState string `json:"replication-state"`
+		PeerNodeID      int32  `json:"peer-node-id"`
+		ConnectionState string `json:"connection-state"`
+		PeerRole        string `json:"peer-role"`
+		// replication-state and percent-in-sync are per peer-device,
+		// nested under the connection — NOT connection-level fields
+		// (verified against drbd-utils user/v9/drbdsetup.c).
+		PeerDevices []struct {
+			ReplicationState string  `json:"replication-state"`
+			PercentInSync    float64 `json:"percent-in-sync"`
+		} `json:"peer_devices"`
 	} `json:"connections"`
 }
 
@@ -748,6 +757,7 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 		Primary:       res.Role == "Primary",
 		Suspended:     res.SuspendedUser,
 		PeerConnected: make(map[int32]bool, len(res.Connections)),
+		ResyncPercent: 100,
 	}
 	if len(res.Devices) > 0 {
 		s.DiskState = res.Devices[0].DiskState
@@ -756,9 +766,16 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 		if c.PeerRole == "Primary" {
 			s.PeerPrimary = true
 		}
-		// Anything other than Established/Off is an active resync.
-		if rs := c.ReplicationState; rs != "" && rs != "Established" && rs != "Off" {
-			s.Resyncing = true
+		// replication-state / percent-in-sync live per peer-device.
+		// Anything other than Established/Off is active resync/verify;
+		// track the least-synced leg for progress reporting.
+		for _, pd := range c.PeerDevices {
+			if rs := pd.ReplicationState; rs != "" && rs != "Established" && rs != "Off" {
+				s.Resyncing = true
+				if pd.PercentInSync < s.ResyncPercent {
+					s.ResyncPercent = pd.PercentInSync
+				}
+			}
 		}
 		s.PeerConnected[c.PeerNodeID] = c.ConnectionState == "Connected"
 		if c.ConnectionState == "StandAlone" {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -644,6 +644,48 @@ func TestStatusSplitBrain(t *testing.T) {
 	}
 }
 
+// percent-in-sync is a peer-device field; Status surfaces the least-synced
+// leg as ResyncPercent (100 when fully in sync). Verified against the
+// drbdsetup source JSON shape.
+func TestStatusResyncPercent(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
+			"devices":[{"disk-state":"Inconsistent"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected",
+				"peer_devices":[{"replication-state":"SyncTarget","percent-in-sync":42.5}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	s, err := d.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Resyncing || s.ResyncPercent != 42.5 {
+		t.Fatalf("want Resyncing with ResyncPercent 42.5, got %+v", s)
+	}
+}
+
+// A fully in-sync volume reports ResyncPercent 100, and connection-level
+// replication-state (the pre-fix wrong nesting) is correctly ignored.
+func TestStatusResyncPercentDefaultsFull(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
+			"devices":[{"disk-state":"UpToDate"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected","replication-state":"SyncTarget",
+				"peer_devices":[{"replication-state":"Established","percent-in-sync":100}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	s, err := d.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Resyncing {
+		t.Fatalf("connection-level replication-state must be ignored (peer-device is Established): %+v", s)
+	}
+	if s.ResyncPercent != 100 {
+		t.Fatalf("in-sync volume must report 100, got %v", s.ResyncPercent)
+	}
+}
+
 func TestStatusResyncing(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -657,14 +699,16 @@ func TestStatusResyncing(t *testing.T) {
 		{"paused", "PausedSyncT", true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			repl := ""
+			// replication-state is a peer-device field, nested under the
+			// connection (verified against drbdsetup source).
+			peerDevs := ""
 			if tc.repl != "" {
-				repl = `,"replication-state":"` + tc.repl + `"`
+				peerDevs = `,"peer_devices":[{"replication-state":"` + tc.repl + `"}]`
 			}
 			fe := &fakeExec{responses: map[string]string{
 				cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
 					"devices":[{"disk-state":"UpToDate"}],
-					"connections":[{"connection-state":"Connected"` + repl + `}]}]`,
+					"connections":[{"connection-state":"Connected"` + peerDevs + `}]}]`,
 			}}
 			d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 


### PR DESCRIPTION
Resolves #108. Came out of reading the drbd-utils source (`user/v9/drbdsetup.c`) to verify the resync-percent JSON field — which turned up a shipped bug.

## The bug

`drbdsetup status --json` nests `replication-state` and `percent-in-sync` under `connections[].peer_devices[]` (`peer_device_status_json`), **not** at the connection level. miroir's `jsonStatus` read `replication-state` at the connection level, so against real `drbdsetup` it was always `""` → **`Status.Resyncing` was always `false` in production.**

Never caught because the unit tests fed miroir's assumed flat shape and the kind e2e doesn't exercise DRBD. Impact was bounded: `Resyncing` only gates the resize coordinator's proactive `!st.Resyncing` precheck, so a mid-resync `drbdadm resize` was attempted, refused by DRBD, and caught by `IsResizeDuringResync(err)` → requeue. Self-correcting via the error path, but the guard never fired.

## The fix

`jsonStatus` now has a `peer_devices` array under each connection; `replication-state` is read there (fixing `Resyncing`). The other fields were verified **correct** where they are: `connection-state`, `peer-role` (connection level), `disk-state` (top-level `devices[]`), `suspended-user` (resource level).

## Resync progress (the #108 enhancement)

Same nesting carries `percent-in-sync`, so the fix also exposes it: `Status.ResyncPercent` (the least-synced peer's percent, 100 when fully in sync) and a new **`miroir_volume_resync_percent`** gauge — the sync-progress observability blockstor/LINSTOR surface and miroir lacked.

## Verification

The JSON shape is confirmed against the drbd-utils source, so this needed no guessing. Tests rebuilt to the **real nested shape**: `TestStatusResyncing` (now nested), `TestStatusResyncPercent` (42.5% mid-sync), `TestStatusResyncPercentDefaultsFull` (in-sync → 100, and a regression asserting connection-level `replication-state` is ignored). Full suite green in `golang:1.26.5`, golangci-lint v2.12.2 clean. A real-node smoke to confirm the percent reads sensibly during an actual sync is still worthwhile but not required for the parse.

```
gh pr merge 111 --squash --repo home-operations/miroir
```
