### PR TITLE
perf(agent): concurrent volume workers + realized-state fast path

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -49,6 +49,7 @@ Kubernetes: `>=1.31.0`
 | agent.resources.limits.memory | string | `"128Mi"` |  |
 | agent.resources.requests.cpu | string | `"10m"` |  |
 | agent.resources.requests.memory | string | `"32Mi"` |  |
+| agent.volumeWorkers | int | `4` | Concurrent volume reconciles per agent. Per-volume work is serialized by controller-runtime regardless; this bounds how many distinct volumes one agent works at once. |
 | autoTieBreaker | bool | `true` | Add a diskless tie-breaker replica to 2-replica freeze volumes when a spare storage node exists, so majority quorum survives a single node loss. Also retrofits existing freeze volumes at controller startup. |
 | drbd.net.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count (e.g. "36864"); raises resync throughput on fast links. |
 | drbd.onIoError | string | `"detach"` |  |

--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -65,6 +65,7 @@ spec:
             - --nodes-config=/etc/miroir/nodes.yaml
             - --metrics-bind-address=:9810
             - --pool-stats-interval={{ .Values.agent.poolStatsInterval }}
+            - --volume-workers={{ .Values.agent.volumeWorkers }}
             - --zap-log-level={{ .Values.logging.level }}
             - --zap-encoder={{ .Values.logging.format }}
             {{- with .Values.agent.extraArgs }}

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -122,6 +122,12 @@
           "required": [],
           "title": "resources",
           "type": "object"
+        },
+        "volumeWorkers": {
+          "default": 4,
+          "description": "Concurrent volume reconciles per agent. Per-volume work is\nserialized by controller-runtime regardless; this bounds how many\ndistinct volumes one agent works at once.",
+          "title": "volumeWorkers",
+          "type": "integer"
         }
       },
       "required": [],

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -116,6 +116,10 @@ agent:
   # How often each agent republishes its pool capacity to its MiroirNode
   # (read by the controller for capacity-aware placement).
   poolStatsInterval: 60s
+  # -- Concurrent volume reconciles per agent. Per-volume work is
+  # serialized by controller-runtime regardless; this bounds how many
+  # distinct volumes one agent works at once.
+  volumeWorkers: 4
   # kubelet plugin-registration sidecar riding the agent DaemonSet.
   registrar:
     image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
@@ -163,7 +167,6 @@ agent:
 #     backend: loopfile
 #     baseDir: /var/lib/miroir
 nodes: {}
-
 
 # =============================================================================
 # Storage classes

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -131,6 +131,7 @@ func main() {
 		thinPool          string
 		drbdStateDir      string
 		poolStatsInterval time.Duration
+		volumeWorkers     int
 	)
 	flag.StringVar(&mode, "mode", "", "controller | agent | setup")
 	flag.StringVar(&csiSocket, "csi-socket", "/csi/csi.sock", "CSI gRPC unix socket path")
@@ -145,6 +146,8 @@ func main() {
 		"max provisioned-over-capacity per pool before CreateVolume is refused (controller; 0 → default 2.0)")
 	flag.BoolVar(&autoTieBreaker, "auto-tie-breaker", true,
 		"add a diskless tie-breaker to 2-replica freeze volumes when a spare node exists (controller)")
+	flag.IntVar(&volumeWorkers, "volume-workers", 4,
+		"concurrent volume reconciles per agent (agent)")
 	flag.DurationVar(&poolStatsInterval, "pool-stats-interval", 0,
 		"how often the agent republishes pool capacity (agent; 0 → default 60s)")
 	flag.StringVar(&vg, "lvm-vg", "vg-miroir", "LVM volume group (agent, lvmthin)")
@@ -312,6 +315,7 @@ func main() {
 			BackendType: backendType,
 			DRBD:        drbdDriver,
 			DRBDEvents:  drbdEvents,
+			Workers:     volumeWorkers,
 		}
 		if err := reconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to set up agent reconciler")

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -20,16 +20,20 @@ limitations under the License.
 package agent
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
+	"sync"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -56,7 +60,33 @@ type VolumeReconciler struct {
 	// DRBDEvents delivers kernel state changes (drbdsetup events2) as
 	// reconcile triggers, ahead of the poll.
 	DRBDEvents <-chan event.GenericEvent
+	// Workers bounds concurrent volume reconciles (default 4). Per-key
+	// serialization is controller-runtime's guarantee; the storage CLIs
+	// are cross-resource-safe and minor allocation holds its own lock.
+	Workers int
+
+	// realized caches the last fully realized state per volume so the
+	// steady-state poll only re-execs `drbdsetup status` instead of the
+	// whole realize/adjust/probe pipeline. See fastPath.
+	realizedMu sync.Mutex
+	realized   map[string]realizedState
 }
