### PR TITLE
feat!: split the image — distroless controller, Debian agent

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,20 +66,42 @@ jobs:
         id: tools
         run: echo "go=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
 
-      - name: Build image
+      # Both builds run concurrently against the same BuildKit daemon, which
+      # dedupes the shared Go builder stage in flight — the agent's Debian
+      # layer pull overlaps the compile. Distinct cache scopes: concurrent
+      # cache-to writes to one scope evict each other.
+      - name: Build controller image
+        id: controller-image
+        background: true
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           load: true
-          tags: miroir:e2e
+          target: controller
+          tags: miroir-controller:e2e
           build-args: GO_VERSION=${{ steps.tools.outputs.go }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=e2e-controller
+          cache-to: type=gha,mode=max,scope=e2e-controller
 
-      - wait: kind
+      - name: Build agent image
+        id: agent-image
+        background: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          load: true
+          target: agent
+          tags: miroir-agent:e2e
+          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
+          cache-from: type=gha,scope=e2e-agent
+          cache-to: type=gha,mode=max,scope=e2e-agent
 
-      - name: Load image into kind
-        run: kind load docker-image miroir:e2e --name miroir-test-e2e
+      - wait: [kind, controller-image, agent-image]
+
+      - name: Load images into kind
+        run: |
+          kind load docker-image miroir-controller:e2e --name miroir-test-e2e
+          kind load docker-image miroir-agent:e2e --name miroir-test-e2e
 
       - name: Provision (loop device, snapshot stack, helm install)
         run: mise run e2e-provision

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,6 @@ jobs:
     outputs:
       go-version: ${{ steps.versions.outputs.go-version }}
     steps:
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -42,8 +41,12 @@ jobs:
         id: versions
         run: echo "go-version=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
 
-  release:
-    name: Release
+  # Two images from one Dockerfile (#110): the controller ships distroless
+  # (it never execs a storage CLI), the agent ships the Debian storage
+  # userland. Separate jobs keep each builder's first-class `digest`
+  # output addressable for the pin step (kopiur's layout).
+  release-controller:
+    name: Release (controller)
     needs: versions
     permissions:
       contents: read
@@ -56,7 +59,43 @@ jobs:
         REVISION=${{ github.sha }}
         GO_VERSION=${{ needs.versions.outputs.go-version }}
       cache: true
-      meta-images: ghcr.io/${{ github.repository }}
+      cache-scope: controller
+      target: controller
+      meta-images: ghcr.io/${{ github.repository }}-controller
+      meta-tags: |
+        type=semver,pattern={{version}}
+        type=raw,value=rolling,enable=${{ github.event_name == 'release' }}
+        type=ref,event=branch
+      output: image
+      platforms: linux/amd64,linux/arm64
+      push: true
+      sbom: true
+      set-meta-annotations: true
+      set-meta-labels: true
+      sign: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  release-agent:
+    name: Release (agent)
+    needs: versions
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    uses: docker/github-builder/.github/workflows/build.yml@c4a1b216d96a8c85b45a9974b37857828274c808 # v1.13.0
+    with:
+      build-args: |
+        VERSION=${{ github.ref_name }}
+        REVISION=${{ github.sha }}
+        GO_VERSION=${{ needs.versions.outputs.go-version }}
+      cache: true
+      cache-scope: agent
+      target: agent
+      meta-images: ghcr.io/${{ github.repository }}-agent
       meta-tags: |
         type=semver,pattern={{version}}
         type=raw,value=rolling,enable=${{ github.event_name == 'release' }}
@@ -76,7 +115,7 @@ jobs:
 
   helm:
     name: Helm
-    needs: release
+    needs: [release-controller, release-agent]
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-24.04
     permissions:
@@ -86,7 +125,6 @@ jobs:
     env:
       VERSION: ${{ github.event.release.tag_name }}
     steps:
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -102,12 +140,28 @@ jobs:
       - name: Generate manifests and CRDs
         run: mise run helm-crds
 
-      - name: Pin the released image digest into the chart
+      # Pin both component images to the exact digests the builders produced
+      # (the signed multi-arch indexes) so installs are immutable. Fail
+      # closed if either digest is missing.
+      - name: Pin the released image digests into the chart
         env:
-          DIGEST: ${{ needs.release.outputs.digest }}
+          CONTROLLER_DIGEST: ${{ needs.release-controller.outputs.digest }}
+          AGENT_DIGEST: ${{ needs.release-agent.outputs.digest }}
         run: |
-          [ -n "${DIGEST}" ] || { echo "::error::empty image digest from build job"; exit 1; }
-          yq -i '.image.digest = strenv(DIGEST)' charts/miroir/values.yaml
+          for pair in "controller:${CONTROLLER_DIGEST}" "agent:${AGENT_DIGEST}"; do
+            comp="${pair%%:*}"
+            digest="${pair#*:}"
+            case "${digest}" in
+              sha256:*) ;;
+              *) echo "::error::build produced no digest for ${comp} (got: '${digest}')"; exit 1 ;;
+            esac
+            case "${comp}" in
+              controller) path=".image.digest" ;;
+              agent)      path=".agent.image.digest" ;;
+            esac
+            yq -i "${path} = \"${digest}\"" charts/miroir/values.yaml
+            echo "pinned ${comp} -> ${digest}"
+          done
 
       - name: Package Helm chart
         run: helm package charts/miroir --version "${VERSION}" --app-version "${VERSION}"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -101,12 +101,14 @@ kind export kubeconfig --name "$cluster" --kubeconfig "$KUBECONFIG"
 '''
 
 [tasks.e2e-image]
-description = "Build the miroir:e2e image and load it into the kind cluster"
+description = "Build the miroir controller+agent e2e images and load them into the kind cluster"
 run = '''
 set -eu
 cluster="${KIND_CLUSTER:-miroir-test-e2e}"
