### PR TITLE
feat: make DRBD replication port base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,11 @@ via CSI.
 - **Other LVM tenants**: bound the thin pool with
   `nodes.<node>.thinPoolSize` (e.g. `400g`) and let the co-tenant
   allocate from the VG's remainder.
+- **Rook/Ceph**: miroir's default DRBD port base (7000) collides with
+  the Ceph mgr dashboard's non-SSL default on host-network clusters.
+  Set `drbd.portBase` in Helm values to move miroir's range, or move
+  the dashboard (`cephClusterSpec.dashboard.port`). See
+  [Troubleshooting](#troubleshooting).
 
 ## Troubleshooting
 
@@ -387,6 +392,22 @@ via CSI.
 - **Replicated volume stuck in `Degraded`**: one leg isn't
   `UpToDate`. `kubectl describe miroirvolume <name>` shows per-node
   status; usually a transient DRBD sync.
+- **Replicated volume stuck `Connecting`, no split-brain, PVC hangs in
+  `ContainerCreating`**: the DRBD replication port (default 7000,
+  allocated per volume ascending) may be occupied by a host-network
+  tenant — most commonly the Ceph mgr dashboard, whose non-SSL default
+  is also 7000. The agent runs `hostNetwork: true`, so DRBD binds on the
+  node's kernel and the collision is silent (no split-brain, so the
+  recovery path never engages). Check `dmesg` on the node for
+  `Failed to initiate connection, err=-98` (EADDRINUSE); peers dialing
+  in reach the dashboard instead and log
+  `Wrong magic value 0x48545450` (`"HTTP"` in ASCII). Identify the
+  squatter with `curl -sI http://<node>:7000/` — a `Ceph-Dashboard`
+  server header confirms it. Fix by setting `drbd.portBase` (e.g.
+  `7100`) in Helm values, or moving the Ceph dashboard
+  (`cephClusterSpec.dashboard.port: 8081`). Existing volumes keep their
+  assigned ports — only new allocations use the new base
+  ([#148](https://github.com/home-operations/miroir/issues/148)).
 
 ## Uninstall
 

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -53,6 +53,7 @@ Kubernetes: `>=1.31.0`
 | autoTieBreaker | bool | `true` | Add a diskless tie-breaker replica to 2-replica freeze volumes when a spare storage node exists, so majority quorum survives a single node loss. Also retrofits existing freeze volumes at controller startup. |
 | drbd.net.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count (e.g. "36864"); raises resync throughput on fast links. |
 | drbd.onIoError | string | `"detach"` |  |
+| drbd.portBase | int | `7000` | Lowest TCP port for DRBD replication links, one per replicated volume ascending (7000, 7001, …). The agent runs hostNetwork so these bind on the node's kernel. Ceph mgr dashboard's non-SSL default is also 7000; co-locating with Rook host-network Ceph requires moving one of them (see issue #148). Existing volumes keep their assigned ports. |
 | drbd.resync.discardGranularity | string | `""` | rs-discard-granularity cluster-wide fallback: during a full resync, runs of zeroes are sent as discards of this size instead of written out (e.g. "65536"), keeping a re-added thin leg thin. Normally leave empty — the agent probes each lvmthin/zfs backing device and renders an exact per-leg value that overrides this (loopfile is never probed: loop devices mishandle it, so also leave this empty on clusters with loopfile-backed replicated volumes). |
 | drbd.resync.fillTarget | string | `""` | c-fill-target, the resync controller's target fill level (e.g. "1M"). |
 | drbd.resync.maxRate | string | `""` | c-max-rate, the resync bandwidth ceiling used when the link is idle (e.g. "720M"). |

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -61,6 +61,7 @@ spec:
             - --provision-timeout={{ .Values.provisionTimeout }}
             - --overcommit-ratio={{ .Values.overcommitRatio }}
             - --auto-tie-breaker={{ .Values.autoTieBreaker }}
+            - --drbd-port-base={{ .Values.drbd.portBase }}
             {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
             - --leader-elect=true
             - --leader-election-id={{ include "miroir.leaderElectionID" . }}

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -162,6 +162,12 @@
           "title": "onIoError",
           "type": "string"
         },
+        "portBase": {
+          "default": 7000,
+          "description": "Lowest TCP port for DRBD replication links, one per replicated volume\nascending (7000, 7001, …). The agent runs hostNetwork so these bind on\nthe node's kernel. Ceph mgr dashboard's non-SSL default is also 7000;\nco-locating with Rook host-network Ceph requires moving one of them\n(see issue #148). Existing volumes keep their assigned ports.",
+          "title": "portBase",
+          "type": "integer"
+        },
         "resync": {
           "properties": {
             "discardGranularity": {

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -227,6 +227,12 @@ volumeSnapshotClass:
 # DRBD's built-in default. Tune to your replication network — see the LINBIT
 # "Tuning the DRBD Resync Controller" guide.
 drbd:
+  # -- Lowest TCP port for DRBD replication links, one per replicated volume
+  # ascending (7000, 7001, …). The agent runs hostNetwork so these bind on
+  # the node's kernel. Ceph mgr dashboard's non-SSL default is also 7000;
+  # co-locating with Rook host-network Ceph requires moving one of them
+  # (see issue #148). Existing volumes keep their assigned ports.
+  portBase: 7000
   # How a diskful replica reacts to a backing-device I/O error. detach
   # (the LINSTOR/DRBD-recommended default) drops the failing leg to
   # Diskless and serves reads/writes via the peer instead of surfacing

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -126,6 +126,7 @@ func main() {
 		provisionTimeout time.Duration
 		overcommitRatio  float64
 		autoTieBreaker   bool
+		drbdPortBase     int
 		leaderElect      bool
 		leaderElectionID string
 		leaderElectionNS string
@@ -151,6 +152,9 @@ func main() {
 		"max provisioned-over-capacity per pool before CreateVolume is refused (controller; 0 → default 2.0)")
 	flag.BoolVar(&autoTieBreaker, "auto-tie-breaker", true,
 		"add a diskless tie-breaker to 2-replica freeze volumes when a spare node exists (controller)")
+	flag.IntVar(&drbdPortBase, "drbd-port-base", 7000,
+		"lowest TCP port for DRBD replication links, one per replicated volume ascending "+
+			"(controller; raise to avoid host-network tenants like Ceph mgr dashboard on 7000)")
 	flag.BoolVar(&leaderElect, "leader-elect", false,
 		"elect a leader via a coordination.k8s.io Lease so extra replicas stand by warm (controller)")
 	flag.StringVar(&leaderElectionID, "leader-election-id", "miroir-controller",
@@ -268,6 +272,7 @@ func main() {
 			ProvisionTimeout: provisionTimeout,
 			OvercommitRatio:  overcommitRatio,
 			AutoTieBreaker:   autoTieBreaker,
+			DRBDPortBase:     int32(drbdPortBase),
 		}
 		if err := setupMembership(mgr, nodes, autoTieBreaker); err != nil {
 			setupLog.Error(err, "unable to set up membership reconcilers")

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -67,6 +67,11 @@ type Controller struct {
 	// AutoTieBreaker adds a diskless tie-breaker replica to new 2-replica
 	// freeze volumes when a spare storage node exists (#70).
 	AutoTieBreaker bool
+	// DRBDPortBase is the lowest TCP port the allocator hands to replicated
+	// volumes (one per resource, ascending). Zero → defaultDRBDPortBase.
+	// Configurable so operators can move the range off host-network tenants
+	// like the Ceph mgr dashboard (default 7000). See issue #148.
+	DRBDPortBase int32
 
 	// allocMu serialises CreateVolume RPCs that run concurrently within
 	// the single controller pod: two interleaved List→Create spans would
@@ -80,6 +85,11 @@ const (
 	// defaultOvercommitRatio caps provisioned-over-capacity per pool
 	// (notes/DESIGN.md §4.6); 2× is the documented default.
 	defaultOvercommitRatio = 2.0
+	// defaultDRBDPortBase is the lowest DRBD replication port when
+	// DRBDPortBase is unset (zero). Ceph mgr dashboard's non-SSL default
+	// is also 7000; operators co-locating with Rook host-network Ceph can
+	// move this via the --drbd-port-base flag / drbd.portBase Helm value.
+	defaultDRBDPortBase = 7000
 	// statsStaleAfter ignores MiroirNode figures older than this as
 	// unknown — the agent republishes every ~60s, so a few missed polls
 	// mean the node is down and its stats can't be trusted for placement.
@@ -561,7 +571,10 @@ func provisionedPerNode(vols []miroirv1alpha1.MiroirVolume, exclude string) map[
 // within the pod. The minor is per-node and allocated locally by each
 // agent.
 func (c *Controller) allocateDRBD(vols []miroirv1alpha1.MiroirVolume) (*miroirv1alpha1.DRBDSpec, error) {
-	const portBase = 7000
+	portBase := c.DRBDPortBase
+	if portBase == 0 {
+		portBase = defaultDRBDPortBase
+	}
 	usedPort := map[int32]bool{}
 	for _, v := range vols {
 		if v.Spec.DRBD != nil {


### PR DESCRIPTION
## What

Make the DRBD replication port base configurable via `--drbd-port-base` controller flag / `drbd.portBase` Helm value. Default stays `7000` (unchanged) so existing deployments are unaffected.

## Why

Fixes #148.

miroir assigns replicated volumes the lowest free TCP port starting at 7000. Ceph mgr dashboard's non-SSL default is also 7000, and on Rook clusters with `network.provider: host` (the common setup) the dashboard binds it directly on the mgr nodes' IPs. The first replicated volume collides silently:

- DRBD logs `Failed to initiate connection, err=-98` (EADDRINUSE); the connection flaps `Connecting → NetworkFailure` forever
- Peers dialing in reach the dashboard instead: `Wrong magic value 0x48545450 in protocol version -22` (`0x48545450` = ASCII `"HTTP"`)
- **No split-brain** is produced, so the recovery path (including 0.4.7's captureKmsg from #145) never engages — the volume wedges silently with a healthy-looking `Connecting` status

This was the true root cause of the birth-split-brain reports in #139/#141/#144 — 0.4.7 (#145) made them self-heal, but the root cause was never the replication logic: it was this port collision.

## Changes

- `internal/csi/controller.go` — `const portBase = 7000` → `c.DRBDPortBase` field with zero-value fallback to `defaultDRBDPortBase` (same pattern as `OvercommitRatio`/`defaultOvercommitRatio`)
- `cmd/main.go` — `--drbd-port-base` flag (default 7000), wired into `Controller` struct
- `charts/miroir/values.yaml` — `drbd.portBase: 7000` under existing `drbd:` section
- `charts/miroir/templates/controller.tpl` — `--drbd-port-base={{ .Values.drbd.portBase }}` in controller args
- `charts/miroir/README.md` + `charts/miroir/values.schema.json` — Auto-generated by helm-docs hook
- `README.md` — Troubleshooting section (port collision symptoms, kernel-log signatures, `curl -sI` identification, fix) + Coexistence section (Rook/Ceph bullet)

## Design decisions

- **Default stays 7000**: silently changing it would surprise existing setups. Keeping it configurable with a documented warning is safer.
- **Existing volumes keep their ports**: only new allocations start from the configured base. The port is stored in the `MiroirVolume` spec, not recomputed.
- **Options 1 & 2 deferred** (from the issue): bind-probe/EADDRINUSE rerouting and surfacing persistent bind failures via captureKmsg. The configurable base solves the problem for affected operators, and captureKmsg is split-brain-gated (this wedge produces none), so option 1 would need a new diagnostic path. Open to revisiting if the configurable base proves insufficient.

## Validation

- `gofmt -d` — clean
- Helm template renders `--drbd-port-base=7000` (default) and `--drbd-port-base=7100` (custom) correctly
- Existing tests construct `&Controller{}` without `DRBDPortBase` — the zero-value fallback to `defaultDRBDPortBase` (7000) preserves all existing test behavior
- Pre-existing `node.go` compilation errors (unrelated, confirmed by stash test) block `go build`/`go test` on this branch

## Workaround for affected operators (pre-merge)

Set `drbd.portBase: 7100` in Helm values (after this PR merges), or move the Ceph dashboard today:
```yaml
# rook-ceph-cluster chart values
cephClusterSpec:
  dashboard:
    port: 8081
```

Reported and validated by @phycoforce in #148.
