### PR TITLE
feat(chart): starter PrometheusRule alerts and Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,13 @@ Each agent additionally exports its pool capacity
 capacity-aware placement and the `PoolUsageHigh` condition, so pool
 exhaustion is alertable, not just an Event.
 
+`monitoring.prometheusRule.enabled: true` ships starter alerts for all
+of the above (split-brain, quorum lost, stranded barrier, disk failed,
+degraded replication, sustained out-of-sync, pool and thin-metadata
+usage), and `monitoring.dashboards.enabled: true` installs a Grafana
+dashboard — as a sidecar-labelled ConfigMap, or a grafana-operator
+`GrafanaDashboard` CR via `monitoring.dashboards.grafanaOperator`.
+
 Both processes also expose controller-runtime metrics
 (`controller_runtime_reconcile_errors_total` is the wedged-reconcile
 signal), and mounted volumes get `kubelet_volume_stats_*` for free

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -60,6 +60,15 @@ Kubernetes: `>=1.31.0`
 | image.repository | string | `"ghcr.io/home-operations/miroir"` |  |
 | image.tag | string | `""` |  |
 | kubeletDir | string | `"/var/lib/kubelet"` |  |
+| monitoring.dashboards.annotations | object | `{}` | Annotations added to the dashboard ConfigMap. |
+| monitoring.dashboards.enabled | bool | `false` | Render the Grafana dashboard ConfigMap (for grafana-operator or the kube-prometheus-stack sidecar). |
+| monitoring.dashboards.grafanaOperator.allowCrossNamespaceImport | bool | `true` | If true allows for a Grafana in any namespace to access this GrafanaDashboard. |
+| monitoring.dashboards.grafanaOperator.enabled | bool | `false` | Render a GrafanaDashboard CR (grafana-operator) instead of a sidecar ConfigMap. |
+| monitoring.dashboards.grafanaOperator.folder | string | `""` | Folder to create the dashboard in. |
+| monitoring.dashboards.grafanaOperator.matchLabels | object | `{}` | Selected labels for Grafana instance. |
+| monitoring.dashboards.grafanaOperator.resyncPeriod | string | `"10m"` | Resync period for the Grafana operator to check for updates to the dashboard. |
+| monitoring.dashboards.labels | object | `{}` | Labels added to the dashboard ConfigMap. |
+| monitoring.dashboards.namespace | string | `""` | Namespace for the dashboard objects; defaults to the release namespace. |
 | monitoring.podMonitor.annotations | object | `{}` | PodMonitor annotations. |
 | monitoring.podMonitor.enabled | bool | `false` | Create a Prometheus Operator PodMonitor (requires its CRDs) scraping the controller and every agent pod on their metrics ports. The per-volume miroir_volume_* gauges are exported by the agents. |
 | monitoring.podMonitor.interval | string | `"30s"` | Scrape interval. |
@@ -69,6 +78,11 @@ Kubernetes: `>=1.31.0`
 | monitoring.podMonitor.podTargetLabels | list | `[]` | Pod target labels to copy from pods. |
 | monitoring.podMonitor.relabelings | list | `[]` | Extra Prometheus relabelings (applied before scraping); a node label from the pod's node name is always added. |
 | monitoring.podMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout. |
+| monitoring.prometheusRule.additionalRuleAnnotations | object | `{}` | Extra annotations added to every alert rule. |
+| monitoring.prometheusRule.additionalRuleLabels | object | `{}` | Extra labels added to every alert rule. |
+| monitoring.prometheusRule.annotations | object | `{}` | PrometheusRule annotations. |
+| monitoring.prometheusRule.enabled | bool | `false` | Create a PrometheusRule with alerting rules (requires the Prometheus Operator CRDs). |
+| monitoring.prometheusRule.labels | object | `{}` | PrometheusRule labels. |
 | nodes | object | `{}` |  |
 | replicatedStorageClass.create | bool | `true` |  |
 | replicatedStorageClass.fsType | string | `"ext4"` |  |

