### PR TITLE
feat(controller): optional leader election for HA replicas

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -69,6 +69,8 @@ Kubernetes: `>=1.31.0`
 | global.nodeSelector | object | `{}` | Controller scheduling defaults. |
 | global.tolerations | list | `[]` |  |
 | image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"ghcr.io/home-operations/miroir-controller","tag":""}` | Controller image (distroless, no storage userland — the controller never execs a storage CLI). |
+| leaderElection.enabled | bool | `false` | Elect even with a single replica (replicaCount > 1 elects regardless; this can never switch election off above one replica). |
+| leaderElection.id | string | `""` | Lease name; empty derives the release-scoped controller name so two releases in one namespace never share a Lease. Keep it stable across upgrades. |
 | logging.format | string | `"json"` | Encoder: json (structured, default) or console (human-readable). |
 | logging.level | string | `"info"` | Log level: debug | info | error (or any zapcore level). |
 | monitoring.dashboards.annotations | object | `{}` | Annotations added to the dashboard ConfigMap. |
@@ -101,6 +103,7 @@ Kubernetes: `>=1.31.0`
 | podLabels | object | `{}` | Extra labels on the controller pod. |
 | priorityClassName | string | `"system-cluster-critical"` | system-cluster-critical protects the single controller from eviction under node pressure — while it is down, no volume can be provisioned, expanded, or snapshotted. |
 | provisionTimeout | string | `"120s"` | Wait for agents to realise a new volume. Keep sidecars.*.timeout at or above this, or the sidecar RPC deadline fires before this one and the knob has no effect. |
+| replicaCount | int | `1` | Controller replicas. Anything above 1 automatically enables leader election: the extras are warm standbys (failover is lease expiry, ~15s, instead of a full pod reschedule), the rollout strategy switches to RollingUpdate, and a PodDisruptionBudget keeps one replica through voluntary disruptions. Pointless on a single-node cluster (the node is the failure domain); pair with global.affinity (pod anti-affinity) so replicas land on different nodes. |
 | replicatedStorageClass.create | bool | `true` |  |
 | replicatedStorageClass.fsType | string | `"ext4"` |  |
 | replicatedStorageClass.isDefault | bool | `false` |  |

--- a/charts/miroir/templates/_helpers.tpl
+++ b/charts/miroir/templates/_helpers.tpl
@@ -125,6 +125,28 @@ Resource names. All derive from fullname so nameOverride / fullnameOverride flow
 {{- end -}}
 
 {{/*
+Effective leader-election state ("true"/"false"). Forced on whenever
+replicaCount > 1 — two active controllers racing port/minor allocation is
+the footgun this derivation exists to prevent — and leaderElection.enabled
+can only add election at one replica, never remove it above.
+*/}}
+{{- define "miroir.leaderElectionEnabled" -}}
+{{- if or (gt (int .Values.replicaCount) 1) .Values.leaderElection.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Leader-election Lease name; the release-scoped default keeps two releases
+in one namespace off the same Lease.
+*/}}
+{{- define "miroir.leaderElectionID" -}}
+{{- .Values.leaderElection.id | default (include "miroir.controllerName" .) -}}
+{{- end -}}
+
+{{/*
 CSI driver name — also the StorageClass provisioner and VolumeSnapshotClass driver.
 Always pinned to .Chart.Name so a nameOverride can't break volume provisioning.
 */}}

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -7,9 +7,13 @@ metadata:
     {{- include "miroir.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   strategy:
+  {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
+    type: RollingUpdate # leader election arbitrates the rollout overlap
+  {{- else }}
     type: Recreate # one writer for allocations; no leader election
+  {{- end }}
   selector:
     matchLabels:
       {{- include "miroir.selectorLabels" . | nindent 6 }}
@@ -57,6 +61,10 @@ spec:
             - --provision-timeout={{ .Values.provisionTimeout }}
             - --overcommit-ratio={{ .Values.overcommitRatio }}
             - --auto-tie-breaker={{ .Values.autoTieBreaker }}
+            {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
+            - --leader-elect=true
+            - --leader-election-id={{ include "miroir.leaderElectionID" . }}
+            {{- end }}
             - --zap-log-level={{ .Values.logging.level }}
             - --zap-encoder={{ .Values.logging.format }}
             {{- with .Values.extraArgs }}
@@ -91,7 +99,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --timeout={{ .Values.sidecars.provisioner.timeout }}
-            - --leader-election=false
+            - --leader-election={{ include "miroir.leaderElectionEnabled" . }}
             - --default-fstype=ext4
           resources:
             requests: { cpu: 10m, memory: 32Mi }
@@ -104,7 +112,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --timeout={{ .Values.sidecars.snapshotter.timeout }}
-            - --leader-election=false
+            - --leader-election={{ include "miroir.leaderElectionEnabled" . }}
           resources:
             requests: { cpu: 10m, memory: 32Mi }
             limits: { memory: 128Mi }
@@ -116,7 +124,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --timeout={{ .Values.sidecars.resizer.timeout }}
-            - --leader-election=false
+            - --leader-election={{ include "miroir.leaderElectionEnabled" . }}
           resources:
             requests: { cpu: 10m, memory: 32Mi }
             limits: { memory: 128Mi }
@@ -129,3 +137,22 @@ spec:
         - name: nodes
           configMap:
             name: {{ include "miroir.nodesConfigName" . }}
+{{- if gt (int .Values.replicaCount) 1 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "miroir.controllerName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+spec:
+  # Drains take controllers one at a time, so the warm standby picks up the
+  # Lease instead of provisioning stalling on a full pod reschedule.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "miroir.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+{{- end }}

--- a/charts/miroir/templates/rbac.tpl
+++ b/charts/miroir/templates/rbac.tpl
@@ -76,6 +76,14 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
+  # leader election (replicaCount > 1 or leaderElection.enabled): the
+  # controller manager and each CSI sidecar hold their own
+  # coordination.k8s.io Lease
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -165,6 +165,111 @@ tests:
               - "--timeout=77s"
               - "--leader-election=false"
 
+  - it: renders no PodDisruptionBudget and no leader election by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect=true"
+
+  - it: replicaCount above 1 auto-enables leader election and RollingUpdate
+    set:
+      replicaCount: 3
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect=true"
+      # release-scoped Lease name so two releases in one namespace never collide
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-election-id=miroir-controller"
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "--leader-election=true"
+      - contains:
+          path: spec.template.spec.containers[2].args
+          content: "--leader-election=true"
+      - contains:
+          path: spec.template.spec.containers[3].args
+          content: "--leader-election=true"
+
+  - it: leaderElection.enabled=false cannot switch election off above one replica
+    set:
+      replicaCount: 2
+      leaderElection:
+        enabled: false
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect=true"
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "--leader-election=true"
+
+  - it: leaderElection.enabled forces election at a single replica, without a PDB
+    set:
+      leaderElection:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        equal:
+          path: spec.replicas
+          value: 1
+      - documentIndex: 0
+        equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect=true"
+
+  - it: leaderElection.id overrides the Lease name
+    set:
+      replicaCount: 2
+      leaderElection:
+        id: my-lease
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-election-id=my-lease"
+
+  - it: replicaCount above 1 adds a PodDisruptionBudget covering the controller
+    set:
+      replicaCount: 2
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: PodDisruptionBudget
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: miroir-controller
+      - documentIndex: 1
+        equal:
+          path: spec.maxUnavailable
+          value: 1
+      - documentIndex: 1
+        equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: controller
+
   - it: the controller pod is cluster-critical by default
     documentIndex: 0
     asserts:

--- a/charts/miroir/tests/rbac_test.yaml
+++ b/charts/miroir/tests/rbac_test.yaml
@@ -105,6 +105,30 @@ tests:
             resources: ["nodes"]
             verbs: ["get", "list", "watch"]
 
+  - it: grants Lease access only when leader election is on
+    documentIndex: 2
+    asserts:
+      - notContains:
+          any: true
+          path: rules
+          content:
+            apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: replicaCount above 1 grants the controller Lease CRUD for leader election
+    set:
+      replicaCount: 2
+    documentIndex: 2
+    asserts:
+      - contains:
+          any: true
+          path: rules
+          content:
+            apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
   - it: controller ClusterRoleBinding binds to miroir-controller ServiceAccount
     documentIndex: 3
     asserts:

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -308,6 +308,26 @@
       "title": "image",
       "type": "object"
     },
+    "leaderElection": {
+      "description": "Leader election turns on by itself when replicaCount \u003e 1 — the\ncontroller and each CSI sidecar then elect through coordination.k8s.io\nLeases — so this key only customises it.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Elect even with a single replica (replicaCount \u003e 1 elects regardless;\nthis can never switch election off above one replica).",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "id": {
+          "default": "",
+          "description": "Lease name; empty derives the release-scoped controller name so two\nreleases in one namespace never share a Lease. Keep it stable across\nupgrades.",
+          "title": "id",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "leaderElection",
+      "type": "object"
+    },
     "logging": {
       "description": "Both processes bind the controller-runtime zap flags.",
       "properties": {
@@ -549,6 +569,12 @@
       "description": "Wait for agents to realise a new volume. Keep sidecars.*.timeout at or\nabove this, or the sidecar RPC deadline fires before this one and the\nknob has no effect.",
       "title": "provisionTimeout",
       "type": "string"
+    },
+    "replicaCount": {
+      "default": 1,
+      "description": "Controller replicas. Anything above 1 automatically enables leader\nelection: the extras are warm standbys (failover is lease expiry, ~15s,\ninstead of a full pod reschedule), the rollout strategy switches to\nRollingUpdate, and a PodDisruptionBudget keeps one replica through\nvoluntary disruptions. Pointless on a single-node cluster (the node is\nthe failure domain); pair with global.affinity (pod anti-affinity) so\nreplicas land on different nodes.",
+      "title": "replicaCount",
+      "type": "integer"
     },
     "replicatedStorageClass": {
       "properties": {

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -57,6 +57,25 @@ overcommitRatio: 2
 # spare storage node exists, so majority quorum survives a single node
 # loss. Also retrofits existing freeze volumes at controller startup.
 autoTieBreaker: true
+# -- Controller replicas. Anything above 1 automatically enables leader
+# election: the extras are warm standbys (failover is lease expiry, ~15s,
+# instead of a full pod reschedule), the rollout strategy switches to
+# RollingUpdate, and a PodDisruptionBudget keeps one replica through
+# voluntary disruptions. Pointless on a single-node cluster (the node is
+# the failure domain); pair with global.affinity (pod anti-affinity) so
+# replicas land on different nodes.
+replicaCount: 1
+# Leader election turns on by itself when replicaCount > 1 — the
+# controller and each CSI sidecar then elect through coordination.k8s.io
+# Leases — so this key only customises it.
+leaderElection:
+  # -- Elect even with a single replica (replicaCount > 1 elects regardless;
+  # this can never switch election off above one replica).
+  enabled: false
+  # -- Lease name; empty derives the release-scoped controller name so two
+  # releases in one namespace never share a Lease. Keep it stable across
+  # upgrades.
+  id: ""
 # -- Controller resources.
 resources:
   requests:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,6 +60,8 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+const modeController = "controller"
+
 // Populated via -ldflags at build time.
 var (
 	version = "dev"
@@ -124,6 +126,9 @@ func main() {
 		provisionTimeout time.Duration
 		overcommitRatio  float64
 		autoTieBreaker   bool
+		leaderElect      bool
+		leaderElectionID string
+		leaderElectionNS string
 
 		// agent mode
 		nodeName          string
@@ -146,6 +151,12 @@ func main() {
 		"max provisioned-over-capacity per pool before CreateVolume is refused (controller; 0 → default 2.0)")
 	flag.BoolVar(&autoTieBreaker, "auto-tie-breaker", true,
 		"add a diskless tie-breaker to 2-replica freeze volumes when a spare node exists (controller)")
+	flag.BoolVar(&leaderElect, "leader-elect", false,
+		"elect a leader via a coordination.k8s.io Lease so extra replicas stand by warm (controller)")
+	flag.StringVar(&leaderElectionID, "leader-election-id", "miroir-controller",
+		"leader-election Lease name; keep it stable across upgrades (controller)")
+	flag.StringVar(&leaderElectionNS, "leader-election-namespace", "",
+		"leader-election Lease namespace; empty auto-detects the pod's namespace in-cluster (controller)")
 	flag.IntVar(&volumeWorkers, "volume-workers", 4,
 		"concurrent volume reconciles per agent (agent)")
 	flag.DurationVar(&poolStatsInterval, "pool-stats-interval", 0,
@@ -196,8 +207,20 @@ func main() {
 		// exposes a single operational port — the agent runs hostNetwork,
 		// so every listener occupies a real node port.
 		HealthProbeBindAddress: "0",
-		// No leader election: the controller is a 1-replica Deployment and
-		// agents are per-node singletons (notes/DESIGN.md §4.2).
+		// Leader election is the opt-in controller HA mode (#132): extra
+		// replicas stand by warm and only the reconcilers wait on the
+		// Lease — the cache, metrics server, and CSI socket run on every
+		// replica because each pod's CSI sidecars elect independently and
+		// reach the driver over the pod-local socket. Gated on controller
+		// mode: agents are per-node singletons, and a shared Lease would
+		// serialize the whole DaemonSet down to one working node.
+		LeaderElection:          mode == modeController && leaderElect,
+		LeaderElectionID:        leaderElectionID,
+		LeaderElectionNamespace: leaderElectionNS,
+		// Safe because nothing runs after mgr.Start returns in controller
+		// mode (the shutdown sweep is agent-only), so the released Lease
+		// can't be beaten to by a still-writing old leader.
+		LeaderElectionReleaseOnCancel: true,
 		Controller: config.Controller{
 			// The priority queue (default-on since controller-runtime
 			// v0.22) enqueues initial-list events at low priority, and a
@@ -224,7 +247,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	identity := &csi.Identity{Version: version, WithController: mode == "controller"}
+	identity := &csi.Identity{Version: version, WithController: mode == modeController}
 
 	// Agent mode only, run after the manager stops (SIGTERM): release DRBD
 	// backings when the node is going down and lift any leftover write
@@ -232,7 +255,7 @@ func main() {
 	var shutdownSweep func()
 
 	switch mode {
-	case "controller":
+	case modeController:
 		nodes, err := nodemap.Load(nodesConfig)
 		if err != nil {
 			setupLog.Error(err, "unable to load node map")
@@ -528,10 +551,20 @@ func resumeStaleBarriers(driver *drbd.Driver, apiBudget time.Duration) error {
 	return nil
 }
 
+// csiRunnable marks the CSI server as running on every replica rather than
+// only the elected leader: each pod's sidecars hold their own Leases and
+// reach the driver over the pod-local socket, so a standby's gRPC server
+// must be up for its sidecars to probe (and to act the moment one of them
+// wins its lease). Without this, mgr.Add defaults a plain Runnable into the
+// leader-election group.
+type csiRunnable struct{ manager.Runnable }
+
+func (csiRunnable) NeedLeaderElection() bool { return false }
+
 // serveCSI runs the CSI gRPC server alongside the manager; controller and
 // node are mutually exclusive (one per mode).
 func serveCSI(mgr ctrl.Manager, socket string, identity *csi.Identity, controller *csi.Controller, node *csi.Node) {
-	err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+	err := mgr.Add(csiRunnable{manager.RunnableFunc(func(ctx context.Context) error {
 		// CSI RPCs read CRs through the manager's cache; wait for sync so
 		// early kubelet/sidecar calls don't race a cold cache.
 		if !mgr.GetCache().WaitForCacheSync(ctx) {
@@ -541,7 +574,7 @@ func serveCSI(mgr ctrl.Manager, socket string, identity *csi.Identity, controlle
 			return csi.Serve(ctx, socket, identity, controller, nil)
 		}
 		return csi.Serve(ctx, socket, identity, nil, node)
-	}))
+	})})
 	if err != nil {
 		setupLog.Error(err, "unable to add CSI server to manager")
 		os.Exit(1)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -27,9 +27,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 )
+
+func TestCSIServerRunsOnEveryReplica(t *testing.T) {
+	// Under leader election (#132) the CSI server must not wait for the
+	// Lease: each pod's sidecars reach the driver over the pod-local
+	// socket, so a standby whose gRPC server never comes up would strand
+	// its sidecars the moment one of them wins its own lease.
+	var r manager.LeaderElectionRunnable = csiRunnable{}
+	if r.NeedLeaderElection() {
+		t.Fatal("csiRunnable must opt out of leader election")
+	}
+}
 
 func TestTransientAPIError(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Implements the opt-in controller HA mode proposed in #132: `replicaCount > 1` runs warm-standby controller replicas, cutting failover from a full Recreate reschedule (minutes if the node is gone) to lease expiry (~15s).

## Values

```yaml
replicaCount: 1    # >1 auto-enables leader election, RollingUpdate, and a PDB
leaderElection:
  enabled: false   # force election at a single replica; cannot disable it above one
  id: ""           # Lease name; empty = release-scoped controller name
