### PR TITLE
feat: RWX export reconciler — per-volume NFS gateway workloads

### DIFF
--- a/charts/miroir/templates/_helpers.tpl
+++ b/charts/miroir/templates/_helpers.tpl
@@ -68,6 +68,18 @@ the agent DaemonSet and the setup Job.
 {{- end -}}
 
 {{/*
+Gateway image ref — the agent userland plus NFS-Ganesha; the controller
+passes it to the per-RWX-volume gateway Deployments it spawns.
+*/}}
+{{- define "miroir.gatewayImage" -}}
+{{- if .Values.gateway.image.digest -}}
+{{- printf "%s@%s" .Values.gateway.image.repository .Values.gateway.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.gateway.image.repository (.Values.gateway.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Standard labels applied to every resource this chart produces. Component is added at the
 call site so each workload remains self-describing ("controller", "agent", "setup",
 "uninstall").
@@ -110,6 +122,9 @@ Resource names. All derive from fullname so nameOverride / fullnameOverride flow
 {{- end -}}
 {{- define "miroir.agentName" -}}
 {{- printf "%s-agent" (include "miroir.fullname" .) -}}
+{{- end -}}
+{{- define "miroir.gatewayName" -}}
+{{- printf "%s-gateway" (include "miroir.fullname" .) -}}
 {{- end -}}
 {{- define "miroir.nodesConfigName" -}}
 {{- printf "%s-nodes" (include "miroir.fullname" .) -}}

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -62,6 +62,10 @@ spec:
             - --overcommit-ratio={{ .Values.overcommitRatio }}
             - --auto-tie-breaker={{ .Values.autoTieBreaker }}
             - --drbd-port-base={{ .Values.drbd.portBase }}
+            # RWX gateway: the controller spawns per-volume NFS-Ganesha
+            # Deployments in its own namespace from this image.
+            - --gateway-image={{ include "miroir.gatewayImage" . }}
+            - --gateway-service-account={{ include "miroir.gatewayName" . }}
             {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
             - --leader-elect=true
             - --leader-election-id={{ include "miroir.leaderElectionID" . }}
@@ -71,10 +75,15 @@ spec:
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.extraEnv }}
           env:
+            # The controller creates gateway workloads in its own namespace.
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }

--- a/charts/miroir/templates/rbac.tpl
+++ b/charts/miroir/templates/rbac.tpl
@@ -144,3 +144,75 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "miroir.agentName" . }}
     namespace: {{ .Release.Namespace }}
