### PR TITLE
fix(agent): discard verify results when a peer drops mid-pass

### DIFF
--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -160,6 +160,16 @@ func (v *VerifyScheduler) verifyVolume(ctx context.Context, vol *miroirv1alpha1.
 			return fmt.Errorf("poll verify status: %w", err)
 		}
 		if !st.Verifying {
+			// A pair that broke mid-pass aborts the verify, and the
+			// out-of-sync count then mixes findings with bits accrued while
+			// the peer was away — the latter heal on an ordinary reconnect
+			// resync, unlike findings. Unattributable: discard and let a
+			// later sweep re-verify.
+			if !diskfulPeersConnected(st, vol, v.NodeName) {
+				ctrl.LoggerFrom(ctx).WithName("verify").Info(
+					"verify interrupted by a peer disconnect; result discarded", "volume", vol.Name)
+				return nil
+			}
 			return v.recordResult(ctx, vol, st.OutOfSyncKiB*1024)
 		}
 	}

--- a/internal/agent/verify_test.go
+++ b/internal/agent/verify_test.go
@@ -55,6 +55,14 @@ const statusClean = `[{"name":"pvc-1",
 	"connections":[{"peer-node-id":1,"connection-state":"Connected",
 		"peer_devices":[{"replication-state":"Established","out-of-sync":0}]}]}]`
 
+// statusAborted is a verify cut short by a peer disconnect: no longer
+// verifying, but the pair is down and the out-of-sync count mixes any
+// findings with bits accrued while the peer is away.
+const statusAborted = `[{"name":"pvc-1",
+	"devices":[{"disk-state":"UpToDate"}],
+	"connections":[{"peer-node-id":1,"connection-state":"Connecting",
+		"peer_devices":[{"replication-state":"Off","out-of-sync":512}]}]}]`
+
 func replicatedVol() *miroirv1alpha1.MiroirVolume {
 	v := vol(volPvc1, nodeKharkiv, nodeParis)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
@@ -210,6 +218,31 @@ func TestVerifyOutOfSyncRecordsAndEvents(t *testing.T) {
 	case <-rec.Events:
 	default:
 		t.Fatal("a dirty verify must emit a VerifyOutOfSync event")
+	}
+}
+
+// A peer disconnect mid-pass aborts the verify and leaves an out-of-sync
+// count that mixes findings with disconnect-accrued bits — the result is
+// unattributable and must be discarded, not recorded or alerted on.
+func TestVerifyDiscardsResultWhenPeerDropsMidPass(t *testing.T) {
+	v := replicatedVol()
+	c := newClient(t, v)
+	fe := &fakeDRBDExec{statusSeq: []string{statusUpToDate, statusVerifying, statusAborted}}
+	rec := events.NewFakeRecorder(4)
+	vs := newVerifyScheduler(t, nodeKharkiv, c, fe, rec)
+
+	if err := vs.runOnce(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdadm verify pvc-1")
+
+	if got := getVol(t, c).Status.PerNode[nodeKharkiv].LastVerifyTime; got != nil {
+		t.Fatalf("an aborted verify must not record a result, got %v", got)
+	}
+	select {
+	case e := <-rec.Events:
+		t.Fatalf("an aborted verify must not emit an event, got %q", e)
+	default:
 	}
 }
 


### PR DESCRIPTION
Follow-up to #158. `verifyVolume` gates on connected diskful peers at the start of a pass, but the completion read recorded `st.OutOfSyncKiB` unconditionally. A peer dropping during a long verify aborts the pass and leaves an out-of-sync count that mixes real verify findings with bitmap bits accrued while the peer was away — the latter heal on an ordinary reconnect resync, unlike findings, so recording the mixed number inflates `lastVerifyOutOfSyncBytes` and fires a `VerifyOutOfSync` warning whose prescribed remedy (manual disconnect/connect) is wrong for most of it.

The completion path now re-checks `diskfulPeersConnected` and discards the result when the pair broke mid-pass (logged, nothing recorded or alerted); the next scheduled sweep re-verifies. Covered by a new test.