### PR TITLE
feat(agent): latch failed disks and skip re-attach (#101)

### DIFF
--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -185,6 +185,13 @@ type ReplicaStatus struct {
 	// knows after the entry has left spec.replicas.
 	// +optional
 	Diskless bool `json:"diskless,omitempty"`
+	// DiskFailed latches a diskful leg DRBD detached after a backing I/O
+	// error (on-io-error detach): the agent renders `adjust --skip-disk`
+	// so the next reconcile does not re-attach the failing disk and
+	// re-trigger the error. Sticky until the replica is removed and
+	// re-added (a fresh backing clears it). Serving continues via the peer.
+	// +optional
+	DiskFailed bool `json:"diskFailed,omitempty"`
 	// Message carries the last reconcile error, if any.
 	Message string `json:"message,omitempty"`
 }

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -275,6 +275,14 @@ spec:
                         DevicePath is the node-local path pods attach to (backing device for
                         replicas:1; /dev/drbd<minor> when replicated).
                       type: string
+                    diskFailed:
+                      description: |-
+                        DiskFailed latches a diskful leg DRBD detached after a backing I/O
+                        error (on-io-error detach): the agent renders `adjust --skip-disk`
+                        so the next reconcile does not re-attach the failing disk and
+                        re-trigger the error. Sticky until the replica is removed and
+                        re-added (a fresh backing clears it). Serving continues via the peer.
+                      type: boolean
                     diskState:
                       description: |-
                         DiskState is the DRBD disk state on this node (UpToDate,

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -275,6 +275,14 @@ spec:
                         DevicePath is the node-local path pods attach to (backing device for
                         replicas:1; /dev/drbd<minor> when replicated).
                       type: string
+                    diskFailed:
+                      description: |-
+                        DiskFailed latches a diskful leg DRBD detached after a backing I/O
+                        error (on-io-error detach): the agent renders `adjust --skip-disk`
+                        so the next reconcile does not re-attach the failing disk and
+                        re-trigger the error. Sticky until the replica is removed and
+                        re-added (a fresh backing clears it). Serving continues via the peer.
+                      type: boolean
                     diskState:
                       description: |-
                         DiskState is the DRBD disk state on this node (UpToDate,

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -195,6 +195,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			resyncPercent: st.ResyncPercent,
 		})
 	}
+	diskFailed := diskFailedLatch(vol, r.NodeName, st, localDiskless)
 	if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
 		DeviceCreated: !localDiskless,
 		DevicePath:    drbd.DevicePath(minor),
@@ -204,7 +205,8 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		Connected:     connected,
 		SplitBrain:    st.SplitBrain,
 		Diskless:      localDiskless,
-		Message:       detachedDiskMessage(vol, r.NodeName, st, localDiskless),
+		DiskFailed:    diskFailed,
+		Message:       detachedDiskMessage(diskFailed),
 	}); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -328,7 +330,11 @@ func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string,
 		LocalDiskless: localDiskless,
 		Secret:        vol.Spec.DRBD.SharedSecret,
 		SkipSeed:      skipSeed,
-		Peers:         peers,
+		// Latched failed: render adjust --skip-disk so the failing disk is
+		// not re-attached. Read from prior status, so it lags the detach by
+		// one reconcile. Cleared by a replica re-add (removal drops the slot).
+		SkipDiskAttach: !localDiskless && vol.Status.PerNode[localNode].DiskFailed,
+		Peers:          peers,
 	}
 }
 
