### PR TITLE
feat: enable RWX (ReadWriteMany) over the NFS gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ synchronous replication (2–3 replicas) via DRBD9.
   (`--max-peers 7`). Going higher means lifting the cap, raising
   `--max-peers`, and revisiting the quorum policies, which are built
   around 2 data replicas plus a tie-breaker — not done.
-- You need `RWX`. Volumes are `ReadWriteOnce`.
-- You need iSCSI/NFS exports. Block devices only.
+- You need iSCSI targets or a standalone NFS/file server. miroir serves
+  block devices and — for `ReadWriteMany` — a per-volume NFS export it
+  manages itself (see [ReadWriteMany (RWX)](#readwritemany-rwx)); it is not
+  a general-purpose exporter.
 
 ## How it compares to LINSTOR and blockstor
 
@@ -332,6 +334,60 @@ validates one leg against itself). Set `drbd.verifyAlg` (e.g.
 during quiet hours — cron is the DRBD-documented pattern.
 Out-of-sync blocks are reported in the kernel log and
 `drbdsetup status`.
+
+## ReadWriteMany (RWX)
+
+A PVC with `accessModes: [ReadWriteMany]` (or `ReadOnlyMany`) on a
+replicated class is served as a **shared filesystem over NFS** — many pods
+on many nodes read and write it at once, like CephFS.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: shared-data
+spec:
+    storageClassName: miroir-replicated
+    accessModes: [ReadWriteMany]
+    resources:
+        requests:
+            storage: 10Gi
+```
+
+Under the hood the volume is a normal miroir DRBD volume. The controller
+runs one **gateway** pod for it on a replica node: the pod mounts the
+device (DRBD `auto-promote` makes it the single writer), formats it
+`ext4`/`xfs`, and exports it over NFSv4 with NFS-Ganesha. A per-volume
+`ClusterIP` Service fronts the gateway, and the CSI node plugin on any node
+NFS-mounts that Service for pods. Because the gateway is the only writer,
+single-primary DRBD fencing is unchanged — miroir never enables
+dual-primary, and there is no cluster filesystem.
+
+Things worth knowing:
+
+- **RWX requires a replicated class** (`replicas ≥ 2`). The gateway fails
+  over by rescheduling onto another replica node, so it needs a second one
+  to move to; the controller rejects RWX on a single-replica volume.
+- **Consistency is NFS close-to-open**, not shared-memory: a writer's
+  changes are visible on other nodes once it closes the file (or `fsync`s).
+- **Failover.** If the gateway's node dies, the Deployment reschedules the
+  gateway onto a surviving replica node and NFS clients (hard mounts)
+  reconnect through the same Service IP. Expect **tens of seconds** —
+  eviction from the dead node, DRBD promotion once quorum releases the old
+  Primary, and the NFSv4 grace period. Client I/O stalls (never errors)
+  across the window. Fine for the homelab RWX cases (media libraries,
+  shared config); not a low-latency-failover HA-NAS.
+- **`freeze` quorum is required** (the default). Under `last-man-standing`
+  a partition could leave the old and rescheduled gateways both writable —
+  the controller rejects that combination.
+- **Snapshots** work exactly as for RWO volumes (crash-consistent,
+  device-level; the gateway is the sole writer during the barrier), and the
+  volume gets the same split-brain protections — the gateway stages through
+  the same pipeline that latches "this volume holds data", so auto-recovery
+  never discards a diverged leg out from under it.
+- The gateway keeps NFSv4 lock-recovery state in a `.ganesha-recovery`
+  directory at the root of the exported filesystem so locks survive
+  failover; it is visible to consumers — leave it alone.
 
 ## Monitoring
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -115,6 +116,11 @@ func setupExport(mgr ctrl.Manager, namespace, image, serviceAccount string) erro
 	return nil
 }
 
+// errNodeUnmapped marks a node that is not in the storage map: it runs a
+// client-only agent (CSI node service for RWX/NFS consumers) rather than
+// failing to start.
+var errNodeUnmapped = errors.New("node absent from the storage node map")
+
 // backendFor resolves this node's storage entry from the node map and
 // builds its backend — shared by setup and agent mode so the two can
 // never wire Config differently.
@@ -125,7 +131,7 @@ func backendFor(nodeName, nodesConfig, vg, thinPool string) (backend.Backend, mi
 	}
 	entry, ok := nodes[nodeName]
 	if !ok {
-		return nil, "", fmt.Errorf("node %s absent from the node map (Helm values: nodes)", nodeName)
+		return nil, "", errNodeUnmapped
 	}
 	be, err := backend.New(entry.Backend, backend.Config{
 		VolumeGroup: vg,
@@ -412,10 +418,17 @@ func main() {
 			setupLog.Error(nil, "--node-name (or NODE_NAME) is required in agent mode")
 			os.Exit(1)
 		}
-		// Agents refuse to start on nodes absent from the node map: the
-		// DaemonSet's chart-side scope is every schedulable node, but only
-		// storage nodes run an agent-backed backend.
+		// The DaemonSet's chart-side scope is every schedulable node, but
+		// only storage nodes run an agent-backed backend. A node absent from
+		// the map holds no volumes and runs a client-only node service so
+		// pods there can still mount RWX (NFS) volumes.
 		be, backendType, err := backendFor(nodeName, nodesConfig, vg, thinPool)
+		if errors.Is(err, errNodeUnmapped) {
+			setupLog.Info("node not in the storage map; running client-only node service", "node", nodeName)
+			node := csi.NewNode(mgr.GetClient(), nodeName, &drbd.Driver{StateDir: drbdStateDir, Exec: backend.RealExec})
+			serveCSI(mgr, csiSocket, identity, nil, node)
+			break
+		}
 		if err != nil {
 			setupLog.Error(err, "unable to build the node's backend")
 			os.Exit(1)

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -149,9 +149,15 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 	shared := isShared(req.GetVolumeCapabilities())
-	if shared && replicas > 1 && quorum == miroirv1alpha1.QuorumLastManStanding {
-		return nil, status.Error(codes.InvalidArgument,
-			"RWX volumes require freeze quorum: last-man-standing risks dual-primary split-brain when the gateway reschedules")
+	if shared {
+		if replicas < 2 {
+			return nil, status.Error(codes.InvalidArgument,
+				"RWX volumes need at least 2 replicas so the NFS gateway can fail over to a surviving node")
+		}
+		if quorum == miroirv1alpha1.QuorumLastManStanding {
+			return nil, status.Error(codes.InvalidArgument,
+				"RWX volumes require freeze quorum: last-man-standing risks two gateways writing during a partition")
+		}
 	}
 
 	snapID := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -148,6 +148,11 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	if err != nil {
 		return nil, err
 	}
+	shared := isShared(req.GetVolumeCapabilities())
+	if shared && replicas > 1 && quorum == miroirv1alpha1.QuorumLastManStanding {
+		return nil, status.Error(codes.InvalidArgument,
+			"RWX volumes require freeze quorum: last-man-standing risks dual-primary split-brain when the gateway reschedules")
+	}
 
 	snapID := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()
 	source, srcReplicas, sourceFormatted, err := c.resolveSource(ctx, snapID, sizeBytes, replicas)
@@ -203,6 +208,9 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		}
 		vol.Spec.DRBD = drbdSpec
 	}
+	if shared {
+		vol.Spec.Export = &miroirv1alpha1.ExportSpec{FSType: exportFSType(req.GetVolumeCapabilities())}
+	}
 	createErr := c.Client.Create(ctx, vol)
 	c.allocMu.Unlock()
 
@@ -224,15 +232,6 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 
-	topology := make([]*csi.Topology, 0, len(vol.Spec.Replicas))
-	for _, r := range vol.Spec.Replicas {
-		if r.Diskless {
-			continue
-		}
-		topology = append(topology, &csi.Topology{
-			Segments: map[string]string{constants.TopologyKey: r.Node},
-		})
-	}
 	var contentSource *csi.VolumeContentSource
 	if source != nil && source.SnapshotName != "" {
 		contentSource = &csi.VolumeContentSource{
@@ -247,7 +246,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		Volume: &csi.Volume{
 			VolumeId:           vol.Name,
 			CapacityBytes:      sizeBytes,
-			AccessibleTopology: topology,
+			AccessibleTopology: accessibleTopology(vol),
 			ContentSource:      contentSource,
 		},
 	}, nil
@@ -282,6 +281,14 @@ func (c *Controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	}
 	if err := validateCapabilities(req.GetVolumeCapabilities()); err != nil {
 		return &csi.ValidateVolumeCapabilitiesResponse{Message: err.Error()}, nil //nolint:nilerr
+	}
+	// Multi-node access is only real if the volume was provisioned with an
+	// NFS gateway; confirming RWX on an RWO volume (or vice versa) would
+	// promise access the mount path cannot deliver.
+	if isShared(req.GetVolumeCapabilities()) != (vol.Spec.Export != nil) {
+		return &csi.ValidateVolumeCapabilitiesResponse{
+			Message: "requested access mode does not match the volume's provisioning",
+		}, nil
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{
 		Confirmed: &csi.ValidateVolumeCapabilitiesResponse_Confirmed{
@@ -615,11 +622,12 @@ func (c *Controller) handleCreateErr(ctx context.Context, err error, vol *miroir
 	existingDiskful := len(existing.Spec.DiskfulReplicas())
 	if existing.Spec.SizeBytes != sizeBytes || existingDiskful != replicas ||
 		(replicas > 1 && existing.Spec.QuorumPolicy != quorum) ||
-		existingSource != sourceSnapshot {
+		existingSource != sourceSnapshot ||
+		(existing.Spec.Export != nil) != (vol.Spec.Export != nil) {
 		return status.Errorf(codes.AlreadyExists,
-			"volume %s exists with size=%d diskful=%d quorum=%s source=%q (requested size=%d replicas=%d quorum=%s source=%q)",
-			vol.Name, existing.Spec.SizeBytes, existingDiskful, existing.Spec.QuorumPolicy, existingSource,
-			sizeBytes, replicas, quorum, sourceSnapshot)
+			"volume %s exists with size=%d diskful=%d quorum=%s source=%q rwx=%t (requested size=%d replicas=%d quorum=%s source=%q rwx=%t)",
+			vol.Name, existing.Spec.SizeBytes, existingDiskful, existing.Spec.QuorumPolicy, existingSource, existing.Spec.Export != nil,
+			sizeBytes, replicas, quorum, sourceSnapshot, vol.Spec.Export != nil)
 	}
 	*vol = *existing
 	return nil
@@ -682,8 +690,6 @@ func (c *Controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	if newSize == 0 {
 		return nil, status.Error(codes.InvalidArgument, "capacity range is required")
 	}
-	nodeExpansion := req.GetVolumeCapability().GetBlock() == nil
-
 	vol := &miroirv1alpha1.MiroirVolume{}
 	if err := c.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -691,6 +697,9 @@ func (c *Controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		}
 		return nil, status.Errorf(codes.Internal, "get volume: %v", err)
 	}
+	// RWX volumes are grown by the gateway (it holds the only mount), and a
+	// block volume needs no filesystem grow — neither triggers node expansion.
+	nodeExpansion := req.GetVolumeCapability().GetBlock() == nil && vol.Spec.Export == nil
 	if newSize > vol.Spec.SizeBytes {
 		base := vol.DeepCopy()
 		vol.Spec.SizeBytes = newSize
@@ -844,20 +853,11 @@ func (c *Controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 
 	for i := start; i < end; i++ {
 		v := &vols.Items[i]
-		topology := make([]*csi.Topology, 0, len(v.Spec.Replicas))
-		for _, r := range v.Spec.Replicas {
-			if r.Diskless {
-				continue
-			}
-			topology = append(topology, &csi.Topology{
-				Segments: map[string]string{constants.TopologyKey: r.Node},
-			})
-		}
 		resp.Entries = append(resp.Entries, &csi.ListVolumesResponse_Entry{
 			Volume: &csi.Volume{
 				VolumeId:           v.Name,
 				CapacityBytes:      v.Spec.SizeBytes,
-				AccessibleTopology: topology,
+				AccessibleTopology: accessibleTopology(v),
 			},
 		})
 	}
@@ -997,14 +997,67 @@ func validateCapabilities(caps []*csi.VolumeCapability) error {
 			csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
 			csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
 			csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:
+		case csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY:
+			// RWX is served over NFS from a shared filesystem; a block
+			// device mounted on two nodes has no such coordination.
+			if c.GetBlock() != nil {
+				return status.Error(codes.InvalidArgument,
+					"multi-node access is filesystem-only; block volumes are single-node")
+			}
 		default:
 			return status.Errorf(codes.InvalidArgument,
-				"unsupported access mode %s (miroir is RWO/RWOP only)",
-				c.GetAccessMode().GetMode())
+				"unsupported access mode %s", c.GetAccessMode().GetMode())
 		}
 		if c.GetMount() == nil && c.GetBlock() == nil {
 			return status.Error(codes.InvalidArgument, "capability must be mount or block")
 		}
 	}
 	return nil
+}
+
+// isShared reports whether the request is for an RWX (multi-node) volume.
+func isShared(caps []*csi.VolumeCapability) bool {
+	for _, c := range caps {
+		switch c.GetAccessMode().GetMode() {
+		case csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY:
+			return true
+		}
+	}
+	return false
+}
+
+// defaultFSType is the filesystem used when a mount capability names none.
+const defaultFSType = "ext4"
+
+// exportFSType is the filesystem the gateway formats an RWX volume with,
+// taken from the first mount capability (ext4 when unset).
+func exportFSType(caps []*csi.VolumeCapability) string {
+	for _, c := range caps {
+		if fs := c.GetMount().GetFsType(); fs != "" {
+			return fs
+		}
+	}
+	return defaultFSType
+}
+
+// accessibleTopology reports the nodes a volume can be published from. It
+// is nil for an RWX volume: its NFS gateway is reachable cluster-wide, so
+// the PV carries no node-affinity constraint and consumers schedule
+// anywhere.
+func accessibleTopology(vol *miroirv1alpha1.MiroirVolume) []*csi.Topology {
+	if vol.Spec.Export != nil {
+		return nil
+	}
+	top := make([]*csi.Topology, 0, len(vol.Spec.Replicas))
+	for _, r := range vol.Spec.Replicas {
+		if r.Diskless {
+			continue
+		}
+		top = append(top, &csi.Topology{
+			Segments: map[string]string{constants.TopologyKey: r.Node},
+		})
+	}
+	return top
 }

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -196,21 +196,99 @@ func TestCreateVolumeSucceedsWhenDegraded(t *testing.T) {
 	}
 }
 
-func TestCreateVolumeRejectsRWX(t *testing.T) {
+func rwxCaps() []*csi.VolumeCapability {
+	return []*csi.VolumeCapability{{
+		AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{FsType: "xfs"}},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+		},
+	}}
+}
+
+func TestCreateVolumeRWXSetsExport(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: rwxCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// An RWX PV carries no node affinity — consumers mount NFS from any node.
+	if len(resp.Volume.AccessibleTopology) != 0 {
+		t.Fatalf("RWX volume must have no accessible topology, got %v", resp.Volume.AccessibleTopology)
+	}
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volPvc1}, vol); err != nil {
+		t.Fatal(err)
+	}
+	if vol.Spec.Export == nil || vol.Spec.Export.FSType != "xfs" {
+		t.Fatalf("expected export spec fsType=xfs, got %+v", vol.Spec.Export)
+	}
+}
+
+func TestCreateVolumeRejectsRWXBlock(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: readyOnGet(s), Nodes: testNodes}
 
 	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name: volPvc1,
 		VolumeCapabilities: []*csi.VolumeCapability{{
-			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+			AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
 			AccessMode: &csi.VolumeCapability_AccessMode{
 				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 			},
 		}},
 	})
 	if status.Code(err) != codes.InvalidArgument {
-		t.Fatalf("RWX must be rejected, got %v", err)
+		t.Fatalf("RWX block must be rejected, got %v", err)
+	}
+}
+
+func TestCreateVolumeRejectsRWXLastManStanding(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, DRBDPortBase: 7000}
+
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: rwxCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2", constants.ParamQuorum: "last-man-standing"},
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("RWX with last-man-standing quorum must be rejected, got %v", err)
+	}
+}
+
+// Confirming RWX access against a volume provisioned without an export
+// gateway would promise access the mount path cannot deliver.
+func TestValidateVolumeCapabilitiesRWXMismatch(t *testing.T) {
+	s := newScheme(t)
+	vol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 1 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv}},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(vol).Build()
+	c := &Controller{Client: cl, Nodes: testNodes}
+
+	resp, err := c.ValidateVolumeCapabilities(t.Context(), &csi.ValidateVolumeCapabilitiesRequest{
+		VolumeId:           volPvc1,
+		VolumeCapabilities: rwxCaps(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Confirmed != nil {
+		t.Fatalf("RWX must not be confirmed for a non-export volume, got %+v", resp.Confirmed)
+	}
+	if resp.Message == "" {
+		t.Fatal("expected a rejection message")
 	}
 }
 

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -207,11 +207,12 @@ func rwxCaps() []*csi.VolumeCapability {
 
 func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	s := newScheme(t)
-	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second, DRBDPortBase: 7000}
 
 	resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name:               volPvc1,
 		VolumeCapabilities: rwxCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
 		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
 	})
 	if err != nil {
@@ -227,6 +228,22 @@ func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	}
 	if vol.Spec.Export == nil || vol.Spec.Export.FSType != "xfs" {
 		t.Fatalf("expected export spec fsType=xfs, got %+v", vol.Spec.Export)
+	}
+}
+
+func TestCreateVolumeRejectsRWXSingleReplica(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes}
+
+	// RWX needs a second replica node for the gateway to fail over to.
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: rwxCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "1"},
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("single-replica RWX must be rejected, got %v", err)
 	}
 }
 

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -26,6 +26,8 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	mount "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,6 +113,19 @@ func (n *Node) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequ
 		return nil, err
 	}
 
+	// RWX volumes are served over NFS by a gateway pod; the device lives on
+	// the gateway's node, not here, so this path never touches it.
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := n.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "volume %s not found", req.GetVolumeId())
+		}
+		return nil, status.Errorf(codes.Unavailable, "volume %s lookup: %v", req.GetVolumeId(), err)
+	}
+	if vol.Spec.Export != nil {
+		return n.stageNFS(req, vol)
+	}
+
 	dev, vol, err := n.devicePath(ctx, req.GetVolumeId())
 	if err != nil {
 		return nil, err
@@ -134,11 +149,48 @@ func (n *Node) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequ
 
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
 	if fsType == "" {
-		fsType = "ext4"
+		fsType = defaultFSType
 	}
 	flags := req.GetVolumeCapability().GetMount().GetMountFlags()
 	if err := stage.EnsureFilesystem(ctx, n.deps(), vol, dev, req.GetStagingTargetPath(), fsType, flags); err != nil {
 		return nil, err
+	}
+	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+// stageNFS mounts an RWX volume's NFS export at the staging path. The
+// gateway pod owns the device, the filesystem, and the Formatted/Activated
+// latches, so a consumer node only mounts.
+func (n *Node) stageNFS(req *csi.NodeStageVolumeRequest, vol *miroirv1alpha1.MiroirVolume) (*csi.NodeStageVolumeResponse, error) {
+	if req.GetVolumeCapability().GetBlock() != nil {
+		return nil, status.Error(codes.InvalidArgument, "RWX volumes are filesystem-only")
+	}
+	if vol.Status.Export == nil || vol.Status.Export.Address == "" {
+		return nil, status.Errorf(codes.Unavailable, "volume %s NFS gateway not ready", vol.Name)
+	}
+
+	target := req.GetStagingTargetPath()
+	notMnt, err := n.Mounter.IsLikelyNotMountPoint(target)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(target, 0o750); err != nil {
+			return nil, status.Errorf(codes.Internal, "mkdir staging path: %v", err)
+		}
+		notMnt = true
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "inspect staging path: %v", err)
+	}
+	if !notMnt {
+		return &csi.NodeStageVolumeResponse{}, nil
+	}
+
+	// hard: a gateway failover must stall I/O, never surface EIO into the
+	// app. noresvport: reconnect from a fresh source port so the mount
+	// survives the Service endpoint moving to the replacement gateway pod.
+	opts := append([]string{"vers=4.1", "hard", "noresvport", "timeo=600", "retrans=5"},
+		req.GetVolumeCapability().GetMount().GetMountFlags()...)
+	source := fmt.Sprintf("%s:/%s", vol.Status.Export.Address, vol.Name)
+	if err := n.Mounter.Mount(source, target, "nfs4", opts); err != nil {
+		return nil, status.Errorf(codes.Unavailable, "mount %s at %s: %v", source, target, err)
 	}
 	return &csi.NodeStageVolumeResponse{}, nil
 }

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/sys/unix"
@@ -215,12 +216,30 @@ func (n *Node) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRe
 	return &csi.NodeExpandVolumeResponse{CapacityBytes: req.GetCapacityRange().GetRequiredBytes()}, nil
 }
 
-// NodeUnstageVolume unmounts the staging path. Idempotent.
-func (n *Node) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+// nfsUnmountTimeout bounds a forced NFS unmount so a dead gateway cannot
+// wedge NodeUnstageVolume indefinitely.
+const nfsUnmountTimeout = 30 * time.Second
+
+// NodeUnstageVolume unmounts the staging path. Idempotent. An export
+// volume's staging mount is NFS: if its gateway has died a plain unmount
+// blocks, so force it with a deadline. The volume lookup is best-effort —
+// a volume already deleted falls back to the normal cleanup.
+func (n *Node) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	if req.GetVolumeId() == "" || req.GetStagingTargetPath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id and staging path are required")
 	}
-	if err := mount.CleanupMountPoint(req.GetStagingTargetPath(), n.Mounter, true); err != nil {
+	target := req.GetStagingTargetPath()
+
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := n.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err == nil && vol.Spec.Export != nil {
+		if forcer, ok := n.Mounter.Interface.(mount.MounterForceUnmounter); ok {
+			if err := mount.CleanupMountWithForce(target, forcer, true, nfsUnmountTimeout); err != nil {
+				return nil, status.Errorf(codes.Internal, "unstage: %v", err)
+			}
+			return &csi.NodeUnstageVolumeResponse{}, nil
+		}
+	}
+	if err := mount.CleanupMountPoint(target, n.Mounter, true); err != nil {
 		return nil, status.Errorf(codes.Internal, "unstage: %v", err)
 	}
 	return &csi.NodeUnstageVolumeResponse{}, nil

--- a/internal/csi/node_test.go
+++ b/internal/csi/node_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -179,6 +180,56 @@ func TestDevicePathActivatedIgnoresSplitSlot(t *testing.T) {
 	n := newNode(t, v, fakeDRBDStatus{st: drbd.Status{DiskState: drbd.DiskUpToDate}})
 	if _, _, err := n.devicePath(t.Context(), volPvc1); err != nil {
 		t.Fatalf("activated volume must stage despite a split slot: %v", err)
+	}
+}
+
+// exportVolume is an RWX volume; address is set only once the gateway
+// Service has a ClusterIP.
+func exportVolume(address string) *miroirv1alpha1.MiroirVolume {
+	v := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec:       miroirv1alpha1.MiroirVolumeSpec{Export: &miroirv1alpha1.ExportSpec{FSType: "ext4"}},
+	}
+	if address != "" {
+		v.Status.Export = &miroirv1alpha1.ExportStatus{Address: address}
+	}
+	return v
+}
+
+func nfsStageReq(vc *csi.VolumeCapability) *csi.NodeStageVolumeRequest {
+	return &csi.NodeStageVolumeRequest{
+		VolumeId:          volPvc1,
+		StagingTargetPath: "/var/lib/kubelet/stage",
+		VolumeCapability:  vc,
+	}
+}
+
+func mountCap() *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+		AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER},
+	}
+}
+
+// Until the gateway Service has an address, staging must fail retryably so
+// the CSI sidecar keeps retrying rather than failing the pod.
+func TestStageNFSGatewayNotReady(t *testing.T) {
+	n := &Node{NodeName: nodeKharkiv}
+	if _, err := n.stageNFS(nfsStageReq(mountCap()), exportVolume("")); status.Code(err) != codes.Unavailable {
+		t.Fatalf("unready gateway must be Unavailable, got %v", err)
+	}
+}
+
+// RWX is filesystem-only; a block capability on an export volume is a
+// misconfiguration, not something to mount.
+func TestStageNFSRejectsBlock(t *testing.T) {
+	n := &Node{NodeName: nodeKharkiv}
+	block := &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
+		AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER},
+	}
+	if _, err := n.stageNFS(nfsStageReq(block), exportVolume("10.96.0.7")); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("block on an RWX volume must be InvalidArgument, got %v", err)
 	}
 }
 

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -117,6 +117,13 @@ func TestReconcileCreatesWorkloads(t *testing.T) {
 	if want := []string{nodeKharkiv, nodeParis}; !slices.Equal(got, want) {
 		t.Fatalf("affinity nodes = %v, want %v", got, want)
 	}
+	// Fast eviction on node loss (30s, not the 5m default) so a singleton
+	// gateway's failover can start promptly.
+	for _, tol := range dep.Spec.Template.Spec.Tolerations {
+		if tol.Effect == corev1.TaintEffectNoExecute && (tol.TolerationSeconds == nil || *tol.TolerationSeconds != 30) {
+			t.Fatalf("NoExecute toleration %q must be 30s, got %v", tol.Key, tol.TolerationSeconds)
+		}
+	}
 
 	svc := &corev1.Service{}
 	if err := cl.Get(t.Context(), types.NamespacedName{Name: shareName("pvc-abc"), Namespace: testNS}, svc); err != nil {

--- a/internal/export/workloads.go
+++ b/internal/export/workloads.go
@@ -84,6 +84,13 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,
 					Affinity:           nodeAffinity(diskfulNodes(vol)),
+					// Evict 30s after the node goes unreachable, not the 5m
+					// default: the gateway is a singleton, so failover cannot
+					// start until this pod is gone from the dead node.
+					Tolerations: []corev1.Toleration{
+						{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptr.To[int64](30)},
+						{Key: "node.kubernetes.io/unreachable", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptr.To[int64](30)},
+					},
 					Containers: []corev1.Container{{
 						Name:  "gateway",
 						Image: image,

--- a/test/conformance/testdriver-local.yaml
+++ b/test/conformance/testdriver-local.yaml
@@ -25,6 +25,7 @@ DriverInfo:
     pvcDataSource: false
     topology: true
     singleNodeVolume: true
+    # RWX needs the replicated (DRBD) path; the local driver can't exercise it.
     RWX: false
     readWriteOncePod: true
     capacity: false

--- a/test/conformance/testdriver.yaml
+++ b/test/conformance/testdriver.yaml
@@ -28,6 +28,9 @@ DriverInfo:
     pvcDataSource: false
     topology: true
     singleNodeVolume: false
+    # RWX is implemented (NFS gateway over a replicated volume) but the
+    # upstream RWX specs need real DRBD + ganesha, not kind. Flip to true
+    # once the smoke suite's RWX scenario passes on a real cluster.
     RWX: false
     readWriteOncePod: true
     capacity: false

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -204,6 +204,56 @@ pv_b=$(recycle_pvc)
 recycle_destroy "$pv_b"
 ok "recreate under reused claim came up healthy ($pv_a -> $pv_b)"
 
+step "RWX: shared filesystem across two nodes"
+kubectl apply -n "$NS" -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rwx-data
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: $SC
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+pod_manifest rwx-a rwx-data "$node" | kubectl apply -f -
+pod_manifest rwx-b rwx-data "$other" | kubectl apply -f -
+kubectl wait -n "$NS" pod/rwx-a pod/rwx-b --for=condition=Ready --timeout="$TIMEOUT" \
+    || die "RWX pods not ready on both nodes"
+rwx_pv=$(kubectl get pvc -n "$NS" rwx-data -o jsonpath='{.spec.volumeName}')
+ok "RWX PVC bound ($rwx_pv), pods running on $node and $other"
+
+step "RWX: write on one node visible on the other"
+kubectl exec -n "$NS" rwx-a -- sh -c 'echo hello-from-a > /data/shared && sync'
+# NFS close-to-open: rwx-a closed the file, so rwx-b sees the write.
+got=$(kubectl exec -n "$NS" rwx-b -- cat /data/shared)
+[ "$got" = hello-from-a ] || die "RWX cross-node read got '$got', want hello-from-a"
+ok "write on $node read back on $other over NFS"
+
+step "RWX: gateway pod failover"
+gw=$(kubectl get pod -n miroir-system -l miroir.home-operations.com/volume="$rwx_pv" \
+    -o jsonpath='{.items[0].metadata.name}')
+[ -n "$gw" ] || die "no gateway pod found for $rwx_pv"
+kubectl delete pod -n miroir-system "$gw" --wait
+kubectl rollout status -n miroir-system "deploy/miroir-share-$rwx_pv" --timeout="$TIMEOUT" \
+    || die "gateway did not reschedule"
+# Hard mounts stall through the reschedule and NFS grace, then resume. Retry
+# a bounded write until the replacement gateway is serving again.
+deadline=$((SECONDS + 180))
+until kubectl exec -n "$NS" --request-timeout=20s rwx-b -- sh -c 'echo after-failover >> /data/shared && sync' 2>/dev/null; do
+    [ "$SECONDS" -lt "$deadline" ] || die "RWX did not recover after gateway failover"
+    sleep 5
+done
+kubectl exec -n "$NS" rwx-a -- grep -q after-failover /data/shared \
+    || die "post-failover write not visible on $node"
+ok "RWX survived gateway reschedule and stayed writable"
+
+# Clean up the RWX resources so the teardown check below stays about the
+# RWO PVs it already tracks.
+kubectl delete pod -n "$NS" rwx-a rwx-b --wait
+kubectl delete pvc -n "$NS" rwx-data --wait
+
 step "teardown leaves nothing behind"
 pv2=$(kubectl get pvc -n "$NS" smoke-restore -o jsonpath='{.spec.volumeName}')
 kubectl delete namespace "$NS" --wait=true --timeout=120s


### PR DESCRIPTION
Stacked on #163 → #162 → #161. Merge the stack bottom-up; this base retargets to `main` as the others land. **This is the PR that turns RWX on.**

## What

With the gateway runtime (#162) and reconciler (#163) in place, this wires the CSI surface so an RWX PVC actually provisions, mounts, and grows.

- **`validateCapabilities`** accepts `MULTI_NODE_MULTI_WRITER` and `MULTI_NODE_READER_ONLY`, **filesystem only** (RWX + block stays rejected — a block device on two nodes has no coordination).
- **`CreateVolume`** records `spec.export{fsType}` for a multi-node request (which triggers the #163 reconciler to spawn the gateway), rejects RWX + `last-man-standing` quorum, and gives export volumes **no `AccessibleTopology`** so their PV has no node affinity and consumers schedule anywhere.
- **`NodeStageVolume`** mounts the gateway's NFS export (`vers=4.1,hard,noresvport,timeo=600,retrans=5`) for export volumes — a consumer node has no local device, and the gateway owns the device + the `Formatted`/`Activated` latches. The mount path is reached *before* device resolution.
- **Client-only agent:** a node absent from the storage map now runs just the CSI node service (via an `errNodeUnmapped` sentinel from `backendFor`) instead of refusing to start, so pods there can mount RWX volumes.
- **`ControllerExpandVolume`** returns `NodeExpansionRequired: false` for export volumes (the gateway grows the fs); **`ValidateVolumeCapabilities`** confirms multi-node access only against a volume that has an export gateway.

The two duplicated `AccessibleTopology` loops (CreateVolume + ListVolumes) are now one `accessibleTopology` helper that returns nil for export volumes.

## Test

- `go build`/`vet`/`golangci-lint` clean.
- `controller_test.go`: RWX+mount sets `spec.export` and empty topology; RWX+block rejected; RWX+last-man-standing rejected; `ValidateVolumeCapabilities` mismatch (RWX caps vs RWO volume) not confirmed.
- `node_test.go`: `stageNFS` returns `Unavailable` until the gateway address is set (sidecar-retry contract), and rejects block on an export volume.
- Full end-to-end (real NFS mount, gateway pod, live-migration-style read/write across nodes) is exercised on a cluster in the smoke/e2e PR — the `csi` package's unit tests are Linux-only and run in CI.

## Caveat / follow-ups

Real-cluster validation (Talos NFS client modules, ganesha dbus-less startup, failover timing) lands in the failover-hardening PR; docs + conformance in the final PR.