+
+// realizedState is the fingerprint of a completed full pass: repeating
+// it is pure waste until the spec changes, the kernel reports different
+// state, or the deep-check interval elapses (the out-of-band-drift net —
+// e.g. a backing device deleted behind the agent's back).
+type realizedState struct {
+	generation int64
+	status     drbd.Status
+	replicated bool
+	fullPassAt time.Time
+}
+
+// deepCheckInterval bounds how long the fast path may skip the full
+// realize pipeline; backend drift with no kernel signature (unreplicated
+// volumes especially) is caught within one interval.
+const deepCheckInterval = 5 * time.Minute
 
 // drbdPollInterval refreshes DRBD state in the CRD: connection/disk state
 // changes in the kernel without generating Kubernetes events.
@@ -81,27 +111,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	localDiskless := mine && vol.Spec.Replicas[idx].Diskless
 
 	if !vol.DeletionTimestamp.IsZero() {
-		// Only the agent owning a replica may release the finalizer, and
-		// only after its local teardown succeeded — a foreign agent
-		// touching it would race the owner and leak the backing device.
-		// A pending-removal replica (finalizer held, not in spec) takes
-		// the same path: volume deletion supersedes the removal gates.
-		if !mine && !controllerutil.ContainsFinalizer(vol, constants.FinalizerPrefix+r.NodeName) {
-			return ctrl.Result{}, nil
-		}
-		if err := r.teardown(ctx, vol); err != nil {
-			if errors.Is(err, backend.ErrBusy) {
-				// A force-deleted pod can leave the device open past
-				// NodeUnstage; retry until the mount goes away.
-				log.Info("device busy during teardown, retrying", "volume", vol.Name)
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-			}
-			return ctrl.Result{}, err
-		}
-		// Drop metrics only once the device is gone: a retrying teardown
-		// must not blank a volume that still exists.
-		dropVolumeMetrics(vol.Name)
-		return ctrl.Result{}, r.removeFinalizer(ctx, vol)
+		return r.reconcileDeletion(ctx, vol, mine)
 	}
 	if !mine {
 		// Not placed here, but a held finalizer means this replica was
@@ -117,6 +127,18 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Info("replica entry incomplete; waiting for membership completion", "volume", vol.Name)
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
+
+	// Steady state: when nothing changed since the last full pass, one
+	// status exec (or none for unreplicated volumes) replaces the whole
+	// realize/adjust/probe pipeline. Peer status writes re-trigger this
+	// reconcile every poll cycle; without the short-circuit each of those
+	// re-runs ~6 execs per volume.
+	if done, res := r.fastPath(ctx, vol, localDiskless); done {
+		return res, nil
+	}
+	// Any pass that reaches the pipeline invalidates the fingerprint; it
+	// is re-stored only after the pass completes cleanly.
+	r.dropRealized(vol.Name)
 
 	var dev string
 	var forceFullSync bool
@@ -153,12 +175,16 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			recordVolumeMetrics(vol.Name, miroirReplicaView{
 				upToDate: true, connected: true, quorum: true, resyncRatio: 1,
 			})
-			return ctrl.Result{}, r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
+			if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
 				DeviceCreated: true,
 				DevicePath:    dev,
 				SizeBytes:     vol.Spec.SizeBytes,
 				Connected:     true,
-			})
+			}); err != nil {
+				return ctrl.Result{}, err
+			}
+			r.storeRealized(vol.Generation, vol.Name, drbd.Status{}, false)
+			return ctrl.Result{}, nil
 		}
 	} else {
 		// Diskless tie-breaker: join DRBD for quorum only, no backing.
@@ -236,7 +262,108 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}); err != nil {
 		return ctrl.Result{}, err
 	}
+	// Cache only the settled state: a mid-grow pass (short requeue, size
+	// withheld) must keep taking the full pipeline until the grow lands.
+	if requeue == drbdPollInterval && reportSize == vol.Spec.SizeBytes {
+		r.storeRealized(vol.Generation, vol.Name, st, true)
+	}
 	return ctrl.Result{RequeueAfter: requeue}, nil
