### PR TITLE
perf: strip managedFields from cached objects

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -181,6 +182,12 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: metricsAddr},
+		// SSA-heavy objects grow a managedFields entry per field manager
+		// (every agent + the CSI controller write each volume), and every
+		// agent caches all volumes cluster-wide — strip them from cached
+		// copies. Nothing reads them locally: conflict detection is
+		// server-side, and the SSA patches build fresh objects.
+		Cache: cache.Options{DefaultTransform: cache.TransformStripManagedFields()},
 		// The dedicated health-probe server is disabled; the probes are
 		// co-hosted on the (plain HTTP) metrics listener so each workload
 		// exposes a single operational port — the agent runs hostNetwork,


### PR DESCRIPTION
First of the two controller-runtime v0.24 adoptions from the API survey (the typed `Apply` migration follows as its own PR).

`cache.DefaultTransform: cache.TransformStripManagedFields()` on the manager. miroir is unusually exposed to managedFields bloat: the per-node SSA status protocol means **every agent (one field manager per node) plus the CSI controller** writes each MiroirVolume, so each object accumulates a managedFields entry per writer — and every agent caches **all** volumes cluster-wide, multiplying it again.

Safety, verified:
- Nothing in miroir reads `ManagedFields` from cached objects — the single reference ([snapshot.go](internal/agent/snapshot.go) `snap.ManagedFields = nil`, the pre-Apply prep) becomes a no-op on already-stripped copies.
- SSA conflict detection is server-side; the volume-status applies build fresh objects rather than round-tripping cache reads.
- `APIReader` paths bypass the cache and are untouched.

Verification: `golangci-lint` (linux) 0 issues, full `go test ./...` in `golang:1.26.3` all packages green.