### PR TITLE
fix: bound drbd-port-base at install and startup

### DIFF
--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -165,6 +165,8 @@
         "portBase": {
           "default": 7000,
           "description": "Lowest TCP port for DRBD replication links, one per replicated volume\nascending (7000, 7001, …). The agent runs hostNetwork so these bind on\nthe node's kernel. Ceph mgr dashboard's non-SSL default is also 7000;\nco-locating with Rook host-network Ceph requires moving one of them\n(see issue #148). Existing volumes keep their assigned ports.",
+          "maximum": 64000,
+          "minimum": 1024,
           "title": "portBase",
           "type": "integer"
         },

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -227,6 +227,11 @@ volumeSnapshotClass:
 # DRBD's built-in default. Tune to your replication network — see the LINBIT
 # "Tuning the DRBD Resync Controller" guide.
 drbd:
+  # @schema
+  # type: integer
+  # minimum: 1024
+  # maximum: 64000
+  # @schema
   # -- Lowest TCP port for DRBD replication links, one per replicated volume
   # ascending (7000, 7001, …). The agent runs hostNetwork so these bind on
   # the node's kernel. Ceph mgr dashboard's non-SSL default is also 7000;

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -117,6 +117,16 @@ func backendFor(nodeName, nodesConfig, vg, thinPool string) (backend.Backend, mi
 	return be, entry.Backend, nil
 }
 
+// validateDRBDPortBase exits on an out-of-range base: the allocator hands
+// out ports ascending from it, so a base near 65535 overflows the port
+// space only once volumes accumulate — fail at startup instead.
+func validateDRBDPortBase(base int) {
+	if base < 1024 || base > 64000 {
+		setupLog.Error(nil, "--drbd-port-base must be within 1024-64000", "value", base)
+		os.Exit(1)
+	}
+}
+
 func main() {
 	var (
 		mode             string
@@ -175,6 +185,8 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog.Info("starting miroir", "mode", mode, "version", version, "commit", commit)
+
+	validateDRBDPortBase(drbdPortBase)
 
 	// Setup mode provisions the node-local pool and exits. It reads the node
 	// map from a file and drives lvm/zfs directly, so it needs neither the


### PR DESCRIPTION
Follow-up to #149. `drbd.portBase` accepted any integer: 0 silently fell back to 7000, sub-1024 values collide with privileged ports, and a base near 65535 only fails once enough volumes accumulate for the ascending allocator to walk past the port ceiling — at CreateVolume time, far from the misconfiguration.

- `values.schema.json` now bounds it to 1024–64000 (via an `@schema` annotation in values.yaml, so the generated schema stays in sync).
- The controller validates `--drbd-port-base` at startup and exits with a clear error, for anyone driving the flag without the chart.

Verified: `helm lint --set drbd.portBase=100` fails schema validation, `=7100` passes; helm unittest green.