### PR TITLE
fix(agent): latch Activated from the live Primary role

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -233,6 +233,11 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if st, err = r.mintBirthUUID(ctx, vol, resource, st, localDiskless); err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
+	// Ordered before handleSplitBrain so the same pass cannot auto-discard
+	// a leg the latch is about to protect.
+	if err := r.latchActivated(ctx, vol, st); err != nil {
+		return ctrl.Result{}, err
+	}
 	// Online growth: once every peer's backing device is at the new size
 	// (the local leg was just resized above), the first diskful replica
 	// grows the DRBD device over them. It withholds the new size from its
@@ -315,6 +320,13 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 	// Connecting that never breaks statusEqual, so only the peers' status
 	// can route it into recoverSplitBrain (issue #144).
 	if !diskfulPeersConnected(st, vol, r.NodeName) && peerReportedSplitBrain(vol, r.NodeName) {
+		return false, ctrl.Result{}
+	}
+	// A Primary leg without the Activated latch takes the full pipeline,
+	// which owns the latch — normally the Primary flip itself breaks
+	// statusEqual, but an informer lagging the latch patch must not park
+	// the unprotected state here.
+	if st.Primary && !vol.Status.Activated {
 		return false, ctrl.Result{}
 	}
 	if !localDiskless {
@@ -780,6 +792,23 @@ func (r *VolumeReconciler) reportError(ctx context.Context, vol *miroirv1alpha1.
 		return err
 	}
 	return cause // requeue with backoff
+}
+
+// latchActivated sets the one-way Activated flag when the kernel reports
+// the local leg Primary — a Primary is (or was) open for writes. Beyond the
+// stage-time twin (csi.markActivated) it covers volumes staged before the
+// field existed: a raw-block consumer running since pre-0.4.5 never
+// restages, and without the latch recoverSplitBrain would treat its
+// data-bearing volume as never-written. MergeFrom, not the agent's SSA
+// apply: Activated is CSI-owned and merge patching the single field avoids
+// co-owning it.
+func (r *VolumeReconciler) latchActivated(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, st drbd.Status) error {
+	if !st.Primary || vol.Status.Activated {
+		return nil
+	}
+	base := vol.DeepCopy()
+	vol.Status.Activated = true
+	return r.Status().Patch(ctx, vol, client.MergeFrom(base))
 }
 
 // patchStatus applies only this node's slot and the derived phase. A

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1042,6 +1042,72 @@ func TestReconcileResizeCoordinatorSkipsWhenAtSize(t *testing.T) {
 	fe.notCalledWith(t, "drbdadm resize")
 }
 
+// A Primary leg latches Activated from the kernel role: a raw-block
+// consumer staged before the field existed never restages, and without
+// the latch recoverSplitBrain would treat its data-bearing volume as
+// never-written and auto-discard a leg.
+func TestReconcilePrimaryLatchesActivated(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+	}
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+		"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`}
+	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+
+	reconcile(t, r, volPvc1)
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.Activated {
+		t.Fatal("Primary leg must latch Status.Activated")
+	}
+}
+
+// A Secondary leg must not latch: an unstaged volume stays eligible for
+// split-brain auto-recovery.
+func TestReconcileSecondaryDoesNotLatchActivated(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+		"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`}
+	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+
+	reconcile(t, r, volPvc1)
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.Activated {
+		t.Fatal("Secondary leg must not latch Status.Activated")
+	}
+}
+
 // A diskless tie-breaker joins DRBD for quorum only: no backend device,
 // no metadata seed, DeviceCreated stays false so CSI never stages here.
 // A FullSync joiner on a restored volume must create a fresh backing,


### PR DESCRIPTION
Follow-up to #145. The split-brain auto-recovery gate (`!Activated && !Formatted`) has a migration hole: `Formatted` protects filesystem volumes, but raw-block volumes never set it, and `Activated` only latches at `NodeStageVolume` — which a consumer running since before the field existed never re-enters. A split-brain on such a volume would run `connect --discard-my-data` against a leg that holds real data.

The agent now also latches `Activated` whenever the kernel reports the local leg Primary (a Primary is or was open for writes), ordered before `handleSplitBrain` so the same pass cannot auto-discard. Since the agent pods restart on upgrade, every staged pre-upgrade volume is protected on its first full pass, without a one-time migration. `statusEqual` already fingerprints `Primary`, so a Primary flip always reaches the full pipeline; a fast-path guard covers an informer lagging the latch patch.

Residual (unchanged): a pre-upgrade raw-block volume whose consumer is stopped across the upgrade stays unprotected until it next stages.

The latch uses a `MergeFrom` single-field status patch like `csi.markActivated`, avoiding SSA co-ownership of a CSI-owned field.