-docker build -t miroir:e2e .
-kind load docker-image miroir:e2e --name "$cluster"
+docker build --target controller -t miroir-controller:e2e .
+docker build --target agent -t miroir-agent:e2e .
+kind load docker-image miroir-controller:e2e --name "$cluster"
+kind load docker-image miroir-agent:e2e --name "$cluster"
 '''
 
 [tasks.e2e-provision]

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -7,30 +7,37 @@ backend = "aqua:dadav/helm-schema"
 [tools."aqua:dadav/helm-schema"."platforms.linux-arm64"]
 checksum = "sha256:f45e427aef848a1565a1341e3d2468840c64dc1d2c0f3b276982b852d587abe8"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194950"
 
 [tools."aqua:dadav/helm-schema"."platforms.linux-arm64-musl"]
 checksum = "sha256:f45e427aef848a1565a1341e3d2468840c64dc1d2c0f3b276982b852d587abe8"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194950"
 
 [tools."aqua:dadav/helm-schema"."platforms.linux-x64"]
 checksum = "sha256:02d7aeb3b915b431a007402778f338daf77839d563cea62d9b375896028a72c7"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194947"
 
 [tools."aqua:dadav/helm-schema"."platforms.linux-x64-musl"]
 checksum = "sha256:02d7aeb3b915b431a007402778f338daf77839d563cea62d9b375896028a72c7"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194947"
 
 [tools."aqua:dadav/helm-schema"."platforms.macos-arm64"]
 checksum = "sha256:e0075eab02f304a8d11bf8a94480fa34ec4f2db2460978d656738bf22f1106d4"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194961"
 
 [tools."aqua:dadav/helm-schema"."platforms.macos-x64"]
 checksum = "sha256:568945c206f746d45bb366369b257dd3ea25fdb8597a6c34ef678fb688b12ebf"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Darwin_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194962"
 
 [tools."aqua:dadav/helm-schema"."platforms.windows-x64"]
 checksum = "sha256:261f93081473ae8d465b29320f55282d979af9aa2c0585ad82dbc10db4d89175"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Windows_x86_64.zip"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194958"
 
 [[tools.cosign]]
 version = "3.1.1"
@@ -39,36 +46,43 @@ backend = "aqua:sigstore/cosign"
 [tools.cosign."platforms.linux-arm64"]
 checksum = "sha256:2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11"
 url = "https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign-linux-arm64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/442898897"
 provenance = "cosign"
 
 [tools.cosign."platforms.linux-arm64-musl"]
 checksum = "sha256:2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11"
 url = "https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign-linux-arm64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/442898897"
 provenance = "cosign"
 
 [tools.cosign."platforms.linux-x64"]
 checksum = "sha256:ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc"
 url = "https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign-linux-amd64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/442898812"
 provenance = "cosign"
 
 [tools.cosign."platforms.linux-x64-musl"]
 checksum = "sha256:ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc"
 url = "https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign-linux-amd64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/442898812"
 provenance = "cosign"
 
 [tools.cosign."platforms.macos-arm64"]
 checksum = "sha256:94b42a9e697be95675f6160ab031a9a5f1ec1e646d6f648d7b2f5cd59ececbc5"
 url = "https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign-darwin-arm64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/442899033"
 provenance = "cosign"
 
 [tools.cosign."platforms.macos-x64"]
 checksum = "sha256:14d2678dfbfde18798151e86fbd91ebdadbb7424b18412a42a155dd8a2df4c7a"
 url = "https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign-darwin-amd64"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/442899292"
 provenance = "cosign"
 
 [tools.cosign."platforms.windows-x64"]
 checksum = "sha256:9d2c026e667bfd979fa7ba1cab8c4b24d2e73f336ec2d57f7fc72c7e73e5b4b6"
 url = "https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign-windows-amd64.exe"
+url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/442899047"
 provenance = "cosign"
 
 [[tools.go]]
@@ -110,69 +124,44 @@ backend = "aqua:golangci/golangci-lint"
 [tools.golangci-lint."platforms.linux-arm64"]
 checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-arm64-musl"]
 checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64-musl"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
 checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-x64"]
 checksum = "sha256:f6f06d94b6241521c53d15450c5209b028270bf966f842afb11c030c79f5bc16"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470980"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.windows-x64"]
 checksum = "sha256:bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e02bb"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-windows-amd64.zip"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471017"
 provenance = "github-attestations"
-
-[[tools.hcloud]]
-version = "1.66.0"
-backend = "aqua:hetznercloud/cli"
-
-[tools.hcloud."platforms.linux-arm64"]
-checksum = "sha256:f9d67b4a1e2a7d88e6360b3e9a5efe9ab6c4e1cf6d0fa45d2740adfa8528d55b"
-url = "https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-linux-arm64.tar.gz"
-
-[tools.hcloud."platforms.linux-arm64-musl"]
-checksum = "sha256:f9d67b4a1e2a7d88e6360b3e9a5efe9ab6c4e1cf6d0fa45d2740adfa8528d55b"
-url = "https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-linux-arm64.tar.gz"
-
-[tools.hcloud."platforms.linux-x64"]
-checksum = "sha256:8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86"
-url = "https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-linux-amd64.tar.gz"
-
-[tools.hcloud."platforms.linux-x64-musl"]
-checksum = "sha256:8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86"
-url = "https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-linux-amd64.tar.gz"
-
-[tools.hcloud."platforms.macos-arm64"]
-checksum = "sha256:b602f1e0d9d0ea6cb721e297688f61adb5508247ff8867c87778a2449fa2fcce"
-url = "https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-darwin-arm64.tar.gz"
-
-[tools.hcloud."platforms.macos-x64"]
-checksum = "sha256:3927d536d4c930dcd2a4e0826ec07f5feb341540a08254a7676bc60882bdfec2"
-url = "https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-darwin-amd64.tar.gz"
-
-[tools.hcloud."platforms.windows-x64"]
-checksum = "sha256:15b4ecf8d57c993f6987530ad1910f1167edf71f702696710d5420bdf0de7639"
-url = "https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-windows-amd64.zip"
 
 [[tools.helm]]
 version = "4.2.3"
@@ -213,30 +202,37 @@ backend = "aqua:norwoodj/helm-docs"
 [tools.helm-docs."platforms.linux-arm64"]
 checksum = "sha256:c3787212332386dcd122debef7848feb165aa701467ae3e3442df7638f3ac4e4"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327216"
 
 [tools.helm-docs."platforms.linux-arm64-musl"]
 checksum = "sha256:c3787212332386dcd122debef7848feb165aa701467ae3e3442df7638f3ac4e4"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327216"
 
 [tools.helm-docs."platforms.linux-x64"]
 checksum = "sha256:a8cf72ada34fad93285ba2a452b38bdc5bd52cc9a571236244ec31022928d6cc"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327210"
 
 [tools.helm-docs."platforms.linux-x64-musl"]
 checksum = "sha256:a8cf72ada34fad93285ba2a452b38bdc5bd52cc9a571236244ec31022928d6cc"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327210"
 
 [tools.helm-docs."platforms.macos-arm64"]
 checksum = "sha256:2d8399db5b33d240d5f8985241bcf5483563150b968e3229823822979f3e4b8b"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327215"
 
 [tools.helm-docs."platforms.macos-x64"]
 checksum = "sha256:b2f1ffd0feef8dc0901a38a2053481d1d67b63ca30da4ac774166c6b52fa2245"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Darwin_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327211"
 
 [tools.helm-docs."platforms.windows-x64"]
 checksum = "sha256:3c54fd78d99e2769cf83a0faf12cf6cd4de1cac6ed7bee8d908a2c8fc23f538c"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Windows_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327219"
 
 [[tools.jq]]
 version = "1.8.2"
@@ -245,36 +241,43 @@ backend = "aqua:jqlang/jq"
 [tools.jq."platforms.linux-arm64"]
 checksum = "sha256:8b85c817833814ddca00a144c33705546355afccf0cf39b188f3cdb48b852309"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-arm64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012756"
 provenance = "github-attestations"
 
 [tools.jq."platforms.linux-arm64-musl"]
 checksum = "sha256:8b85c817833814ddca00a144c33705546355afccf0cf39b188f3cdb48b852309"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-arm64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012756"
 provenance = "github-attestations"
 
 [tools.jq."platforms.linux-x64"]
 checksum = "sha256:b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-amd64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012752"
 provenance = "github-attestations"
 
 [tools.jq."platforms.linux-x64-musl"]
 checksum = "sha256:b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-amd64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012752"
 provenance = "github-attestations"
 
 [tools.jq."platforms.macos-arm64"]
 checksum = "sha256:2d75340ba57a4b4b4c8708a21c2dc8e958a48aaa8bba13b27f77f6e4c0eca07e"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-macos-arm64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012783"
 provenance = "github-attestations"
 
 [tools.jq."platforms.macos-x64"]
 checksum = "sha256:e94b266e3c26690550006abe63152b782280f4e14374accdf04cbde844f00bc0"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-macos-amd64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012782"
 provenance = "github-attestations"
 
 [tools.jq."platforms.windows-x64"]
 checksum = "sha256:a6fc67fedaf9128a3309a1e2ebb8b986aeccf70122ee46d2cb4849e423f0c627"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-windows-amd64.exe"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012788"
 provenance = "github-attestations"
 
 [[tools.kind]]
@@ -284,30 +287,37 @@ backend = "aqua:kubernetes-sigs/kind"
 [tools.kind."platforms.linux-arm64"]
 checksum = "sha256:b92cd615e97585de8ddade28ed5cd7feb4248d717c233eea5b03c37298900f5d"
 url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-arm64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/kind/releases/assets/436442565"
 
 [tools.kind."platforms.linux-arm64-musl"]
 checksum = "sha256:b92cd615e97585de8ddade28ed5cd7feb4248d717c233eea5b03c37298900f5d"
 url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-arm64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/kind/releases/assets/436442565"
 
 [tools.kind."platforms.linux-x64"]
 checksum = "sha256:50030de23cf40a18505f20426f6a8506bedf13c6e509244bd1fa9463721b0f54"
 url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/kind/releases/assets/436442498"
 
 [tools.kind."platforms.linux-x64-musl"]
 checksum = "sha256:50030de23cf40a18505f20426f6a8506bedf13c6e509244bd1fa9463721b0f54"
 url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/kind/releases/assets/436442498"
 
 [tools.kind."platforms.macos-arm64"]
 checksum = "sha256:dca67911095a110c2b5c36e26df6cac860c602033e456c0db47be498cdef1ebb"
 url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-darwin-arm64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/kind/releases/assets/436442412"
 
 [tools.kind."platforms.macos-x64"]
 checksum = "sha256:295ac6d0d634c9819c9907df45e3017d1f13166bd13c3404c45e79f7faa47498"
 url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-darwin-amd64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/kind/releases/assets/436442366"
 
 [tools.kind."platforms.windows-x64"]
 checksum = "sha256:0bcb2d1cfedc1912d664014db716937e8a0e843e91c6807b4db2025dbc8989fa"
 url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-windows-amd64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/kind/releases/assets/436442633"
 
 [[tools.kube-controller-tools]]
 version = "0.21.0"
@@ -426,38 +436,6 @@ url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/leftho
 url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227505"
 provenance = "github-attestations"
 
-[[tools.opentofu]]
-version = "1.12.3"
-backend = "aqua:opentofu/opentofu"
-
-[tools.opentofu."platforms.linux-arm64"]
-checksum = "sha256:98861dad4ac08882dcf255fe5d48bed7deddc34e8d6544f8690c65212320ad64"
-url = "https://github.com/opentofu/opentofu/releases/download/v1.12.3/tofu_1.12.3_linux_arm64.tar.gz"
-
-[tools.opentofu."platforms.linux-arm64-musl"]
-checksum = "sha256:98861dad4ac08882dcf255fe5d48bed7deddc34e8d6544f8690c65212320ad64"
-url = "https://github.com/opentofu/opentofu/releases/download/v1.12.3/tofu_1.12.3_linux_arm64.tar.gz"
-
-[tools.opentofu."platforms.linux-x64"]
-checksum = "sha256:f87d45408dcbb963ddbe10b2f75e55b3495310556e05c35765dfd5913551f182"
-url = "https://github.com/opentofu/opentofu/releases/download/v1.12.3/tofu_1.12.3_linux_amd64.tar.gz"
-
-[tools.opentofu."platforms.linux-x64-musl"]
-checksum = "sha256:f87d45408dcbb963ddbe10b2f75e55b3495310556e05c35765dfd5913551f182"
-url = "https://github.com/opentofu/opentofu/releases/download/v1.12.3/tofu_1.12.3_linux_amd64.tar.gz"
-
-[tools.opentofu."platforms.macos-arm64"]
-checksum = "sha256:0c8ddee4294f7cea34d82b122fa805febce41d21905a54dc9ce9f79ee8145284"
-url = "https://github.com/opentofu/opentofu/releases/download/v1.12.3/tofu_1.12.3_darwin_arm64.tar.gz"
-
-[tools.opentofu."platforms.macos-x64"]
-checksum = "sha256:e4d5fa86cfbe7eb8b56ec19e4c7e0bc7885845ca4e4a955c49d184ae82c62ab2"
-url = "https://github.com/opentofu/opentofu/releases/download/v1.12.3/tofu_1.12.3_darwin_amd64.tar.gz"
-
-[tools.opentofu."platforms.windows-x64"]
-checksum = "sha256:34ddbab9eb07a72ea5cf36d98d97ce1931242cb89693cbf5dce06d65ba37d8cc"
-url = "https://github.com/opentofu/opentofu/releases/download/v1.12.3/tofu_1.12.3_windows_amd64.tar.gz"
-
 [[tools.oxfmt]]
 version = "0.58.0"
 backend = "npm:oxfmt"
@@ -469,101 +447,37 @@ backend = "aqua:kubernetes-sigs/controller-runtime/setup-envtest"
 [tools.setup-envtest."platforms.linux-arm64"]
 checksum = "sha256:c5d8968ec3f2a120b66bc13bd36f80fe4150c34aae7cc491bf9624c8680296c7"
 url = "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.24.1/setup-envtest-linux-arm64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases/assets/418514276"
 
 [tools.setup-envtest."platforms.linux-arm64-musl"]
 checksum = "sha256:c5d8968ec3f2a120b66bc13bd36f80fe4150c34aae7cc491bf9624c8680296c7"
 url = "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.24.1/setup-envtest-linux-arm64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases/assets/418514276"
 
 [tools.setup-envtest."platforms.linux-x64"]
 checksum = "sha256:a9a78fadfc338a38188332f36863c76877f1c86df1a83d2241d2bfc3935297d2"
 url = "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.24.1/setup-envtest-linux-amd64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases/assets/418514280"
 
 [tools.setup-envtest."platforms.linux-x64-musl"]
 checksum = "sha256:a9a78fadfc338a38188332f36863c76877f1c86df1a83d2241d2bfc3935297d2"
 url = "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.24.1/setup-envtest-linux-amd64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases/assets/418514280"
 
 [tools.setup-envtest."platforms.macos-arm64"]
 checksum = "sha256:7e59a0d526f6946aa2f114d34b2e309639c811f3a4f83d56f37b6e3197c6fdfb"
 url = "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.24.1/setup-envtest-darwin-arm64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases/assets/418514281"
 
 [tools.setup-envtest."platforms.macos-x64"]
 checksum = "sha256:3fb17f2b1b0f09b7e5395180bd2bcb1d53bb78d72bb0415106b7ae8bf64e23d0"
 url = "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.24.1/setup-envtest-darwin-amd64"
+url_api = "https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases/assets/418514278"
 
 [tools.setup-envtest."platforms.windows-x64"]
 checksum = "sha256:e50f6272ff3c649a57c41eb6cae1957083185a150d1a0cca4061c71430298260"
 url = "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.24.1/setup-envtest-windows-amd64.exe"
-
-[[tools.stern]]
-version = "1.34.0"
-backend = "aqua:stern/stern"
-
-[tools.stern."platforms.linux-arm64"]
-checksum = "sha256:e215cfc5e42d71e93b77d3fac8f0df7d736271f44b2d92a5b417eaa588edff3a"
-url = "https://github.com/stern/stern/releases/download/v1.34.0/stern_1.34.0_linux_arm64.tar.gz"
-
-[tools.stern."platforms.linux-arm64-musl"]
-checksum = "sha256:e215cfc5e42d71e93b77d3fac8f0df7d736271f44b2d92a5b417eaa588edff3a"
-url = "https://github.com/stern/stern/releases/download/v1.34.0/stern_1.34.0_linux_arm64.tar.gz"
-
-[tools.stern."platforms.linux-x64"]
-checksum = "sha256:7754adfa653939240f7d20fff4ada9b69cda40c9e70732301f67bb8045f1ef3e"
-url = "https://github.com/stern/stern/releases/download/v1.34.0/stern_1.34.0_linux_amd64.tar.gz"
-
-[tools.stern."platforms.linux-x64-musl"]
-checksum = "sha256:7754adfa653939240f7d20fff4ada9b69cda40c9e70732301f67bb8045f1ef3e"
-url = "https://github.com/stern/stern/releases/download/v1.34.0/stern_1.34.0_linux_amd64.tar.gz"
-
-[tools.stern."platforms.macos-arm64"]
-checksum = "sha256:4014d84096e1e603ee115864e03a1e15fb9bae9876647bf7bb8031eee278dcd3"
-url = "https://github.com/stern/stern/releases/download/v1.34.0/stern_1.34.0_darwin_arm64.tar.gz"
-
-[tools.stern."platforms.macos-x64"]
-checksum = "sha256:153355317f21e565ea10bc710d4c2e3d98fd06f83cae5eb927e7031cc724a7a6"
-url = "https://github.com/stern/stern/releases/download/v1.34.0/stern_1.34.0_darwin_amd64.tar.gz"
-
-[tools.stern."platforms.windows-x64"]
-checksum = "sha256:22ed0c8eb0c15cbd2651c944517f6c06aa6ffa11467be55f7673f7242f1bafd3"
-url = "https://github.com/stern/stern/releases/download/v1.34.0/stern_1.34.0_windows_amd64.tar.gz"
-
-[[tools.talosctl]]
-version = "1.13.5"
-backend = "aqua:siderolabs/talos"
-
-[tools.talosctl."platforms.linux-arm64"]
-checksum = "sha256:bd053d8264c1b0c091cbaf15e7b414ab1cd14a56ddd5860f2e2ba01e5aee3bc3"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-linux-arm64"
-provenance = "cosign"
-
-[tools.talosctl."platforms.linux-arm64-musl"]
-checksum = "sha256:bd053d8264c1b0c091cbaf15e7b414ab1cd14a56ddd5860f2e2ba01e5aee3bc3"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-linux-arm64"
-provenance = "cosign"
-
-[tools.talosctl."platforms.linux-x64"]
-checksum = "sha256:cb12209727c0c4d57d74c0595f34d441ba491421e1d3c8a5142ed91028a20232"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-linux-amd64"
-provenance = "cosign"
-
-[tools.talosctl."platforms.linux-x64-musl"]
-checksum = "sha256:cb12209727c0c4d57d74c0595f34d441ba491421e1d3c8a5142ed91028a20232"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-linux-amd64"
-provenance = "cosign"
-
-[tools.talosctl."platforms.macos-arm64"]
-checksum = "sha256:5cfc42f5a51b01ea391c9760a1c5450517f7e85a74d145fd20b6abc4ac1df37e"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-darwin-arm64"
-provenance = "cosign"
-
-[tools.talosctl."platforms.macos-x64"]
-checksum = "sha256:b5808a8f650c53987d0133704259f3cdf31c081710bda598f9b4cab934abc78c"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-darwin-amd64"
-provenance = "cosign"
-
-[tools.talosctl."platforms.windows-x64"]
-checksum = "sha256:dd36d21d7157568387fa62e4f092b8a8536bb85f2362ababee493c503e48a0f2"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-windows-amd64.exe"
-provenance = "cosign"
+url_api = "https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases/assets/418514277"
 
 [[tools.yq]]
 version = "4.53.3"
@@ -572,30 +486,44 @@ backend = "aqua:mikefarah/yq"
 [tools.yq."platforms.linux-arm64"]
 checksum = "sha256:578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_arm64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146727"
+provenance = "cosign"
 
 [tools.yq."platforms.linux-arm64-musl"]
 checksum = "sha256:578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_arm64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146727"
+provenance = "cosign"
 
 [tools.yq."platforms.linux-x64"]
 checksum = "sha256:fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146735"
+provenance = "cosign"
 
 [tools.yq."platforms.linux-x64-musl"]
 checksum = "sha256:fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146735"
+provenance = "cosign"
 
 [tools.yq."platforms.macos-arm64"]
-checksum = "sha256:877de31753a4dd2401aa048937aa9a7fc4d5f6ce858cf31508c5802954297213"
-url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_arm64"
+checksum = "sha256:b4ba1ecce3c47f00803f4f964de38394326c7a32eb6540616e04fb2935a0f08d"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146744"
+provenance = "cosign"
 
 [tools.yq."platforms.macos-x64"]
 checksum = "sha256:b4ba1ecce3c47f00803f4f964de38394326c7a32eb6540616e04fb2935a0f08d"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146744"
+provenance = "cosign"
 
 [tools.yq."platforms.windows-x64"]
 checksum = "sha256:e279bc506a452eeafcdf364f91a025455e402a8001169083caf01f4b64a544e2"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_windows_amd64.exe"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146721"
+provenance = "cosign"
 
 [[tools.zizmor]]
 version = "1.26.1"
@@ -604,6 +532,7 @@ backend = "aqua:zizmorcore/zizmor"
 [tools.zizmor."platforms.linux-arm64"]
 checksum = "sha256:711f5af366b299128f9a04b1470e37d990b41fbd21f14a1a4148d25004a83762"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417983"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-arm64-musl"]
@@ -612,6 +541,7 @@ provenance = "github-attestations"
 [tools.zizmor."platforms.linux-x64"]
 checksum = "sha256:8556289a64e7aaf2400cd516f61a471aa91c5902cc56ad96a82fd12f90c2ef73"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417985"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-x64-musl"]
@@ -620,14 +550,17 @@ provenance = "github-attestations"
 [tools.zizmor."platforms.macos-arm64"]
 checksum = "sha256:68ab2b37836bbd44f6cfffcc102b9ffffbc20c5d67d84293dafb63bd2775a1da"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417984"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-x64"]
 checksum = "sha256:2967414a561f8c1264121e8f723c3b5abcf3d1bf7ce5063114df99985dd75801"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417982"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.windows-x64"]
 checksum = "sha256:c6cea156935e3b9d36faeca4fd8f622d23f7a7578da26adb34e6456abd9beb9a"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417981"
 provenance = "github-attestations"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,29 +12,42 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpat
     -ldflags "-X main.version=${VERSION} -X main.commit=${REVISION}" \
     -o /miroir cmd/main.go
 
-# The agent drives lvm/zfs/mkfs on the host through this container's
+# Controller: talks to the Kubernetes API only — it never execs a storage
+# CLI, so it ships without one (and without a shell). The chart already
+# runs it as 65532, this base's nonroot user.
+FROM gcr.io/distroless/static:nonroot AS controller
+COPY --from=build /miroir /usr/local/bin/miroir
+ENTRYPOINT ["/usr/local/bin/miroir"]
+
+# Agent: drives lvm/zfs/drbd/mkfs on the host through this container's
 # userland; the kernel modules come from the Talos kernel + extensions.
-# Alpine's zfs userland (2.4.x) must share a minor version with the
-# siderolabs/zfs extension's module — verify on upgrades.
-# drbd-utils is pinned to the Alpine 3.24 series (bumped 9.33 → 9.34 with
-# the repo): GI seeding depends on drbdmeta CLI behavior — re-validate
-# against smoke.sh + conformance (the kind e2e does not exercise DRBD)
-# before bumping further.
-FROM alpine:3.24
-RUN apk add --no-cache \
+# Debian (glibc) because the DRBD/ZFS ecosystem — LINBIT, Piraeus,
+# blockstor — builds and tests the storage stack against glibc only.
+# zfsutils-linux lives in contrib. Version notes (trixie, no backports):
+#   - drbd-utils 9.22: every CLI/JSON surface miroir uses predates it
+#     (adjust --skip-disk 8.9.7, status --json 8.9.8, quorum 8.9.11;
+#     peer_devices/percent-in-sync/out-of-sync verified in the v9.22.0
+#     source). GI seeding depends on drbdmeta CLI behavior — re-validate
+#     with smoke.sh + conformance on real DRBD (the kind e2e exercises
+#     the local backend only) before shipping a base bump.
+#   - zfs userland 2.3 against the siderolabs/zfs 2.4 module: userland
+#     older than the module is the supported direction, and miroir only
+#     uses ancient ops (create -V/snapshot/clone/promote/volsize).
+FROM debian:trixie-slim AS agent
+RUN sed -i 's|^Components: main$|Components: main contrib|' /etc/apt/sources.list.d/debian.sources && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    drbd-utils \
     lvm2 \
-    zfs \
-    'drbd-utils=~9.34' \
+    zfsutils-linux \
     e2fsprogs \
-    e2fsprogs-extra \
     xfsprogs \
-    xfsprogs-extra \
-    blkid \
-    util-linux-misc \
-    # loopfile backend: full losetup (-j/-O/-c, beyond busybox's) and GNU cp
-    # for reflink (cp --reflink → FICLONE); both shadow busybox via PATH.
-    losetup \
-    coreutils
+    # explicit though present in the base: losetup/blkid/lsblk (util-linux),
+    # mount, and GNU cp for reflink clones (cp --reflink → FICLONE).
+    util-linux \
+    mount \
+    coreutils && \
+    rm -rf /var/lib/apt/lists/*
 # No udevd is reachable from the container: stop libdevmapper from waiting
 # on udev cookies and lvm from querying udev for the device list.
 # global_filter rejects DRBD devices: lvm's device scan would block in D

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN sed -i 's|^Components: main$|Components: main contrib|' /etc/apt/sources.lis
     zfsutils-linux \
     e2fsprogs \
     xfsprogs \
+    # modprobe: lvm2 and drbdsetup load missing dm/drbd kernel targets on
+    # demand through the pod's read-only /lib/modules hostPath (Alpine got
+    # this implicitly from busybox; trixie-slim ships no kmod).
+    kmod \
     # explicit though present in the base: losetup/blkid/lsblk (util-linux),
     # mount, and GNU cp for reflink clones (cp --reflink → FICLONE).
     util-linux \

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -35,11 +35,15 @@ Kubernetes: `>=1.31.0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| agent.extraArgs | list | `[]` | Extra arguments for the agent container. |
+| agent.extraEnv | list | `[]` | Extra environment variables for the agent container. |
 | agent.image.digest | string | `""` |  |
 | agent.image.pullPolicy | string | `"IfNotPresent"` |  |
 | agent.image.repository | string | `"ghcr.io/home-operations/miroir-agent"` |  |
 | agent.image.tag | string | `""` |  |
 | agent.kubeletDir | string | `"/var/lib/kubelet"` | Kubelet root on the nodes; CSI sockets and mounts hang off it. |
+| agent.podAnnotations | object | `{}` | Extra annotations on the agent pods. |
+| agent.podLabels | object | `{}` | Extra labels on the agent pods. |
 | agent.poolStatsInterval | string | `"60s"` |  |
 | agent.registrar.image | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"` |  |
 | agent.resources.limits.memory | string | `"128Mi"` |  |
@@ -55,6 +59,8 @@ Kubernetes: `>=1.31.0`
 | drbd.resync.planAhead | string | `""` | c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller. |
 | drbd.resync.rate | string | `""` | resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0). |
 | drbd.verifyAlg | string | `"crc32c"` | verify-alg arms `drbdadm verify <res>` — the only cross-leg integrity check (a zfs scrub only validates one leg against itself). Defaulted to crc32c: drbd.ko depends on libcrc32c so it is present on every node, and it costs nothing until a verify runs. Schedule the verify pass yourself (cron, quiet hours); out-of-sync blocks surface in the kernel log and `drbdsetup status`. Empty disables verification. |
+| extraArgs | list | `[]` | Extra arguments for the controller container. |
+| extraEnv | list | `[]` | Extra environment variables for the controller container. |
 | fullnameOverride | string | `""` | Override the fully qualified name prefix of every rendered object. |
 | global.affinity | object | `{}` |  |
 | global.commonLabels | object | `{}` | Labels stamped on every rendered object (fleet-wide labelling). |
@@ -62,6 +68,8 @@ Kubernetes: `>=1.31.0`
 | global.nodeSelector | object | `{}` | Controller scheduling defaults. |
 | global.tolerations | list | `[]` |  |
 | image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"ghcr.io/home-operations/miroir-controller","tag":""}` | Controller image (distroless, no storage userland — the controller never execs a storage CLI). |
+| logging.format | string | `"json"` | Encoder: json (structured, default) or console (human-readable). |
+| logging.level | string | `"info"` | Log level: debug | info | error (or any zapcore level). |
 | monitoring.dashboards.annotations | object | `{}` | Annotations added to the dashboard ConfigMap. |
 | monitoring.dashboards.enabled | bool | `false` | Render the Grafana dashboard ConfigMap (for grafana-operator or the kube-prometheus-stack sidecar). |
 | monitoring.dashboards.grafanaOperator.allowCrossNamespaceImport | bool | `true` | If true allows for a Grafana in any namespace to access this GrafanaDashboard. |
@@ -88,6 +96,8 @@ Kubernetes: `>=1.31.0`
 | nameOverride | string | `""` | Override the chart name used in labels and default object names. |
 | nodes | object | `{}` |  |
 | overcommitRatio | int | `2` | Thin-provisioning overcommit guardrail: CreateVolume is refused when a node's provisioned total would exceed capacity × this ratio. 2× is the classic CoW headroom; raise it only if you trust your usage to stay sparse, lower it toward 1 to provision conservatively. |
+| podAnnotations | object | `{}` | Extra annotations on the controller pod. |
+| podLabels | object | `{}` | Extra labels on the controller pod. |
 | priorityClassName | string | `"system-cluster-critical"` | system-cluster-critical protects the single controller from eviction under node pressure — while it is down, no volume can be provisioned, expanded, or snapshotted. |
 | provisionTimeout | string | `"120s"` | Wait for agents to realise a new volume. Keep sidecars.*.timeout at or above this, or the sidecar RPC deadline fires before this one and the knob has no effect. |
 | replicatedStorageClass.create | bool | `true` |  |

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -53,6 +53,7 @@ Kubernetes: `>=1.31.0`
 | drbd.resync.planAhead | string | `""` | c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller. |
 | drbd.resync.rate | string | `""` | resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0). |
 | drbd.verifyAlg | string | `"crc32c"` | verify-alg arms `drbdadm verify <res>` — the only cross-leg integrity check (a zfs scrub only validates one leg against itself). Defaulted to crc32c: drbd.ko depends on libcrc32c so it is present on every node, and it costs nothing until a verify runs. Schedule the verify pass yourself (cron, quiet hours); out-of-sync blocks surface in the kernel log and `drbdsetup status`. Empty disables verification. |
+| fullnameOverride | string | `""` | Override the fully qualified name prefix of every rendered object. |
 | global.affinity | object | `{}` |  |
 | global.commonLabels | object | `{}` | Labels stamped on every rendered object (fleet-wide labelling). |
 | global.imagePullSecrets | list | `[]` | Pull secrets added to every pod (controller, agent, setup, uninstall). |
@@ -83,6 +84,7 @@ Kubernetes: `>=1.31.0`
 | monitoring.prometheusRule.annotations | object | `{}` | PrometheusRule annotations. |
 | monitoring.prometheusRule.enabled | bool | `false` | Create a PrometheusRule with alerting rules (requires the Prometheus Operator CRDs). |
 | monitoring.prometheusRule.labels | object | `{}` | PrometheusRule labels. |
+| nameOverride | string | `""` | Override the chart name used in labels and default object names. |
 | nodes | object | `{}` |  |
 | overcommitRatio | int | `2` | Thin-provisioning overcommit guardrail: CreateVolume is refused when a node's provisioned total would exceed capacity × this ratio. 2× is the classic CoW headroom; raise it only if you trust your usage to stay sparse, lower it toward 1 to provision conservatively. |
 | priorityClassName | string | `"system-cluster-critical"` | system-cluster-critical protects the single controller from eviction under node pressure — while it is down, no volume can be provisioned, expanded, or snapshotted. |

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -39,15 +39,17 @@ Kubernetes: `>=1.31.0`
 | agent.image.pullPolicy | string | `"IfNotPresent"` |  |
 | agent.image.repository | string | `"ghcr.io/home-operations/miroir-agent"` |  |
 | agent.image.tag | string | `""` |  |
+| agent.kubeletDir | string | `"/var/lib/kubelet"` | Kubelet root on the nodes; CSI sockets and mounts hang off it. |
 | agent.poolStatsInterval | string | `"60s"` |  |
+| agent.registrar.image | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"` |  |
 | agent.resources.limits.memory | string | `"128Mi"` |  |
 | agent.resources.requests.cpu | string | `"10m"` |  |
 | agent.resources.requests.memory | string | `"32Mi"` |  |
 | autoTieBreaker | bool | `true` | Add a diskless tie-breaker replica to 2-replica freeze volumes when a spare storage node exists, so majority quorum survives a single node loss. Also retrofits existing freeze volumes at controller startup. |
+| drbd.net.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count (e.g. "36864"); raises resync throughput on fast links. |
 | drbd.onIoError | string | `"detach"` |  |
 | drbd.resync.discardGranularity | string | `""` | rs-discard-granularity: during a full resync, runs of zeroes are sent as discards of this size instead of written out (e.g. "65536"), keeping a re-added thin leg thin. lvmthin/zfs only — leave empty on clusters with loopfile-backed replicated volumes (loop devices mishandle it) or entirely to keep DRBD's default (off). |
 | drbd.resync.fillTarget | string | `""` | c-fill-target, the resync controller's target fill level (e.g. "1M"). |
-| drbd.resync.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864"). |
 | drbd.resync.maxRate | string | `""` | c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. "720M"). |
 | drbd.resync.minRate | string | `"10M"` | c-min-rate, the resync floor guaranteed even under application I/O. Defaulted to 10M: DRBD's kernel default (250 KiB/s) leaves a degraded volume resyncing for days under load; 10 MiB/s heals a 100Gi leg in hours while still yielding most of a 1GbE link to applications. Lower on a slow shared link. |
 | drbd.resync.planAhead | string | `""` | c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller. |
@@ -60,7 +62,6 @@ Kubernetes: `>=1.31.0`
 | global.nodeSelector | object | `{}` | Controller scheduling defaults. |
 | global.tolerations | list | `[]` |  |
 | image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"ghcr.io/home-operations/miroir-controller","tag":""}` | Controller image (distroless, no storage userland — the controller never execs a storage CLI). |
-| kubeletDir | string | `"/var/lib/kubelet"` |  |
 | monitoring.dashboards.annotations | object | `{}` | Annotations added to the dashboard ConfigMap. |
 | monitoring.dashboards.enabled | bool | `false` | Render the Grafana dashboard ConfigMap (for grafana-operator or the kube-prometheus-stack sidecar). |
 | monitoring.dashboards.grafanaOperator.allowCrossNamespaceImport | bool | `true` | If true allows for a Grafana in any namespace to access this GrafanaDashboard. |
@@ -98,7 +99,6 @@ Kubernetes: `>=1.31.0`
 | resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | Controller resources. |
 | sidecars.provisioner.image | string | `"registry.k8s.io/sig-storage/csi-provisioner:v6.3.0"` |  |
 | sidecars.provisioner.timeout | string | `"120s"` |  |
-| sidecars.registrar.image | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"` |  |
 | sidecars.resizer.image | string | `"registry.k8s.io/sig-storage/csi-resizer:v2.2.1"` |  |
 | sidecars.resizer.timeout | string | `"120s"` |  |
 | sidecars.snapshotter.image | string | `"registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0"` |  |

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -53,6 +53,11 @@ Kubernetes: `>=1.31.0`
 | drbd.resync.planAhead | string | `""` | c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller. |
 | drbd.resync.rate | string | `""` | resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0). |
 | drbd.verifyAlg | string | `"crc32c"` | verify-alg arms `drbdadm verify <res>` — the only cross-leg integrity check (a zfs scrub only validates one leg against itself). Defaulted to crc32c: drbd.ko depends on libcrc32c so it is present on every node, and it costs nothing until a verify runs. Schedule the verify pass yourself (cron, quiet hours); out-of-sync blocks surface in the kernel log and `drbdsetup status`. Empty disables verification. |
+| global.affinity | object | `{}` |  |
+| global.commonLabels | object | `{}` | Labels stamped on every rendered object (fleet-wide labelling). |
+| global.imagePullSecrets | list | `[]` | Pull secrets added to every pod (controller, agent, setup, uninstall). |
+| global.nodeSelector | object | `{}` | Controller scheduling defaults. |
+| global.tolerations | list | `[]` |  |
 | image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"ghcr.io/home-operations/miroir-controller","tag":""}` | Controller image (distroless, no storage userland — the controller never execs a storage CLI). |
 | kubeletDir | string | `"/var/lib/kubelet"` |  |
 | monitoring.dashboards.annotations | object | `{}` | Annotations added to the dashboard ConfigMap. |

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -35,6 +35,10 @@ Kubernetes: `>=1.31.0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| agent.image.digest | string | `""` |  |
+| agent.image.pullPolicy | string | `"IfNotPresent"` |  |
+| agent.image.repository | string | `"ghcr.io/home-operations/miroir-agent"` |  |
+| agent.image.tag | string | `""` |  |
 | agent.poolStatsInterval | string | `"60s"` |  |
 | agent.resources.limits.memory | string | `"128Mi"` |  |
 | agent.resources.requests.cpu | string | `"10m"` |  |
@@ -55,10 +59,7 @@ Kubernetes: `>=1.31.0`
 | drbd.resync.planAhead | string | `""` | c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller. |
 | drbd.resync.rate | string | `""` | resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0). |
 | drbd.verifyAlg | string | `"crc32c"` | verify-alg arms `drbdadm verify <res>` — the only cross-leg integrity check (a zfs scrub only validates one leg against itself). Defaulted to crc32c: drbd.ko depends on libcrc32c so it is present on every node, and it costs nothing until a verify runs. Schedule the verify pass yourself (cron, quiet hours); out-of-sync blocks surface in the kernel log and `drbdsetup status`. Empty disables verification. |
-| image.digest | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/home-operations/miroir"` |  |
-| image.tag | string | `""` |  |
+| image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"ghcr.io/home-operations/miroir-controller","tag":""}` | Controller image (distroless, no storage userland — the controller never execs a storage CLI). |
 | kubeletDir | string | `"/var/lib/kubelet"` |  |
 | monitoring.dashboards.annotations | object | `{}` | Annotations added to the dashboard ConfigMap. |
 | monitoring.dashboards.enabled | bool | `false` | Render the Grafana dashboard ConfigMap (for grafana-operator or the kube-prometheus-stack sidecar). |

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -43,13 +43,7 @@ Kubernetes: `>=1.31.0`
 | agent.resources.limits.memory | string | `"128Mi"` |  |
 | agent.resources.requests.cpu | string | `"10m"` |  |
 | agent.resources.requests.memory | string | `"32Mi"` |  |
-| controller.autoTieBreaker | bool | `true` |  |
-| controller.overcommitRatio | int | `2` |  |
-| controller.priorityClassName | string | `"system-cluster-critical"` |  |
-| controller.provisionTimeout | string | `"120s"` |  |
-| controller.resources.limits.memory | string | `"128Mi"` |  |
-| controller.resources.requests.cpu | string | `"10m"` |  |
-| controller.resources.requests.memory | string | `"32Mi"` |  |
+| autoTieBreaker | bool | `true` | Add a diskless tie-breaker replica to 2-replica freeze volumes when a spare storage node exists, so majority quorum survives a single node loss. Also retrofits existing freeze volumes at controller startup. |
 | drbd.onIoError | string | `"detach"` |  |
 | drbd.resync.discardGranularity | string | `""` | rs-discard-granularity: during a full resync, runs of zeroes are sent as discards of this size instead of written out (e.g. "65536"), keeping a re-added thin leg thin. lvmthin/zfs only — leave empty on clusters with loopfile-backed replicated volumes (loop devices mishandle it) or entirely to keep DRBD's default (off). |
 | drbd.resync.fillTarget | string | `""` | c-fill-target, the resync controller's target fill level (e.g. "1M"). |
@@ -85,12 +79,16 @@ Kubernetes: `>=1.31.0`
 | monitoring.prometheusRule.enabled | bool | `false` | Create a PrometheusRule with alerting rules (requires the Prometheus Operator CRDs). |
 | monitoring.prometheusRule.labels | object | `{}` | PrometheusRule labels. |
 | nodes | object | `{}` |  |
+| overcommitRatio | int | `2` | Thin-provisioning overcommit guardrail: CreateVolume is refused when a node's provisioned total would exceed capacity × this ratio. 2× is the classic CoW headroom; raise it only if you trust your usage to stay sparse, lower it toward 1 to provision conservatively. |
+| priorityClassName | string | `"system-cluster-critical"` | system-cluster-critical protects the single controller from eviction under node pressure — while it is down, no volume can be provisioned, expanded, or snapshotted. |
+| provisionTimeout | string | `"120s"` | Wait for agents to realise a new volume. Keep sidecars.*.timeout at or above this, or the sidecar RPC deadline fires before this one and the knob has no effect. |
 | replicatedStorageClass.create | bool | `true` |  |
 | replicatedStorageClass.fsType | string | `"ext4"` |  |
 | replicatedStorageClass.isDefault | bool | `false` |  |
 | replicatedStorageClass.name | string | `"miroir-replicated"` |  |
 | replicatedStorageClass.quorum | string | `"freeze"` |  |
 | replicatedStorageClass.reclaimPolicy | string | `"Delete"` |  |
+| resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | Controller resources. |
 | sidecars.provisioner.image | string | `"registry.k8s.io/sig-storage/csi-provisioner:v6.3.0"` |  |
 | sidecars.provisioner.timeout | string | `"120s"` |  |
 | sidecars.registrar.image | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"` |  |

--- a/charts/miroir/templates/_helpers.tpl
+++ b/charts/miroir/templates/_helpers.tpl
@@ -52,6 +52,22 @@ Return the image pull policy, defaulting to IfNotPresent.
 {{- end -}}
 
 {{/*
+Agent image ref — the Debian image carrying the storage userland; used by
+the agent DaemonSet and the setup Job.
+*/}}
+{{- define "miroir.agentImage" -}}
+{{- if .Values.agent.image.digest -}}
+{{- printf "%s@%s" .Values.agent.image.repository .Values.agent.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.agent.image.repository (.Values.agent.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "miroir.agentImagePullPolicy" -}}
+{{- .Values.agent.image.pullPolicy | default "IfNotPresent" -}}
+{{- end -}}
+
+{{/*
 Standard labels applied to every resource this chart produces. Component is added at the
 call site so each workload remains self-describing ("controller", "agent", "setup",
 "uninstall").

--- a/charts/miroir/templates/_helpers.tpl
+++ b/charts/miroir/templates/_helpers.tpl
@@ -77,6 +77,20 @@ helm.sh/chart: {{ include "miroir.chart" . }}
 {{ include "miroir.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- with .Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Pod-level imagePullSecrets from global; emits nothing when unset so
+callers can use it verbatim.
+*/}}
+{{- define "miroir.imagePullSecrets" -}}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -88,7 +88,7 @@ spec:
               mountPath: /etc/miroir
               readOnly: true
             - name: kubelet
-              mountPath: {{ .Values.kubeletDir }}
+              mountPath: {{ .Values.agent.kubeletDir }}
               mountPropagation: Bidirectional
             # Plain bind of host /dev (no mountPropagation): the
             # container must share the host's devtmpfs inode table so
@@ -126,10 +126,10 @@ spec:
               mountPath: {{ $dir }}
 {{- end }}
         - name: node-driver-registrar
-          image: {{ .Values.sidecars.registrar.image }}
+          image: {{ .Values.agent.registrar.image }}
           args:
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path={{ .Values.kubeletDir }}/plugins/miroir.home-operations.com/csi.sock
+            - --kubelet-registration-path={{ .Values.agent.kubeletDir }}/plugins/miroir.home-operations.com/csi.sock
           resources:
             requests: { cpu: 5m, memory: 16Mi }
             limits: { memory: 64Mi }
@@ -144,15 +144,15 @@ spec:
             name: {{ include "miroir.nodesConfigName" . }}
         - name: socket-dir
           hostPath:
-            path: {{ .Values.kubeletDir }}/plugins/miroir.home-operations.com
+            path: {{ .Values.agent.kubeletDir }}/plugins/miroir.home-operations.com
             type: DirectoryOrCreate
         - name: registration
           hostPath:
-            path: {{ .Values.kubeletDir }}/plugins_registry
+            path: {{ .Values.agent.kubeletDir }}/plugins_registry
             type: Directory
         - name: kubelet
           hostPath:
-            path: {{ .Values.kubeletDir }}
+            path: {{ .Values.agent.kubeletDir }}
             type: Directory
         - name: dev
           hostPath:

--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -27,6 +27,13 @@ spec:
       labels:
         {{- include "miroir.labels" . | nindent 8 }}
         app.kubernetes.io/component: agent
+        {{- with .Values.agent.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.agent.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "miroir.agentName" . }}
       # hostNetwork so the pod IP is the node IP and the container
@@ -58,11 +65,19 @@ spec:
             - --nodes-config=/etc/miroir/nodes.yaml
             - --metrics-bind-address=:9810
             - --pool-stats-interval={{ .Values.agent.poolStatsInterval }}
+            - --zap-log-level={{ .Values.logging.level }}
+            - --zap-encoder={{ .Values.logging.format }}
+            {{- with .Values.agent.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- with .Values.agent.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           securityContext:
             privileged: true
           ports:

--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -41,6 +41,7 @@ spec:
       # after workloads — their DRBD legs are then Secondary and safe to
       # release (see agentShutdownSweep). Needs Talos
       # shutdownGracePeriodCriticalPods >= the grace period below (see README).
+      {{- include "miroir.imagePullSecrets" . | nindent 6 }}
       priorityClassName: system-node-critical
       # Longer grace lets the cordon-gated DRBD teardown finish before SIGKILL;
       # routine restarts stay schedulable and skip it.

--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -49,8 +49,8 @@ spec:
         - operator: Exists # CSI node service must run on every schedulable node
       containers:
         - name: agent
-          image: {{ include "miroir.image" . }}
-          imagePullPolicy: {{ include "miroir.imagePullPolicy" . }}
+          image: {{ include "miroir.agentImage" . }}
+          imagePullPolicy: {{ include "miroir.agentImagePullPolicy" . }}
           args:
             - --mode=agent
             - --csi-socket=/csi/csi.sock

--- a/charts/miroir/templates/configmap.tpl
+++ b/charts/miroir/templates/configmap.tpl
@@ -58,10 +58,8 @@ data:
         {{- end }}
         }
         net {
-        {{- with .Values.drbd.resync }}
-        {{- if .maxBuffers }}
-            max-buffers {{ .maxBuffers }};
-        {{- end }}
+        {{- with .Values.drbd.net.maxBuffers }}
+            max-buffers {{ . }};
         {{- end }}
         {{- with .Values.drbd.verifyAlg }}
             verify-alg {{ . }};

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -19,6 +19,13 @@ spec:
       labels:
         {{- include "miroir.labels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "miroir.controllerName" . }}
       {{- include "miroir.imagePullSecrets" . | nindent 6 }}
@@ -50,6 +57,15 @@ spec:
             - --provision-timeout={{ .Values.provisionTimeout }}
             - --overcommit-ratio={{ .Values.overcommitRatio }}
             - --auto-tie-breaker={{ .Values.autoTieBreaker }}
+            - --zap-log-level={{ .Values.logging.level }}
+            - --zap-encoder={{ .Values.logging.format }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -21,6 +21,19 @@ spec:
         app.kubernetes.io/component: controller
     spec:
       serviceAccountName: {{ include "miroir.controllerName" . }}
+      {{- include "miroir.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       priorityClassName: {{ .Values.priorityClassName }}
       securityContext:
         runAsNonRoot: true

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: controller
     spec:
       serviceAccountName: {{ include "miroir.controllerName" . }}
-      priorityClassName: {{ .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -34,9 +34,9 @@ spec:
             - --mode=controller
             - --csi-socket=/csi/csi.sock
             - --nodes-config=/etc/miroir/nodes.yaml
-            - --provision-timeout={{ .Values.controller.provisionTimeout }}
-            - --overcommit-ratio={{ .Values.controller.overcommitRatio }}
-            - --auto-tie-breaker={{ .Values.controller.autoTieBreaker }}
+            - --provision-timeout={{ .Values.provisionTimeout }}
+            - --overcommit-ratio={{ .Values.overcommitRatio }}
+            - --auto-tie-breaker={{ .Values.autoTieBreaker }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
@@ -50,7 +50,7 @@ spec:
             initialDelaySeconds: 10
           readinessProbe:
             httpGet: { path: /readyz, port: metrics }
-          resources: {{- toYaml .Values.controller.resources | nindent 12 }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/miroir/templates/setup-job.tpl
+++ b/charts/miroir/templates/setup-job.tpl
@@ -24,8 +24,10 @@ spec:
         - operator: Exists
       containers:
         - name: setup
-          image: {{ include "miroir.image" $ }}
-          imagePullPolicy: {{ include "miroir.imagePullPolicy" $ }}
+          # The setup Job bootstraps the node pool with the same storage
+          # userland the agent uses.
+          image: {{ include "miroir.agentImage" $ }}
+          imagePullPolicy: {{ include "miroir.agentImagePullPolicy" $ }}
           args:
             - --mode=setup
             - --node-name={{ $name }}

--- a/charts/miroir/templates/setup-job.tpl
+++ b/charts/miroir/templates/setup-job.tpl
@@ -16,6 +16,7 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "miroir.setupServiceAccountName" $ }}
+      {{- include "miroir.imagePullSecrets" $ | nindent 6 }}
       nodeName: {{ $name }}
       restartPolicy: Never
       hostNetwork: true

--- a/charts/miroir/templates/uninstall-job.tpl
+++ b/charts/miroir/templates/uninstall-job.tpl
@@ -14,6 +14,7 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "miroir.uninstallServiceAccountName" . }}
+      {{- include "miroir.imagePullSecrets" . | nindent 6 }}
       restartPolicy: Never
       containers:
         - name: kubectl

--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -268,3 +268,32 @@ tests:
           value: ghcr-pull
       - notExists:
           path: spec.template.spec.nodeSelector
+
+  - it: wires agent pod metadata and extra args/env after NODE_NAME
+    set:
+      nodes:
+        kharkiv:
+          backend: lvmthin
+          device: /dev/disk/by-partlabel/r-miroir
+      agent:
+        podAnnotations:
+          reloader.stakater.com/auto: "true"
+        extraArgs:
+          - --drbd-poll-interval=10s
+        extraEnv:
+          - name: GOMEMLIMIT
+            value: 100MiB
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --drbd-poll-interval=10s
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: NODE_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: GOMEMLIMIT
+      - equal:
+          path: spec.template.metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"

--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -249,3 +249,22 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: "ghcr.io/home-operations/miroir-agent@sha256:def456"
+
+  - it: applies global pull secrets but not global scheduling (agent runs everywhere)
+    set:
+      nodes:
+        kharkiv:
+          backend: lvmthin
+          device: /dev/disk/by-partlabel/r-miroir
+      global:
+        imagePullSecrets:
+          - name: ghcr-pull
+        nodeSelector:
+          kubernetes.io/arch: amd64
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: ghcr-pull
+      - notExists:
+          path: spec.template.spec.nodeSelector

--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -49,7 +49,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/home-operations/miroir:0.0.1"
+          value: "ghcr.io/home-operations/miroir-agent:0.0.1"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
@@ -233,3 +233,19 @@ tests:
             hostPath:
               path: /var/lib/miroir
               type: DirectoryOrCreate
+
+  - it: pins the agent image by digest when set, overriding the tag
+    set:
+      nodes:
+        kharkiv:
+          backend: lvmthin
+          device: /dev/disk/by-partlabel/r-miroir
+      agent:
+        image:
+          tag: 1.2.3
+          digest: sha256:def456
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/home-operations/miroir-agent@sha256:def456"

--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -115,7 +115,7 @@ tests:
 
   - it: binds /var/lib/kubelet at kubeletDir with Bidirectional propagation
     set:
-      kubeletDir: /var/snap/kubelet
+      agent.kubeletDir: /var/snap/kubelet
       nodes:
         kharkiv:
           backend: lvmthin

--- a/charts/miroir/tests/configmap_test.yaml
+++ b/charts/miroir/tests/configmap_test.yaml
@@ -122,6 +122,7 @@ tests:
           planAhead: "20"
           maxRate: 720M
           minRate: 20M
+        net:
           maxBuffers: "36864"
     documentIndex: 1
     asserts:

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -276,3 +276,38 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: mir
+
+  - it: wires logging, pod metadata, and extra args/env
+    set:
+      logging:
+        level: debug
+        format: console
+      podLabels:
+        sidecar.istio.io/inject: "false"
+      podAnnotations:
+        reloader.stakater.com/auto: "true"
+      extraArgs:
+        - --leak-check=true
+      extraEnv:
+        - name: GOMEMLIMIT
+          value: 100MiB
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-log-level=debug
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-encoder=console
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leak-check=true
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: GOMEMLIMIT
+      - equal:
+          path: spec.template.metadata.labels["sidecar.istio.io/inject"]
+          value: "false"
+      - equal:
+          path: spec.template.metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -224,3 +224,42 @@ tests:
             name: nodes
             configMap:
               name: miroir-nodes
+
+  - it: applies global pull secrets, scheduling, and common labels
+    set:
+      global:
+        imagePullSecrets:
+          - name: ghcr-pull
+        nodeSelector:
+          kubernetes.io/arch: amd64
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: storage
+            effect: NoSchedule
+        commonLabels:
+          team: platform
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: ghcr-pull
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+      - equal:
+          path: metadata.labels.team
+          value: platform
+
+  - it: renders no scheduling or pull-secret fields by default
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.imagePullSecrets
+      - notExists:
+          path: spec.template.spec.nodeSelector
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -263,3 +263,16 @@ tests:
           path: spec.template.spec.nodeSelector
       - notExists:
           path: spec.template.spec.tolerations
+
+  - it: honours fullnameOverride and nameOverride
+    set:
+      fullnameOverride: replicator
+      nameOverride: mir
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: replicator-controller
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: mir

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -105,18 +105,18 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
           value: metrics
 
-  - it: flows controller.provisionTimeout into the controller args
+  - it: flows provisionTimeout into the controller args
     set:
-      controller.provisionTimeout: 90s
+      provisionTimeout: 90s
     documentIndex: 0
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--provision-timeout=90s"
 
-  - it: controller.autoTieBreaker=false opts out of tie-breaker placement
+  - it: autoTieBreaker=false opts out of tie-breaker placement
     set:
-      controller.autoTieBreaker: false
+      autoTieBreaker: false
     documentIndex: 0
     asserts:
       - contains:

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -67,7 +67,7 @@ tests:
           value: controller
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/home-operations/miroir:0.0.1"
+          value: "ghcr.io/home-operations/miroir-controller:0.0.1"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
@@ -196,7 +196,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/home-operations/miroir@sha256:abc123"
+          value: "ghcr.io/home-operations/miroir-controller@sha256:abc123"
 
   - it: respects a non-default Release namespace
     release:

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -80,72 +80,11 @@
       "title": "agent",
       "type": "object"
     },
-    "controller": {
-      "properties": {
-        "autoTieBreaker": {
-          "default": true,
-          "description": "Add a diskless tie-breaker replica to 2-replica freeze volumes when a\nspare storage node exists, so majority quorum survives a single node\nloss. Also retrofits existing freeze volumes at controller startup.",
-          "title": "autoTieBreaker",
-          "type": "boolean"
-        },
-        "overcommitRatio": {
-          "default": 2,
-          "description": "Thin-provisioning overcommit guardrail: CreateVolume is refused when a\nnode's provisioned total would exceed capacity × this ratio. 2× is the\nclassic CoW headroom; raise it only if you trust your usage to stay\nsparse, lower it toward 1 to provision conservatively.",
-          "title": "overcommitRatio",
-          "type": "integer"
-        },
-        "priorityClassName": {
-          "default": "system-cluster-critical",
-          "description": "system-cluster-critical protects the single controller from eviction\nunder node pressure — while it is down, no volume can be provisioned,\nexpanded, or snapshotted.",
-          "title": "priorityClassName",
-          "type": "string"
-        },
-        "provisionTimeout": {
-          "default": "120s",
-          "description": "Wait for agents to realise a new volume. Keep sidecars.*.timeout at or\nabove this, or the sidecar RPC deadline fires before this one and the\nknob has no effect.",
-          "title": "provisionTimeout",
-          "type": "string"
-        },
-        "resources": {
-          "properties": {
-            "limits": {
-              "properties": {
-                "memory": {
-                  "default": "128Mi",
-                  "title": "memory",
-                  "type": "string"
-                }
-              },
-              "required": [],
-              "title": "limits",
-              "type": "object"
-            },
-            "requests": {
-              "properties": {
-                "cpu": {
-                  "default": "10m",
-                  "title": "cpu",
-                  "type": "string"
-                },
-                "memory": {
-                  "default": "32Mi",
-                  "title": "memory",
-                  "type": "string"
-                }
-              },
-              "required": [],
-              "title": "requests",
-              "type": "object"
-            }
-          },
-          "required": [],
-          "title": "resources",
-          "type": "object"
-        }
-      },
-      "required": [],
-      "title": "controller",
-      "type": "object"
+    "autoTieBreaker": {
+      "default": true,
+      "description": "Add a diskless tie-breaker replica to 2-replica freeze volumes when a\nspare storage node exists, so majority quorum survives a single node\nloss. Also retrofits existing freeze volumes at controller startup.",
+      "title": "autoTieBreaker",
+      "type": "boolean"
     },
     "drbd": {
       "description": "DRBD replication tuning applied cluster-wide through the common{} section of\nglobal_common.conf; every resource inherits it. Leave a value empty to use\nDRBD's built-in default. Tune to your replication network — see the LINBIT\n\"Tuning the DRBD Resync Controller\" guide.",
@@ -443,6 +382,24 @@
       "title": "nodes",
       "type": "object"
     },
+    "overcommitRatio": {
+      "default": 2,
+      "description": "Thin-provisioning overcommit guardrail: CreateVolume is refused when a\nnode's provisioned total would exceed capacity × this ratio. 2× is the\nclassic CoW headroom; raise it only if you trust your usage to stay\nsparse, lower it toward 1 to provision conservatively.",
+      "title": "overcommitRatio",
+      "type": "integer"
+    },
+    "priorityClassName": {
+      "default": "system-cluster-critical",
+      "description": "Controller settings live at the top level (kopiur layout); other\ncomponents are nested (agent, sidecars, monitoring).\nsystem-cluster-critical protects the single controller from eviction\nunder node pressure — while it is down, no volume can be provisioned,\nexpanded, or snapshotted.",
+      "title": "priorityClassName",
+      "type": "string"
+    },
+    "provisionTimeout": {
+      "default": "120s",
+      "description": "Wait for agents to realise a new volume. Keep sidecars.*.timeout at or\nabove this, or the sidecar RPC deadline fires before this one and the\nknob has no effect.",
+      "title": "provisionTimeout",
+      "type": "string"
+    },
     "replicatedStorageClass": {
       "properties": {
         "create": {
@@ -479,6 +436,43 @@
       },
       "required": [],
       "title": "replicatedStorageClass",
+      "type": "object"
+    },
+    "resources": {
+      "description": "Controller resources.",
+      "properties": {
+        "limits": {
+          "properties": {
+            "memory": {
+              "default": "128Mi",
+              "title": "memory",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "limits",
+          "type": "object"
+        },
+        "requests": {
+          "properties": {
+            "cpu": {
+              "default": "10m",
+              "title": "cpu",
+              "type": "string"
+            },
+            "memory": {
+              "default": "32Mi",
+              "title": "memory",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "requests",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "resources",
       "type": "object"
     },
     "sidecars": {

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "agent": {
+      "description": "=============================================================================\nAgent (per-node DaemonSet: storage userland + CSI node service)\n=============================================================================",
       "properties": {
         "image": {
           "description": "Agent image (Debian + the lvm/zfs/drbd/mkfs userland the agent and the\nsetup Job exec on each storage node).",
@@ -87,7 +88,7 @@
       "type": "boolean"
     },
     "drbd": {
-      "description": "DRBD replication tuning applied cluster-wide through the common{} section of\nglobal_common.conf; every resource inherits it. Leave a value empty to use\nDRBD's built-in default. Tune to your replication network — see the LINBIT\n\"Tuning the DRBD Resync Controller\" guide.",
+      "description": "=============================================================================\nDRBD replication tuning\n=============================================================================\nDRBD replication tuning applied cluster-wide through the common{} section of\nglobal_common.conf; every resource inherits it. Leave a value empty to use\nDRBD's built-in default. Tune to your replication network — see the LINBIT\n\"Tuning the DRBD Resync Controller\" guide.",
       "properties": {
         "onIoError": {
           "default": "detach",
@@ -202,7 +203,7 @@
       "type": "object"
     },
     "image": {
-      "description": "Controller image (distroless, no storage userland — the controller never\nexecs a storage CLI).",
+      "description": "=============================================================================\nController (root = controller, kopiur layout; components nest below)\n=============================================================================\nController image (distroless, no storage userland — the controller never\nexecs a storage CLI).",
       "properties": {
         "digest": {
           "default": "",
@@ -237,7 +238,7 @@
       "type": "string"
     },
     "monitoring": {
-      "description": "Requires the Prometheus Operator CRDs (deployed separately).",
+      "description": "=============================================================================\nMonitoring\n=============================================================================\nRequires the Prometheus Operator CRDs (deployed separately).",
       "properties": {
         "dashboards": {
           "properties": {
@@ -423,7 +424,7 @@
       "type": "string"
     },
     "nodes": {
-      "description": "Per-node storage topology — the single source of truth for which nodes\nhold volumes and how. Rendered into the miroir-nodes ConfigMap, read by\nthe controller (placement) and each agent (backend selection).\nOptional per-node `zone` (rack, host group, AZ): when set, the controller\nspreads a volume's replicas across distinct zones; empty is unconstrained.\nnodes:\n  kharkiv:\n    backend: lvmthin\n    device: /dev/disk/by-partlabel/r-miroir\n    # thinPoolSize: 400g   # bound the pool when sharing the VG\n    # zone: rack-1         # spread replicas across failure domains\n  paris:\n    backend: zfs\n    zfsDataset: data-pool/miroir\n    # zone: rack-2\n  le-havre:\n    # loopfile: sparse files on the node's existing filesystem — no\n    # dedicated disk or pool. baseDir must be reflink-capable (XFS\n    # reflink=1, e.g. Talos /var, or btrfs) for CoW snapshots; the agent\n    # refuses to start otherwise. The dir is hostPath-mounted into the\n    # agent at the same path.\n    backend: loopfile\n    baseDir: /var/lib/miroir",
+      "description": "=============================================================================\nStorage topology\n=============================================================================\nPer-node storage topology — the single source of truth for which nodes\nhold volumes and how. Rendered into the miroir-nodes ConfigMap, read by\nthe controller (placement) and each agent (backend selection).\nOptional per-node `zone` (rack, host group, AZ): when set, the controller\nspreads a volume's replicas across distinct zones; empty is unconstrained.\nnodes:\n  kharkiv:\n    backend: lvmthin\n    device: /dev/disk/by-partlabel/r-miroir\n    # thinPoolSize: 400g   # bound the pool when sharing the VG\n    # zone: rack-1         # spread replicas across failure domains\n  paris:\n    backend: zfs\n    zfsDataset: data-pool/miroir\n    # zone: rack-2\n  le-havre:\n    # loopfile: sparse files on the node's existing filesystem — no\n    # dedicated disk or pool. baseDir must be reflink-capable (XFS\n    # reflink=1, e.g. Talos /var, or btrfs) for CoW snapshots; the agent\n    # refuses to start otherwise. The dir is hostPath-mounted into the\n    # agent at the same path.\n    backend: loopfile\n    baseDir: /var/lib/miroir",
       "required": [],
       "title": "nodes",
       "type": "object"
@@ -436,7 +437,7 @@
     },
     "priorityClassName": {
       "default": "system-cluster-critical",
-      "description": "Controller settings live at the top level (kopiur layout); other\ncomponents are nested (agent, sidecars, monitoring).\nsystem-cluster-critical protects the single controller from eviction\nunder node pressure — while it is down, no volume can be provisioned,\nexpanded, or snapshotted.",
+      "description": "system-cluster-critical protects the single controller from eviction\nunder node pressure — while it is down, no volume can be provisioned,\nexpanded, or snapshotted.",
       "title": "priorityClassName",
       "type": "string"
     },
@@ -522,6 +523,7 @@
       "type": "object"
     },
     "sidecars": {
+      "description": "=============================================================================\nCSI sidecars (upstream sig-storage images)\n=============================================================================",
       "properties": {
         "provisioner": {
           "properties": {
@@ -545,6 +547,7 @@
           "properties": {
             "image": {
               "default": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0",
+              "description": "Runs in the agent DaemonSet (kubelet plugin registration), not the\ncontroller pod; kept here so the sig-storage images share one block.",
               "title": "image",
               "type": "string"
             }
@@ -562,7 +565,7 @@
             },
             "timeout": {
               "default": "120s",
-              "description": "Online grow can block on a rebooting node; keep \u003e= controller.provisionTimeout.",
+              "description": "Online grow can block on a rebooting node; keep \u003e= provisionTimeout.",
               "title": "timeout",
               "type": "string"
             }
@@ -595,6 +598,7 @@
       "type": "object"
     },
     "storageClass": {
+      "description": "=============================================================================\nStorage classes\n=============================================================================",
       "properties": {
         "create": {
           "default": true,
@@ -633,7 +637,7 @@
       "type": "object"
     },
     "uninstall": {
-      "description": "Pre-delete hook Job: deletes miroirsnapshots/miroirvolumes (so the agent\ntears down DRBD/LVM) before the CRDs are released. Needs only `kubectl`.",
+      "description": "=============================================================================\nUninstall hook\n=============================================================================\nPre-delete hook Job: deletes miroirsnapshots/miroirvolumes (so the agent\ntears down DRBD/LVM) before the CRDs are released. Needs only `kubectl`.",
       "properties": {
         "image": {
           "default": "registry.k8s.io/kubectl:v1.36.2",

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -34,11 +34,30 @@
           "title": "image",
           "type": "object"
         },
+        "kubeletDir": {
+          "default": "/var/lib/kubelet",
+          "description": "Kubelet root on the nodes; CSI sockets and mounts hang off it.",
+          "title": "kubeletDir",
+          "type": "string"
+        },
         "poolStatsInterval": {
           "default": "60s",
           "description": "Per-node backend selection comes from node annotations:\n  miroir.home-operations.com/backend: lvmthin | zfs\n  miroir.home-operations.com/device: /dev/disk/by-partlabel/r-miroir   (lvmthin)\n  miroir.home-operations.com/zfs-dataset: data-pool/miroir              (zfs)\nNodes also need the label miroir.home-operations.com/storage: \"true\" to receive replicas.\n\nHow often each agent republishes its pool capacity to its MiroirNode\n(read by the controller for capacity-aware placement).",
           "title": "poolStatsInterval",
           "type": "string"
+        },
+        "registrar": {
+          "description": "kubelet plugin-registration sidecar riding the agent DaemonSet.",
+          "properties": {
+            "image": {
+              "default": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0",
+              "title": "image",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "registrar",
+          "type": "object"
         },
         "resources": {
           "properties": {
@@ -90,6 +109,19 @@
     "drbd": {
       "description": "=============================================================================\nDRBD replication tuning\n=============================================================================\nDRBD replication tuning applied cluster-wide through the common{} section of\nglobal_common.conf; every resource inherits it. Leave a value empty to use\nDRBD's built-in default. Tune to your replication network — see the LINBIT\n\"Tuning the DRBD Resync Controller\" guide.",
       "properties": {
+        "net": {
+          "properties": {
+            "maxBuffers": {
+              "default": "",
+              "description": "max-buffers, the DRBD receive-buffer count (e.g. \"36864\"); raises\nresync throughput on fast links.",
+              "title": "maxBuffers",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "net",
+          "type": "object"
+        },
         "onIoError": {
           "default": "detach",
           "description": "How a diskful replica reacts to a backing-device I/O error. detach\n(the LINSTOR/DRBD-recommended default) drops the failing leg to\nDiskless and serves reads/writes via the peer instead of surfacing\nEIO into the pod. Set to pass_on to propagate errors instead.",
@@ -108,12 +140,6 @@
               "default": "",
               "description": "c-fill-target, the resync controller's target fill level (e.g. \"1M\").",
               "title": "fillTarget",
-              "type": "string"
-            },
-            "maxBuffers": {
-              "default": "",
-              "description": "max-buffers, the DRBD receive-buffer count in the net{} section (e.g. \"36864\").",
-              "title": "maxBuffers",
               "type": "string"
             },
             "maxRate": {
@@ -231,11 +257,6 @@
       "required": [],
       "title": "image",
       "type": "object"
-    },
-    "kubeletDir": {
-      "default": "/var/lib/kubelet",
-      "title": "kubeletDir",
-      "type": "string"
     },
     "monitoring": {
       "description": "=============================================================================\nMonitoring\n=============================================================================\nRequires the Prometheus Operator CRDs (deployed separately).",
@@ -541,19 +562,6 @@
           },
           "required": [],
           "title": "provisioner",
-          "type": "object"
-        },
-        "registrar": {
-          "properties": {
-            "image": {
-              "default": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0",
-              "description": "Runs in the agent DaemonSet (kubelet plugin registration), not the\ncontroller pod; kept here so the sig-storage images share one block.",
-              "title": "image",
-              "type": "string"
-            }
-          },
-          "required": [],
-          "title": "registrar",
           "type": "object"
         },
         "resizer": {

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -4,6 +4,22 @@
     "agent": {
       "description": "=============================================================================\nAgent (per-node DaemonSet: storage userland + CSI node service)\n=============================================================================",
       "properties": {
+        "extraArgs": {
+          "description": "Extra arguments for the agent container.",
+          "items": {
+            "required": []
+          },
+          "title": "extraArgs",
+          "type": "array"
+        },
+        "extraEnv": {
+          "description": "Extra environment variables for the agent container.",
+          "items": {
+            "required": []
+          },
+          "title": "extraEnv",
+          "type": "array"
+        },
         "image": {
           "description": "Agent image (Debian + the lvm/zfs/drbd/mkfs userland the agent and the\nsetup Job exec on each storage node).",
           "properties": {
@@ -39,6 +55,18 @@
           "description": "Kubelet root on the nodes; CSI sockets and mounts hang off it.",
           "title": "kubeletDir",
           "type": "string"
+        },
+        "podAnnotations": {
+          "description": "Extra annotations on the agent pods.",
+          "required": [],
+          "title": "podAnnotations",
+          "type": "object"
+        },
+        "podLabels": {
+          "description": "Extra labels on the agent pods.",
+          "required": [],
+          "title": "podLabels",
+          "type": "object"
         },
         "poolStatsInterval": {
           "default": "60s",
@@ -182,6 +210,22 @@
       "title": "drbd",
       "type": "object"
     },
+    "extraArgs": {
+      "description": "Extra arguments for the controller container.",
+      "items": {
+        "required": []
+      },
+      "title": "extraArgs",
+      "type": "array"
+    },
+    "extraEnv": {
+      "description": "Extra environment variables for the controller container.",
+      "items": {
+        "required": []
+      },
+      "title": "extraEnv",
+      "type": "array"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Override the fully qualified name prefix of every rendered object.",
@@ -256,6 +300,26 @@
       },
       "required": [],
       "title": "image",
+      "type": "object"
+    },
+    "logging": {
+      "description": "Both processes bind the controller-runtime zap flags.",
+      "properties": {
+        "format": {
+          "default": "json",
+          "description": "Encoder: json (structured, default) or console (human-readable).",
+          "title": "format",
+          "type": "string"
+        },
+        "level": {
+          "default": "info",
+          "description": "Log level: debug | info | error (or any zapcore level).",
+          "title": "level",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "logging",
       "type": "object"
     },
     "monitoring": {
@@ -455,6 +519,18 @@
       "description": "Thin-provisioning overcommit guardrail: CreateVolume is refused when a\nnode's provisioned total would exceed capacity × this ratio. 2× is the\nclassic CoW headroom; raise it only if you trust your usage to stay\nsparse, lower it toward 1 to provision conservatively.",
       "title": "overcommitRatio",
       "type": "integer"
+    },
+    "podAnnotations": {
+      "description": "Extra annotations on the controller pod.",
+      "required": [],
+      "title": "podAnnotations",
+      "type": "object"
+    },
+    "podLabels": {
+      "description": "Extra labels on the controller pod.",
+      "required": [],
+      "title": "podLabels",
+      "type": "object"
     },
     "priorityClassName": {
       "default": "system-cluster-critical",

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -3,6 +3,36 @@
   "properties": {
     "agent": {
       "properties": {
+        "image": {
+          "description": "Agent image (Debian + the lvm/zfs/drbd/mkfs userland the agent and the\nsetup Job exec on each storage node).",
+          "properties": {
+            "digest": {
+              "default": "",
+              "description": "Pins the image by digest (sha256:…); takes precedence over the tag.\nThe release pipeline fills this with the published image's digest.",
+              "title": "digest",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/home-operations/miroir-agent",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "",
+              "description": "Overrides the image tag; defaults to the chart appVersion.",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "image",
+          "type": "object"
+        },
         "poolStatsInterval": {
           "default": "60s",
           "description": "Per-node backend selection comes from node annotations:\n  miroir.home-operations.com/backend: lvmthin | zfs\n  miroir.home-operations.com/device: /dev/disk/by-partlabel/r-miroir   (lvmthin)\n  miroir.home-operations.com/zfs-dataset: data-pool/miroir              (zfs)\nNodes also need the label miroir.home-operations.com/storage: \"true\" to receive replicas.\n\nHow often each agent republishes its pool capacity to its MiroirNode\n(read by the controller for capacity-aware placement).",
@@ -193,6 +223,7 @@
       "type": "object"
     },
     "image": {
+      "description": "Controller image (distroless, no storage userland — the controller never\nexecs a storage CLI).",
       "properties": {
         "digest": {
           "default": "",
@@ -206,7 +237,7 @@
           "type": "string"
         },
         "repository": {
-          "default": "ghcr.io/home-operations/miroir",
+          "default": "ghcr.io/home-operations/miroir-controller",
           "title": "repository",
           "type": "string"
         },

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -155,6 +155,12 @@
       "title": "drbd",
       "type": "object"
     },
+    "fullnameOverride": {
+      "default": "",
+      "description": "Override the fully qualified name prefix of every rendered object.",
+      "title": "fullnameOverride",
+      "type": "string"
+    },
     "global": {
       "description": "Fleet-wide defaults (kopiur layout). imagePullSecrets and commonLabels\nreach every pod/object; the scheduling globals apply to the controller —\nthe only freely schedulable workload (the agent DaemonSet must run on\nevery schedulable node for the CSI node service, and the setup Job is\nnode-pinned).",
       "properties": {
@@ -409,6 +415,12 @@
       "required": [],
       "title": "monitoring",
       "type": "object"
+    },
+    "nameOverride": {
+      "default": "",
+      "description": "Override the chart name used in labels and default object names.",
+      "title": "nameOverride",
+      "type": "string"
     },
     "nodes": {
       "description": "Per-node storage topology — the single source of truth for which nodes\nhold volumes and how. Rendered into the miroir-nodes ConfigMap, read by\nthe controller (placement) and each agent (backend selection).\nOptional per-node `zone` (rack, host group, AZ): when set, the controller\nspreads a volume's replicas across distinct zones; empty is unconstrained.\nnodes:\n  kharkiv:\n    backend: lvmthin\n    device: /dev/disk/by-partlabel/r-miroir\n    # thinPoolSize: 400g   # bound the pool when sharing the VG\n    # zone: rack-1         # spread replicas across failure domains\n  paris:\n    backend: zfs\n    zfsDataset: data-pool/miroir\n    # zone: rack-2\n  le-havre:\n    # loopfile: sparse files on the node's existing filesystem — no\n    # dedicated disk or pool. baseDir must be reflink-capable (XFS\n    # reflink=1, e.g. Talos /var, or btrfs) for CoW snapshots; the agent\n    # refuses to start otherwise. The dir is hostPath-mounted into the\n    # agent at the same path.\n    backend: loopfile\n    baseDir: /var/lib/miroir",

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -156,7 +156,41 @@
       "type": "object"
     },
     "global": {
-      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "description": "Fleet-wide defaults (kopiur layout). imagePullSecrets and commonLabels\nreach every pod/object; the scheduling globals apply to the controller —\nthe only freely schedulable workload (the agent DaemonSet must run on\nevery schedulable node for the CSI node service, and the setup Job is\nnode-pinned).",
+      "properties": {
+        "affinity": {
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
+        "commonLabels": {
+          "description": "Labels stamped on every rendered object (fleet-wide labelling).",
+          "required": [],
+          "title": "commonLabels",
+          "type": "object"
+        },
+        "imagePullSecrets": {
+          "description": "Pull secrets added to every pod (controller, agent, setup, uninstall).",
+          "items": {
+            "required": []
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        },
+        "nodeSelector": {
+          "description": "Controller scheduling defaults.",
+          "required": [],
+          "title": "nodeSelector",
+          "type": "object"
+        },
+        "tolerations": {
+          "items": {
+            "required": []
+          },
+          "title": "tolerations",
+          "type": "array"
+        }
+      },
       "required": [],
       "title": "global",
       "type": "object"

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -18,6 +18,9 @@ global:
   tolerations: []
   affinity: {}
 
+# =============================================================================
+# Controller (root = controller, kopiur layout; components nest below)
+# =============================================================================
 # -- Controller image (distroless, no storage userland — the controller never
 # execs a storage CLI).
 image:
@@ -30,59 +33,6 @@ image:
   digest: ""
   pullPolicy: IfNotPresent
 
-sidecars:
-  provisioner:
-    image: registry.k8s.io/sig-storage/csi-provisioner:v6.3.0
-    # LVM/ZFS provisioning on a cold node can exceed the 10s sidecar
-    # default; the driver returns DeadlineExceeded and the provisioner
-    # retries, but a roomier timeout avoids churn.
-    timeout: 120s
-  registrar:
-    image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
-  snapshotter:
-    image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
-    # CreateSnapshot returns fast (readiness is polled), so the default
-    # suffices; raise if snapshot RPCs are slow.
-    timeout: 120s
-  resizer:
-    image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
-    # Online grow can block on a rebooting node; keep >= controller.provisionTimeout.
-    timeout: 120s
-
-# Pre-delete hook Job: deletes miroirsnapshots/miroirvolumes (so the agent
-# tears down DRBD/LVM) before the CRDs are released. Needs only `kubectl`.
-uninstall:
-  image: registry.k8s.io/kubectl:v1.36.2
-
-kubeletDir: /var/lib/kubelet
-
-# Per-node storage topology — the single source of truth for which nodes
-# hold volumes and how. Rendered into the miroir-nodes ConfigMap, read by
-# the controller (placement) and each agent (backend selection).
-# Optional per-node `zone` (rack, host group, AZ): when set, the controller
-# spreads a volume's replicas across distinct zones; empty is unconstrained.
-# nodes:
-#   kharkiv:
-#     backend: lvmthin
-#     device: /dev/disk/by-partlabel/r-miroir
-#     # thinPoolSize: 400g   # bound the pool when sharing the VG
-#     # zone: rack-1         # spread replicas across failure domains
-#   paris:
-#     backend: zfs
-#     zfsDataset: data-pool/miroir
-#     # zone: rack-2
-#   le-havre:
-#     # loopfile: sparse files on the node's existing filesystem — no
-#     # dedicated disk or pool. baseDir must be reflink-capable (XFS
-#     # reflink=1, e.g. Talos /var, or btrfs) for CoW snapshots; the agent
-#     # refuses to start otherwise. The dir is hostPath-mounted into the
-#     # agent at the same path.
-#     backend: loopfile
-#     baseDir: /var/lib/miroir
-nodes: {}
-
-# Controller settings live at the top level (kopiur layout); other
-# components are nested (agent, sidecars, monitoring).
 # -- system-cluster-critical protects the single controller from eviction
 # under node pressure — while it is down, no volume can be provisioned,
 # expanded, or snapshotted.
@@ -108,6 +58,33 @@ resources:
   limits:
     memory: 128Mi
 
+# =============================================================================
+# CSI sidecars (upstream sig-storage images)
+# =============================================================================
+sidecars:
+  provisioner:
+    image: registry.k8s.io/sig-storage/csi-provisioner:v6.3.0
+    # LVM/ZFS provisioning on a cold node can exceed the 10s sidecar
+    # default; the driver returns DeadlineExceeded and the provisioner
+    # retries, but a roomier timeout avoids churn.
+    timeout: 120s
+  registrar:
+    # Runs in the agent DaemonSet (kubelet plugin registration), not the
+    # controller pod; kept here so the sig-storage images share one block.
+    image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
+  snapshotter:
+    image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
+    # CreateSnapshot returns fast (readiness is polled), so the default
+    # suffices; raise if snapshot RPCs are slow.
+    timeout: 120s
+  resizer:
+    image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
+    # Online grow can block on a rebooting node; keep >= provisionTimeout.
+    timeout: 120s
+
+# =============================================================================
+# Agent (per-node DaemonSet: storage userland + CSI node service)
+# =============================================================================
 agent:
   # Agent image (Debian + the lvm/zfs/drbd/mkfs userland the agent and the
   # setup Job exec on each storage node).
@@ -135,6 +112,71 @@ agent:
     limits:
       memory: 128Mi
 
+# =============================================================================
+# Storage topology
+# =============================================================================
+# Per-node storage topology — the single source of truth for which nodes
+# hold volumes and how. Rendered into the miroir-nodes ConfigMap, read by
+# the controller (placement) and each agent (backend selection).
+# Optional per-node `zone` (rack, host group, AZ): when set, the controller
+# spreads a volume's replicas across distinct zones; empty is unconstrained.
+# nodes:
+#   kharkiv:
+#     backend: lvmthin
+#     device: /dev/disk/by-partlabel/r-miroir
+#     # thinPoolSize: 400g   # bound the pool when sharing the VG
+#     # zone: rack-1         # spread replicas across failure domains
+#   paris:
+#     backend: zfs
+#     zfsDataset: data-pool/miroir
+#     # zone: rack-2
+#   le-havre:
+#     # loopfile: sparse files on the node's existing filesystem — no
+#     # dedicated disk or pool. baseDir must be reflink-capable (XFS
+#     # reflink=1, e.g. Talos /var, or btrfs) for CoW snapshots; the agent
+#     # refuses to start otherwise. The dir is hostPath-mounted into the
+#     # agent at the same path.
+#     backend: loopfile
+#     baseDir: /var/lib/miroir
+nodes: {}
+
+kubeletDir: /var/lib/kubelet
+
+# =============================================================================
+# Storage classes
+# =============================================================================
+storageClass:
+  create: true
+  name: miroir-local
+  # Coexists with OpenEBS: openebs-zfs stays the cluster default.
+  isDefault: false
+  fsType: ext4
+  replicas: 1
+  reclaimPolicy: Delete
+
+replicatedStorageClass:
+  create: true
+  name: miroir-replicated
+  isDefault: false
+  fsType: ext4
+  # freeze: refuse writes (I/O errors) without a peer majority — never
+  # diverges; with autoTieBreaker a third node keeps 2-replica volumes
+  # writable through a single node loss. last-man-standing: the survivor
+  # keeps writing even alone, at the risk of split-brain. See the root
+  # README, "Replication and quorum".
+  quorum: freeze # | last-man-standing
+  reclaimPolicy: Delete
+
+# Requires the cluster-wide snapshot-controller + CRDs (deployed
+# separately; kube-system/snapshot-controller in the homelab).
+volumeSnapshotClass:
+  create: true
+  name: miroir-snap
+  deletionPolicy: Delete
+
+# =============================================================================
+# DRBD replication tuning
+# =============================================================================
 # DRBD replication tuning applied cluster-wide through the common{} section of
 # global_common.conf; every resource inherits it. Leave a value empty to use
 # DRBD's built-in default. Tune to your replication network — see the LINBIT
@@ -176,35 +218,9 @@ drbd:
   # in the kernel log and `drbdsetup status`. Empty disables verification.
   verifyAlg: crc32c
 
-storageClass:
-  create: true
-  name: miroir-local
-  # Coexists with OpenEBS: openebs-zfs stays the cluster default.
-  isDefault: false
-  fsType: ext4
-  replicas: 1
-  reclaimPolicy: Delete
-
-replicatedStorageClass:
-  create: true
-  name: miroir-replicated
-  isDefault: false
-  fsType: ext4
-  # freeze: refuse writes (I/O errors) without a peer majority — never
-  # diverges; with autoTieBreaker a third node keeps 2-replica volumes
-  # writable through a single node loss. last-man-standing: the survivor
-  # keeps writing even alone, at the risk of split-brain. See the root
-  # README, "Replication and quorum".
-  quorum: freeze # | last-man-standing
-  reclaimPolicy: Delete
-
-# Requires the cluster-wide snapshot-controller + CRDs (deployed
-# separately; kube-system/snapshot-controller in the homelab).
-volumeSnapshotClass:
-  create: true
-  name: miroir-snap
-  deletionPolicy: Delete
-
+# =============================================================================
+# Monitoring
+# =============================================================================
 # Requires the Prometheus Operator CRDs (deployed separately).
 monitoring:
   podMonitor:
@@ -262,3 +278,11 @@ monitoring:
       resyncPeriod: "10m"
       # -- Selected labels for Grafana instance.
       matchLabels: {}
+
+# =============================================================================
+# Uninstall hook
+# =============================================================================
+# Pre-delete hook Job: deletes miroirsnapshots/miroirvolumes (so the agent
+# tears down DRBD/LVM) before the CRDs are released. Needs only `kubectl`.
+uninstall:
+  image: registry.k8s.io/kubectl:v1.36.2

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -68,10 +68,6 @@ sidecars:
     # default; the driver returns DeadlineExceeded and the provisioner
     # retries, but a roomier timeout avoids churn.
     timeout: 120s
-  registrar:
-    # Runs in the agent DaemonSet (kubelet plugin registration), not the
-    # controller pod; kept here so the sig-storage images share one block.
-    image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
   snapshotter:
     image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
     # CreateSnapshot returns fast (readiness is polled), so the default
@@ -105,6 +101,11 @@ agent:
   # How often each agent republishes its pool capacity to its MiroirNode
   # (read by the controller for capacity-aware placement).
   poolStatsInterval: 60s
+  # kubelet plugin-registration sidecar riding the agent DaemonSet.
+  registrar:
+    image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
+  # -- Kubelet root on the nodes; CSI sockets and mounts hang off it.
+  kubeletDir: /var/lib/kubelet
   resources:
     requests:
       cpu: 10m
@@ -140,7 +141,6 @@ agent:
 #     baseDir: /var/lib/miroir
 nodes: {}
 
-kubeletDir: /var/lib/kubelet
 
 # =============================================================================
 # Storage classes
@@ -202,14 +202,16 @@ drbd:
     minRate: 10M
     # -- resync-rate, the fixed rate used only when the controller is off (planAhead empty or 0).
     rate: ""
-    # -- max-buffers, the DRBD receive-buffer count in the net{} section (e.g. "36864").
-    maxBuffers: ""
     # -- rs-discard-granularity: during a full resync, runs of zeroes are
     # sent as discards of this size instead of written out (e.g. "65536"),
     # keeping a re-added thin leg thin. lvmthin/zfs only — leave empty on
     # clusters with loopfile-backed replicated volumes (loop devices
     # mishandle it) or entirely to keep DRBD's default (off).
     discardGranularity: ""
+  net:
+    # -- max-buffers, the DRBD receive-buffer count (e.g. "36864"); raises
+    # resync throughput on fast links.
+    maxBuffers: ""
   # -- verify-alg arms `drbdadm verify <res>` — the only cross-leg
   # integrity check (a zfs scrub only validates one leg against itself).
   # Defaulted to crc32c: drbd.ko depends on libcrc32c so it is present on

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -1,3 +1,18 @@
+# Fleet-wide defaults (kopiur layout). imagePullSecrets and commonLabels
+# reach every pod/object; the scheduling globals apply to the controller —
+# the only freely schedulable workload (the agent DaemonSet must run on
+# every schedulable node for the CSI node service, and the setup Job is
+# node-pinned).
+global:
+  # -- Pull secrets added to every pod (controller, agent, setup, uninstall).
+  imagePullSecrets: []
+  # -- Labels stamped on every rendered object (fleet-wide labelling).
+  commonLabels: {}
+  # -- Controller scheduling defaults.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 # -- Controller image (distroless, no storage userland — the controller never
 # execs a storage CLI).
 image:

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -18,6 +18,13 @@ global:
   tolerations: []
   affinity: {}
 
+# Both processes bind the controller-runtime zap flags.
+logging:
+  # -- Log level: debug | info | error (or any zapcore level).
+  level: info
+  # -- Encoder: json (structured, default) or console (human-readable).
+  format: json
+
 # =============================================================================
 # Controller (root = controller, kopiur layout; components nest below)
 # =============================================================================
@@ -57,6 +64,14 @@ resources:
     memory: 32Mi
   limits:
     memory: 128Mi
+# -- Extra labels on the controller pod.
+podLabels: {}
+# -- Extra annotations on the controller pod.
+podAnnotations: {}
+# -- Extra arguments for the controller container.
+extraArgs: []
+# -- Extra environment variables for the controller container.
+extraEnv: []
 
 # =============================================================================
 # CSI sidecars (upstream sig-storage images)
@@ -112,6 +127,14 @@ agent:
       memory: 32Mi
     limits:
       memory: 128Mi
+  # -- Extra labels on the agent pods.
+  podLabels: {}
+  # -- Extra annotations on the agent pods.
+  podAnnotations: {}
+  # -- Extra arguments for the agent container.
+  extraArgs: []
+  # -- Extra environment variables for the agent container.
+  extraEnv: []
 
 # =============================================================================
 # Storage topology

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -1,5 +1,7 @@
+# -- Controller image (distroless, no storage userland — the controller never
+# execs a storage CLI).
 image:
-  repository: ghcr.io/home-operations/miroir
+  repository: ghcr.io/home-operations/miroir-controller
   # Overrides the image tag; defaults to the chart appVersion so the chart and
   # image versions stay in lock-step (set to e.g. "main" to track the rolling tag).
   tag: ""
@@ -85,6 +87,16 @@ controller:
       memory: 128Mi
 
 agent:
+  # Agent image (Debian + the lvm/zfs/drbd/mkfs userland the agent and the
+  # setup Job exec on each storage node).
+  image:
+    repository: ghcr.io/home-operations/miroir-agent
+    # Overrides the image tag; defaults to the chart appVersion.
+    tag: ""
+    # Pins the image by digest (sha256:…); takes precedence over the tag.
+    # The release pipeline fills this with the published image's digest.
+    digest: ""
+    pullPolicy: IfNotPresent
   # Per-node backend selection comes from node annotations:
   #   miroir.home-operations.com/backend: lvmthin | zfs
   #   miroir.home-operations.com/device: /dev/disk/by-partlabel/r-miroir   (lvmthin)

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -61,30 +61,32 @@ kubeletDir: /var/lib/kubelet
 #     baseDir: /var/lib/miroir
 nodes: {}
 
-controller:
-  # system-cluster-critical protects the single controller from eviction
-  # under node pressure — while it is down, no volume can be provisioned,
-  # expanded, or snapshotted.
-  priorityClassName: system-cluster-critical
-  # Wait for agents to realise a new volume. Keep sidecars.*.timeout at or
-  # above this, or the sidecar RPC deadline fires before this one and the
-  # knob has no effect.
-  provisionTimeout: 120s
-  # Thin-provisioning overcommit guardrail: CreateVolume is refused when a
-  # node's provisioned total would exceed capacity × this ratio. 2× is the
-  # classic CoW headroom; raise it only if you trust your usage to stay
-  # sparse, lower it toward 1 to provision conservatively.
-  overcommitRatio: 2
-  # Add a diskless tie-breaker replica to 2-replica freeze volumes when a
-  # spare storage node exists, so majority quorum survives a single node
-  # loss. Also retrofits existing freeze volumes at controller startup.
-  autoTieBreaker: true
-  resources:
-    requests:
-      cpu: 10m
-      memory: 32Mi
-    limits:
-      memory: 128Mi
+# Controller settings live at the top level (kopiur layout); other
+# components are nested (agent, sidecars, monitoring).
+# -- system-cluster-critical protects the single controller from eviction
+# under node pressure — while it is down, no volume can be provisioned,
+# expanded, or snapshotted.
+priorityClassName: system-cluster-critical
+# -- Wait for agents to realise a new volume. Keep sidecars.*.timeout at or
+# above this, or the sidecar RPC deadline fires before this one and the
+# knob has no effect.
+provisionTimeout: 120s
+# -- Thin-provisioning overcommit guardrail: CreateVolume is refused when a
+# node's provisioned total would exceed capacity × this ratio. 2× is the
+# classic CoW headroom; raise it only if you trust your usage to stay
+# sparse, lower it toward 1 to provision conservatively.
+overcommitRatio: 2
+# -- Add a diskless tie-breaker replica to 2-replica freeze volumes when a
+# spare storage node exists, so majority quorum survives a single node
+# loss. Also retrofits existing freeze volumes at controller startup.
+autoTieBreaker: true
+# -- Controller resources.
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    memory: 128Mi
 
 agent:
   # Agent image (Debian + the lvm/zfs/drbd/mkfs userland the agent and the

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -1,3 +1,8 @@
+# -- Override the chart name used in labels and default object names.
+nameOverride: ""
+# -- Override the fully qualified name prefix of every rendered object.
+fullnameOverride: ""
+
 # Fleet-wide defaults (kopiur layout). imagePullSecrets and commonLabels
 # reach every pod/object; the scheduling globals apply to the controller —
 # the only freely schedulable workload (the agent DaemonSet must run on

--- a/deploy/e2e/values.yaml
+++ b/deploy/e2e/values.yaml
@@ -3,9 +3,15 @@
 # path are only known after the cluster is up). Local backend only — kind has
 # no DRBD, so the replicated class is omitted.
 image:
-  repository: miroir
+  repository: miroir-controller
   tag: e2e
   pullPolicy: IfNotPresent
+
+agent:
+  image:
+    repository: miroir-agent
+    tag: e2e
+    pullPolicy: IfNotPresent
 
 storageClass:
   create: true


### PR DESCRIPTION
Closes #110. blockstor's Dockerfile layout (one file, two named final targets) with kopiur's two-image release wiring, per the issue's proposal.

## The split

| Target | Base | Ships | Used by |
|---|---|---|---|
| `controller` | `gcr.io/distroless/static:nonroot` | the binary only — no shell, no package surface (**91.6MB**) | controller Deployment |
| `agent` | `debian:trixie-slim` (glibc) | `drbd-utils`, `lvm2`, `zfsutils-linux` (contrib), `e2fsprogs`, `xfsprogs`, util-linux (`losetup`/`blkid`/`lsblk`), GNU coreutils + the `lvmlocal.conf` udev/global_filter setup (377MB) | agent DaemonSet + setup Job |

The controller never execs a storage CLI; it drops an entire root-owned LVM/ZFS/DRBD toolchain it couldn't even use (the chart already runs it as 65532). The agent moves to **glibc** — the configuration LINBIT/Piraeus/blockstor actually build and test — retiring the musl-port risk the old Dockerfile fretted about. `lsblk` is now in the image, unblocking #107.

## trixie version facts (verified, not assumed)

- **drbd-utils 9.22** (no newer in backports): every surface miroir uses predates it — `adjust --skip-disk` (8.9.7, the #113 latch), `status --json` (8.9.8), quorum (8.9.11); `peer_devices` / `percent-in-sync` / `out-of-sync` / `suspended-*` all verified present in the v9.22.0 `drbdsetup.c` source (#111/#116 parsing safe).
- **zfs userland 2.3.2** against the siderolabs/zfs 2.4 module: userland-older-than-module is the supported direction, and miroir uses only ancient ops (`create -V`/snapshot/clone/promote/volsize). Same choice blockstor made.

## Wiring (kopiur pattern)

- **Release**: two `build.yml` jobs (`target:` + `cache-scope:` per component) publishing `ghcr.io/home-operations/miroir-controller` and `-agent`, multi-arch + signed + SBOM; the helm job pins **both** digests fail-closed (`.image.digest` / `.agent.image.digest`).
- **Chart** ⚠️ breaking: several values moved in this PR — see **Migrating your values** below for the complete old → new map and an example.
- **e2e**: both targets build **concurrently as background steps** against one BuildKit daemon — in-flight vertex dedup compiles the shared Go builder stage once while the Debian layer pull overlaps it; distinct `gha` cache scopes (concurrent `cache-to` writes to one scope evict each other); a single `wait: [kind, controller-image, agent-image]` joins everything. (Considered kopiur's matrix-build job: right for three expensive independent Rust images feeding multiple test shards, wrong for two builds sharing 90% of their work feeding one job — the artifact handoff would cost more than the build.)
- Builder stays `golang:alpine`: with `CGO_ENABLED=0` the builder libc never touches the shipped binary, and alpine is the org-standard, smaller pull.

## Migrating your values

This PR restructures the chart values (kopiur layout: **root = controller**, components nest). The generated `values.schema.json` rejects every old path loudly at upgrade, so a stale values file fails fast instead of silently misconfiguring.

| Old | New |
|---|---|
| `image.repository: ghcr.io/home-operations/miroir` | `image.repository: ghcr.io/home-operations/miroir-controller` (default — remove your override unless it pointed elsewhere) |
| *(single image served the agent)* | `agent.image.repository: ghcr.io/home-operations/miroir-agent` (new, default) |
| `controller.priorityClassName` | `priorityClassName` |
| `controller.provisionTimeout` | `provisionTimeout` |
| `controller.overcommitRatio` | `overcommitRatio` |
| `controller.autoTieBreaker` | `autoTieBreaker` |
| `controller.resources` | `resources` |
| `kubeletDir` | `agent.kubeletDir` |
| `sidecars.registrar.image` | `agent.registrar.image` |
| `drbd.resync.maxBuffers` | `drbd.net.maxBuffers` |

New (optional, no action needed): `global.{imagePullSecrets,commonLabels,nodeSelector,tolerations,affinity}`, `nameOverride`/`fullnameOverride` (previously implemented but rejected by the schema), `logging.{level,format}`, and `podLabels`/`podAnnotations`/`extraArgs`/`extraEnv` on the controller (root) and `agent.*`.

Example — a values file from 0.3.x:

```yaml
# before
controller:
  provisionTimeout: 180s
  resources:
    limits:
      memory: 256Mi
kubeletDir: /var/lib/kubelet
drbd:
  resync:
    minRate: 20M
    maxBuffers: "36864"
```

```yaml
# after
provisionTimeout: 180s
resources:
  limits:
    memory: 256Mi
agent:
  kubeletDir: /var/lib/kubelet   # omit — this is the default
drbd:
  resync:
    minRate: 20M
  net:
    maxBuffers: "36864"
```

The rendered defaults are otherwise identical — a default install before and after this PR produces the same objects (modulo the two image refs).

## Verification

- Both targets build; agent verified to contain **every tool the backends exec** (drbdadm/drbdsetup/drbdmeta, lvm2, zfs, mkfs/resize for ext4+xfs, blkid/lsblk/losetup/mount, GNU `cp --reflink`); controller runs and provably has no `/bin/sh`.
- helm-unittest 72/72 (image assertions updated + new agent digest-pin test); helm lint clean; schema/README regenerated.
- Local kind run validated the Debian agent **up to the kernel boundary**: it correctly drove `lvcreate --type thin-pool`, failing only because Docker Desktop's linuxkit kernel ships no `dm_thin_pool` module — a pre-existing local limitation affecting the old alpine image identically. **This PR's CI e2e is the real functional gate**: ubuntu loads `dm_thin_pool` and runs the full lvmthin provision + specs against the split images.

## ⚠️ Gate before release (per #110)

CI green validates the local backend only. The agent's drbd-utils moves 9.34 (alpine) → 9.22 (trixie), and GI seeding depends on `drbdmeta` CLI behavior the kind e2e cannot exercise — **run smoke.sh + conformance on real DRBD hardware before cutting a release with this**. Merging to main is safe (rolling tag only); the release gate is the hardware run.