```

Leader election derives from the values (same shape as tuppr), so the `replicaCount: 3` + no-election footgun cannot happen: `replicaCount > 1` always elects, and `leaderElection.enabled` can only add election at one replica, never remove it. The single-replica default renders byte-for-byte unchanged, including its zero-lease RBAC.

## Design

- **Manager**: new `--leader-elect` / `--leader-election-id` / `--leader-election-namespace` flags; election is gated to controller mode so the flag can never serialize the agent DaemonSet onto one Lease. `LeaderElectionReleaseOnCancel` gives fast graceful handoff (nothing runs after `mgr.Start` returns in controller mode).
- **CSI server runs on every replica**: `mgr.Add` defaults plain Runnables into the leader-election group, so the CSI runnable explicitly opts out. Each pod's sidecars hold their own Leases and reach the driver over the pod-local socket — which is also why the in-process `allocMu` stays sufficient across replicas: CreateVolume is only ever driven by the single active provisioner.
- **Sidecars**: `--leader-election` flips with the derived state; each elects independently. Lease names (driver-derived per sidecar, release-scoped for the manager) cannot collide across a multi-release install.
- **Chart**: RollingUpdate replaces Recreate only when electing (Recreate + LE is contradictory), Lease CRUD is added to the controller ClusterRole only when electing, and a `PodDisruptionBudget` (`maxUnavailable: 1`) renders only at `replicaCount > 1`.
- Reconcilers start on lease acquisition with a fresh initial list and `UsePriorityQueue: false` stays global, so the #122 startup-starvation guarantee carries over to leader handoff.

## Verification

Ran two `bin/miroir --mode=controller --leader-elect` instances against an envtest kube-apiserver (1.36) with the chart CRDs:

- One instance acquired the Lease and started the membership + tie-breaker reconcilers; the standby ran none but served full CSI on its socket (GetPluginInfo/Probe/ControllerGetCapabilities answered, probed with a gRPC client speaking what a sidecar speaks).
- SIGTERM on the leader: standby acquired and had workers running in **~150ms** (release-on-cancel).
- SIGKILL on the leader: next standby acquired in **~17.5s**, matching the lease-expiry prediction.
- `--leader-elect` out-of-cluster without a namespace fails fast with a clear error; the default no-election run creates no Lease and starts reconcilers immediately.

Also: golangci-lint clean, `go test ./...` green, helm lint clean, 86/86 helm-unittest passing, README/schema regenerated.

Closes #132