+---
+# The controller manages per-RWX-volume gateway workloads in its own
+# namespace only — a namespaced Role, not cluster-wide.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "miroir.controllerName" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "miroir.controllerName" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "miroir.controllerName" . }}-gateway
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "miroir.controllerName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+# Gateway pods read their volume and latch its Formatted/Activated status
+# while staging. MiroirVolumes are cluster-scoped, so this is a ClusterRole.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "miroir.gatewayName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "miroir.gatewayName" . }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["miroir.home-operations.com"]
+    resources: ["miroirvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["miroir.home-operations.com"]
+    resources: ["miroirvolumes/status"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "miroir.gatewayName" . }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "miroir.gatewayName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "miroir.gatewayName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -38,6 +38,14 @@ tests:
       - lengthEqual:
           path: spec.template.spec.containers
           count: 4
+      # RWX: the controller is told which gateway image and ServiceAccount
+      # to spawn per-volume NFS gateways with.
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --gateway-image=ghcr.io/home-operations/miroir-gateway:0.0.1
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --gateway-service-account=miroir-gateway
       - contains:
           any: true
           path: spec.template.spec.containers
@@ -407,8 +415,13 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --leak-check=true
+      # POD_NAMESPACE is always env[0] (the controller creates gateway
+      # workloads in its own namespace); extra env follows it.
       - equal:
           path: spec.template.spec.containers[0].env[0].name
+          value: POD_NAMESPACE
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
           value: GOMEMLIMIT
       - equal:
           path: spec.template.metadata.labels["sidecar.istio.io/inject"]

--- a/charts/miroir/tests/rbac_test.yaml
+++ b/charts/miroir/tests/rbac_test.yaml
@@ -5,10 +5,10 @@ release:
   name: miroir
   namespace: miroir-system
 tests:
-  - it: emits two ServiceAccounts, two ClusterRoles, two ClusterRoleBindings
+  - it: emits controller + agent + gateway RBAC (SAs, cluster roles, and the namespaced gateway Role)
     asserts:
       - hasDocuments:
-          count: 6
+          count: 11
       - documentIndex: 0
         equal:
           path: kind
@@ -30,6 +30,28 @@ tests:
           path: kind
           value: ClusterRole
       - documentIndex: 5
+        equal:
+          path: kind
+          value: ClusterRoleBinding
+      # Gateway RBAC: the controller's namespaced Role to manage gateway
+      # workloads, then the gateway SA + cluster role for volume access.
+      - documentIndex: 6
+        equal:
+          path: kind
+          value: Role
+      - documentIndex: 7
+        equal:
+          path: kind
+          value: RoleBinding
+      - documentIndex: 8
+        equal:
+          path: kind
+          value: ServiceAccount
+      - documentIndex: 9
+        equal:
+          path: kind
+          value: ClusterRole
+      - documentIndex: 10
         equal:
           path: kind
           value: ClusterRoleBinding

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/home-operations/miroir/internal/constants"
 	"github.com/home-operations/miroir/internal/csi"
 	"github.com/home-operations/miroir/internal/drbd"
+	"github.com/home-operations/miroir/internal/export"
 	"github.com/home-operations/miroir/internal/gateway"
 	"github.com/home-operations/miroir/internal/membership"
 	"github.com/home-operations/miroir/internal/nodemap"
@@ -90,6 +91,26 @@ func setupMembership(mgr ctrl.Manager, nodes nodemap.Map, autoTieBreaker bool) e
 	tb := &membership.TieBreakerReconciler{Client: mgr.GetClient(), Nodes: nodes}
 	if err := tb.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("tie-breaker reconciler: %w", err)
+	}
+	return nil
+}
+
+// setupExport registers the RWX gateway reconciler, which maintains the
+// per-volume NFS-Ganesha Deployment and Service. It is skipped when no
+// gateway image is configured — RWX is off until the chart wires one.
+func setupExport(mgr ctrl.Manager, namespace, image, serviceAccount string) error {
+	if image == "" {
+		setupLog.Info("no --gateway-image set; RWX (ReadWriteMany) volumes are disabled")
+		return nil
+	}
+	r := &export.Reconciler{
+		Client:         mgr.GetClient(),
+		Namespace:      namespace,
+		Image:          image,
+		ServiceAccount: serviceAccount,
+	}
+	if err := r.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("export reconciler: %w", err)
 	}
 	return nil
 }
