### PR TITLE
ci(e2e): matrix the e2e job over local and conformance suites

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,9 +24,25 @@ permissions:
 
 jobs:
   e2e:
-    name: E2E (kind, local backend)
+    name: E2E (${{ matrix.suite }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Go e2e specs (lifecycle, placement, block) on miroir-local.
+          - suite: local
+            task: e2e-run
+            timeout: 20
+            disk: 10G
+          # Upstream Kubernetes external-storage suite on miroir-local.
+          # Bigger backing device: parallel specs provision many volumes
+          # and the controller's overcommit guard counts virtual size.
+          - suite: conformance
+            task: e2e-conformance
+            timeout: 45
+            disk: 40G
     permissions:
       contents: read
     steps:
@@ -69,7 +85,8 @@ jobs:
       # Both builds run concurrently against the same BuildKit daemon, which
       # dedupes the shared Go builder stage in flight — the agent's Debian
       # layer pull overlaps the compile. Distinct cache scopes: concurrent
-      # cache-to writes to one scope evict each other.
+      # cache-to writes to one scope evict each other, so only the local
+      # leg writes back; the conformance leg reads the same scopes.
       - name: Build controller image
         id: controller-image
         background: true
@@ -81,7 +98,7 @@ jobs:
           tags: miroir-controller:e2e
           build-args: GO_VERSION=${{ steps.tools.outputs.go }}
           cache-from: type=gha,scope=e2e-controller
-          cache-to: type=gha,mode=max,scope=e2e-controller
+          cache-to: ${{ matrix.suite == 'local' && 'type=gha,mode=max,scope=e2e-controller' || '' }}
 
       - name: Build agent image
         id: agent-image
@@ -94,7 +111,7 @@ jobs:
           tags: miroir-agent:e2e
           build-args: GO_VERSION=${{ steps.tools.outputs.go }}
           cache-from: type=gha,scope=e2e-agent
-          cache-to: type=gha,mode=max,scope=e2e-agent
+          cache-to: ${{ matrix.suite == 'local' && 'type=gha,mode=max,scope=e2e-agent' || '' }}
 
       - wait: [kind, controller-image, agent-image]
 
@@ -105,9 +122,20 @@ jobs:
 
       - name: Provision (loop device, snapshot stack, helm install)
         run: mise run e2e-provision
+        env:
+          MIROIR_E2E_DISK_SIZE: ${{ matrix.disk }}
 
-      - name: Run e2e specs (miroir-local / lvmthin / replicas:1)
-        run: mise run e2e-run
+      - name: Cache conformance test binaries
+        if: matrix.suite == 'conformance'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: test/conformance/.bin
+          key: conformance-bin-${{ hashFiles('.mise/config.toml') }}
+
+      - name: Run ${{ matrix.suite }} suite
+        run: mise run "$TASK"
+        env:
+          TASK: ${{ matrix.task }}
 
       - name: Diagnostics
         if: failure()

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -127,7 +127,7 @@ snap_ver="v8.6.0"
 # Back the lvmthin VG with a loop device on a sparse file in the node; the
 # agent's Setup() builds the PV/VG/thin-pool on it.
 echo "==> seeding loop-backed block device on $node"
-docker exec "$node" sh -c '
+docker exec -e DISK_SIZE="${MIROIR_E2E_DISK_SIZE:-10G}" "$node" sh -c '
   set -e
   modprobe dm_thin_pool 2>/dev/null || true
   modprobe loop 2>/dev/null || true
@@ -136,7 +136,7 @@ docker exec "$node" sh -c '
   # kind nodes run no udev and ship no /run/lvm; the agent hostPath-mounts both.
   mkdir -p /run/udev /run/lvm
   mkdir -p /var/lib/miroir-e2e
-  [ -f /var/lib/miroir-e2e/disk.img ] || truncate -s 10G /var/lib/miroir-e2e/disk.img
+  [ -f /var/lib/miroir-e2e/disk.img ] || truncate -s "$DISK_SIZE" /var/lib/miroir-e2e/disk.img
   losetup -j /var/lib/miroir-e2e/disk.img | grep -q . || losetup -f /var/lib/miroir-e2e/disk.img
 '
 device="$(docker exec "$node" losetup -j /var/lib/miroir-e2e/disk.img -O NAME -n | tr -d ' ')"
@@ -165,6 +165,11 @@ helm upgrade --install miroir charts/miroir \
 description = "Run the Go e2e specs against the provisioned kind cluster"
 env = { KUBECONFIG = "{{config_root}}/bin/e2e/kubeconfig" }
 run = "go test -tags e2e ./test/e2e/ -v -ginkgo.v -timeout 20m"
+
+[tasks.e2e-conformance]
+description = "Run the upstream external-storage conformance suite against the provisioned kind cluster"
+env = { KUBECONFIG = "{{config_root}}/bin/e2e/kubeconfig" }
+run = "TESTDRIVER=testdriver-local.yaml ./test/conformance/run.sh"
 
 [tasks.e2e-diagnostics]
 description = "Dump kind cluster state for debugging a failed e2e"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -508,9 +508,8 @@ url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146735"
 provenance = "cosign"
 
 [tools.yq."platforms.macos-arm64"]
-checksum = "sha256:b4ba1ecce3c47f00803f4f964de38394326c7a32eb6540616e04fb2935a0f08d"
-url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_amd64"
-url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146744"
+checksum = "sha256:877de31753a4dd2401aa048937aa9a7fc4d5f6ce858cf31508c5802954297213"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_arm64"
 provenance = "cosign"
 
 [tools.yq."platforms.macos-x64"]

--- a/test/conformance/run.sh
+++ b/test/conformance/run.sh
@@ -5,6 +5,7 @@
 #   ./test/conformance/run.sh                 # parallel-safe set
 #   SKIP='\[Disruptive\]' ./run.sh PROCS=1    # include [Serial] specs
 #   FOCUS='.*snapshot.*' ./run.sh             # narrow down
+#   TESTDRIVER=testdriver-local.yaml ./run.sh # kind / miroir-local
 #
 # The e2e.test/ginkgo binaries are fetched to match the server version
 # and cached under .bin/.
@@ -22,6 +23,7 @@ if [ ! -x "$bin/e2e.test" ]; then
 fi
 
 KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
+TESTDRIVER=${TESTDRIVER:-testdriver.yaml}
 FOCUS=${FOCUS:-'miroir.home-operations.com'}
 # Disruptive specs restart kubelet; Serial ones assume exclusive use of
 # the cluster; the volumeMode host check nsenters the node and runs sh,
@@ -33,6 +35,6 @@ mkdir -p report
 exec "$bin/ginkgo" -procs="$PROCS" \
     -focus="$FOCUS" -skip="$SKIP" -timeout=3h \
     "$bin/e2e.test" -- \
-    -storage.testdriver="$PWD/testdriver.yaml" \
+    -storage.testdriver="$PWD/$TESTDRIVER" \
     -kubeconfig="$KUBECONFIG" \
     -report-dir="$PWD/report"

--- a/test/conformance/testdriver-local.yaml
+++ b/test/conformance/testdriver-local.yaml
@@ -1,0 +1,30 @@
+# Driver definition for the kind e2e: miroir-local (lvmthin, replicas:1),
+# where volumes are pinned to their node — hence singleNodeVolume: true.
+StorageClass:
+  FromExistingClassName: miroir-local
+SnapshotClass:
+  FromExistingClassName: miroir-snap
+DriverInfo:
+  Name: miroir.home-operations.com
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 10Gi
+  SupportedFsType:
+    ext4: {}
+  Capabilities:
+    persistence: true
+    block: true
+    exec: true
+    fsGroup: true
+    multipods: true
+    controllerExpansion: true
+    nodeExpansion: true
+    onlineExpansion: true
+    offlineExpansion: true
+    snapshotDataSource: true
+    pvcDataSource: false
+    topology: true
+    singleNodeVolume: true
+    RWX: false
+    readWriteOncePod: true
+    capacity: false


### PR DESCRIPTION
Restructures the E2E workflow into a matrix over test types:

- **local** — the existing Go e2e specs (lifecycle, placement, block), unchanged.
- **conformance** — the upstream Kubernetes external-storage suite (`test/conformance/run.sh`) now also runs in kind against `miroir-local`, via a new `testdriver-local.yaml` (`singleNodeVolume: true`) and `mise run e2e-conformance`. The `e2e.test`/`ginkgo` binaries are cached; the backing loop device grows to 40G (sparse) so parallel specs clear the overcommit guard.

Notes:

- No replicated (DRBD) leg: DRBD9 resource names and minors are kernel-global (`drbd_find_resource` walks one global list; a second `new-resource` from another netns returns the existing object). Multi-node kind shares one kernel, so two agents can never form a 2-replica volume — option 2 in #125 is off the table on any container-based runner; real replicated CI needs VMs. Details in #125.
- The required-status name changes from `E2E (kind, local backend)` to `E2E (local)` / `E2E (conformance)` — branch protection may need updating.
- Image build cache: only the local leg writes the gha cache scopes; the conformance leg reads them.

Refs #125