@@ -511,6 +517,12 @@ func (r *VolumeReconciler) growIfCoordinator(ctx context.Context, vol *miroirv1a
 	if !behind || coord == nil || coord.Node != r.NodeName {
 		return reportSize, drbdPollInterval, nil
 	}
+	// A latched-failed coordinator has no local disk (Diskless): drbdadm
+	// resize would error, and removing the replica re-elects the coordinator
+	// to a healthy peer anyway. Withhold and poll rather than error-loop.
+	if st.DiskState == drbd.DiskDiskless {
+		return vol.Status.PerNode[r.NodeName].SizeBytes, 5 * time.Second, nil
+	}
 	// drbdadm resize is refused mid-resync, so withhold the size and retry
 	// on the next poll instead of failing the reconcile.
 	if !peerBackingsGrown(vol, r.NodeName) || st.Resyncing {
@@ -529,16 +541,29 @@ func (r *VolumeReconciler) growIfCoordinator(ctx context.Context, vol *miroirv1a
 	return reportSize, drbdPollInterval, nil
 }
 
-// detachedDiskMessage explains a diskful leg DRBD dropped to Diskless// detachedDiskMessage explains a diskful leg DRBD dropped to Diskless
-// after a backing-device I/O error (on-io-error detach): the volume keeps
-// serving via the peer, but the operator otherwise sees only
-// "DiskState: Diskless" with no cause. Gated on the leg having previously
-// been attached so a normal bring-up (briefly Diskless) does not cry wolf.
-func detachedDiskMessage(vol *miroirv1alpha1.MiroirVolume, self string, st drbd.Status, localDiskless bool) string {
+// diskFailedLatch reports whether this diskful leg is latched failed: DRBD
+// detached it to Diskless after a backing-device I/O error (on-io-error
+// detach) and it must not be re-attached (drbdResource renders
+// adjust --skip-disk while latched). It is sticky — once a prior reconcile
+// recorded DiskFailed it stays latched even though prev DiskState is now
+// Diskless (the fresh-detach test alone would clear it). It clears only
+// when the leg reaches a non-Diskless state again (a re-add re-attaches a
+// fresh disk) or the replica is removed (removal drops this status slot).
+// Gated on the leg having previously been attached so a normal bring-up
+// (briefly Diskless) does not cry wolf.
+func diskFailedLatch(vol *miroirv1alpha1.MiroirVolume, self string, st drbd.Status, localDiskless bool) bool {
 	if localDiskless || st.DiskState != drbd.DiskDiskless {
-		return ""
+		return false
 	}
-	if prev := vol.Status.PerNode[self].DiskState; prev == "" || prev == drbd.DiskDiskless {
+	prev := vol.Status.PerNode[self]
+	return prev.DiskFailed || (prev.DiskState != "" && prev.DiskState != drbd.DiskDiskless)
+}
+
+// detachedDiskMessage explains a latched-failed leg to the operator, who
+// otherwise sees only "DiskState: Diskless" with no cause. Persists as long
+// as the leg is latched, not just the reconcile the detach was first seen.
+func detachedDiskMessage(diskFailed bool) string {
+	if !diskFailed {
 		return ""
 	}
 	return "backing device detached after an I/O error; serving via the peer — " +

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -811,6 +811,82 @@ func TestReconcileDetachedDiskGetsActionableMessage(t *testing.T) {
 	if !st.DeviceCreated {
 		t.Fatalf("detached leg must stay DeviceCreated (Degraded, not Failed): %+v", st)
 	}
+	if !st.DiskFailed {
+		t.Fatalf("first detach must latch DiskFailed so the next reconcile skips re-attach: %+v", st)
+	}
+	// The latch is read from the prior reconcile's status, so this first
+	// detection still ran a bare adjust (one re-attach), then latched.
+	fe.calledWith(t, "drbdadm adjust "+volPvc1)
+	fe.notCalledWith(t, "--skip-disk")
+}
+
+// Once a leg is latched failed (prior reconcile set DiskFailed), the agent
+// renders adjust --skip-disk so DRBD reconciles net/connection state but
+// does not re-attach the failing disk — stopping the on-io-error flap
+// (#101). The latch is sticky: it stays set though prev DiskState is now
+// Diskless, and clears only on a replica re-add.
+func TestReconcileLatchedDiskSkipsReAttach(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	// Already latched by a prior reconcile: Diskless and DiskFailed.
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateDiskless, DiskFailed: true, SizeBytes: 1 << 30},
+	}
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"Diskless"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
+	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+
+	reconcile(t, r, volPvc1)
+
+	fe.calledWith(t, "drbdadm adjust --skip-disk "+volPvc1)
+	fe.notCalledWith(t, "adjust "+volPvc1) // never a bare re-attach
+	fe.notCalledWith(t, "create-md")       // never touch the failing disk
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if st := got.Status.PerNode[nodeKharkiv]; !st.DiskFailed {
+		t.Fatalf("latch must stay set while the leg is Diskless: %+v", st)
+	}
+}
+
+// A latched-failed coordinator (Diskless) cannot drbdadm resize its absent
+// local disk. The grow must be withheld, not attempted — otherwise the
+// reconcile error-loops on a resize the diskless node can never do.
+func TestReconcileLatchedCoordinatorSkipsResize(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.SizeBytes = 2 << 30 // grown; the coordinator is behind
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	// kharkiv is replicas[0] (coordinator), latched failed and still at the
+	// old size.
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateDiskless, DiskFailed: true, SizeBytes: 1 << 30},
+		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 2 << 30},
+	}
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"Diskless"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
+	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdadm resize")
 }
 
 // The resize coordinator must not run drbdadm resize once its realized

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -98,7 +98,10 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 	// A diskless tie-breaker has no backing device — no metadata, no
 	// device-node, no marker. It only needs the .res rendered (writeConfig
 	// above) and drbdadm up/adjust so DRBD joins the resource for quorum.
