### PR TITLE
fix: replace day0 seeding with a connect-first birth generation (#139)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ ENTRYPOINT ["/usr/local/bin/miroir"]
 # zfsutils-linux lives in contrib. Version notes (trixie, no backports):
 #   - drbd-utils 9.22: every CLI/JSON surface miroir uses predates it
 #     (adjust --skip-disk 8.9.7, status --json 8.9.8, quorum 8.9.11;
-#     peer_devices/percent-in-sync/out-of-sync verified in the v9.22.0
-#     source). GI seeding depends on drbdmeta CLI behavior — re-validate
-#     with smoke.sh + conformance on real DRBD (the kind e2e exercises
-#     the local backend only) before shipping a base bump.
+#     peer_devices/percent-in-sync/out-of-sync/peer-disk-state verified
+#     in the v9.22.0 source). The birth generation depends on drbdadm
+#     new-current-uuid --clear-bitmap behavior — re-validate with
+#     smoke.sh + conformance on real DRBD (the kind e2e exercises the
+#     local backend only) before shipping a base bump.
 #   - zfs userland 2.3 against the siderolabs/zfs 2.4 module: userland
 #     older than the module is the supported direction, and miroir only
 #     uses ancient ops (create -V/snapshot/clone/promote/volsize).

--- a/internal/agent/kmsg.go
+++ b/internal/agent/kmsg.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// kmsgReadCap bounds the drain loop: /dev/kmsg yields one record per read
+// and a busy logger could otherwise keep the loop alive indefinitely.
+const kmsgReadCap = 8192
+
+// captureKmsg returns the last limit kernel-log records mentioning
+// resource. The DRBD handshake verdict ("Split-Brain detected",
+// "Unrelated data, aborting") is kernel-log only — the status API reports
+// just the resulting StandAlone — so this is the one place the actual
+// failure reason is visible. The agent runs privileged with the host /dev
+// mounted, so /dev/kmsg is readable; any failure returns nil and the
+// caller degrades to logging without the kernel context.
+func captureKmsg(path, resource string, limit int) []string {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	// Drain everything buffered: /dev/kmsg returns one record per read and
+	// EAGAIN once caught up; EPIPE marks a record overwritten mid-read and
+	// the next read continues. A regular file (tests) arrives in chunks
+	// holding several newline-separated records.
+	var raw strings.Builder
+	buf := make([]byte, 8192)
+	for range kmsgReadCap {
+		n, err := f.Read(buf)
+		if n > 0 {
+			raw.Write(buf[:n])
+			if buf[n-1] != '\n' {
+				raw.WriteByte('\n')
+			}
+		}
+		if err != nil {
+			if errors.Is(err, syscall.EPIPE) {
+				continue
+			}
+			break // EAGAIN (drained), EOF, or anything else
+		}
+	}
+
+	var lines []string
+	for line := range strings.SplitSeq(strings.TrimSuffix(raw.String(), "\n"), "\n") {
+		if strings.Contains(line, resource) {
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) > limit {
+		lines = lines[len(lines)-limit:]
+	}
+	return lines
+}

--- a/internal/agent/kmsg_test.go
+++ b/internal/agent/kmsg_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCaptureKmsgFiltersAndCaps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kmsg")
+	var b strings.Builder
+	b.WriteString("6,100,1;drbd pvc-other: Connection established\n")
+	for i := range 40 {
+		fmt.Fprintf(&b, "6,%d,1;drbd pvc-1: record %d\n", 200+i, i)
+	}
+	b.WriteString("6,300,1;drbd pvc-1: Split-Brain detected but unresolved, dropping connection!\n")
+	if err := os.WriteFile(path, []byte(b.String()), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := captureKmsg(path, "pvc-1", 30)
+	if len(lines) != 30 {
+		t.Fatalf("want 30 lines (cap), got %d", len(lines))
+	}
+	for _, l := range lines {
+		if strings.Contains(l, "pvc-other") {
+			t.Fatalf("foreign resource leaked through the filter: %q", l)
+		}
+	}
+	if last := lines[len(lines)-1]; !strings.Contains(last, "Split-Brain detected") {
+		t.Fatalf("the newest record must survive the cap, got %q", last)
+	}
+}
+
+func TestCaptureKmsgMissingFile(t *testing.T) {
+	if lines := captureKmsg(filepath.Join(t.TempDir(), "absent"), "pvc-1", 30); lines != nil {
+		t.Fatalf("missing file must yield nil, got %v", lines)
+	}
+}

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -64,6 +64,9 @@ type VolumeReconciler struct {
 	// serialization is controller-runtime's guarantee; the storage CLIs
 	// are cross-resource-safe and minor allocation holds its own lock.
 	Workers int
+	// KmsgPath overrides /dev/kmsg for the split-brain kernel-log capture
+	// (tests point it at a plain file).
+	KmsgPath string
 
 	// realized caches the last fully realized state per volume so the
 	// steady-state poll only re-execs `drbdsetup status` instead of the
@@ -148,12 +151,11 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	r.dropRealized(vol.Name)
 
 	var dev string
-	var forceFullSync bool
 	var err error
 	if !localDiskless {
 		// Realize: create (or grow) the backing device — a CoW clone when the
 		// volume restores from a snapshot.
-		dev, forceFullSync, err = r.realizeBacking(ctx, vol, vol.Spec.Replicas[idx].FullSync)
+		dev, err = r.realizeBacking(ctx, vol, vol.Spec.Replicas[idx].FullSync)
 		if err != nil {
 			return ctrl.Result{}, r.reportError(ctx, vol, err)
 		}
@@ -217,8 +219,18 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				"volume", vol.Name, "error", err)
 		}
 	}
-	resource := drbdResource(vol, r.NodeName, dev, minor, localDiskless, forceFullSync, discardGranularity)
+	resource := drbdResource(vol, r.NodeName, dev, minor, localDiskless, discardGranularity)
 	if err := r.DRBD.Apply(ctx, resource); err != nil {
+		return ctrl.Result{}, r.reportError(ctx, vol, err)
+	}
+	st, err := r.DRBD.Status(ctx, vol.Name)
+	if err != nil {
+		return ctrl.Result{}, r.reportError(ctx, vol, err)
+	}
+	// Birth generation, ordered before growIfCoordinator so resize never
+	// runs against a both-Inconsistent device; status is re-read so this
+	// same pass proceeds against UpToDate legs.
+	if st, err = r.mintBirthUUID(ctx, vol, resource, st, localDiskless); err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
 	// Online growth: once every peer's backing device is at the new size
@@ -227,24 +239,12 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// status until then — the CSI expansion wait keys on status, and the
 	// filesystem must not grow against a still-small DRBD device. A
 	// diskless tie-breaker must never be the resize coordinator.
-	st, err := r.DRBD.Status(ctx, vol.Name)
-	if err != nil {
-		return ctrl.Result{}, r.reportError(ctx, vol, err)
-	}
 	reportSize, requeue, err := r.growIfCoordinator(ctx, vol, st)
 	if err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
 	connected := diskfulPeersConnected(st, vol, r.NodeName)
-	// The losing leg of a split never parks StandAlone locally — it sits
-	// Connecting while the survivor refuses the handshake — so its only
-	// signal that it must discard is a peer's reported split-brain (issue
-	// #144). Gated on !connected so a stale peer report cannot churn a
-	// healthy volume.
-	splitActive := st.SplitBrain || (!connected && peerReportedSplitBrain(vol, r.NodeName))
-	if splitActive {
-		r.recoverSplitBrain(ctx, vol, resource, st.SplitBrain)
-	}
+	splitActive := r.handleSplitBrain(ctx, vol, resource, st, connected)
 	diskFailed := diskFailedLatch(vol, r.NodeName, st, localDiskless)
 	if !localDiskless {
 		recordVolumeMetrics(vol.Name, miroirReplicaView{
@@ -342,7 +342,11 @@ func statusEqual(a, b drbd.Status) bool {
 		a.ResyncPercent == b.ResyncPercent &&
 		a.Quorum == b.Quorum &&
 		a.OutOfSyncKiB == b.OutOfSyncKiB &&
-		maps.Equal(a.PeerConnected, b.PeerConnected)
+		maps.Equal(a.PeerConnected, b.PeerConnected) &&
+		// A peer disk-state flip (DUnknown → Inconsistent at birth) can be
+		// the only change in a pass — without it the winner's fingerprint
+		// stays valid and the birth-generation trigger never re-runs.
+		maps.Equal(a.PeerDiskState, b.PeerDiskState)
 }
 
 func (r *VolumeReconciler) storeRealized(gen int64, name string, st drbd.Status, replicated bool) {
@@ -431,71 +435,42 @@ func peerBackingsGrown(vol *miroirv1alpha1.MiroirVolume, self string) bool {
 	return true
 }
 
-// wipedBacking reports the node-wipe signature: this node's status slot
-// says the backing was realized, but the device is gone and so is the
-// local seed marker (a reinstall takes both). Re-seeding the day0 GI
-// would pose the empty recreated device as the peers' identical twin and
-// the partial resync would miss every write since creation — the caller
-// forces the just-created-metadata path so the first handshake
-// full-syncs this leg instead. Cheap steady-state: the marker check
-// short-circuits once Apply has seeded.
-func (r *VolumeReconciler) wipedBacking(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) (bool, error) {
-	if vol.Spec.DRBD == nil || r.DRBD.Seeded(vol.Name) ||
-		!vol.Status.PerNode[r.NodeName].DeviceCreated {
-		return false, nil
-	}
-	exists, err := r.Backend.Exists(ctx, vol.Name)
-	if err != nil {
-		return false, err
-	}
-	return !exists, nil
-}
-
 // realizeBacking creates the backing device: fresh, or cloned from a
-// snapshot for restores. Clones are byte-identical on every replica, so
-// the day0 GI seed keeps restored volumes from resyncing. forceFullSync
-// reports the node-wipe signature (wipedBacking): the recreated device
-// must join as a full SyncTarget, never re-seed the day0 GI.
-func (r *VolumeReconciler) realizeBacking(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, fullSync bool) (dev string, forceFullSync bool, err error) {
-	if forceFullSync, err = r.wipedBacking(ctx, vol); err != nil {
-		return "", false, err
-	}
+// snapshot for restores. Clones are byte-identical on every replica and
+// carry the source's live DRBD metadata, so restored legs connect with
+// identical inherited generations and skip the resync. A wiped node's
+// recreated device gets fresh just-created metadata and full-syncs at the
+// first handshake — no special-casing needed.
+func (r *VolumeReconciler) realizeBacking(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, fullSync bool) (dev string, err error) {
 	if vol.Spec.Source == nil || fullSync {
 		// A FullSync joiner never clones, even on a restored volume: its
 		// node holds no source snapshot, and its content arrives over the
 		// wire as a full SyncTarget regardless of what the backing holds.
-		dev, err = r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
-		return dev, forceFullSync, err
+		return r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
 	}
 	// The backing is cloned once and survives reboots; the source snapshot
 	// may be gone by then, so recover an existing device without it.
 	if exists, err := r.Backend.Exists(ctx, vol.Name); err != nil {
-		return "", false, err
+		return "", err
 	} else if exists {
-		dev, err = r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
-		return dev, forceFullSync, err
+		return r.Backend.Create(ctx, vol.Name, vol.Spec.SizeBytes)
 	}
 	snap := &miroirv1alpha1.MiroirSnapshot{}
 	if err := r.Get(ctx, types.NamespacedName{Name: vol.Spec.Source.SnapshotName}, snap); err != nil {
-		return "", false, err
+		return "", err
 	}
-	dev, err = r.Backend.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name)
-	return dev, forceFullSync, err
+	return r.Backend.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name)
 }
 
 // drbdResource maps the CRD desired state to a render input. Entries the
 // membership reconciler has not completed yet (no address) are left out:
 // rendering them would produce a config DRBD cannot parse, and the peer
 // cannot connect before completion anyway.
-func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string, minor int32, localDiskless, forceFullSync bool, discardGranularity int64) drbd.Resource {
+func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string, minor int32, localDiskless bool, discardGranularity int64) drbd.Resource {
 	peers := make([]drbd.Peer, 0, len(vol.Spec.Replicas))
-	skipSeed := forceFullSync
 	for _, rep := range vol.Spec.Replicas {
 		if rep.Address == "" {
 			continue
-		}
-		if rep.Node == localNode && rep.FullSync {
-			skipSeed = true
 		}
 		peers = append(peers, drbd.Peer{
 			Node:     rep.Node,
@@ -513,7 +488,6 @@ func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string,
 		LocalDisk:     localDisk,
 		LocalDiskless: localDiskless,
 		Secret:        vol.Spec.DRBD.SharedSecret,
-		SkipSeed:      skipSeed,
 		// Latched failed: render adjust --skip-disk so the failing disk is
 		// not re-attached. Read from prior status, so it lags the detach by
 		// one reconcile. Cleared by a replica re-add (removal drops the slot).
@@ -525,9 +499,10 @@ func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string,
 
 // recoverSplitBrain reacts to a split-brain, seen locally (a StandAlone
 // connection) or reported by a peer's status slot. A volume that never held
-// data holds nothing to lose, so it applies ResolveSplitBrain to self-heal
-// (issue #139: a fresh replicated volume that comes up split-brain otherwise
-// loops forever and blocks its consumer). "Held data" is either Activated
+// data holds nothing to lose, so it applies ResolveSplitBrain to self-heal —
+// the safety net for volumes born under releases whose per-node day0
+// seeding could birth-diverge (issue #139; the birth generation now makes
+// that impossible for new volumes). "Held data" is either Activated
 // (staged for a consumer) or Formatted (carries a filesystem) — Formatted
 // latches before the grow-to-fill step, so a formatted volume whose stage
 // failed at resize is still covered. Such a volume logs the manual remedy on
@@ -555,6 +530,19 @@ func (r *VolumeReconciler) recoverSplitBrain(ctx context.Context, vol *miroirv1a
 	r.recoveryMu.Unlock()
 
 	log := ctrl.LoggerFrom(ctx)
+	// The kernel log carries the handshake's actual verdict ("Split-Brain
+	// detected", "Unrelated data, aborting") — the status API only shows
+	// the resulting StandAlone. Captured before recovery mutates state,
+	// floored with it to once per poll interval.
+	kmsgPath := r.KmsgPath
+	if kmsgPath == "" {
+		kmsgPath = "/dev/kmsg"
+	}
+	if lines := captureKmsg(kmsgPath, vol.Name, 30); len(lines) > 0 {
+		log.Info("kernel log at split-brain detection", "volume", vol.Name, "kmsg", lines)
+	} else {
+		log.V(1).Info("kernel log unreadable at split-brain detection", "volume", vol.Name, "path", kmsgPath)
+	}
 	if vol.Status.Activated || vol.Status.Formatted {
 		if localSplit && !vol.Status.PerNode[r.NodeName].SplitBrain {
 			log.Error(errSplitBrain,
@@ -583,6 +571,69 @@ func peerReportedSplitBrain(vol *miroirv1alpha1.MiroirVolume, self string) bool 
 		}
 	}
 	return false
+}
+
+// mintBirthUUID creates a fresh volume's birth generation and returns the
+// refreshed status. A fresh volume's legs all attach Inconsistent at
+// just-created metadata and wait, connected; the winner then mints the one
+// UUID every leg adopts over the live connections — a single replicated
+// generation cannot birth-diverge (issue #139). A no-op (status returned
+// unchanged) on every leg but the winner's, and on any volume not waiting
+// on birth.
+func (r *VolumeReconciler) mintBirthUUID(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, res drbd.Resource, st drbd.Status, localDiskless bool) (drbd.Status, error) {
+	if !birthInitPending(vol, st, r.NodeName, localDiskless) || !drbd.IsWinner(res) {
+		return st, nil
+	}
+	ctrl.LoggerFrom(ctx).Info("creating birth generation (skip initial sync)", "volume", vol.Name)
+	if err := r.DRBD.InitialUUID(ctx, vol.Name); err != nil {
+		return st, err
+	}
+	return r.DRBD.Status(ctx, vol.Name)
+}
+
+// handleSplitBrain detects an active split and routes it into recovery.
+// The losing leg of a split never parks StandAlone locally — it sits
+// Connecting while the survivor refuses the handshake — so its only signal
+// that it must discard is a peer's reported split-brain (issue #144).
+// Gated on !connected so a stale peer report cannot churn a healthy
+// volume.
+func (r *VolumeReconciler) handleSplitBrain(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, res drbd.Resource, st drbd.Status, connected bool) bool {
+	splitActive := st.SplitBrain || (!connected && peerReportedSplitBrain(vol, r.NodeName))
+	if splitActive {
+		r.recoverSplitBrain(ctx, vol, res, st.SplitBrain)
+	}
+	return splitActive
+}
+
+// birthInitPending reports whether this leg is waiting on the one-time
+// birth generation: a never-written replicated volume whose local disk and
+// every diskful peer's disk sit Inconsistent over established connections.
+// The Activated/Formatted gate means divergent real data can never be
+// declared clean; a FullSync joiner means the volume already has a
+// generation, so this is birth only. Clone restores never qualify — their
+// adopted metadata attaches past Inconsistent.
+func birthInitPending(vol *miroirv1alpha1.MiroirVolume, st drbd.Status, self string, localDiskless bool) bool {
+	if vol.Spec.DRBD == nil || localDiskless {
+		return false
+	}
+	if vol.Status.Activated || vol.Status.Formatted {
+		return false
+	}
+	if st.DiskState != drbd.DiskInconsistent {
+		return false
+	}
+	for _, rep := range vol.Spec.Replicas {
+		if rep.FullSync {
+			return false
+		}
+		if rep.Node == self || rep.Diskless || rep.Address == "" {
+			continue
+		}
+		if !st.PeerConnected[rep.NodeID] || st.PeerDiskState[rep.NodeID] != drbd.DiskInconsistent {
+			return false
+		}
+	}
+	return true
 }
 
 // reconcileRemoval tears down a replica that was removed from

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -614,8 +615,12 @@ func TestReconcile_ResizeRaceWithResyncIsTransient(t *testing.T) {
 type fakeDRBDExec struct {
 	calls      []string
 	statusJSON string
-	responses  map[string]string
-	errOn      map[string]error
+	// statusSeq is consumed first, one entry per `drbdsetup status --json`
+	// call — the birth-generation pass reads status twice (pre/post fire)
+	// and needs different answers. Falls back to statusJSON when drained.
+	statusSeq []string
+	responses map[string]string
+	errOn     map[string]error
 }
 
 func (f *fakeDRBDExec) run(_ context.Context, name string, args ...string) (string, error) {
@@ -625,6 +630,11 @@ func (f *fakeDRBDExec) run(_ context.Context, name string, args ...string) (stri
 		if strings.Contains(line, key) {
 			return "", err
 		}
+	}
+	if strings.HasPrefix(line, "drbdsetup status --json") && len(f.statusSeq) > 0 {
+		out := f.statusSeq[0]
+		f.statusSeq = f.statusSeq[1:]
+		return out, nil
 	}
 	if strings.HasPrefix(line, "drbdsetup status") {
 		return f.statusJSON, nil
@@ -1046,7 +1056,7 @@ func TestRealizeBackingFullSyncJoinerCreatesFresh(t *testing.T) {
 	fb := newFakeBackend()
 	r := &VolumeReconciler{Client: c, NodeName: nodeParis, Backend: fb}
 
-	if _, _, err := r.realizeBacking(t.Context(), v, true); err != nil {
+	if _, err := r.realizeBacking(t.Context(), v, true); err != nil {
 		t.Fatal(err)
 	}
 	if len(fb.fromSnapVol) != 0 {
@@ -1059,8 +1069,8 @@ func TestRealizeBackingFullSyncJoinerCreatesFresh(t *testing.T) {
 
 // A backing device that vanished after this node had realized it (the
 // status slot still says DeviceCreated) is the node-wipe signature: the
-// recreated device must full-sync, never re-seed the day0 GI and pose as
-// the peers' identical twin.
+// recreated device gets fresh just-created metadata and full-syncs at the
+// first handshake instead of posing as the peers' identical twin.
 func TestReconcileWipedNodeForcesFullSync(t *testing.T) {
 	s := newScheme(t)
 	v := vol(volPvc1, nodeKharkiv, nodeParis)
@@ -1870,4 +1880,196 @@ func TestFastPathMissesOnPeerReportedSplitBrain(t *testing.T) {
 
 	reconcile(t, r, volPvc1)
 	fe.calledWith(t, "drbdadm connect --discard-my-data pvc-1")
+}
+
+// --- birth generation ---------------------------------------------------
+
+const (
+	birthReadyJSON = `[{"name":"pvc-1","role":"Secondary",
+		"devices":[{"disk-state":"Inconsistent"}],
+		"connections":[{"peer-node-id":%d,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"Inconsistent"}]}]}]`
+	birthDoneJSON = `[{"name":"pvc-1","role":"Secondary",
+		"devices":[{"disk-state":"UpToDate"}],
+		"connections":[{"peer-node-id":%d,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"UpToDate"}]}]}]`
+)
+
+// birthSetup builds a fresh 2-diskful volume (kharkiv node id 0 = winner,
+// paris node id 1) and a reconciler on nodeName whose kernel answers the
+// queued --json statuses (peerNodeID fills the connection entries).
+func birthSetup(t *testing.T, nodeName string, peerNodeID int, statusSeq ...string) (*VolumeReconciler, *fakeDRBDExec, *miroirv1alpha1.MiroirVolume) {
+	t.Helper()
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = addrParis
+
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
+		"resource \"pvc-1\" {\n    on \""+nodeName+"\" {\n        device minor 1000;\n    }\n}\n",
+	), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	seq := make([]string, len(statusSeq))
+	for i, tmpl := range statusSeq {
+		seq[i] = fmt.Sprintf(tmpl, peerNodeID)
+	}
+	fe := &fakeDRBDExec{statusSeq: seq}
+	if len(seq) > 0 {
+		fe.statusJSON = seq[len(seq)-1] // stable fallback once drained
+	}
+	// The kernel probe (plain, non-json status) must fail or probeMetadata
+	// reads the fallback JSON as "resource attached" and adopts — bypassing
+	// the create-md path a fresh volume must take.
+	fe.errOn = map[string]error{"drbdsetup status " + volPvc1: errors.New("no such resource")}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeName, Backend: newFakeBackend(),
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+	return r, fe, v
+}
+
+// The winner mints the birth generation once every diskful leg sits
+// Inconsistent over established connections, and the same pass proceeds
+// against the resulting UpToDate state.
+func TestReconcileBirthWinnerMintsInitialUUID(t *testing.T) {
+	r, fe, _ := birthSetup(t, nodeKharkiv, 1, birthReadyJSON, birthDoneJSON)
+	reconcile(t, r, volPvc1)
+	// The full fresh path: metadata created and left just-created, then the
+	// one replicated generation minted over the live connections.
+	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
+	fe.notCalledWith(t, "set-gi")
+	fe.calledWith(t, "drbdadm new-current-uuid --clear-bitmap pvc-1/0")
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if st := got.Status.PerNode[nodeKharkiv]; st.DiskState != diskStateUpToDate {
+		t.Fatalf("winner must report the post-birth state, got %+v", st)
+	}
+}
+
+// The loser waits: only the winner may mint, or two generations could race.
+func TestReconcileBirthLoserWaits(t *testing.T) {
+	r, fe, _ := birthSetup(t, nodeParis, 0, birthReadyJSON)
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "new-current-uuid")
+}
+
+// No mint while a diskful peer is still disconnected or its disk state is
+// unknown — the generation must land on every leg over live connections.
+func TestReconcileBirthWaitsForPeers(t *testing.T) {
+	for name, status := range map[string]string{
+		"peer connecting": `[{"name":"pvc-1","role":"Secondary",
+			"devices":[{"disk-state":"Inconsistent"}],
+			"connections":[{"peer-node-id":%d,"connection-state":"Connecting",
+				"peer_devices":[{"peer-disk-state":"DUnknown"}]}]}]`,
+		"peer disk unknown": `[{"name":"pvc-1","role":"Secondary",
+			"devices":[{"disk-state":"Inconsistent"}],
+			"connections":[{"peer-node-id":%d,"connection-state":"Connected",
+				"peer_devices":[{"peer-disk-state":"DUnknown"}]}]}]`,
+	} {
+		r, fe, _ := birthSetup(t, nodeKharkiv, 1, status)
+		reconcile(t, r, volPvc1)
+		if n := countCalls(fe, "new-current-uuid"); n != 0 {
+			t.Fatalf("%s: must not mint, got %d calls", name, n)
+		}
+	}
+}
+
+// A FullSync joiner means the volume already has a generation elsewhere:
+// never mint over it.
+func TestReconcileBirthSkipsFullSyncJoiner(t *testing.T) {
+	r, fe, v := birthSetup(t, nodeKharkiv, 1, birthReadyJSON)
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: v.Name}, got); err != nil {
+		t.Fatal(err)
+	}
+	got.Spec.Replicas[1].FullSync = true
+	if err := r.Update(t.Context(), got); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "new-current-uuid")
+}
+
+// An Activated volume held data: an all-Inconsistent state is then a real
+// incident, never something to paper over with a fresh generation.
+func TestReconcileBirthSkipsActivatedVolume(t *testing.T) {
+	r, fe, _ := birthSetup(t, nodeKharkiv, 1, birthReadyJSON)
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	got.Status.Activated = true
+	if err := r.Status().Update(t.Context(), got); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "new-current-uuid")
+}
+
+// A failed mint surfaces as a reconcile error (retried with backoff) and
+// keeps DeviceCreated so the phase never reads as a hard provisioning
+// failure.
+func TestReconcileBirthMintErrorRetries(t *testing.T) {
+	r, fe, _ := birthSetup(t, nodeKharkiv, 1, birthReadyJSON)
+	fe.errOn = map[string]error{"new-current-uuid": errors.New("exit status 1")}
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err == nil {
+		t.Fatal("a failed mint must surface as a reconcile error")
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.PerNode[nodeKharkiv].DeviceCreated {
+		t.Fatal("DeviceCreated must survive a failed mint")
+	}
+}
+
+// Regression for the fast-path wedge: a peer disk flipping DUnknown →
+// Inconsistent can be the only change in a pass. The fingerprint must
+// miss on it, or the winner never re-enters the pipeline and the volume
+// parks Creating forever.
+func TestFastPathMissesOnPeerDiskStateChange(t *testing.T) {
+	r, fe, v := birthSetup(t, nodeKharkiv, 1)
+	fe.statusJSON = `[{"name":"pvc-1","role":"Secondary",
+		"devices":[{"disk-state":"Inconsistent"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"DUnknown"}]}]}]`
+	st, err := r.DRBD.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.storeRealized(v.Generation, volPvc1, st, true)
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	got.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, SizeBytes: 1 << 30},
+	}
+	if err := r.Status().Update(t.Context(), got); err != nil {
+		t.Fatal(err)
+	}
+
+	// The peer's disk turns Inconsistent; everything else is unchanged.
+	fe.statusSeq = []string{
+		fmt.Sprintf(birthReadyJSON, 1), // fastPath live check → fingerprint miss
+		fmt.Sprintf(birthReadyJSON, 1), // pipeline status → trigger fires
+		fmt.Sprintf(birthDoneJSON, 1),  // post-mint re-read
+	}
+	reconcile(t, r, volPvc1)
+	fe.calledWith(t, "drbdadm new-current-uuid --clear-bitmap pvc-1/0")
 }

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -47,15 +47,6 @@ type Driver struct {
 	Mknod func(path string, mode uint32, dev int) error
 }
 
-// Seeded reports whether Apply has completed the create-md + GI phase for
-// the resource on this node (the .md-created marker). Absent marker with
-// a previously realized volume is the node-wipe signature the agent keys
-// its re-seed guard on.
-func (d *Driver) Seeded(name string) bool {
-	_, err := os.Stat(d.path(name + ".md-created"))
-	return err == nil
-}
-
 // Apply converges the kernel state for one resource: write config when it
 // isMissingMetadata matches drbdadm's complaint when a backing device
 // carries no DRBD metadata (attach against a blank/replaced disk).
@@ -64,10 +55,11 @@ func isMissingMetadata(err error) bool {
 	return strings.Contains(s, "no valid meta") || strings.Contains(s, "No valid meta")
 }
 
-// ensureMarkedMetadata creates + GI-seeds metadata once per backing device,
-// gated on the .md-created marker: the marker lands only after a fully
-// successful seed, so a retry never adopts half-seeded metadata (which
-// deadlocks the first handshake — both sides Inconsistent, no sync source).
+// ensureMarkedMetadata creates metadata once per backing device, gated on
+// the .md-created marker: the marker lands only after a fully successful
+// create, so a retry never adopts a half-written attempt. The all-legs
+// Inconsistent state this leaves behind is deliberate — the winner resolves
+// it with the birth generation once every leg is connected (InitialUUID).
 func (d *Driver) ensureMarkedMetadata(ctx context.Context, r Resource) error {
 	marker := d.path(r.Name + ".md-created")
 	if _, err := os.Stat(marker); err != nil {
@@ -88,8 +80,9 @@ func (d *Driver) ensureMarkedMetadata(ctx context.Context, r Resource) error {
 	return os.WriteFile(marker, nil, 0o640)
 }
 
-// changed, create and GI-seed metadata once (see seedGI for how fresh
-// volumes skip the initial sync), bring the resource up / adjust.
+// changed, create metadata once (left at UUID_JUST_CREATED — see
+// ensureMetadata for how the birth generation lands), bring the resource
+// up / adjust.
 func (d *Driver) Apply(ctx context.Context, r Resource) error {
 	if err := d.writeConfig(r); err != nil {
 		return err
@@ -123,7 +116,7 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 		// (data disk swapped, /etc/drbd.d intact) makes ensureMarkedMetadata
 		// skip create-md, so adjust attaches a blank device and fails "no
 		// valid meta-data". Drop the marker and re-run: probeMetadata sees
-		// no metadata and create-md + SkipSeed makes this a full SyncTarget.
+		// no metadata and just-created metadata makes this a full SyncTarget.
 		// Unreachable with --skip-disk (no attach → no metadata read).
 		if !r.LocalDiskless && !r.SkipDiskAttach && isMissingMetadata(err) {
 			if rmErr := os.Remove(d.path(r.Name + ".md-created")); rmErr != nil && !os.IsNotExist(rmErr) {
@@ -150,19 +143,28 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 	return d.ensureDeviceNode(r.Minor)
 }
 
-// ensureMetadata creates and GI-seeds the backing metadata, surviving a
-// crash at any point: the .md-seeding sentinel written before create-md
-// proves on-disk metadata is our own unfinished attempt and safe to
-// re-seed. The on-disk probe stays the authority for "metadata exists" —
-// markers are hostPath state that can vanish while the LV still holds a
-// live GI, and a blind create-md --force would wipe it.
+// ensureMetadata creates the backing metadata, surviving a crash at any
+// point: the .md-seeding sentinel written before create-md proves on-disk
+// metadata is our own unfinished attempt and safe to recreate. The on-disk
+// probe stays the authority for "metadata exists" — markers are hostPath
+// state that can vanish while the LV still holds a live GI, and a blind
+// create-md --force would wipe it.
+//
+// Metadata is deliberately left at create-md's UUID_JUST_CREATED. A fresh
+// volume's legs connect Inconsistent (unpromotable) and the winner then
+// creates the birth generation over the live connections (InitialUUID) —
+// one UUID replicated to every peer, so birth divergence is impossible. A
+// leg joining an existing volume takes the same just-created metadata into
+// its first handshake and elects full SyncTarget — the only correct
+// outcome, since the peers' bitmaps never tracked writes against a replica
+// that did not exist yet.
 func (d *Driver) ensureMetadata(ctx context.Context, r Resource) error {
 	hasMD, attached, dump, err := d.probeMetadata(ctx, r.Name)
 	if err != nil {
 		return err
 	}
 	if attached {
-		// A previous life completed seeding and adjust; the metadata is
+		// A previous life completed bring-up and adjust; the metadata is
 		// live — never touch it.
 		return d.markAdopted(r.Name)
 	}
@@ -172,7 +174,7 @@ func (d *Driver) ensureMetadata(ctx context.Context, r Resource) error {
 		return serr
 	}
 	if hasMD && os.IsNotExist(serr) {
-		// Metadata without any marker: lost hostPath state. Re-seed only
+		// Metadata without any marker: lost hostPath state. Recreate only
 		// when the GI proves no Primary ever wrote; anything else is a
 		// live volume — adopt it untouched.
 		if !virginMetadata(dump, r.Name) {
@@ -190,14 +192,7 @@ func (d *Driver) ensureMetadata(ctx context.Context, r Resource) error {
 			return fmt.Errorf("create-md %s: %w", r.Name, err)
 		}
 	}
-	if r.SkipSeed {
-		// Late joiner: just-created metadata (UUID_JUST_CREATED) makes
-		// the first handshake elect this node full SyncTarget — the only
-		// correct outcome, since the peers' bitmaps never tracked writes
-		// against a replica that did not exist yet.
-		return nil
-	}
-	return d.seedGI(ctx, r)
+	return nil
 }
 
 // probeMetadata reports the backing device's DRBD metadata state.
@@ -585,72 +580,12 @@ func Day0GI(name string) string {
 	return strings.ToUpper(hex.EncodeToString(h[:8]))
 }
 
-// seedGI lets fresh volumes skip the initial sync: every replica stamps
-// the same deterministic day0 generation identifier into the metadata
-// slots of the local node and every peer — the winner node (lowest node
-// id) with Consistent+UpToDate flags, every other node with
-// WasUpToDate — so the first handshake sees identical generations and
-// clean bitmaps. Valid because thin backings read zeros.
-//
-// The non-winner stamps WasUpToDate (MDF_WAS_UP_TO_DATE) without
-// Consistent: the kernel's attach-time "new region assumed zeroed" path
-// requires either WasUpToDate or a non-zero rs-discard-granularity to
-// keep the bitmap clean on a freshly-grown thin device. A flagless seed
-// attaches with the full device marked out-of-sync, triggering a full
-// initial sync. WasUpToDate without Consistent still attaches
-// Inconsistent (cannot be promoted); it reaches UpToDate at the first
-// handshake with zero resync.
-//
-// Only the local node's slot and actual peer slots are seeded (not all
-// 32 metadata slots): unoccupied slots are never read during the
-// handshake, and 32 subprocess calls add unnecessary cold-start
-// latency. The local slot MUST be included: seeding only peer slots
-// leaves the local current-UUID at create-md's random value and the
-// handshake aborts "unrelated data" → permanent StandAlone. Peers
-// includes the local node, so iterating r.Peers covers both.
-//
-// GI string is positional: current:bitmap:hist0:hist1[:consistent:uptodate].
-// Bitmap base stays 0 ("no out-of-sync bits") — a non-zero base reads as
-// a live resync anchor and triggers a full SyncTarget.
-func (d *Driver) seedGI(ctx context.Context, r Resource) error {
-	if r.LocalDiskless {
-		return nil
-	}
-	gi := Day0GI(r.Name) + ":0:0:0"
-	if isWinner(r) {
-		// The winner is UpToDate from metadata alone; everyone else
-		// reaches it at the first handshake.
-		gi += ":1:1"
-	} else {
-		// WasUpToDate without Consistent: attaches Inconsistent
-		// (safe — cannot be promoted), but the kernel's "new region
-		// assumed zeroed" attach path keeps the bitmap clean so no
-		// full resync is triggered.
-		gi += ":0:1"
-	}
-	// drbdmeta's DEVICE argument is the minor — resource/volume syntax
-	// is drbdadm-only. Fed a name, the shipped utils derive minor -1 and
-	// probe it with a malformed drbdsetup call whose output is
-	// version-dependent (observed flaking per-invocation on real
-	// hardware). The real minor keeps the in-use probe well-defined:
-	// unconfigured proceeds, configured refuses.
-	minor := strconv.Itoa(int(r.Minor))
-	for _, p := range r.Peers {
-		_, err := d.Exec(ctx, "drbdmeta", "--force", minor, "v09",
-			r.LocalDisk, "internal",
-			"set-gi", "--node-id", strconv.Itoa(int(p.NodeID)), gi)
-		if err != nil {
-			return fmt.Errorf("set-gi %s node-id %d: %w", r.Name, p.NodeID, err)
-		}
-	}
-	return nil
-}
-
-// isWinner picks the seed winner deterministically: the lowest node id
-// among diskful peers. A diskless tie-breaker never holds data, so it
-// must never win — with it elected, no diskful node would seed
-// UpToDate and the first handshake would deadlock all-Inconsistent.
-func isWinner(r Resource) bool {
+// IsWinner picks the birth-generation winner deterministically: the lowest
+// node id among diskful peers. A diskless tie-breaker never holds data, so
+// it must never win. Node ids are controller-assigned and stable, and every
+// agent reads the same spec, so all nodes elect the same single winner
+// without coordinating.
+func IsWinner(r Resource) bool {
 	lowest := int32(-1)
 	var lowestNode string
 	for _, p := range r.Peers {
@@ -665,12 +600,28 @@ func isWinner(r Resource) bool {
 	return lowestNode == r.LocalNode
 }
 
+// InitialUUID creates a fresh volume's first data generation — DRBD's
+// documented skip-initial-sync: with every leg attached Inconsistent at
+// UUID_JUST_CREATED and all connections established, new-current-uuid
+// --clear-bitmap mints one UUID and replicates it to every peer, flipping
+// all legs UpToDate with zero resync. Valid because thin backings read
+// zeros. Run on the winner (IsWinner) only, and only while the volume has
+// never held data — the caller gates on both (see agent birthInitPending).
+// One replicated UUID cannot birth-diverge, unlike per-node manufactured
+// generations (issue #139).
+func (d *Driver) InitialUUID(ctx context.Context, name string) error {
+	if _, err := d.adm(ctx, "new-current-uuid", "--clear-bitmap", name+"/0"); err != nil {
+		return fmt.Errorf("new-current-uuid %s: %w", name, err)
+	}
+	return nil
+}
+
 // ResolveSplitBrain runs DRBD's documented split-brain recovery around the
-// seed winner: every leg disconnects, then the winner (lowest diskful node
-// id, matching seedGI) and the diskless tie-breaker reconnect as survivors
-// while every other diskful leg reconnects with --discard-my-data, becoming
-// SyncTarget. Because the winner is derived the same way on every node, the
-// agents converge without coordinating.
+// winner: every leg disconnects, then the winner (lowest diskful node id)
+// and the diskless tie-breaker reconnect as survivors while every other
+// diskful leg reconnects with --discard-my-data, becoming SyncTarget.
+// Because the winner is derived the same way on every node, the agents
+// converge without coordinating.
 //
 // --discard-my-data drops the loser leg's generation, so this is only valid
 // on a volume that never held data; the caller gates on that (see
@@ -685,7 +636,7 @@ func (d *Driver) ResolveSplitBrain(ctx context.Context, r Resource) error {
 	// here harmlessly, so the result is ignored.
 	_, _ = d.adm(ctx, "disconnect", r.Name)
 
-	if r.LocalDiskless || isWinner(r) {
+	if r.LocalDiskless || IsWinner(r) {
 		if _, err := d.adm(ctx, "connect", r.Name); err != nil {
 			return fmt.Errorf("connect %s: %w", r.Name, err)
 		}
@@ -703,8 +654,10 @@ func (d *Driver) ResolveSplitBrain(ctx context.Context, r Resource) error {
 // best-effort: teardown's Backend.Delete destroys the whole device anyway.
 func (d *Driver) WipeMetadata(ctx context.Context, name, disk string, minor int32) error {
 	// drbdmeta wants the minor as its DEVICE handle — fed a name the shipped
-	// utils derive minor -1 and flake (see seedGI). The resource is down, so
-	// the minor probes as unconfigured and wipe-md proceeds.
+	// utils derive minor -1 and probe it with a malformed drbdsetup call
+	// whose output is version-dependent (observed flaking per-invocation on
+	// real hardware). The resource is down, so the minor probes as
+	// unconfigured and wipe-md proceeds.
 	if _, err := d.Exec(ctx, "drbdmeta", "--force", strconv.Itoa(int(minor)),
 		"v09", disk, "internal", "wipe-md"); err != nil {
 		return fmt.Errorf("wipe-md %s: %w", name, err)
@@ -736,6 +689,11 @@ func (d *Driver) Down(ctx context.Context, name string) error {
 // DiskUpToDate is the disk state of a replica holding current data.
 const DiskUpToDate = "UpToDate"
 
+// DiskInconsistent is the disk state of a replica with no usable data
+// generation yet: freshly created metadata before the birth generation, or
+// a sync target mid-resync. Never promotable.
+const DiskInconsistent = "Inconsistent"
+
 // DiskDiskless is the disk state of a replica with no attached backing
 // device — a quorum-only tie-breaker, or a diskful leg DRBD detached
 // after an I/O error (on-io-error detach). Do NOT use it to infer
@@ -764,6 +722,11 @@ type Status struct {
 	// tie-breaker's link state (the exact bug #78 removed) — filter by
 	// the spec's diskful node ids instead (see agent.diskfulPeersConnected).
 	PeerConnected map[int32]bool
+	// PeerDiskState maps each peer's DRBD node id to that peer's disk
+	// state as this node sees it (UpToDate, Inconsistent, Diskless,
+	// DUnknown before the handshake reports it…). The birth-generation
+	// trigger keys on every diskful leg reading Inconsistent.
+	PeerDiskState map[int32]string
 	// SplitBrain is true when a connection is StandAlone — DRBD refused
 	// to reconnect after detecting divergent data.
 	SplitBrain bool
@@ -801,6 +764,7 @@ type jsonStatus struct {
 		// (verified against drbd-utils user/v9/drbdsetup.c).
 		PeerDevices []struct {
 			ReplicationState string  `json:"replication-state"`
+			PeerDiskState    string  `json:"peer-disk-state"`
 			PercentInSync    float64 `json:"percent-in-sync"`
 			OutOfSyncKiB     int64   `json:"out-of-sync"`
 		} `json:"peer_devices"`
@@ -826,6 +790,7 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 		Primary:       res.Role == "Primary",
 		Suspended:     res.SuspendedUser,
 		PeerConnected: make(map[int32]bool, len(res.Connections)),
+		PeerDiskState: make(map[int32]string, len(res.Connections)),
 		ResyncPercent: 100,
 	}
 	if len(res.Devices) > 0 {
@@ -847,6 +812,11 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 				}
 			}
 			s.OutOfSyncKiB = max(s.OutOfSyncKiB, pd.OutOfSyncKiB)
+		}
+		// Single-volume resources: the first peer-device carries the peer's
+		// disk state.
+		if len(c.PeerDevices) > 0 {
+			s.PeerDiskState[c.PeerNodeID] = c.PeerDevices[0].PeerDiskState
 		}
 		s.PeerConnected[c.PeerNodeID] = c.ConnectionState == "Connected"
 		if c.ConnectionState == "StandAlone" {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -244,24 +244,16 @@ func (f *fakeExec) notCalledWith(t *testing.T, substr string) {
 func TestApplyFreshResource(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeKharkiv) // node-id 0 → winner
+	r := testResource(nodeKharkiv)
 
 	if err := d.Apply(t.Context(), r); err != nil {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
-	// Winner seeds Consistent+UpToDate flags into the local slot and
-	// every peer slot — partial seeding leaves the local current-UUID
-	// random and the first handshake aborts "unrelated data".
-	fe.calledWith(t, "set-gi --node-id 0 "+Day0GI(volPvc1)+":0:0:0:1:1")
-	fe.calledWith(t, "set-gi --node-id 1 "+Day0GI(volPvc1)+":0:0:0:1:1")
-	// Only actual peer slots are seeded, not all 32 metadata slots.
-	fe.notCalledWith(t, "set-gi --node-id 31")
-	// drbdmeta is addressed by minor: the resource/volume form is drbdadm
-	// syntax and makes drbdmeta consult kernel state through a malformed
-	// drbdsetup invocation with undefined output.
-	fe.calledWith(t, "drbdmeta --force 1000 v09 /dev/vg-miroir/pvc-1 internal set-gi")
-	fe.notCalledWith(t, "drbdmeta --force pvc-1/0")
+	// Metadata stays at UUID_JUST_CREATED: the birth generation is minted
+	// once by the winner over live connections (InitialUUID), never
+	// manufactured per node.
+	fe.notCalledWith(t, "set-gi")
 	fe.calledWith(t, "drbdadm adjust pvc-1")
 
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.res")); err != nil {
@@ -272,38 +264,13 @@ func TestApplyFreshResource(t *testing.T) {
 	}
 }
 
-func TestApplyNonWinnerSeedsWasUpToDate(t *testing.T) {
+func TestInitialUUID(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeParis) // node-id 1 → not winner
-
-	if err := d.Apply(t.Context(), r); err != nil {
+	if err := d.InitialUUID(t.Context(), volPvc1); err != nil {
 		t.Fatal(err)
 	}
-	// Non-winner seeds WasUpToDate (without Consistent): attaches
-	// Inconsistent but keeps the bitmap clean so no full resync fires.
-	// Reaches UpToDate at the first handshake.
-	fe.calledWith(t, "set-gi --node-id 0 "+Day0GI(volPvc1)+":0:0:0:0:1")
-	fe.calledWith(t, "set-gi --node-id 1 "+Day0GI(volPvc1)+":0:0:0:0:1")
-	fe.notCalledWith(t, ":1:1")
-	fe.notCalledWith(t, "set-gi --node-id 31")
-}
-
-func TestApplySkipSeedLeavesJustCreatedMetadata(t *testing.T) {
-	fe := &fakeExec{}
-	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeKharkiv)
-	r.SkipSeed = true // late joiner: must full-sync, not pose as a day0 twin
-
-	if err := d.Apply(t.Context(), r); err != nil {
-		t.Fatal(err)
-	}
-	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
-	fe.notCalledWith(t, "set-gi")
-	fe.calledWith(t, "drbdadm adjust pvc-1")
-	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-created")); err != nil {
-		t.Fatal("marker not written")
-	}
+	fe.calledWith(t, "drbdadm new-current-uuid --clear-bitmap pvc-1/0")
 }
 
 // KernelAvailable keys on the kernel answering, not the binary being on
@@ -378,8 +345,8 @@ func TestApplySkipDiskAttachLeavesDiskDetached(t *testing.T) {
 
 // A backing disk replaced under a surviving .md-created marker makes the
 // first adjust fail "no valid meta-data"; Apply drops the stale marker,
-// recreates metadata (SkipSeed → full SyncTarget), and retries adjust.
-func TestApplyReseedsOnMissingMetadata(t *testing.T) {
+// recreates metadata (just-created → full SyncTarget), and retries adjust.
+func TestApplyRecreatesOnMissingMetadata(t *testing.T) {
 	dir := t.TempDir()
 	// Pre-existing marker from the pre-replacement life of the volume.
 	if err := os.WriteFile(filepath.Join(dir, "pvc-1.md-created"), nil, 0o640); err != nil {
@@ -389,10 +356,8 @@ func TestApplyReseedsOnMissingMetadata(t *testing.T) {
 		"adjust pvc-1": errors.New("drbdadm: no valid meta-data found"),
 	}}
 	d := &Driver{StateDir: dir, Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeKharkiv)
-	r.SkipSeed = true // the recreated leg must full-sync, never re-seed day0
 
-	if err := d.Apply(t.Context(), r); err != nil {
+	if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err != nil {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
@@ -431,40 +396,38 @@ func TestApplyIdempotent(t *testing.T) {
 	fe.calledWith(t, "drbdadm adjust pvc-1")
 }
 
-func TestApplyReseedsAfterMidSeedCrash(t *testing.T) {
+func TestApplyRetriesAfterCreateMDCrash(t *testing.T) {
 	fe := &fakeExec{errOn: map[string]error{
-		"set-gi --node-id 1": errors.New("exit status 20: Unexpected output from drbdsetup"),
+		"create-md": errors.New("exit status 20: open failed"),
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 	r := testResource(nodeParis)
 
 	if err := d.Apply(t.Context(), r); err == nil {
-		t.Fatal("expected mid-seed failure")
+		t.Fatal("expected create-md failure")
 	}
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-created")); !os.IsNotExist(err) {
-		t.Fatal("marker must not be written after a failed seed")
+		t.Fatal("marker must not be written after a failed create")
+	}
+	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-seeding")); err != nil {
+		t.Fatal("sentinel must survive the failed attempt")
 	}
 
-	// Retry: metadata now exists on disk (create-md ran), but the seeding
-	// sentinel proves it is our own half-seeded attempt — it must be
-	// re-seeded in full, never adopted (adoption deadlocks the handshake:
-	// both replicas Inconsistent, no sync source). The dump is
-	// deliberately non-virgin so only the sentinel can explain the
-	// re-seed.
+	// Retry: metadata landed on disk before the crash surfaced (still the
+	// just-created UUID), and the sentinel proves it is our own attempt —
+	// the retry completes without another create-md and lands the marker.
 	fe.errOn = nil
-	fe.responses = map[string]string{cmdDumpMD: mockCurrentUUID}
+	fe.responses = map[string]string{cmdDumpMD: "current-uuid 0x" + justCreatedUUID + ";"}
 	fe.calls = nil
 	if err := d.Apply(t.Context(), r); err != nil {
 		t.Fatal(err)
 	}
-	fe.calledWith(t, "set-gi --node-id 1 "+Day0GI(volPvc1))
-	fe.notCalledWith(t, "set-gi --node-id 31")
 	fe.notCalledWith(t, "create-md")
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-created")); err != nil {
-		t.Fatal("marker not written after successful re-seed")
+		t.Fatal("marker not written after successful retry")
 	}
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-seeding")); !os.IsNotExist(err) {
-		t.Fatal("seeding sentinel must be removed after success")
+		t.Fatal("sentinel must be removed after success")
 	}
 }
 
@@ -580,10 +543,10 @@ func TestApplyAdoptsLiveMetadataWithoutMarkers(t *testing.T) {
 	}
 }
 
-func TestApplyReseedsVirginMetadataWithoutMarkers(t *testing.T) {
-	// Markers lost, device detached, GI still the day0 seed with clean
-	// bitmaps: provably no data — re-seeding is safe and unsticks a
-	// partially seeded volume.
+func TestApplyClaimsVirginMetadataWithoutMarkers(t *testing.T) {
+	// Markers lost, device detached, GI still a day0 seed (older release)
+	// with clean bitmaps: provably no data — claim it as our own (marker
+	// lands) without recreating; a written volume would be adopted instead.
 	fe := &fakeExec{responses: map[string]string{
 		cmdDumpMD: "current-uuid 0x" + Day0GI(volPvc1) + ";\nbitmap-uuid 0x0000000000000000;",
 	}}
@@ -592,9 +555,14 @@ func TestApplyReseedsVirginMetadataWithoutMarkers(t *testing.T) {
 	if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err != nil {
 		t.Fatal(err)
 	}
-	fe.calledWith(t, "set-gi --node-id 1")
-	fe.notCalledWith(t, "set-gi --node-id 31")
 	fe.notCalledWith(t, "create-md")
+	fe.notCalledWith(t, "set-gi")
+	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-created")); err != nil {
+		t.Fatal("virgin metadata must be claimed with the marker")
+	}
+	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-adopted")); !os.IsNotExist(err) {
+		t.Fatal("virgin metadata is ours, not an adoption")
+	}
 }
 
 func TestVirginMetadata(t *testing.T) {
@@ -678,6 +646,29 @@ func TestStatusPerPeerConnected(t *testing.T) {
 	}
 	if !s.PeerConnected[1] || s.PeerConnected[2] {
 		t.Fatalf("per-peer state wrong: %+v", s.PeerConnected)
+	}
+}
+
+// Per-peer disk state keys on the DRBD node id — the birth-generation
+// trigger requires every diskful leg to read Inconsistent.
+func TestStatusPerPeerDiskState(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
+			"devices":[{"disk-state":"Inconsistent"}],
+			"connections":[
+				{"peer-node-id":1,"connection-state":"Connected",
+				 "peer_devices":[{"peer-disk-state":"Inconsistent"}]},
+				{"peer-node-id":2,"connection-state":"Connecting",
+				 "peer_devices":[{"peer-disk-state":"DUnknown"}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	s, err := d.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.PeerDiskState[1] != DiskInconsistent || s.PeerDiskState[2] != "DUnknown" {
+		t.Fatalf("per-peer disk state wrong: %+v", s.PeerDiskState)
 	}
 }
 

--- a/internal/drbd/res.go
+++ b/internal/drbd/res.go
@@ -53,7 +53,7 @@ type Resource struct {
 	// LocalDiskless is true.
 	LocalDisk string
 	// LocalDiskless is true when the local node is a diskless tie-breaker:
-	// Apply skips create-md/seedGI and the local peer renders "disk none".
+	// Apply skips create-md and the local peer renders "disk none".
 	LocalDiskless bool
 	// Secret authenticates peers (cram-hmac challenge-response). Empty
 	// renders no auth — volumes created before secrets existed.
@@ -69,10 +69,6 @@ type Resource struct {
 	// Probed from the backing device; never set for loopfile (loop devices
 	// mishandle it). Overrides the cluster-wide common{} knob.
 	DiscardGranularityBytes int64
-	// SkipSeed leaves fresh metadata at create-md's just-created state
-	// instead of day0 GI seeding: a replica joining an existing volume
-	// must full-sync from its peers, not pose as a pristine twin.
-	SkipSeed bool
 	// Peers are all members of the resource, including the local node.
 	// A Peer with Diskless=true renders "disk none" and omits meta-disk.
 	Peers []Peer

--- a/internal/drbd/res_test.go
+++ b/internal/drbd/res_test.go
@@ -107,7 +107,7 @@ func TestRenderFreezeQuorumOptions(t *testing.T) {
 // The seed winner is the lowest diskful node id: a diskless tie-breaker
 // holding the lowest id must never win, or no diskful node would seed
 // UpToDate and the first handshake would deadlock all-Inconsistent.
-func TestSeedWinnerSkipsDiskless(t *testing.T) {
+func TestWinnerSkipsDiskless(t *testing.T) {
 	r := Resource{
 		LocalNode: nodeKharkiv,
 		Peers: []Peer{
@@ -116,12 +116,12 @@ func TestSeedWinnerSkipsDiskless(t *testing.T) {
 			{Node: nodeParis, NodeID: 2},
 		},
 	}
-	if !isWinner(r) {
+	if !IsWinner(r) {
 		t.Fatal("kharkiv (lowest diskful id) must win, not the diskless tie-breaker")
 	}
 	r.LocalNode = nodeOslo
-	if isWinner(r) {
-		t.Fatal("a diskless tie-breaker must never be the seed winner")
+	if IsWinner(r) {
+		t.Fatal("a diskless tie-breaker must never be the winner")
 	}
 }
 


### PR DESCRIPTION
Fixes #139 at the source. Stacked on #145 (base branch); retarget to main once #145 merges.

Every fix so far (#142, #145) was recovery. This addresses the generator: fresh replicated volumes could come up split-brain within seconds of creation, before any write — so the divergence is born in the bring-up itself. The old bring-up had each diskful agent independently manufacture an "identical" generation via `drbdmeta set-gi` with a name-derived day0 UUID. Two per-node stamped generations that must handshake as one is the fragility.

## New bring-up

DRBD's documented skip-initial-sync (what LINSTOR uses): `create-md` on every diskful leg (metadata stays at `UUID_JUST_CREATED`), all legs attach Inconsistent — unpromotable, so nothing can stage or write — and connect first. The winner (lowest diskful node id, same election as recovery) then runs `drbdadm new-current-uuid --clear-bitmap` once: one UUID minted and replicated over the live connections, every leg flips UpToDate with zero resync. A single replicated generation cannot birth-diverge.

- `birthInitPending` gates the mint: never-written volume (`Activated`/`Formatted` latches), local disk Inconsistent, no `FullSync` joiner, every diskful peer connected with an Inconsistent disk (diskless tie-breaker excluded — quorum forms after). `Status` now parses `peer-disk-state`, and `statusEqual` compares it so a peer disk flipping `DUnknown` → `Inconsistent` re-enters the pipeline instead of being fast-path cached past the trigger.
- The mint runs before `growIfCoordinator` (resize never executes against a both-Inconsistent device) and re-reads status so the same pass proceeds against UpToDate legs.
- Crash safety: if the winner mints and a peer drops before adopting, the peer reconnects still just-created and full-syncs — the ordinary late-joiner path, never a split.
- `seedGI`, `Resource.SkipSeed`, `wipedBacking`, `forceFullSync`, `Driver.Seeded` removed: with universal just-created metadata, a wiped or replaced disk full-syncs at the first handshake by construction. `Day0GI` stays so `virginMetadata` still recognizes legacy volumes.
- Clone restores are untouched: they adopt the source's live metadata and never present Inconsistent-at-birth, so the mint cannot fire on real data; the `Activated || Formatted` gate backs that up.
- #145's recovery loop stays as the safety net for volumes born under older releases.

## Forensics

Split detection now captures the kernel log via `/dev/kmsg` (the agent is privileged with host `/dev` mounted): the handshake's actual verdict ("Split-Brain detected" vs "Unrelated data") was never visible — the status API only shows the resulting StandAlone. Logged once per poll interval alongside recovery, so if anything ever splits again the root cause is in the log.

## Behavior changes (deliberate)

- A fresh replicated volume reaches Ready only after **all diskful agents are up and connected** at creation. Previously the day0 winner alone could reach Degraded with a peer down. CreateVolume's existing timeout/retry semantics cover the failure mode.
- Volumes created during a mixed-version agent rollout (one leg old day0 seeding, one leg new) converge via a full sync or one recovery cycle instead of instantly — transient to the rollout window.

## Tests

Fresh Apply creates metadata without `set-gi`; `InitialUUID` exec; `peer-disk-state` parsing; the reconciler birth matrix (winner mints through the real create-md path and reports UpToDate; loser waits; waits on disconnected/DUnknown peers; skips FullSync/Activated volumes; a failed mint retries preserving DeviceCreated); the fast-path regression for the peer-disk-state wedge; kmsg capture filtering/cap/missing-file. Legacy day0 recognition tests kept.

## Must verify on a real DRBD node before merge

The unit suite pins the orchestration, not the kernel:
1. `drbdadm new-current-uuid --clear-bitmap <res>/0` — accepted spelling on the shipped drbd-utils; all-Inconsistent connected resource flips all legs UpToDate with zero resync; harmless when repeated.
2. `drbdsetup status --json` reports `peer-disk-state: "Inconsistent"` for a connected just-created↔just-created pair (and `DUnknown` pre-handshake).
3. `smoke.sh` end to end — its delete→recreate-same-claim step is the deterministic #139 repro.
4. The reporter's on-demand repro (offer in #144); any residual split now logs the kernel verdict.