### PR TITLE
ci: run workflows on ubuntu-26.04 runners

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   e2e:
     name: E2E (kind, local backend)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   golangci-lint:
     name: Go Lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -61,7 +61,7 @@ jobs:
 
   helm-lint:
     name: Helm Lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   versions:
     name: Versions
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     outputs:
@@ -117,7 +117,7 @@ jobs:
     name: Helm
     needs: [release-controller, release-agent]
     if: ${{ github.event_name == 'release' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   renovate:
     name: Renovate
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   stale:
     name: Stale
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ env:
 jobs:
   test:
     name: Go Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -63,7 +63,7 @@ jobs:
 
   helm-unittest:
     name: Helm Unit Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Bumps every workflow job from `ubuntu-24.04` to `ubuntu-26.04` (10 jobs across 7 workflows).

## Notes

- The 26.04 x64/arm images are in [public preview](https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/) as of 2026-06-11, so longer queue times are possible while GitHub balances capacity. Reverting is a one-line change per job if that bites.
- Investigated for #125 but does **not** resolve it: the 26.04 image ships kernel `7.0.0-1007-azure`, and DRBD 9 is still out-of-tree (LINBIT is upstreaming DRBD 9.3, optimistically landing in Linux 7.2, ~Sept/Oct 2026). Any in-tree `drbd.ko` on the runner remains the 8.4 driver, which doesn't speak the v9 genl API, so the DKMS build remains the only CI path to replicated coverage for now. If DKMS-in-CI is attempted, `drbd-dkms` compat with kernel 7.0 needs checking first.