-	if !r.LocalDiskless {
+	// A SkipDiskAttach leg is latched failed: leave its backing disk alone
+	// (no create-md on a disk DRBD dropped on I/O error). The disk phase is
+	// skipped below, so nothing reads or writes the failing device.
+	if !r.LocalDiskless && !r.SkipDiskAttach {
 		if err := d.ensureMarkedMetadata(ctx, r); err != nil {
 			return err
 		}
@@ -107,13 +110,22 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 	// adjust is idempotent: up when down, reconfigure on change, no-op
 	// otherwise. A half-torn kernel slot can answer "Unknown resource"
 	// to adjust but accept a plain up — fall back rather than loop.
-	if _, err := d.adm(ctx, "adjust", r.Name); err != nil {
+	// --skip-disk reconciles net/connection state but leaves the disk
+	// detached (drbdadm_adjust.c drops the ADJUST_DISK phase), so a latched
+	// leg is not re-attached. It is always up (Diskless is an up-resource
+	// state), so the Unknown-resource up fallback below is unreachable.
+	adjustArgs := []string{"adjust", r.Name}
+	if r.SkipDiskAttach {
+		adjustArgs = []string{"adjust", "--skip-disk", r.Name}
+	}
+	if _, err := d.adm(ctx, adjustArgs...); err != nil {
 		// A stale .md-created marker surviving a backing-disk replacement
 		// (data disk swapped, /etc/drbd.d intact) makes ensureMarkedMetadata
 		// skip create-md, so adjust attaches a blank device and fails "no
 		// valid meta-data". Drop the marker and re-run: probeMetadata sees
 		// no metadata and create-md + SkipSeed makes this a full SyncTarget.
-		if !r.LocalDiskless && isMissingMetadata(err) {
+		// Unreachable with --skip-disk (no attach → no metadata read).
+		if !r.LocalDiskless && !r.SkipDiskAttach && isMissingMetadata(err) {
 			if rmErr := os.Remove(d.path(r.Name + ".md-created")); rmErr != nil && !os.IsNotExist(rmErr) {
 				return rmErr
 			}

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -258,6 +258,27 @@ func TestApplySkipSeedLeavesJustCreatedMetadata(t *testing.T) {
 	}
 }
 
+// A latched-failed leg (SkipDiskAttach) renders adjust --skip-disk and
+// leaves the backing disk untouched: no create-md, no bare adjust that
+// would re-attach the failing disk and re-trigger the I/O error (#101).
+func TestApplySkipDiskAttachLeavesDiskDetached(t *testing.T) {
+	fe := &fakeExec{}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	r := testResource(nodeKharkiv)
+	r.SkipDiskAttach = true
+
+	if err := d.Apply(t.Context(), r); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdadm adjust --skip-disk pvc-1")
+	// The failing disk is never re-attached or re-created.
+	fe.notCalledWith(t, "adjust pvc-1")
+	fe.notCalledWith(t, "create-md")
+	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-created")); !os.IsNotExist(err) {
+		t.Fatal("skip-disk leg must not create metadata")
+	}
+}
+
 // A backing disk replaced under a surviving .md-created marker makes the
 // first adjust fail "no valid meta-data"; Apply drops the stale marker,
 // recreates metadata (SkipSeed → full SyncTarget), and retries adjust.

--- a/internal/drbd/res.go
+++ b/internal/drbd/res.go
@@ -58,6 +58,11 @@ type Resource struct {
 	// Secret authenticates peers (cram-hmac challenge-response). Empty
 	// renders no auth — volumes created before secrets existed.
 	Secret string
+	// SkipDiskAttach renders `drbdadm adjust --skip-disk`: reconcile the
+	// net/connection state but leave the disk detached. Set when a leg is
+	// latched failed (DiskFailed) so adjust does not re-attach a disk DRBD
+	// detached on an I/O error — the flap the latch exists to stop.
+	SkipDiskAttach bool
 	// SkipSeed leaves fresh metadata at create-md's just-created state
 	// instead of day0 GI seeding: a replica joining an existing volume
 	// must full-sync from its peers, not pose as a pristine twin.


### PR DESCRIPTION
## Problem (#101)

A diskful leg whose backing device fails triggers DRBD's `on-io-error detach` (miroir's chart default): the leg drops to **Diskless** while the volume keeps serving through its peer. But miroir runs `drbdadm adjust` on **every** reconcile (~30s poll), and `adjust` **re-attaches** the leg — `drbdadm_adjust.c`'s `compare_volume` sets `adj_attach` for any config that still declares a disk (which the `.res` always does). The disk fails again → detaches again. The result is a **resync/detach flap every poll** that hammers failing hardware and churns the CRD.

This is the exact failure LINSTOR guards against with its `DrbdOptions/SkipDisk` property. Both the flap and the fix were confirmed from the drbd-utils source (see #101) — no hardware needed.

## Fix — latch the failure, stop re-attaching

- **`ReplicaStatus.DiskFailed`** latches a diskful leg DRBD detached to Diskless *after it had been attached* (a fresh bring-up is briefly Diskless and must not cry wolf). **Sticky** — it survives `prev DiskState` itself becoming `Diskless`.
- While latched, `drbdResource` renders **`drbdadm adjust --skip-disk`**, which reconciles net/connection state but drops the `ADJUST_DISK` phase (`adm_adjust` only enables it when `--skip-disk` is absent). The failing disk is **not** re-attached; serving continues via the peer.
- The disk-touching metadata steps (`create-md`, the missing-metadata self-heal) are skipped too — nothing reads or writes the failing device.
- **Clear = remove + re-add the replica.** Removal already drops this node's status slot (`perNode:{node:null}`), so the re-added leg starts un-latched and full-syncs a fresh backing. **No new API.**

## Behaviour notes

- The latch is read from the **prior** reconcile's status, so it lags the detach by exactly one cycle: the just-detached leg re-attaches **once**, then stays detached. (LINSTOR has the same prop-propagation window.)
- A latched (Diskless) **resize coordinator** withholds the grow instead of erroring on a `drbdadm resize` its absent local disk cannot do — removing the replica re-elects the coordinator to a healthy peer.
- The operator-facing "detached after an I/O error…" message now **persists while latched**, not just the one reconcile the detach was first observed (previously it flickered off after a single cycle).

## Verification

- `GOOS=linux go build/vet ./...` clean; `golangci-lint` (linux) 0 issues.
- `go test ./...` in `golang:1.26.3` (CI-equivalent linux) — all packages incl. csi/cmd pass.
- New tests: `drbd.TestApplySkipDiskAttachLeavesDiskDetached` (adjust `--skip-disk`, no `create-md`, no bare adjust); `agent.TestReconcileLatchedDiskSkipsReAttach` (sticky latch → `--skip-disk`); `agent.TestReconcileLatchedCoordinatorSkipsResize` (no resize on a diskless coordinator); extended `TestReconcileDetachedDiskGetsActionableMessage` (first detach latches `DiskFailed`, still bare-adjusts once).
- CRD regenerated (`diskFailed` field); generators idempotent; `helm-test` 59/59.

No Dockerfile/image change — `drbd-utils` already ships and `--skip-disk` is a `drbdadm` flag.

Closes #101