@@ -216,6 +237,9 @@ func main() {
 		leaderElect      bool
 		leaderElectionID string
 		leaderElectionNS string
+		podNamespace     string
+		gatewayImage     string
+		gatewaySA        string
 
 		// agent mode
 		nodeName          string
@@ -253,6 +277,12 @@ func main() {
 		"leader-election Lease name; keep it stable across upgrades (controller)")
 	flag.StringVar(&leaderElectionNS, "leader-election-namespace", "",
 		"leader-election Lease namespace; empty auto-detects the pod's namespace in-cluster (controller)")
+	flag.StringVar(&podNamespace, "namespace", os.Getenv("POD_NAMESPACE"),
+		"the controller's own namespace, where per-RWX-volume gateway workloads are created (controller)")
+	flag.StringVar(&gatewayImage, "gateway-image", "",
+		"container image for per-RWX-volume NFS gateway pods; empty disables RWX (controller)")
+	flag.StringVar(&gatewaySA, "gateway-service-account", "",
+		"ServiceAccount for gateway pods, with the RBAC the gateway needs (controller)")
 	flag.IntVar(&volumeWorkers, "volume-workers", 4,
 		"concurrent volume reconciles per agent (agent)")
 	flag.DurationVar(&poolStatsInterval, "pool-stats-interval", 0,
@@ -369,6 +399,10 @@ func main() {
 		}
 		if err := setupMembership(mgr, nodes, autoTieBreaker); err != nil {
 			setupLog.Error(err, "unable to set up membership reconcilers")
+			os.Exit(1)
+		}
+		if err := setupExport(mgr, podNamespace, gatewayImage, gatewaySA); err != nil {
+			setupLog.Error(err, "unable to set up export reconciler")
 			os.Exit(1)
 		}
 		serveCSI(mgr, csiSocket, identity, controller, nil)

--- a/internal/export/reconciler.go
+++ b/internal/export/reconciler.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package export reconciles the NFS gateway for RWX (ReadWriteMany)
+// volumes. When a MiroirVolume has spec.export set, this controller-pod
+// reconciler maintains a per-volume Deployment (the NFS-Ganesha share
+// manager, pinned to the volume's diskful replica nodes) and a ClusterIP
+// Service fronting it, and publishes the Service's address on
+// status.export.address for the CSI node service to mount. Both workloads
+// are owned by the MiroirVolume, so deleting the volume garbage-collects
+// them.
+package export
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+// Reconciler maintains the NFS gateway workloads for RWX volumes. It runs
+// in the controller pod: creating Deployments/Services and reading the
+// storage topology are controller-scoped concerns.
+type Reconciler struct {
+	client.Client
+	// Namespace is where the gateway Deployments and Services live (the
+	// release namespace, the controller's own).
+	Namespace string
+	// Image is the gateway container image (agent userland + NFS-Ganesha).
+	Image string
+	// ServiceAccount is the gateway pods' ServiceAccount, chart-created
+	// with the RBAC the gateway needs (miroirvolumes get/list/watch +
+	// status patch).
+	ServiceAccount string
+}
+
+// Reconcile ensures the gateway Deployment and Service exist for an RWX
+// volume and records the Service address. Owned workloads are garbage
+// collected when the volume is deleted, so a missing volume is a no-op.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(ctx, req.NamespacedName, vol); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	// Only RWX volumes have a gateway; a volume being deleted keeps its
+	// workloads until GC removes them with the owner.
+	if vol.Spec.Export == nil || !vol.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.ensureDeployment(ctx, vol); err != nil {
+		return ctrl.Result{}, err
+	}
+	addr, err := r.ensureService(ctx, vol)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.publishAddress(ctx, vol, addr); err != nil {
+		return ctrl.Result{}, err
+	}
+	log.Info("reconciled RWX gateway", "volume", vol.Name, "address", addr)
+	return ctrl.Result{}, nil
+}
+
+// ensureDeployment creates or updates the gateway Deployment, refreshing
+// its node affinity when the volume's replica set changes.
+func (r *Reconciler) ensureDeployment(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) error {
+	want := buildDeployment(vol, r.Namespace, r.Image, r.ServiceAccount)
+	dep := &appsv1.Deployment{}
+	dep.Name = want.Name
+	dep.Namespace = want.Namespace
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, dep, func() error {
+		dep.Labels = want.Labels
+		dep.Spec = want.Spec
+		return controllerutil.SetControllerReference(vol, dep, r.Scheme())
+	})
+	return err
+}
+
+// ensureService creates or adopts the gateway Service and returns its
+// ClusterIP. It never overwrites the Service spec's ClusterIP — that is
+// apiserver-assigned and consumers mount it, so it must stay stable across
+// gateway pod restarts.
+func (r *Reconciler) ensureService(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) (string, error) {
+	want := buildService(vol, r.Namespace)
+	svc := &corev1.Service{}
+	svc.Name = want.Name
+	svc.Namespace = want.Namespace
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, svc, func() error {
+		svc.Labels = want.Labels
+		// Set only the fields we own; ClusterIP/ClusterIPs stay whatever
+		// the apiserver assigned so an adopted Service keeps its address.
+		svc.Spec.Type = want.Spec.Type
+		svc.Spec.Selector = want.Spec.Selector
+		svc.Spec.Ports = want.Spec.Ports
+		return controllerutil.SetControllerReference(vol, svc, r.Scheme())
+	})
+	if err != nil {
+		return "", err
+	}
+	return svc.Spec.ClusterIP, nil
+}
+
+// publishAddress records the Service ClusterIP on status so the node
+// service can mount the export. It is a status patch (no generation bump),
+// so it does not re-trigger this generation-filtered reconciler.
+func (r *Reconciler) publishAddress(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, addr string) error {
+	if addr == "" {
+		// The apiserver has not assigned a ClusterIP yet; the owned-Service
+		// watch requeues us when it does.
+		return nil
+	}
+	want := &miroirv1alpha1.ExportStatus{Address: addr}
+	if equality.Semantic.DeepEqual(vol.Status.Export, want) {
+		return nil
+	}
+	base := vol.DeepCopy()
+	vol.Status.Export = want
+	return r.Status().Patch(ctx, vol, client.MergeFrom(base))
+}
+
+// SetupWithManager registers the reconciler. Generation-filtered on the
+// volume (status churn from agents carries nothing this reconciler reads),
+// and it owns its Deployment/Service so drift on those heals.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&miroirv1alpha1.MiroirVolume{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Named("export").
+		Complete(r)
+}

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"slices"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+const (
+	testNS      = "miroir-system"
+	nodeKharkiv = "kharkiv"
+	nodeParis   = "paris"
+	nodeOslo    = "oslo"
+
+	testClusterIP = "10.96.1.5"
+)
+
+// exportVolume is an RWX volume with a data replica on each named node.
+func exportVolume(name string, nodes ...string) *miroirv1alpha1.MiroirVolume {
+	reps := make([]miroirv1alpha1.Replica, len(nodes))
+	for i, n := range nodes {
+		reps[i] = miroirv1alpha1.Replica{Node: n, NodeID: int32(i)}
+	}
+	return &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID("uid-" + name)},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 1 << 30,
+			Replicas:  reps,
+			Export:    &miroirv1alpha1.ExportSpec{FSType: "ext4"},
+		},
+	}
+}
+
+func newReconciler(objs ...client.Object) (*Reconciler, client.Client) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = miroirv1alpha1.AddToScheme(scheme)
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		WithObjects(objs...).Build()
+	return &Reconciler{
+		Client:         cl,
+		Namespace:      testNS,
+		Image:          "ghcr.io/home-operations/miroir-gateway:test",
+		ServiceAccount: "miroir-gateway",
+	}, cl
+}
+
+func reconcile(t *testing.T, r *Reconciler, name string) {
+	t.Helper()
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+}
+
+func getDeployment(t *testing.T, cl client.Client, vol string) *appsv1.Deployment {
+	t.Helper()
+	dep := &appsv1.Deployment{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: shareName(vol), Namespace: testNS}, dep); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	return dep
+}
+
+func TestReconcileCreatesWorkloads(t *testing.T) {
+	vol := exportVolume("pvc-abc", nodeKharkiv, nodeParis)
+	r, cl := newReconciler(vol)
+	reconcile(t, r, "pvc-abc")
+
+	dep := getDeployment(t, cl, "pvc-abc")
+	// Owned by the volume so deleting it garbage-collects the gateway.
+	if len(dep.OwnerReferences) != 1 || dep.OwnerReferences[0].Name != "pvc-abc" ||
+		dep.OwnerReferences[0].Controller == nil || !*dep.OwnerReferences[0].Controller {
+		t.Fatalf("deployment must be controller-owned by the volume, got %+v", dep.OwnerReferences)
+	}
+	c := dep.Spec.Template.Spec.Containers[0]
+	if !slices.Contains(c.Args, "--volume=pvc-abc") || !slices.Contains(c.Args, "--mode=gateway") {
+		t.Fatalf("container args = %v", c.Args)
+	}
+	if c.Image != "ghcr.io/home-operations/miroir-gateway:test" {
+		t.Fatalf("image = %q", c.Image)
+	}
+	if dep.Spec.Template.Spec.ServiceAccountName != "miroir-gateway" {
+		t.Fatalf("service account = %q", dep.Spec.Template.Spec.ServiceAccountName)
+	}
+	// Scheduled onto exactly the volume's diskful replica nodes.
+	got := affinityNodes(t, dep)
+	slices.Sort(got)
+	if want := []string{nodeKharkiv, nodeParis}; !slices.Equal(got, want) {
+		t.Fatalf("affinity nodes = %v, want %v", got, want)
+	}
+
+	svc := &corev1.Service{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: shareName("pvc-abc"), Namespace: testNS}, svc); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP || svc.Spec.Ports[0].Port != nfsPort {
+		t.Fatalf("service = %+v", svc.Spec)
+	}
+}
+
+func TestReconcileAdoptsServiceAndPublishesAddress(t *testing.T) {
+	vol := exportVolume("pvc-xyz", nodeKharkiv, nodeParis)
+	// A Service already exists with an apiserver-assigned ClusterIP (as
+	// after a controller restart): the reconciler must adopt it, keep the
+	// address, and publish it.
+	existing := buildService(vol, testNS)
+	existing.Spec.ClusterIP = testClusterIP
+	r, cl := newReconciler(vol, existing)
+
+	reconcile(t, r, "pvc-xyz")
+
+	svc := &corev1.Service{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: shareName("pvc-xyz"), Namespace: testNS}, svc); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if svc.Spec.ClusterIP != testClusterIP {
+		t.Fatalf("adopted Service must keep its ClusterIP, got %q", svc.Spec.ClusterIP)
+	}
+	if len(svc.OwnerReferences) != 1 {
+		t.Fatalf("adopted Service must gain the volume owner ref, got %+v", svc.OwnerReferences)
+	}
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: "pvc-xyz"}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.Export == nil || got.Status.Export.Address != testClusterIP {
+		t.Fatalf("status.export.address = %+v, want 10.96.1.5", got.Status.Export)
+	}
+}
+
+func TestReconcileSkipsNonExportVolume(t *testing.T) {
+	vol := exportVolume("pvc-plain", nodeKharkiv)
+	vol.Spec.Export = nil // a plain RWO volume
+	r, cl := newReconciler(vol)
+
+	reconcile(t, r, "pvc-plain")
+
+	dep := &appsv1.Deployment{}
+	err := cl.Get(t.Context(), types.NamespacedName{Name: shareName("pvc-plain"), Namespace: testNS}, dep)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("a non-export volume must get no gateway, got err=%v", err)
+	}
+}
+
+func TestReconcileUpdatesAffinityOnReplicaChange(t *testing.T) {
+	vol := exportVolume("pvc-move", nodeKharkiv, nodeParis)
+	r, cl := newReconciler(vol)
+	reconcile(t, r, "pvc-move")
+
+	// The replica set is edited (a replica moves to oslo); the gateway's
+	// affinity must follow so it can still schedule on a data node.
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: "pvc-move"}, got); err != nil {
+		t.Fatal(err)
+	}
+	got.Spec.Replicas = []miroirv1alpha1.Replica{
+		{Node: nodeKharkiv, NodeID: 0},
+		{Node: nodeOslo, NodeID: 1},
+	}
+	if err := cl.Update(t.Context(), got); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, "pvc-move")
+
+	nodes := affinityNodes(t, getDeployment(t, cl, "pvc-move"))
+	slices.Sort(nodes)
+	if want := []string{nodeKharkiv, nodeOslo}; !slices.Equal(nodes, want) {
+		t.Fatalf("affinity nodes after move = %v, want %v", nodes, want)
+	}
+}
+
+// affinityNodes extracts the node names the Deployment's required node
+// affinity pins to.
+func affinityNodes(t *testing.T, dep *appsv1.Deployment) []string {
+	t.Helper()
+	aff := dep.Spec.Template.Spec.Affinity
+	if aff == nil || aff.NodeAffinity == nil ||
+		aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatal("deployment has no required node affinity")
+	}
+	terms := aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 || len(terms[0].MatchExpressions) != 1 {
+		t.Fatalf("unexpected affinity terms: %+v", terms)
+	}
+	return terms[0].MatchExpressions[0].Values
+}

