### PR TITLE
fix: opt out of the workqueue priority queue — starved initial-list events wedge volume realization

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,8 +34,10 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -186,6 +188,16 @@ func main() {
 		HealthProbeBindAddress: "0",
 		// No leader election: the controller is a 1-replica Deployment and
 		// agents are per-node singletons (notes/DESIGN.md §4.2).
+		Controller: config.Controller{
+			// The priority queue (default-on since controller-runtime
+			// v0.22) enqueues initial-list events at low priority, and a
+			// steadily busy queue never drains them: a volume created
+			// moments before an agent start is delivered only through the
+			// initial list, so its realization starves indefinitely —
+			// silently, and again after every restart. FIFO restores the
+			// guarantee that startup work eventually runs.
+			UsePriorityQueue: ptr.To(false),
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to create manager")

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -54,7 +54,7 @@ type VolumeReconciler struct {
 	// DRBD drives the replication layer for multi-replica volumes.
 	DRBD *drbd.Driver
 	// DRBDEvents delivers kernel state changes (drbdsetup events2) as
-	// reconcile triggers, ahead of the next poll.
+	// reconcile triggers, ahead of the poll.
 	DRBDEvents <-chan event.GenericEvent
 }
 
@@ -111,7 +111,10 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	if vol.Spec.DRBD != nil && vol.Spec.Replicas[idx].Address == "" {
 		// A just-added entry the membership reconciler has not completed
-		// yet (no NodeID/address): nothing can be realized safely.
+		// yet (no NodeID/address): nothing can be realized safely. Logged
+		// so a volume stuck waiting is visible — this wait is normally a
+		// single pass, never a steady state.
+		log.Info("replica entry incomplete; waiting for membership completion", "volume", vol.Name)
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -940,7 +940,10 @@ func (c *Controller) snapshotSource(ctx context.Context, snapID string) (*miroir
 // volumes (idempotent CreateVolume retries).
 func (c *Controller) markVolumeFormatted(ctx context.Context, name string) error {
 	vol := &miroirv1alpha1.MiroirVolume{}
-	if err := c.Client.Get(ctx, types.NamespacedName{Name: name}, vol); err != nil {
+	// Read through APIReader: this runs right after Create, and the
+	// informer cache reliably lags a just-created object — a cached Get
+	// here 404s and fails the whole CreateVolume into a retry loop.
+	if err := c.reader().Get(ctx, types.NamespacedName{Name: name}, vol); err != nil {
 		return err
 	}
 	return markFormatted(ctx, c.Client, vol)

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -698,6 +698,42 @@ func TestCreateVolumeAlreadyExistsCacheLagIsUnavailable(t *testing.T) {
 	}
 }
 
+// markVolumeFormatted runs right after Create, when the informer cache
+// reliably lags the just-created object: it must read through APIReader,
+// or every fresh clone fails CreateVolume into a retry loop.
+func TestMarkVolumeFormattedReadsThroughAPIReader(t *testing.T) {
+	s := newScheme(t)
+	existing := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin}},
+		},
+	}
+	// One store: reads through the cached client 404 (informer lag), while
+	// APIReader and the write path see the real object.
+	real := fake.NewClientBuilder().WithScheme(s).WithObjects(existing).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	cached := interceptor.NewClient(real, interceptor.Funcs{
+		Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+			return apierrors.NewNotFound(
+				miroirv1alpha1.GroupVersion.WithResource("miroirvolumes").GroupResource(), volPvc1)
+		},
+	})
+	c := &Controller{Client: cached, APIReader: real, Nodes: testNodes}
+
+	if err := c.markVolumeFormatted(t.Context(), volPvc1); err != nil {
+		t.Fatalf("APIReader has the volume; formatted flag must be recorded: %v", err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := real.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.Formatted {
+		t.Fatal("formatted flag must be recorded on the volume")
+	}
+}
+
 func TestPickNodeNoStorageNodes(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).Build(), Nodes: nodemap.Map{}}


### PR DESCRIPTION
## Root cause (proven on a live wedged volume)

controller-runtime's priority queue (default-on since v0.22; we're on v0.24.1) enqueues **initial-list events at low priority (-100)**. On an agent whose normal-priority queue stays busy (steady 30s DRBD polls across ~90 volumes), the low-priority items **never pop**:

```
workqueue_depth{controller="agent-volume",priority="-100"} 3     <- starved 30+ min
workqueue_depth{controller="agent-volume",priority="0"}    101
```

A volume created moments **before** an agent (re)start is delivered only through the initial list, so its realization starves indefinitely — no backing device, no `status.perNode` slot, no log, no error. Restarting the agent re-lists and re-starves it; the volume sits `Degraded` with the seed leg stuck in DRBD `Connecting` until deleted. Volumes created while the agent runs arrive as watch ADDs at normal priority and realize fine, which is why this only fires when volume creation coincides with an agent rollout (here: hourly backup clones landing in the same minute as a chart upgrade — three volumes wedged >40 min across multiple agent restarts).

Proof: touching a label on a live wedged volume (generation 1, spec complete since creation) produced a normal-priority watch event and the agent realized the leg within seconds, after 30 minutes of silence.

## Fixes

- **`UsePriorityQueue: ptr.To(false)`** on the manager: FIFO restores the guarantee that startup work eventually runs. The agent's initial list *is* data-plane work (realize volumes created while it was down), not deprioritizable backlog.
- **Log the membership-incomplete wait** at Info — the one legitimate silent requeue in the volume reconciler, so a stuck volume is visible at default verbosity.
- **`markVolumeFormatted` reads through `APIReader`**: it runs right after `Create`, where the cached `Get` reliably 404s and failed the whole CreateVolume into a retry loop (same reasoning as `handleCreateErr` above it).

Follow-up worth an issue: e2e only covers `replicas: 1` local volumes (kind has no DRBD), so replicated realize paths — including this one — have no CI coverage.