+}
+
+// fastPath reports whether this reconcile can settle without the realize
+// pipeline: same generation, settled size, a fresh-enough full pass, and —
+// for replicated volumes — kernel state identical to the fingerprint. On
+// the hit it refreshes the metrics (cheap sets) and skips the status patch
+// entirely: the CRD already reflects this state, and phase converges via
+// whichever peer actually changed.
+func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, localDiskless bool) (bool, ctrl.Result) {
+	r.realizedMu.Lock()
+	entry, ok := r.realized[vol.Name]
+	r.realizedMu.Unlock()
+	if !ok || entry.generation != vol.Generation ||
+		time.Since(entry.fullPassAt) >= deepCheckInterval ||
+		(!localDiskless && vol.Status.PerNode[r.NodeName].SizeBytes != vol.Spec.SizeBytes) {
+		return false, ctrl.Result{}
+	}
+	if !entry.replicated {
+		recordVolumeMetrics(vol.Name, miroirReplicaView{
+			upToDate: true, connected: true, quorum: true, resyncRatio: 1,
+		})
+		return true, ctrl.Result{}
+	}
+	st, err := r.DRBD.Status(ctx, vol.Name)
+	if err != nil || !statusEqual(st, entry.status) {
+		return false, ctrl.Result{}
+	}
+	if !localDiskless {
+		recordVolumeMetrics(vol.Name, miroirReplicaView{
+			upToDate:       st.DiskState == drbd.DiskUpToDate,
+			connected:      diskfulPeersConnected(st, vol, r.NodeName),
+			splitBrain:     st.SplitBrain,
+			suspended:      st.Suspended,
+			quorum:         st.Quorum,
+			diskFailed:     diskFailedLatch(vol, r.NodeName, st, localDiskless),
+			resyncRatio:    st.ResyncPercent / 100,
+			outOfSyncBytes: float64(st.OutOfSyncKiB) * 1024,
+		})
+	}
+	return true, ctrl.Result{RequeueAfter: drbdPollInterval}
+}
+
+func statusEqual(a, b drbd.Status) bool {
+	return a.DiskState == b.DiskState &&
+		a.Primary == b.Primary &&
+		a.PeerPrimary == b.PeerPrimary &&
+		a.Suspended == b.Suspended &&
+		a.SplitBrain == b.SplitBrain &&
+		a.Resyncing == b.Resyncing &&
+		a.ResyncPercent == b.ResyncPercent &&
+		a.Quorum == b.Quorum &&
+		a.OutOfSyncKiB == b.OutOfSyncKiB &&
+		maps.Equal(a.PeerConnected, b.PeerConnected)
+}
+
+func (r *VolumeReconciler) storeRealized(gen int64, name string, st drbd.Status, replicated bool) {
+	r.realizedMu.Lock()
+	defer r.realizedMu.Unlock()
+	if r.realized == nil {
+		r.realized = map[string]realizedState{}
+	}
+	r.realized[name] = realizedState{
+		generation: gen, status: st, replicated: replicated, fullPassAt: time.Now(),
+	}
+}
+
+func (r *VolumeReconciler) dropRealized(name string) {
+	r.realizedMu.Lock()
+	defer r.realizedMu.Unlock()
+	delete(r.realized, name)
+}
+
+// reconcileDeletion tears down the local leg of a deleted volume. Only
+// the agent owning a replica may release the finalizer, and only after
+// its local teardown succeeded — a foreign agent touching it would race
+// the owner and leak the backing device. A pending-removal replica
+// (finalizer held, not in spec) takes the same path: volume deletion
+// supersedes the removal gates.
+func (r *VolumeReconciler) reconcileDeletion(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, mine bool) (ctrl.Result, error) {
+	if !mine && !controllerutil.ContainsFinalizer(vol, constants.FinalizerPrefix+r.NodeName) {
+		return ctrl.Result{}, nil
+	}
+	if err := r.teardown(ctx, vol); err != nil {
+		if errors.Is(err, backend.ErrBusy) {
+			// A force-deleted pod can leave the device open past
+			// NodeUnstage; retry until the mount goes away.
+			ctrl.LoggerFrom(ctx).Info("device busy during teardown, retrying", "volume", vol.Name)
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	// Drop metrics only once the device is gone: a retrying teardown
+	// must not blank a volume that still exists.
+	dropVolumeMetrics(vol.Name)
+	r.dropRealized(vol.Name)
+	return ctrl.Result{}, r.removeFinalizer(ctx, vol)
 }
 
 // diskfulPeersConnected reports whether this node's replication links to
@@ -396,6 +523,7 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 		return ctrl.Result{}, err
 	}
 	dropVolumeMetrics(vol.Name)
+	r.dropRealized(vol.Name)
 	// Drop this node's status slot — merge-patch null deletes the key.
 	// Best-effort ordering: a crash here leaves a stale slot, which
 	// nothing reads (phase and growth iterate spec.replicas only).
@@ -661,9 +789,12 @@ func computePhase(vol *miroirv1alpha1.MiroirVolume) miroirv1alpha1.VolumePhase {
 
 // SetupWithManager registers the reconciler.
 func (r *VolumeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// The snapshot controller stays single-worker (its round protocol
+	// assumes head-of-line ordering); volumes have no cross-key coupling.
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&miroirv1alpha1.MiroirVolume{}).
-		Named("agent-volume")
+		Named("agent-volume").
+		WithOptions(controller.Options{MaxConcurrentReconciles: cmp.Or(r.Workers, 4)})
 	if r.DRBDEvents != nil {
 		b = b.WatchesRawSource(source.Channel(r.DRBDEvents, &handler.EnqueueRequestForObject{}))
 	}

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1501,3 +1501,140 @@ func TestReconcileLoopfileSkipsDiscardProbe(t *testing.T) {
 	reconcile(t, r, volPvc1)
 	fe.notCalledWith(t, "lsblk")
 }
+
+// countCalls counts fake exec invocations containing substr.
+func countCalls(fe *fakeDRBDExec, substr string) int {
+	n := 0
+	for _, c := range fe.calls {
+		if strings.Contains(c, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// steadyVolume builds a settled replicated volume + exec fake for the
+// fast-path tests: status at spec size, kernel UpToDate and connected.
+func steadyVolume(t *testing.T) (*miroirv1alpha1.MiroirVolume, *fakeDRBDExec, *VolumeReconciler) {
+	t.Helper()
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+	}
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `","quorum":true}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
+	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+		BackendType: miroirv1alpha1.BackendLVMThin,
+		DRBD:        &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+	return v, fe, r
+}
+
+// A second reconcile over unchanged state must cost one status exec, not
+// the realize/adjust/probe pipeline — peer status writes re-trigger the
+// reconcile every poll cycle and would otherwise re-run everything.
+func TestReconcileFastPathSkipsPipeline(t *testing.T) {
+	_, fe, r := steadyVolume(t)
+
+	reconcile(t, r, volPvc1) // full pass, stores the fingerprint
+	adjusts, statuses := countCalls(fe, "adjust"), countCalls(fe, "drbdsetup status --json")
+
+	reconcile(t, r, volPvc1) // steady state: fast path
+	if got := countCalls(fe, "adjust"); got != adjusts {
+		t.Fatalf("fast path ran adjust (%d -> %d):\n%v", adjusts, got, fe.calls)
+	}
+	if got := countCalls(fe, "lsblk"); got != 1 {
+		t.Fatalf("fast path must not re-probe discard granularity: %v", fe.calls)
+	}
+	if got := countCalls(fe, "drbdsetup status --json"); got != statuses+1 {
+		t.Fatalf("fast path must still read kernel state once (%d -> %d)", statuses, got)
+	}
+}
+
+// Kernel drift breaks the fingerprint: the next pass takes the full
+// pipeline and re-converges.
+func TestReconcileFastPathInvalidatedByStatusDrift(t *testing.T) {
+	_, fe, r := steadyVolume(t)
+	reconcile(t, r, volPvc1)
+	adjusts := countCalls(fe, "adjust")
+
+	// A peer drops: connection state changes under the same generation.
+	fe.statusJSON = `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `","quorum":true}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connecting"}]}]`
+	reconcile(t, r, volPvc1)
+	if got := countCalls(fe, "adjust"); got <= adjusts {
+		t.Fatalf("status drift must force the full pipeline: %v", fe.calls)
+	}
+}
+
+// A spec change (generation bump) breaks the fingerprint.
+func TestReconcileFastPathInvalidatedByGeneration(t *testing.T) {
+	v, fe, r := steadyVolume(t)
+	reconcile(t, r, volPvc1)
+	adjusts := countCalls(fe, "adjust")
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	got.Generation = v.Generation + 1
+	if err := r.Update(t.Context(), got); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, volPvc1)
+	if n := countCalls(fe, "adjust"); n <= adjusts {
+		t.Fatalf("generation bump must force the full pipeline: %v", fe.calls)
+	}
+}
+
+// A mid-grow pass (reported size withheld) must not be cached: the next
+// reconcile keeps taking the full pipeline until the grow settles.
+func TestReconcileFastPathSkipsMidGrow(t *testing.T) {
+	_, fe, r := steadyVolume(t)
+	reconcile(t, r, volPvc1)
+
+	// Spec grows; the local slot lags behind.
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	got.Spec.SizeBytes = 2 << 30
+	got.Generation++
+	if err := r.Update(t.Context(), got); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, volPvc1) // grow pass: withholds size, must not cache
+	adjusts := countCalls(fe, "adjust")
+	reconcile(t, r, volPvc1)
+	if n := countCalls(fe, "adjust"); n <= adjusts {
+		t.Fatalf("mid-grow state must keep the full pipeline: %v", fe.calls)
+	}
+}
+
+// The deep-check interval bounds how long drift with no kernel signature
+// (a backing device deleted out-of-band) can hide behind the fast path.
+func TestReconcileFastPathDeepCheckExpiry(t *testing.T) {
+	_, fe, r := steadyVolume(t)
+	reconcile(t, r, volPvc1)
+	adjusts := countCalls(fe, "adjust")
+
+	r.realizedMu.Lock()
+	e := r.realized[volPvc1]
+	e.fullPassAt = time.Now().Add(-deepCheckInterval - time.Minute)
+	r.realized[volPvc1] = e
+	r.realizedMu.Unlock()
+
+	reconcile(t, r, volPvc1)
+	if n := countCalls(fe, "adjust"); n <= adjusts {
+		t.Fatalf("expired fingerprint must force the full pipeline: %v", fe.calls)
+	}
+}


### PR DESCRIPTION
Closes #124 — both halves, per the issue's framing that they're complementary.

## The problem (from #122's evidence)

`workqueue_depth{controller="agent-volume",priority="0"} 101` at steady state: one worker, ~90 volumes, every no-op reconcile re-running ~6 execs (`drbdsetup status`, `adjust`, backend probes, `lsblk`). Worse than the 30s poll alone: **every peer's status write re-triggers the local reconcile** (the agent-volume controller can't be generation-filtered — it needs status-driven wakeups), so each volume reconciles several times per poll cycle. New volumes waited minutes behind queued no-ops even after #122's FIFO fix.

## Fix 1 — `--volume-workers` (default 4)

`MaxConcurrentReconciles` on **agent-volume only**. Safety, stated and relied on: controller-runtime never runs the same key concurrently; `drbdadm`/`lvm`/`zfs` are cross-resource-safe; minor allocation holds `lockMinors`. The **snapshot controller stays single-worker** — its round-serialization protocol (#85) assumes head-of-line ordering. Chart: `agent.volumeWorkers`.

## Fix 2 — realized-state fast path

Per-volume fingerprint `{generation, kernel status, full-pass time}` stored after each clean full pass. On the next reconcile, if nothing changed: **one `drbdsetup status` exec** (zero for unreplicated volumes) replaces the pipeline, metrics refresh (cheap sets), and the byte-identical status patch is skipped — phase converges via whichever peer actually changed, exactly the #60 co-write design.

Invalidation is the load-bearing part:

| Trigger | Effect |
|---|---|
| spec change | generation mismatch → full pass |
| any kernel state difference (this is where events2 triggers land) | `statusEqual` fails → full pass |
| mid-grow (reported size withheld / short requeue) | **never cached** — grows keep the full pipeline until settled |
| any error, teardown, replica removal | fingerprint dropped |
| 5-minute deep check | bounds out-of-band backend drift with no kernel signature (e.g. an LV deleted behind the agent's back — the #88 wipe-detection path needs its `Exists` probe) |
| pipeline entry | fingerprint dropped first, re-stored only on clean completion — a failed pass can't leave a stale hit |

Net effect at 90 volumes: steady-state cost drops from ~6 execs × several triggers per volume per 30s to ~1 exec per trigger, across 4 workers — orders of magnitude of queue headroom, while every change signal still forces the full pipeline.

## Tests

Five new fast-path tests pin the contract: steady state skips `adjust`/`lsblk` but still reads kernel state; status drift, generation bump, and deep-check expiry each force the full pipeline; mid-grow states are never cached. Plus `go test -race` clean over the agent suite (the new map is mutex-guarded; same-key serialization covers the rest). `reconcileDeletion` extracted from `Reconcile` (the traditional gocyclo trip).

## Verification

`golangci-lint` (linux) 0 issues · race detector clean · full `go test ./...` in `golang:1.26.3` 7/7 packages · helm-unittest 78/78 · helm-docs/schema regenerated.