### PR TITLE
fix: repair split-brain auto-recovery and activated-latch timing (#141)

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -493,16 +493,18 @@ func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string,
 	}
 }
 
-// recoverSplitBrain reacts to a StandAlone split-brain. A volume that was
-// never activated holds no data, so it applies ResolveSplitBrain to self-heal
-// (issue #139: a fresh replicated volume that comes up split-brain otherwise
-// loops forever and blocks its consumer). An activated volume may hold data:
-// it logs the manual remedy on the transition edge and is left for an
-// operator. Failures are retried next poll — the split state is never
-// fast-path cached.
+// recoverSplitBrain reacts to a StandAlone split-brain. A volume that never
+// held data holds nothing to lose, so it applies ResolveSplitBrain to
+// self-heal (issue #139: a fresh replicated volume that comes up split-brain
+// otherwise loops forever and blocks its consumer). "Held data" is either
+// Activated (staged for a consumer) or Formatted (carries a filesystem) —
+// Formatted latches before the grow-to-fill step, so a formatted volume whose
+// stage failed at resize is still covered. Such a volume logs the manual
+// remedy on the transition edge and is left for an operator. Failures are
+// retried next poll — the split state is never fast-path cached.
 func (r *VolumeReconciler) recoverSplitBrain(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, res drbd.Resource) {
 	log := ctrl.LoggerFrom(ctx)
-	if vol.Status.Activated {
+	if vol.Status.Activated || vol.Status.Formatted {
 		if !vol.Status.PerNode[r.NodeName].SplitBrain {
 			log.Error(errSplitBrain,
 				"manual resolution required (drbdadm connect --discard-my-data on the losing node)",
@@ -510,7 +512,7 @@ func (r *VolumeReconciler) recoverSplitBrain(ctx context.Context, vol *miroirv1a
 		}
 		return
 	}
-	log.Info("auto-recovering split-brain on never-activated volume", "volume", vol.Name)
+	log.Info("auto-recovering split-brain on never-written volume", "volume", vol.Name)
 	if err := r.DRBD.ResolveSplitBrain(ctx, res); err != nil {
 		log.Error(err, "split-brain auto-recovery failed", "volume", vol.Name)
 	}

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1747,9 +1747,9 @@ func splitBrainSetup(t *testing.T, nodeName, peerNodeID string, activated bool) 
 func TestReconcileSplitBrainWinnerReconnectsWhenNeverActivated(t *testing.T) {
 	r, fe := splitBrainSetup(t, nodeKharkiv, "1", false)
 	reconcile(t, r, volPvc1)
+	fe.calledWith(t, "drbdadm disconnect pvc-1")
 	fe.calledWith(t, "drbdadm connect pvc-1")
 	fe.notCalledWith(t, "discard-my-data")
-	fe.notCalledWith(t, "drbdadm disconnect")
 }
 
 // The losing leg (paris, node id 1) discards its own generation so it
@@ -1765,6 +1765,24 @@ func TestReconcileSplitBrainLoserDiscardsWhenNeverActivated(t *testing.T) {
 // is left for an operator.
 func TestReconcileSplitBrainNoAutoRecoveryWhenActivated(t *testing.T) {
 	r, fe := splitBrainSetup(t, nodeParis, "0", true)
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "discard-my-data")
+	fe.notCalledWith(t, "drbdadm disconnect")
+}
+
+// A formatted-but-not-activated volume (e.g. a clone whose stage failed at
+// grow-to-fill after mkfs/mount) carries data and must not be auto-discarded,
+// even though Activated is still false.
+func TestReconcileSplitBrainNoAutoRecoveryWhenFormatted(t *testing.T) {
+	r, fe := splitBrainSetup(t, nodeParis, "0", false)
+	var v miroirv1alpha1.MiroirVolume
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, &v); err != nil {
+		t.Fatal(err)
+	}
+	v.Status.Formatted = true
+	if err := r.Status().Update(t.Context(), &v); err != nil {
+		t.Fatal(err)
+	}
 	reconcile(t, r, volPvc1)
 	fe.notCalledWith(t, "discard-my-data")
 	fe.notCalledWith(t, "drbdadm disconnect")

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -160,20 +160,18 @@ func (n *Node) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequ
 		return nil, err
 	}
 
-	// devicePath passed (UpToDate, not split) and the volume is about to be
-	// written (fs write probe or block publish). Latch it activated, which
-	// closes split-brain auto-recovery — that only runs on a volume that
-	// never held data.
-	if err := n.markActivated(ctx, vol); err != nil {
-		return nil, status.Errorf(codes.Internal, "record activated flag: %v", err)
-	}
-
 	if req.GetVolumeCapability().GetBlock() != nil {
 		// Nothing to mount for raw block, but the device node must exist —
 		// an LV present in metadata yet not activated would otherwise fail
 		// later at publish with a confusing ENOENT.
 		if _, err := os.Stat(dev); err != nil {
 			return nil, status.Errorf(codes.Unavailable, "block device %s not ready: %v", dev, err)
+		}
+		// Stage succeeded: publish will hand the device to a consumer that may
+		// write. Latch activated so split-brain auto-recovery, which discards a
+		// leg, no longer touches this volume.
+		if err := n.markActivated(ctx, vol); err != nil {
+			return nil, status.Errorf(codes.Internal, "record activated flag: %v", err)
 		}
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
@@ -257,6 +255,14 @@ func (n *Node) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequ
 		if _, err := resizer.Resize(dev, req.GetStagingTargetPath()); err != nil {
 			return nil, status.Errorf(codes.Internal, "grow filesystem on %s: %v", dev, err)
 		}
+	}
+	// Stage fully succeeded (mkfs + mount + grow): the volume now carries a
+	// filesystem and a consumer may write. Latch activated only here, never on
+	// a stage that failed the write probe or mkfs — a volume that never
+	// completed staging holds no data and must stay eligible for split-brain
+	// auto-recovery.
+	if err := n.markActivated(ctx, vol); err != nil {
+		return nil, status.Errorf(codes.Internal, "record activated flag: %v", err)
 	}
 	return &csi.NodeStageVolumeResponse{}, nil
 }

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -666,26 +666,30 @@ func isWinner(r Resource) bool {
 }
 
 // ResolveSplitBrain runs DRBD's documented split-brain recovery around the
-// seed winner: the winner (lowest diskful node id, matching seedGI) leaves
-// StandAlone as the survivor; every other diskful leg disconnects and
-// reconnects with --discard-my-data, becoming SyncTarget. A diskless
-// tie-breaker only reconnects. Because the winner is derived the same way on
-// every node, the agents converge without coordinating.
+// seed winner: every leg disconnects, then the winner (lowest diskful node
+// id, matching seedGI) and the diskless tie-breaker reconnect as survivors
+// while every other diskful leg reconnects with --discard-my-data, becoming
+// SyncTarget. Because the winner is derived the same way on every node, the
+// agents converge without coordinating.
 //
 // --discard-my-data drops the loser leg's generation, so this is only valid
 // on a volume that never held data; the caller gates on that (see
 // VolumeReconciler.recoverSplitBrain).
 func (d *Driver) ResolveSplitBrain(ctx context.Context, r Resource) error {
+	// Disconnect first, on every role. A plain connect aborts (exit 10,
+	// "Device has a net-config") on any peer that already has one, and after a
+	// split-brain the local node holds a net-config toward at least one peer
+	// (StandAlone or Connecting); --discard-my-data is likewise only honored on
+	// a connect out of StandAlone. Clearing all connections first makes the
+	// connect below well-defined. A resource with nothing to disconnect errors
+	// here harmlessly, so the result is ignored.
+	_, _ = d.adm(ctx, "disconnect", r.Name)
+
 	if r.LocalDiskless || isWinner(r) {
 		if _, err := d.adm(ctx, "connect", r.Name); err != nil {
 			return fmt.Errorf("connect %s: %w", r.Name, err)
 		}
 		return nil
-	}
-	// --discard-my-data is honored only on a connect out of StandAlone, so
-	// disconnect first.
-	if _, err := d.adm(ctx, "disconnect", r.Name); err != nil {
-		return fmt.Errorf("disconnect %s: %w", r.Name, err)
 	}
 	if _, err := d.adm(ctx, "connect", "--discard-my-data", r.Name); err != nil {
 		return fmt.Errorf("connect --discard-my-data %s: %w", r.Name, err)

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -144,13 +144,15 @@ func fakeMknod(string, uint32, int) error { return nil }
 func TestResolveSplitBrainWinnerReconnects(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	// kharkiv is node id 0 — the seed winner and the survivor.
+	// kharkiv is node id 0 — the seed winner and the survivor. It disconnects
+	// first (a bare connect aborts on a peer that already has a net-config)
+	// then reconnects without discarding data.
 	if err := d.ResolveSplitBrain(context.Background(), testResource(nodeKharkiv)); err != nil {
 		t.Fatalf("ResolveSplitBrain: %v", err)
 	}
+	fe.calledWith(t, "drbdadm disconnect pvc-1")
 	fe.calledWith(t, "drbdadm connect pvc-1")
 	fe.notCalledWith(t, "discard-my-data")
-	fe.notCalledWith(t, "disconnect")
 }
 
 func TestResolveSplitBrainLoserDiscards(t *testing.T) {
@@ -173,6 +175,7 @@ func TestResolveSplitBrainDisklessReconnects(t *testing.T) {
 	if err := d.ResolveSplitBrain(context.Background(), r); err != nil {
 		t.Fatalf("ResolveSplitBrain: %v", err)
 	}
+	fe.calledWith(t, "drbdadm disconnect pvc-1")
 	fe.calledWith(t, "drbdadm connect pvc-1")
 	fe.notCalledWith(t, "discard-my-data")
 }


### PR DESCRIPTION
Fixes #141. Follow-up to #139: the 0.4.5 auto-recovery never fired successfully, and a failed stage could permanently disable it on an empty volume.

Bug 1 — winner branch of ResolveSplitBrain
The winner/diskless branch issued a bare `drbdadm connect <res>`, which aborts (exit 10, "Device has a net-config") on the first peer that already has one. In a birth-split the survivor always has a configured peer, so the branch failed every reconcile poll and never reconnected the StandAlone peer.

Fix: disconnect first on every role, then reconnect (loser adds `--discard-my-data`). The leading disconnect's result is ignored — a resource with nothing to disconnect errors harmlessly, and `--discard-my-data` is only honored on a connect out of StandAlone.

Bug 2 — markActivated latched on a failed stage
`markActivated` (the one-way latch that marks a volume as possibly data-bearing and disables auto-recovery) ran after `devicePath()` passed but before the write probe / mkfs / mount. A transient window let a stage pass the split check, latch activated, then fail the write probe on a quorum-frozen device — classifying a never-written volume as data-bearing for good.

Fix: latch only on full stage success — before the block-path return, and at the end of the mount path after mkfs + mount + grow.

Recovery gate
`recoverSplitBrain` now gates on `Activated || Formatted`. `Formatted` latches before the grow-to-fill step in every filesystem sub-path, so a formatted volume whose stage fails at resize is still treated as data-bearing and never auto-discarded.

Tests
- `ResolveSplitBrain` winner/diskless tests updated to expect disconnect-then-connect; loser unchanged.
- `TestReconcileSplitBrainNoAutoRecoveryWhenFormatted` covers the `Formatted` gate.

Verification: gofmt, `GOOS=linux go vet`, and `internal/drbd` + `internal/agent` unit tests pass; `internal/csi` compiles for Linux. Not exercisable end-to-end here (no DRBD cluster) — the smoke.sh delete→recreate check and the reporter's cluster are the runtime validation.