--- a/charts/miroir/dashboards/miroir.json
+++ b/charts/miroir/dashboards/miroir.json
@@ -1,0 +1,1052 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "miroir \u2014 DRBD-replicated local storage: volume health, replication, pools, and operator activity.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Volume health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Volumes with at least one reporting replica.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(count by (volume) (miroir_volume_up_to_date))",
+          "refId": "A"
+        }
+      ],
+      "title": "Volumes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Volumes DRBD refuses to reconnect after divergence \u2014 manual resolution required.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(miroir_volume_split_brain == 1) OR on() vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Split-brain",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Freeze-policy legs with IO suspended awaiting quorum \u2014 workloads are hanging.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(miroir_volume_quorum == 0) OR on() vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Quorum lost",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Legs latched failed after a backing-disk I/O error \u2014 replace the disk, then remove and re-add.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(miroir_volume_disk_failed == 1) OR on() vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Disks failed",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Diskful legs below UpToDate \u2014 resyncing, detached, or disconnected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(miroir_volume_up_to_date == 0) OR on() vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Legs not UpToDate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Legs under a snapshot write barrier; sustained means a stranded barrier.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(miroir_volume_suspended == 1) OR on() vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "IO suspended",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Per volume: legs not UpToDate plus legs with replication links down. 0 is healthy.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (volume) ((1 - miroir_volume_up_to_date{volume=~\"$volume\"}) OR (1 - miroir_volume_connected{volume=~\"$volume\"}))",
+          "refId": "A",
+          "legendFormat": "{{volume}}"
+        }
+      ],
+      "title": "Unhealthy legs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Fraction in sync of the least-synced peer per volume; 1 when fully in sync.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "min by (volume) (miroir_volume_resync_ratio{volume=~\"$volume\"})",
+          "refId": "A",
+          "legendFormat": "{{volume}}"
+        }
+      ],
+      "title": "Resync progress",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Worst per-peer out-of-sync amount \u2014 exposure if the healthiest peer is lost; also counts online-verify findings.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (volume) (miroir_volume_out_of_sync_bytes{volume=~\"$volume\"})",
+          "refId": "A",
+          "legendFormat": "{{volume}}"
+        }
+      ],
+      "title": "Out-of-sync bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Series appear only while a leg has lost quorum or holds a failed disk.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "miroir_volume_quorum{volume=~\"$volume\"} == 0",
+          "refId": "A",
+          "legendFormat": "quorum lost: {{volume}} on {{node}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "miroir_volume_disk_failed{volume=~\"$volume\"} == 1",
+          "refId": "B",
+          "legendFormat": "disk failed: {{volume}} on {{node}}"
+        }
+      ],
+      "title": "Quorum / disk-failed legs",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Pools",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "miroir_pool_capacity_bytes",
+          "refId": "A",
+          "legendFormat": "capacity: {{node}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "miroir_pool_allocated_bytes",
+          "refId": "B",
+          "legendFormat": "allocated: {{node}}"
+        }
+      ],
+      "title": "Pool capacity and allocation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Thin pools fail writes when exhausted; ZFS degrades past ~85%. The PoolUsageHigh alert fires at 80%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "miroir_pool_allocated_bytes / miroir_pool_capacity_bytes",
+          "refId": "A",
+          "legendFormat": "{{node}}"
+        }
+      ],
+      "title": "Pool used ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "dm-thin metadata usage (lvmthin only); exhaustion corrupts the pool even with data space free.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "miroir_pool_meta_used_ratio",
+          "refId": "A",
+          "legendFormat": "{{node}}"
+        }
+      ],
+      "title": "Thin-pool metadata used",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 17,
+      "panels": [],
+      "title": "Operator",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller) (rate(controller_runtime_reconcile_total{pod=~\".*miroir.*\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{controller}}"
+        }
+      ],
+      "title": "Reconcile rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "A sustained error rate means a wedged reconcile \u2014 check the owning pod's logs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller) (rate(controller_runtime_reconcile_errors_total{pod=~\".*miroir.*\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{controller}}"
+        }
+      ],
+      "title": "Reconcile errors",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["miroir", "storage", "drbd", "csi"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
+      {
+        "name": "volume",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(miroir_volume_up_to_date, volume)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "current": {},
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "miroir \u2014 replicated storage",
+  "uid": "miroir-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/charts/miroir/templates/dashboard.tpl
+++ b/charts/miroir/templates/dashboard.tpl
@@ -1,0 +1,22 @@
+{{- if .Values.monitoring.dashboards.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "miroir.fullname" . }}-dashboard
+  namespace: {{ .Values.monitoring.dashboards.namespace | default .Release.Namespace }}
+  {{- with .Values.monitoring.dashboards.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+    {{- if not .Values.monitoring.dashboards.grafanaOperator.enabled }}
+    grafana_dashboard: "1"
+    {{- end }}
+    {{- with .Values.monitoring.dashboards.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  miroir.json: |
+{{ .Files.Get "dashboards/miroir.json" | nindent 4 }}
+{{- end }}

--- a/charts/miroir/templates/grafanadashboard.tpl
+++ b/charts/miroir/templates/grafanadashboard.tpl
@@ -1,0 +1,25 @@
+{{- if and .Values.monitoring.dashboards.enabled .Values.monitoring.dashboards.grafanaOperator.enabled }}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "miroir.fullname" . }}-dashboard
+  namespace: {{ .Values.monitoring.dashboards.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+spec:
+  allowCrossNamespaceImport: {{ .Values.monitoring.dashboards.grafanaOperator.allowCrossNamespaceImport }}
+  resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
+  {{- with .Values.monitoring.dashboards.grafanaOperator.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  instanceSelector:
+    matchLabels:
+    {{- if .Values.monitoring.dashboards.grafanaOperator.matchLabels }}
+      {{- toYaml .Values.monitoring.dashboards.grafanaOperator.matchLabels | nindent 6 }}
+    {{- else }}
+      {{- fail "monitoring.dashboards.grafanaOperator.matchLabels must be set when grafanaOperator is enabled" }}
+    {{- end }}
+  configMapRef:
+    name: {{ include "miroir.fullname" . }}-dashboard
+    key: miroir.json
+{{- end }}

--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -1,0 +1,202 @@
+{{- /* Per-rule labels: severity plus the user's additionalRuleLabels. */}}
+{{- define "miroir.alertRuleLabels" -}}
+{{- $labels := dict "severity" .severity -}}
+{{- with .root.Values.monitoring.prometheusRule.additionalRuleLabels -}}
+{{- $labels = merge $labels . -}}
+{{- end -}}
+{{- toYaml $labels -}}
+{{- end -}}
+{{- if .Values.monitoring.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "miroir.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.monitoring.prometheusRule.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    - name: miroir.volumes
+      rules:
+        # DRBD refused to reconnect after divergence; data is forked and
+        # only an operator can pick the losing side.
+        - alert: MiroirVolumeSplitBrain
+          expr: miroir_volume_split_brain == 1
+          for: 1m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
+          annotations:
+            summary: >-
+              Volume {{ "{{" }} $labels.volume {{ "}}" }} is split-brain on
+              {{ "{{" }} $labels.node {{ "}}" }}
+            description: >-
+              DRBD detected divergent data and refused to reconnect. Resolve
+              manually: run drbdadm connect --discard-my-data on the losing
+              node (its writes since the split are lost).
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        # A freeze volume without quorum suspends IO: pods using it are
+        # hanging right now, even though the local disk is healthy.
+        - alert: MiroirVolumeQuorumLost
+          expr: miroir_volume_quorum == 0
+          for: 2m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
+          annotations:
+            summary: >-
+              Volume {{ "{{" }} $labels.volume {{ "}}" }} lost quorum on
+              {{ "{{" }} $labels.node {{ "}}" }} — IO is suspended
+            description: >-
+              The replica partition no longer holds a quorum majority and
+              DRBD is freezing writes; workloads on this volume are hanging.
+              Restore connectivity to the peers (or the tie-breaker) to
+              resume IO.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        # Snapshot write barriers last seconds; a sustained suspend means a
+        # stranded barrier freezing the workload.
+        - alert: MiroirVolumeSuspendedBarrier
+          expr: miroir_volume_suspended == 1
+          for: 10m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
+          annotations:
+            summary: >-
+              Volume {{ "{{" }} $labels.volume {{ "}}" }} IO has been
+              suspended for 10m on {{ "{{" }} $labels.node {{ "}}" }}
+            description: >-
+              A snapshot write barrier (suspend-io) has been held far longer
+              than a snapshot round takes — likely a stranded barrier. The
+              agent lifts stale barriers on restart; check agent logs and
+              the MiroirSnapshot status.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        # on-io-error detach latched a failing backing disk; serving
+        # continues via the peer but redundancy is reduced until re-added.
+        - alert: MiroirVolumeDiskFailed
+          expr: miroir_volume_disk_failed == 1
+          for: 5m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
+          annotations:
+            summary: >-
+              Backing disk failed for volume
+              {{ "{{" }} $labels.volume {{ "}}" }} on
+              {{ "{{" }} $labels.node {{ "}}" }}
+            description: >-
+              The backing device was detached after an I/O error and is
+              latched failed; the volume serves via its peer. Replace the
+              disk, then remove and re-add this replica to rebuild it.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        # A leg that stays out of UpToDate is running on reduced redundancy.
+        - alert: MiroirVolumeNotUpToDate
+          expr: miroir_volume_up_to_date == 0
+          for: 15m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
+          annotations:
+            summary: >-
+              Replica of {{ "{{" }} $labels.volume {{ "}}" }} on
+              {{ "{{" }} $labels.node {{ "}}" }} is not UpToDate
+            description: >-
+              The leg has not returned to UpToDate within 15 minutes —
+              a resync may be stuck or the disk detached. Check
+              kubectl describe miroirvolume {{ "{{" }} $labels.volume {{ "}}" }}.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        # Replication links to diskful peers are down.
+        - alert: MiroirVolumeDisconnected
+          expr: miroir_volume_connected == 0
+          for: 10m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
+          annotations:
+            summary: >-
+              Volume {{ "{{" }} $labels.volume {{ "}}" }} replication links
+              down from {{ "{{" }} $labels.node {{ "}}" }}
+            description: >-
+              Not all replication links to diskful peers are established;
+              writes are not being replicated to the disconnected peers.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        # Out-of-sync data that a resync does not drain within an hour is
+        # stuck exposure — or online-verify found silent corruption.
+        - alert: MiroirVolumeOutOfSync
+          expr: miroir_volume_out_of_sync_bytes > 0
+          for: 1h
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
+          annotations:
+            summary: >-
+              Volume {{ "{{" }} $labels.volume {{ "}}" }} has
+              {{ "{{" }} $value | humanize1024 {{ "}}" }}B out of sync on
+              {{ "{{" }} $labels.node {{ "}}" }}
+            description: >-
+              A peer has been out of sync for over an hour without a resync
+              draining it — a down peer accumulating exposure, a stalled
+              resync, or blocks flagged by drbdadm verify. A verify finding
+              needs a disconnect/connect cycle to resync.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+    - name: miroir.pools
+      rules:
+        # Matches the agent's PoolUsageHigh condition: thin pools and ZFS
+        # degrade badly past ~85% full.
+        - alert: MiroirPoolUsageHigh
+          expr: miroir_pool_allocated_bytes / miroir_pool_capacity_bytes > 0.80
+          for: 15m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
+          annotations:
+            summary: >-
+              Storage pool on {{ "{{" }} $labels.node {{ "}}" }} is
+              {{ "{{" }} $value | humanizePercentage {{ "}}" }} full
+            description: >-
+              Pool usage crossed 80%. Thin-provisioned pools fail writes when
+              exhausted and ZFS performance degrades past ~85% — expand the
+              pool or move volumes off this node.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        # dm-thin metadata exhaustion corrupts the pool even with data
+        # space free.
+        - alert: MiroirPoolMetaUsageHigh
+          expr: miroir_pool_meta_used_ratio > 0.80
+          for: 15m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
+          annotations:
+            summary: >-
+              Thin-pool metadata on {{ "{{" }} $labels.node {{ "}}" }} is
+              {{ "{{" }} $value | humanizePercentage {{ "}}" }} used
+            description: >-
+              dm-thin metadata usage crossed 80%; exhausting it corrupts the
+              pool even while data space remains. Extend the metadata LV
+              (lvextend --poolmetadatasize).
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+{{- end }}

--- a/charts/miroir/tests/dashboard_test.yaml
+++ b/charts/miroir/tests/dashboard_test.yaml
@@ -1,0 +1,74 @@
+suite: dashboard
+templates:
+  - dashboard.tpl
+  - grafanadashboard.tpl
+release:
+  name: miroir
+  namespace: miroir-system
+tests:
+  - it: should not create dashboard objects by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a sidecar ConfigMap when enabled
+    set:
+      monitoring.dashboards.enabled: true
+    template: dashboard.tpl
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: miroir-dashboard
+      - equal:
+          path: metadata.labels.grafana_dashboard
+          value: "1"
+      - exists:
+          path: data["miroir.json"]
+
+  - it: should not render a GrafanaDashboard without the operator flag
+    set:
+      monitoring.dashboards.enabled: true
+    template: grafanadashboard.tpl
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a GrafanaDashboard CR for the grafana-operator
+    set:
+      monitoring.dashboards.enabled: true
+      monitoring.dashboards.grafanaOperator.enabled: true
+      monitoring.dashboards.grafanaOperator.matchLabels:
+        dashboards: grafana
+    template: grafanadashboard.tpl
+    asserts:
+      - isKind:
+          of: GrafanaDashboard
+      - equal:
+          path: spec.instanceSelector.matchLabels.dashboards
+          value: grafana
+      - equal:
+          path: spec.configMapRef.key
+          value: miroir.json
+
+  - it: should drop the sidecar label when the operator imports the ConfigMap
+    set:
+      monitoring.dashboards.enabled: true
+      monitoring.dashboards.grafanaOperator.enabled: true
+      monitoring.dashboards.grafanaOperator.matchLabels:
+        dashboards: grafana
+    template: dashboard.tpl
+    asserts:
+      - notExists:
+          path: metadata.labels.grafana_dashboard
+
+  - it: should honor a custom namespace
+    set:
+      monitoring.dashboards.enabled: true
+      monitoring.dashboards.namespace: monitoring
+    template: dashboard.tpl
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring

--- a/charts/miroir/tests/prometheusrule_test.yaml
+++ b/charts/miroir/tests/prometheusrule_test.yaml
@@ -1,0 +1,101 @@
+suite: prometheusrule
+templates:
+  - prometheusrule.tpl
+release:
+  name: miroir
+  namespace: miroir-system
+tests:
+  - it: should not create a PrometheusRule by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a PrometheusRule when enabled
+    set:
+      monitoring.prometheusRule.enabled: true
+    asserts:
+      - isKind:
+          of: PrometheusRule
+      - equal:
+          path: metadata.name
+          value: miroir
+      - equal:
+          path: metadata.namespace
+          value: miroir-system
+
+  - it: should have the volume and pool rule groups
+    set:
+      monitoring.prometheusRule.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.groups
+          count: 2
+      - equal:
+          path: spec.groups[0].name
+          value: miroir.volumes
+      - lengthEqual:
+          path: spec.groups[0].rules
+          count: 7
+      - equal:
+          path: spec.groups[1].name
+          value: miroir.pools
+      - lengthEqual:
+          path: spec.groups[1].rules
+          count: 2
+
+  - it: should mark IO-freezing conditions critical
+    set:
+      monitoring.prometheusRule.enabled: true
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].alert
+          value: MiroirVolumeSplitBrain
+      - equal:
+          path: spec.groups[0].rules[0].labels.severity
+          value: critical
+      - equal:
+          path: spec.groups[0].rules[1].alert
+          value: MiroirVolumeQuorumLost
+      - equal:
+          path: spec.groups[0].rules[1].labels.severity
+          value: critical
+      - equal:
+          path: spec.groups[0].rules[3].alert
+          value: MiroirVolumeDiskFailed
+      - equal:
+          path: spec.groups[0].rules[3].labels.severity
+          value: warning
+
+  - it: should add extra labels to the PrometheusRule
+    set:
+      monitoring.prometheusRule.enabled: true
+      monitoring.prometheusRule.labels:
+        role: alert-rules
+    asserts:
+      - equal:
+          path: metadata.labels.role
+          value: alert-rules
+
+  - it: should add additional labels and annotations to every rule
+    set:
+      monitoring.prometheusRule.enabled: true
+      monitoring.prometheusRule.additionalRuleLabels:
+        team: platform
+      monitoring.prometheusRule.additionalRuleAnnotations:
+        runbook_url: https://example.com/runbooks/miroir
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].labels.team
+          value: platform
+      - equal:
+          path: spec.groups[0].rules[0].labels.severity
+          value: critical
+      - equal:
+          path: spec.groups[0].rules[0].annotations.runbook_url
+          value: https://example.com/runbooks/miroir
+      - equal:
+          path: spec.groups[1].rules[1].labels.team
+          value: platform
+      - equal:
+          path: spec.groups[1].rules[1].annotations.runbook_url
+          value: https://example.com/runbooks/miroir

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -229,6 +229,74 @@
     "monitoring": {
       "description": "Requires the Prometheus Operator CRDs (deployed separately).",
       "properties": {
+        "dashboards": {
+          "properties": {
+            "annotations": {
+              "description": "Annotations added to the dashboard ConfigMap.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Render the Grafana dashboard ConfigMap (for grafana-operator or the kube-prometheus-stack sidecar).",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "grafanaOperator": {
+              "properties": {
+                "allowCrossNamespaceImport": {
+                  "default": true,
+                  "description": "If true allows for a Grafana in any namespace to access this GrafanaDashboard.",
+                  "title": "allowCrossNamespaceImport",
+                  "type": "boolean"
+                },
+                "enabled": {
+                  "default": false,
+                  "description": "Render a GrafanaDashboard CR (grafana-operator) instead of a sidecar ConfigMap.",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "folder": {
+                  "default": "",
+                  "description": "Folder to create the dashboard in.",
+                  "title": "folder",
+                  "type": "string"
+                },
+                "matchLabels": {
+                  "description": "Selected labels for Grafana instance.",
+                  "required": [],
+                  "title": "matchLabels",
+                  "type": "object"
+                },
+                "resyncPeriod": {
+                  "default": "10m",
+                  "description": "Resync period for the Grafana operator to check for updates to the dashboard.",
+                  "title": "resyncPeriod",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "grafanaOperator",
+              "type": "object"
+            },
+            "labels": {
+              "description": "Labels added to the dashboard ConfigMap.",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "namespace": {
+              "default": "",
+              "description": "Namespace for the dashboard objects; defaults to the release namespace.",
+              "title": "namespace",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "dashboards",
+          "type": "object"
+        },
         "podMonitor": {
           "properties": {
             "annotations": {
@@ -294,6 +362,43 @@
           },
           "required": [],
           "title": "podMonitor",
+          "type": "object"
+        },
+        "prometheusRule": {
+          "properties": {
+            "additionalRuleAnnotations": {
+              "description": "Extra annotations added to every alert rule.",
+              "required": [],
+              "title": "additionalRuleAnnotations",
+              "type": "object"
+            },
+            "additionalRuleLabels": {
+              "description": "Extra labels added to every alert rule.",
+              "required": [],
+              "title": "additionalRuleLabels",
+              "type": "object"
+            },
+            "annotations": {
+              "description": "PrometheusRule annotations.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Create a PrometheusRule with alerting rules (requires the Prometheus Operator CRDs).",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "labels": {
+              "description": "PrometheusRule labels.",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "prometheusRule",
           "type": "object"
         }
       },

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -195,3 +195,36 @@ monitoring:
     relabelings: []
     # -- Pod target labels to copy from pods.
     podTargetLabels: []
+
+  prometheusRule:
+    # -- Create a PrometheusRule with alerting rules (requires the Prometheus Operator CRDs).
+    enabled: false
+    # -- PrometheusRule annotations.
+    annotations: {}
+    # -- PrometheusRule labels.
+    labels: {}
+    # -- Extra labels added to every alert rule.
+    additionalRuleLabels: {}
+    # -- Extra annotations added to every alert rule.
+    additionalRuleAnnotations: {}
+
+  dashboards:
+    # -- Render the Grafana dashboard ConfigMap (for grafana-operator or the kube-prometheus-stack sidecar).
+    enabled: false
+    # -- Namespace for the dashboard objects; defaults to the release namespace.
+    namespace: ""
+    # -- Annotations added to the dashboard ConfigMap.
+    annotations: {}
+    # -- Labels added to the dashboard ConfigMap.
+    labels: {}
+    grafanaOperator:
+      # -- Render a GrafanaDashboard CR (grafana-operator) instead of a sidecar ConfigMap.
+      enabled: false
+      # -- If true allows for a Grafana in any namespace to access this GrafanaDashboard.
+      allowCrossNamespaceImport: true
+      # -- Folder to create the dashboard in.
+      folder: ""
+      # -- Resync period for the Grafana operator to check for updates to the dashboard.
+      resyncPeriod: "10m"
+      # -- Selected labels for Grafana instance.
+      matchLabels: {}


### PR DESCRIPTION
Part 3 (final) of the observability review: the alerting + visualization layer on top of #114 (scrape wiring) and #116 (missing signals). Follows the tuppr/kopiur chart pattern — same values contract (`monitoring.prometheusRule.*`, `monitoring.dashboards.*` with the `grafanaOperator` variant), same template shapes, both **default off**.

## Alerts — `monitoring.prometheusRule.enabled`

9 rules in two groups, severity assigned by blast radius: **critical only where IO is frozen or data diverged**, warning for reduced redundancy and capacity.

| Alert | Expr | For | Severity |
|---|---|---|---|
| MiroirVolumeSplitBrain | `split_brain == 1` | 1m | critical |
| MiroirVolumeQuorumLost | `quorum == 0` | 2m | critical — workloads hanging (the freeze-policy incident) |
| MiroirVolumeSuspendedBarrier | `suspended == 1` | 10m | critical — snapshot rounds last seconds; sustained = stranded barrier |
| MiroirVolumeDiskFailed | `disk_failed == 1` | 5m | warning — replace disk, remove + re-add |
| MiroirVolumeNotUpToDate | `up_to_date == 0` | 15m | warning |
| MiroirVolumeDisconnected | `connected == 0` | 10m | warning |
| MiroirVolumeOutOfSync | `out_of_sync_bytes > 0` | 1h | warning — down peer / stalled resync / `drbdadm verify` findings |
| MiroirPoolUsageHigh | `allocated / capacity > 0.80` | 15m | warning — matches the agent's `PoolUsageHigh` line |
| MiroirPoolMetaUsageHigh | `meta_used_ratio > 0.80` | 15m | warning — dm-thin metadata exhaustion corrupts the pool |

Every annotation carries a remediation, `additionalRuleLabels` / `additionalRuleAnnotations` merge into every rule (tuppr contract, deduplicated via a small named template instead of tuppr's per-rule inline merge), and the rendered rules pass **`promtool check rules` (9 rules, SUCCESS)**.

## Dashboard — `monitoring.dashboards.enabled`

`dashboards/miroir.json` shipped exactly like tuppr's: a sidecar-labelled ConfigMap (`grafana_dashboard: "1"`) by default, or a grafana-operator `GrafanaDashboard` CR importing the same ConfigMap via `grafanaOperator.enabled` (sidecar label dropped, `matchLabels` required). Four rows:

- **Volume health** — stat tiles: volumes, split-brain, quorum-lost, disks-failed, not-UpToDate, IO-suspended counts (zero-filled via `OR on() vector(0)` so healthy reads 0, not No data)
- **Replication** — unhealthy legs per volume, resync ratio (0–1), out-of-sync bytes, quorum/disk-failed event series; filterable by a multi-select `$volume` variable
- **Pools** — capacity vs allocated per node, used ratio (80% threshold), thin-metadata ratio
- **Operator** — reconcile + reconcile-error rates by controller (scoped `pod=~".*miroir.*"`)

## Verification

helm-unittest **71/71** across 10 suites (new prometheusrule + dashboard suites: default-off, kinds, group/rule counts, severities, label/annotation merge, operator-variant label swap, custom namespace) · `helm lint` clean · full render inspected with everything enabled · dockerized `promtool check rules` green · helm-docs + schema regenerated.