### PR TITLE
feat(metrics): quorum, disk-failed, out-of-sync, and pool capacity gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,13 +328,22 @@ PodMonitor scraping the controller **and every agent** on their
 each storage node; a `node` label is added to every series). The
 agent exports, per volume on that node:
 
-| Metric                       | Meaning                                                                                    |
-| ---------------------------- | ------------------------------------------------------------------------------------------ |
-| `miroir_volume_up_to_date`   | 1 when this node's replica is UpToDate (unreplicated volumes are always 1 once created)    |
-| `miroir_volume_connected`    | 1 when all replication links to diskful peers are established (tie-breaker links excluded) |
-| `miroir_volume_split_brain`  | 1 when DRBD refused to reconnect after divergence — manual resolution required             |
-| `miroir_volume_suspended`    | 1 while the snapshot write barrier freezes IO; sustained means a stranded barrier          |
-| `miroir_volume_resync_ratio` | fraction (0-1) in sync of the least-synced diskful peer; 1 when fully in sync              |
+| Metric                            | Meaning                                                                                                                                     |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `miroir_volume_up_to_date`        | 1 when this node's replica is UpToDate (unreplicated volumes are always 1 once created)                                                     |
+| `miroir_volume_connected`         | 1 when all replication links to diskful peers are established (tie-breaker links excluded)                                                  |
+| `miroir_volume_split_brain`       | 1 when DRBD refused to reconnect after divergence — manual resolution required                                                              |
+| `miroir_volume_suspended`         | 1 while the snapshot write barrier freezes IO; sustained means a stranded barrier                                                           |
+| `miroir_volume_resync_ratio`      | fraction (0-1) in sync of the least-synced diskful peer; 1 when fully in sync                                                               |
+| `miroir_volume_quorum`            | 0 while a `freeze` volume has lost quorum and its IO is suspended — the "workloads are hanging" signal (always 1 under `last-man-standing`) |
+| `miroir_volume_disk_failed`       | 1 when this leg's disk was detached after an I/O error and latched failed — replace the disk, then remove and re-add the replica            |
+| `miroir_volume_out_of_sync_bytes` | worst per-peer out-of-sync bytes: the exposure if the healthiest peer is lost; also counts online-verify findings                           |
+
+Each agent additionally exports its pool capacity
+(`miroir_pool_capacity_bytes` / `miroir_pool_allocated_bytes` /
+`miroir_pool_meta_used_ratio`) — the same sample that feeds
+capacity-aware placement and the `PoolUsageHigh` condition, so pool
+exhaustion is alertable, not just an Event.
 
 Both processes also expose controller-runtime metrics
 (`controller_runtime_reconcile_errors_total` is the wedged-reconcile
@@ -388,7 +397,7 @@ shows the failing call to clean up manually.
 - [x] Per-volume DRBD state metrics (`miroir_volume_up_to_date` /
       `connected` / `split_brain` / `suspended` / `resync_ratio`;
       opt-in PodMonitor via `monitoring.podMonitor.enabled`)
-- [ ] Per-volume quorum / failed-disk / out-of-sync gauges and pool
+- [x] Per-volume quorum / failed-disk / out-of-sync gauges and pool
       capacity metrics
 
 **Natural extensions**

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -46,10 +46,41 @@ var (
 		Name: "miroir_volume_resync_ratio",
 		Help: "Fraction in sync (0-1) of the least-synced diskful peer while resyncing; 1 when fully in sync (unreplicated volumes report 1).",
 	}, []string{volumeLabel})