--- a/internal/export/workloads.go
+++ b/internal/export/workloads.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/constants"
+)
+
+const (
+	// sharePrefix names the per-volume Deployment and Service. Volume
+	// names are pvc-<uuid> (40 chars); the prefix keeps the Service name
+	// (a 63-char DNS label) within bounds.
+	sharePrefix = "miroir-share-"
+	// gatewayAppName is the app.kubernetes.io/name on gateway pods.
+	gatewayAppName = "miroir-gateway"
+	// nfsPort is the NFSv4 port the gateway serves and the Service fronts.
+	nfsPort = 2049
+)
+
+// shareName is the Deployment/Service name for a volume's gateway.
+func shareName(volume string) string {
+	return sharePrefix + volume
+}
+
+// shareLabels identify a volume's gateway pods and select them from the
+// Service. app is constant; volume disambiguates one gateway from another.
+func shareLabels(volume string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":            gatewayAppName,
+		"app.kubernetes.io/component":       "gateway",
+		"miroir.home-operations.com/volume": volume,
+	}
+}
+
+// diskfulNodes lists the nodes holding a data replica — the only nodes a
+// gateway may schedule on (a diskless tie-breaker has no device to mount).
+func diskfulNodes(vol *miroirv1alpha1.MiroirVolume) []string {
+	reps := vol.Spec.DiskfulReplicas()
+	nodes := make([]string, 0, len(reps))
+	for _, r := range reps {
+		nodes = append(nodes, r.Node)
+	}
+	return nodes
+}
+
+// buildDeployment renders the desired gateway Deployment for a volume.
+// replicas:1 with the Recreate strategy: two gateways writing the same
+// device is exactly the dual-primary case single-primary DRBD forbids, so
+// the old pod must be gone before the new one promotes.
+func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, serviceAccount string) *appsv1.Deployment {
+	labels := shareLabels(vol.Name)
+	privileged := true
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: shareName(vol.Name), Namespace: namespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas:             ptr.To[int32](1),
+			Strategy:             appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
+			RevisionHistoryLimit: ptr.To[int32](1),
+			Selector:             &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccount,
+					Affinity:           nodeAffinity(diskfulNodes(vol)),
+					Containers: []corev1.Container{{
+						Name:  "gateway",
+						Image: image,
+						Args:  []string{"--mode=gateway", "--volume=" + vol.Name},
+						Env: []corev1.EnvVar{{
+							Name:      "NODE_NAME",
+							ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}},
+						}, {
+							Name:      "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+						}},
+						SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
+						Ports:           []corev1.ContainerPort{{Name: "nfs", ContainerPort: nfsPort, Protocol: corev1.ProtocolTCP}},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name: "dev", MountPath: "/dev",
+						}},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(nfsPort)},
+							},
+							InitialDelaySeconds: 5,
+							PeriodSeconds:       10,
+						},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "dev",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{Path: "/dev", Type: ptr.To(corev1.HostPathDirectory)},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// buildService renders the desired ClusterIP Service fronting a volume's
+// gateway pod. The ClusterIP is allocated by the apiserver and must stay
+// stable across gateway pod restarts (consumers mount it), so the
+// reconciler adopts an existing Service rather than recreating it.
+func buildService(vol *miroirv1alpha1.MiroirVolume, namespace string) *corev1.Service {
+	labels := shareLabels(vol.Name)
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: shareName(vol.Name), Namespace: namespace, Labels: labels},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: labels,
+			Ports: []corev1.ServicePort{{
+				Name:       "nfs",
+				Port:       nfsPort,
+				TargetPort: intstr.FromInt32(nfsPort),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	}
+}
+
+// nodeAffinity pins scheduling to the volume's diskful replica nodes.
+func nodeAffinity(nodes []string) *corev1.Affinity {
+	if len(nodes) == 0 {
+		return nil
+	}
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key:      constants.TopologyKey,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   nodes,
+					}},
+				}},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Stacked on #162 → #161. Merge those first; this base retargets to `main` as they land.

