### PR TITLE
fix(nodemap): reject duplicate replication addresses at load

### DIFF
--- a/internal/nodemap/nodemap.go
+++ b/internal/nodemap/nodemap.go
@@ -106,6 +106,9 @@ func Load(path string) (Map, error) {
 	if err := yaml.UnmarshalStrict(raw, &m); err != nil {
 		return nil, fmt.Errorf("parse node map %s: %w", path, err)
 	}
+	// Keyed by the parsed form so differently written but equal IPs
+	// (IPv6 zero-compression) still collide.
+	addrOwner := map[string]string{}
 	for name, n := range m {
 		switch n.Backend {
 		case miroirv1alpha1.BackendLVMThin, miroirv1alpha1.BackendZFS, miroirv1alpha1.BackendLoopfile:
@@ -118,8 +121,18 @@ func Load(path string) (Map, error) {
 		if n.Backend == miroirv1alpha1.BackendLoopfile && n.BaseDir == "" {
 			return nil, fmt.Errorf("node %s: loopfile backend requires baseDir", name)
 		}
-		if n.Address != "" && net.ParseIP(n.Address) == nil {
-			return nil, fmt.Errorf("node %s: invalid address %q", name, n.Address)
+		if n.Address != "" {
+			ip := net.ParseIP(n.Address)
+			if ip == nil {
+				return nil, fmt.Errorf("node %s: invalid address %q", name, n.Address)
+			}
+			// Two nodes dialing one endpoint makes every shared volume's
+			// DRBD connections ambiguous at connect time — fail at load.
+			if other, dup := addrOwner[ip.String()]; dup {
+				return nil, fmt.Errorf("nodes %s and %s share replication address %s",
+					min(name, other), max(name, other), n.Address)
+			}
+			addrOwner[ip.String()] = name
 		}
 	}
 	return m, nil

--- a/internal/nodemap/nodemap_test.go
+++ b/internal/nodemap/nodemap_test.go
@@ -95,6 +95,8 @@ func TestLoadErrors(t *testing.T) {
 		"malformed yaml":           "kharkiv: : :\n",
 		"invalid address":          "kharkiv:\n  backend: lvmthin\n  address: not-an-ip\n",
 		"address is a CIDR":        "kharkiv:\n  backend: lvmthin\n  address: 10.0.0.0/24\n",
+		"duplicate address":        "kharkiv:\n  backend: lvmthin\n  address: 10.0.100.1\nparis:\n  backend: lvmthin\n  address: 10.0.100.1\n",
+		"duplicate address ipv6":   "kharkiv:\n  backend: lvmthin\n  address: fd00:1::2\nparis:\n  backend: lvmthin\n  address: fd00:0001:0:0::2\n",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Follow-up to #155 (refs #154). A copy-paste slip giving two nodes the same `address:` passed validation and only surfaced later as ambiguous DRBD connection failures on every volume sharing the pair. `nodemap.Load` now rejects it up front, comparing on the parsed IP so differently written but equal IPv6 addresses (zero-compression) collide too. The error names both nodes deterministically regardless of map iteration order.