+	metricQuorum = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "miroir_volume_quorum",
+		Help: "1 when this node's replica sees DRBD quorum; 0 while a freeze-policy volume has lost quorum and its IO is suspended (always 1 under last-man-standing, and for unreplicated volumes).",
+	}, []string{volumeLabel})
+	metricDiskFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "miroir_volume_disk_failed",
+		Help: "1 when this leg's backing disk was detached after an I/O error and is latched failed — replace the disk, then remove and re-add the replica.",
+	}, []string{volumeLabel})
+	metricOutOfSyncBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "miroir_volume_out_of_sync_bytes",
+		Help: "Largest per-peer out-of-sync amount in bytes: the exposure if the healthiest peer is lost. Grows while a peer is down with no resync running; also counts online-verify findings.",
+	}, []string{volumeLabel})
+
+	// Pool gauges are unlabelled: each node runs exactly one backend pool,
+	// and the PodMonitor stamps a node label on every series.
+	metricPoolCapacity = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "miroir_pool_capacity_bytes",
+		Help: "Total capacity of this node's backend pool.",
+	})
+	metricPoolAllocated = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "miroir_pool_allocated_bytes",
+		Help: "Bytes allocated from this node's backend pool.",
+	})
+	metricPoolMetaUsedRatio = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "miroir_pool_meta_used_ratio",
+		Help: "Fraction (0-1) of dm-thin metadata used; 0 for backends without a metadata pool.",
+	})
 )
 
 func init() {
-	metrics.Registry.MustRegister(metricUpToDate, metricConnected, metricSplitBrain, metricSuspended, metricResyncRatio)
+	metrics.Registry.MustRegister(
+		metricUpToDate, metricConnected, metricSplitBrain, metricSuspended,
+		metricResyncRatio, metricQuorum, metricDiskFailed, metricOutOfSyncBytes,
+		metricPoolCapacity, metricPoolAllocated, metricPoolMetaUsedRatio,
+	)
 }
 
 func recordVolumeMetrics(volume string, st miroirReplicaView) {
@@ -58,6 +89,17 @@ func recordVolumeMetrics(volume string, st miroirReplicaView) {
 	metricSplitBrain.WithLabelValues(volume).Set(boolGauge(st.splitBrain))
 	metricSuspended.WithLabelValues(volume).Set(boolGauge(st.suspended))
 	metricResyncRatio.WithLabelValues(volume).Set(st.resyncRatio)
+	metricQuorum.WithLabelValues(volume).Set(boolGauge(st.quorum))
+	metricDiskFailed.WithLabelValues(volume).Set(boolGauge(st.diskFailed))
+	metricOutOfSyncBytes.WithLabelValues(volume).Set(st.outOfSyncBytes)
+}
+
+// recordPoolMetrics publishes the node pool sample; one pool per node, so
+// the gauges carry no labels and are never deleted.
+func recordPoolMetrics(capacityBytes, allocatedBytes int64, metaUsedRatio float64) {
+	metricPoolCapacity.Set(float64(capacityBytes))
+	metricPoolAllocated.Set(float64(allocatedBytes))
+	metricPoolMetaUsedRatio.Set(metaUsedRatio)
 }
 
 func dropVolumeMetrics(volume string) {
@@ -66,14 +108,20 @@ func dropVolumeMetrics(volume string) {
 	metricSplitBrain.DeleteLabelValues(volume)
 	metricSuspended.DeleteLabelValues(volume)
 	metricResyncRatio.DeleteLabelValues(volume)
+	metricQuorum.DeleteLabelValues(volume)
+	metricDiskFailed.DeleteLabelValues(volume)
+	metricOutOfSyncBytes.DeleteLabelValues(volume)
 }
 
 type miroirReplicaView struct {
-	upToDate    bool
-	connected   bool
-	splitBrain  bool
-	suspended   bool
-	resyncRatio float64
+	upToDate       bool
+	connected      bool
+	splitBrain     bool
+	suspended      bool
+	quorum         bool
+	diskFailed     bool
+	resyncRatio    float64
+	outOfSyncBytes float64
 }
 
 func boolGauge(b bool) float64 {

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -54,11 +54,14 @@ func hasSeries(t *testing.T, family, volume string) bool {
 func TestVolumeMetricsLifecycle(t *testing.T) {
 	const volume = "pvc-metrics-lifecycle"
 	recordVolumeMetrics(volume, miroirReplicaView{
-		upToDate:    true,
-		connected:   false,
-		splitBrain:  true,
-		suspended:   false,
-		resyncRatio: 0.425,
+		upToDate:       true,
+		connected:      false,
+		splitBrain:     true,
+		suspended:      false,
+		quorum:         true,
+		diskFailed:     true,
+		resyncRatio:    0.425,
+		outOfSyncBytes: 2048 * 1024,
 	})
 
 	if got := testutil.ToFloat64(metricUpToDate.WithLabelValues(volume)); got != 1 {
@@ -76,6 +79,15 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 	if got := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volume)); got != 0.425 {
 		t.Fatalf("resync_ratio = %v, want 0.425", got)
 	}
+	if got := testutil.ToFloat64(metricQuorum.WithLabelValues(volume)); got != 1 {
+		t.Fatalf("quorum = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volume)); got != 1 {
+		t.Fatalf("disk_failed = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metricOutOfSyncBytes.WithLabelValues(volume)); got != 2048*1024 {
+		t.Fatalf("out_of_sync_bytes = %v, want %v", got, 2048*1024)
+	}
 
 	dropVolumeMetrics(volume)
 	for _, family := range []string{
@@ -84,6 +96,9 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 		"miroir_volume_split_brain",
 		"miroir_volume_suspended",
 		"miroir_volume_resync_ratio",
+		"miroir_volume_quorum",
+		"miroir_volume_disk_failed",
+		"miroir_volume_out_of_sync_bytes",
 	} {
 		if hasSeries(t, family, volume) {
 			t.Fatalf("%s{volume=%q} still exposed after drop", family, volume)

--- a/internal/agent/poolstats.go
+++ b/internal/agent/poolstats.go
@@ -92,6 +92,9 @@ func (p *PoolStatsPublisher) publish(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("read pool stats: %w", err)
 	}
+	// Publish the sample even when the CRD update below conflicts: the
+	// gauges describe the pool, not the API object.
+	recordPoolMetrics(stats.SizeBytes, stats.UsedBytes, stats.MetaUsedPercent/100)
 
 	node := &miroirv1alpha1.MiroirNode{ObjectMeta: metav1.ObjectMeta{Name: p.NodeName}}
 	if _, err := controllerutil.CreateOrUpdate(ctx, p.Client, node, func() error {

--- a/internal/agent/poolstats_test.go
+++ b/internal/agent/poolstats_test.go
@@ -19,6 +19,8 @@ package agent
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -150,6 +152,15 @@ func TestPoolStatsPublisherRaisesHighMetadataUsage(t *testing.T) {
 		t.Fatal(err)
 	}
 	n := get()
+	if v := testutil.ToFloat64(metricPoolCapacity); v != 100*poolGiB {
+		t.Fatalf("miroir_pool_capacity_bytes = %v, want %v", v, 100*poolGiB)
+	}
+	if v := testutil.ToFloat64(metricPoolAllocated); v != 10*poolGiB {
+		t.Fatalf("miroir_pool_allocated_bytes = %v, want %v", v, 10*poolGiB)
+	}
+	if v := testutil.ToFloat64(metricPoolMetaUsedRatio); v != 0.9 {
+		t.Fatalf("miroir_pool_meta_used_ratio = %v, want 0.9", v)
+	}
 	if n.Status.MetaUsedPercent != 90 {
 		t.Fatalf("MetaUsedPercent = %d, want 90", n.Status.MetaUsedPercent)
 	}

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -141,9 +141,12 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 		if vol.Spec.DRBD == nil {
 			log.V(1).Info("replica realized", "volume", vol.Name, "device", dev)
-			// resyncRatio 1, not the zero value: no peers means fully in
-			// sync — 0 would perma-fire any <1 alert.
-			recordVolumeMetrics(vol.Name, miroirReplicaView{upToDate: true, connected: true, resyncRatio: 1})
+			// resyncRatio 1 and quorum true, not the zero values: an
+			// unreplicated volume is fully in sync with itself and has no
+			// quorum to lose — zeros would perma-fire the alerts.
+			recordVolumeMetrics(vol.Name, miroirReplicaView{
+				upToDate: true, connected: true, quorum: true, resyncRatio: 1,
+			})
 			return ctrl.Result{}, r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
 				DeviceCreated: true,
 				DevicePath:    dev,
@@ -188,18 +191,21 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			"volume", vol.Name)
 	}
 	connected := diskfulPeersConnected(st, vol, r.NodeName)
+	diskFailed := diskFailedLatch(vol, r.NodeName, st, localDiskless)
 	if !localDiskless {
 		recordVolumeMetrics(vol.Name, miroirReplicaView{
 			upToDate:   st.DiskState == drbd.DiskUpToDate,
 			connected:  connected,
 			splitBrain: st.SplitBrain,
 			suspended:  st.Suspended,
-			// drbdsetup reports percent-in-sync; the exported gauge is a
-			// 0-1 ratio per Prometheus base-unit conventions.
-			resyncRatio: st.ResyncPercent / 100,
+			quorum:     st.Quorum,
+			diskFailed: diskFailed,
+			// drbdsetup reports percent-in-sync and KiB; the exported
+			// gauges are a 0-1 ratio and bytes per Prometheus base units.
+			resyncRatio:    st.ResyncPercent / 100,
+			outOfSyncBytes: float64(st.OutOfSyncKiB) * 1024,
 		})
 	}
-	diskFailed := diskFailedLatch(vol, r.NodeName, st, localDiskless)
 	if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
 		DeviceCreated: !localDiskless,
 		DevicePath:    drbd.DevicePath(minor),

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -863,6 +863,10 @@ func TestReconcileLatchedDiskSkipsReAttach(t *testing.T) {
 	if st := got.Status.PerNode[nodeKharkiv]; !st.DiskFailed {
 		t.Fatalf("latch must stay set while the leg is Diskless: %+v", st)
 	}
+	// The latch is the actionable hardware-failure alert signal.
+	if v := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volPvc1)); v != 1 {
+		t.Fatalf("miroir_volume_disk_failed = %v, want 1", v)
+	}
 }
 
 // A latched-failed coordinator (Diskless) cannot drbdadm resize its absent
@@ -893,6 +897,39 @@ func TestReconcileLatchedCoordinatorSkipsResize(t *testing.T) {
 
 	reconcile(t, r, volPvc1)
 	fe.notCalledWith(t, "drbdadm resize")
+}
+
+// A freeze-policy volume that lost quorum suspends IO while its local
+// disk stays UpToDate — quorum is the only signal distinguishing "frozen,
+// workloads hanging" from a benign peer outage. The gauge must go 0.
+func TestReconcileQuorumLostExportsGauge(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+	}
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"UpToDate","quorum":false}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connecting"}]}]`}
+	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+
+	reconcile(t, r, volPvc1)
+
+	if v := testutil.ToFloat64(metricQuorum.WithLabelValues(volPvc1)); v != 0 {
+		t.Fatalf("miroir_volume_quorum = %v, want 0 on quorum loss", v)
+	}
+	// Local disk is fine — up_to_date must stay 1 (quorum is the signal).
+	if v := testutil.ToFloat64(metricUpToDate.WithLabelValues(volPvc1)); v != 1 {
+		t.Fatalf("miroir_volume_up_to_date = %v, want 1", v)
+	}
 }
 
 // The resize coordinator must not run drbdadm resize once its realized

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -726,6 +726,14 @@ type Status struct {
 	// ResyncPercent is the least-synced diskful peer's percent-in-sync
 	// while resyncing; 100 when fully in sync (nothing to catch up).
 	ResyncPercent float64
+	// Quorum is the device quorum flag: false while a freeze-policy
+	// volume has lost quorum and DRBD is suspending its IO. Always true
+	// when quorum is off (last-man-standing).
+	Quorum bool
+	// OutOfSyncKiB is the largest per-peer out-of-sync amount (KiB, as
+	// drbdsetup reports it) — the data-loss exposure if the healthiest
+	// peer is lost. Grows while a peer is down with no resync running.
+	OutOfSyncKiB int64
 }
 
 // drbdsetup status --json shapes (the fields miroir reads).
@@ -735,6 +743,7 @@ type jsonStatus struct {
 	SuspendedUser bool   `json:"suspended-user"`
 	Devices       []struct {
 		DiskState string `json:"disk-state"`
+		Quorum    bool   `json:"quorum"`
 	} `json:"devices"`
 	Connections []struct {
 		PeerNodeID      int32  `json:"peer-node-id"`
@@ -746,6 +755,7 @@ type jsonStatus struct {
 		PeerDevices []struct {
 			ReplicationState string  `json:"replication-state"`
 			PercentInSync    float64 `json:"percent-in-sync"`
+			OutOfSyncKiB     int64   `json:"out-of-sync"`
 		} `json:"peer_devices"`
 	} `json:"connections"`
 }
@@ -773,6 +783,7 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 	}
 	if len(res.Devices) > 0 {
 		s.DiskState = res.Devices[0].DiskState
+		s.Quorum = res.Devices[0].Quorum
 	}
 	for _, c := range res.Connections {
 		if c.PeerRole == "Primary" {
@@ -788,6 +799,7 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 					s.ResyncPercent = pd.PercentInSync
 				}
 			}
+			s.OutOfSyncKiB = max(s.OutOfSyncKiB, pd.OutOfSyncKiB)
 		}
 		s.PeerConnected[c.PeerNodeID] = c.ConnectionState == "Connected"
 		if c.ConnectionState == "StandAlone" {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -671,9 +671,9 @@ func TestStatusSplitBrain(t *testing.T) {
 func TestStatusResyncPercent(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{
 		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
-			"devices":[{"disk-state":"Inconsistent"}],
+			"devices":[{"disk-state":"Inconsistent","quorum":true}],
 			"connections":[{"peer-node-id":1,"connection-state":"Connected",
-				"peer_devices":[{"replication-state":"SyncTarget","percent-in-sync":42.5}]}]}]`,
+				"peer_devices":[{"replication-state":"SyncTarget","percent-in-sync":42.5,"out-of-sync":2048}]}]}]`,
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 	s, err := d.Status(t.Context(), volPvc1)
@@ -682,6 +682,37 @@ func TestStatusResyncPercent(t *testing.T) {
 	}
 	if !s.Resyncing || s.ResyncPercent != 42.5 {
 		t.Fatalf("want Resyncing with ResyncPercent 42.5, got %+v", s)
+	}
+	if !s.Quorum || s.OutOfSyncKiB != 2048 {
+		t.Fatalf("want Quorum with OutOfSyncKiB 2048, got %+v", s)
+	}
+}
+
+// The device quorum flag surfaces a freeze-policy volume whose partition
+// lost quorum (IO suspending); out-of-sync tracks the worst peer.
+func TestStatusQuorumLost(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
+			"devices":[{"disk-state":"UpToDate","quorum":false}],
+			"connections":[
+				{"peer-node-id":1,"connection-state":"Connecting",
+					"peer_devices":[{"replication-state":"Off","out-of-sync":4096}]},
+				{"peer-node-id":2,"connection-state":"Connecting",
+					"peer_devices":[{"replication-state":"Off","out-of-sync":1024}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	s, err := d.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Quorum {
+		t.Fatalf("quorum lost must surface as Quorum=false: %+v", s)
+	}
+	if s.OutOfSyncKiB != 4096 {
+		t.Fatalf("OutOfSyncKiB must track the worst peer (4096), got %d", s.OutOfSyncKiB)
+	}
+	if s.Resyncing {
+		t.Fatalf("Off replication must not read as resync: %+v", s)
 	}
 }
 


### PR DESCRIPTION
Part 2 of the observability review (PR B — missing signals). Follows #114, which made these scrapable in the first place. All names pre-checked against [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/) (booleans unitless, `_bytes` base unit, ratios 0–1).

## New volume gauges (agent, per volume)

| Gauge | Why it earns a slot | Ecosystem precedent |
|---|---|---|
| `miroir_volume_quorum` | A **`freeze` volume that loses quorum suspends IO while its local disk stays UpToDate** — previously the metrics read `up_to_date=1, connected=0, suspended=0`, indistinguishable from a benign peer outage while workloads hang. This is the incident signal for the default quorum policy. | `drbd_device_quorum`; LINBIT's canonical `drbdResourceSuspended` alert |
| `miroir_volume_disk_failed` | Exports the #113 latch: distinguishes "failed hardware — replace disk, remove + re-add" (permanent, operator action) from a transient resync, which `up_to_date=0` alone can't. | `drbd_device_unintentionaldiskless` (miroir's latch is strictly better info) |
| `miroir_volume_out_of_sync_bytes` | Worst per-peer out-of-sync. Quantifies exposure while a peer is down with **no resync running** (`resync_ratio` only moves during an active sync) and is the only visibility into what `drbd.verifyAlg` online-verify finds. Max over peers = the loss if the healthiest peer dies. | `drbd_peerdevice_outofsync_bytes`; blockstor carries `outOfSyncKib` in CRD status |

Parsing: device `quorum` and peer-device `out-of-sync` are unconditionally present in the `drbdsetup status --json` output the agent already fetches (verified against drbd-utils `drbdsetup.c`) — zero extra exec cost. `Status.Suspended` stays user-suspend-only: the snapshot barrier keys on it (4 sites), so quorum gets its own field. Unreplicated volumes report `quorum=1` (no quorum to lose — consistent with #114's zero-value lesson).

## New pool gauges (agent, per node)

`miroir_pool_capacity_bytes` / `miroir_pool_allocated_bytes` / `miroir_pool_meta_used_ratio` — the same sample poolstats already takes every 60s for MiroirNode status and the `PoolUsageHigh` condition. Pool exhaustion becomes **alertable** rather than Event-only (LINSTOR precedent: `linstor_storage_pool_capacity_{free,total}_bytes`). Unlabelled by design: one pool per node, and the #114 PodMonitor stamps a `node` label on every series. Published even when the CRD status update conflicts — the gauges describe the pool, not the API object.

## Unit discipline

Internal fields mirror drbdsetup verbatim (`ResyncPercent`, `OutOfSyncKiB` — same convention as #111/#114); conversion to Prometheus base units (ratio 0–1, bytes) happens at the metric edge.

## Tests

- Parse: quorum flag + worst-peer `out-of-sync` max on the existing fixtures + a dedicated quorum-lost fixture (`Off` replication ≠ resync).
- End-to-end `TestReconcileQuorumLostExportsGauge`: status JSON with `quorum:false` → gauge 0 **while `up_to_date` stays 1** (pinning exactly the blind spot this fixes).
- `disk_failed` gauge asserted on the latched-reconcile test; pool gauges asserted from the poolstats publish; lifecycle test covers the three new families' record + drop.

## Verification

`golangci-lint` (linux) 0 issues · full `go test ./...` in `golang:1.26.3` all green · helm-unittest 59/59 (no chart changes — #114's PodMonitor already scrapes everything here) · README metric table + pool paragraph + roadmap updated.