## What

The controller-side piece that **spawns and heals** an RWX volume's gateway — the reconciler and its RBAC.

**`feat(export)`: `internal/export`.**
A controller-pod reconciler watching MiroirVolumes with `spec.export`. Per RWX volume it maintains:
- a **Deployment** (`miroir-share-<vol>`, `replicas: 1`, `Recreate`) running `--mode=gateway`, pinned by **node affinity to the volume's diskful replica nodes**, privileged with a `/dev` hostPath;
- a **ClusterIP Service** (`:2049`) fronting it — **adopted, never recreated**, so its ClusterIP stays stable across gateway pod restarts (consumers mount it);
- `status.export.address` = the Service ClusterIP, for the CSI node service (PR4) to mount.

Both workloads are **owned by the MiroirVolume** (cluster-scoped owner → namespaced dependents, which Kubernetes GC supports), so deleting the volume garbage-collects the gateway — no `DeleteVolume` changes. It `Owns()` both, so drift on them heals; it's generation-filtered on the volume so its own status patch doesn't loop. Registered in the controller and **gated on `--gateway-image`**, so RWX stays off until the chart wires one.

**`feat(chart)`: RBAC + controller wiring.**
- Controller gains a **namespaced Role** (not cluster-wide) for `deployments`/`services` in its own namespace — least privilege for the workload-creating capability.
- A **gateway ServiceAccount + ClusterRole**: read cluster-scoped MiroirVolumes and patch their status (the gateway owns the `Formatted`/`Activated` latches while staging).
- Controller args `--gateway-image`, `--gateway-service-account`, and a `POD_NAMESPACE` downward-API env.

## Not in this PR

CreateVolume still rejects `MULTI_NODE_*`, so no MiroirVolume ever gets `spec.export` yet — the reconciler is dormant until PR4 flips CSI acceptance on. This PR is the mechanism, wired and RBAC'd but not yet triggered.

## Test

- `go build`/`vet`/`golangci-lint` clean.
- `internal/export` unit tests (fake client, run on any OS): workload shapes + owner refs, Service adoption keeps ClusterIP + publishes address, non-export volume gets nothing, affinity re-renders when the replica set changes.
- `helm lint`, `helm unittest` (90), `helm-docs-check` — green; RBAC and controller tests updated for the new objects/args.