### PR TITLE
feat: harden RWX gateway failover and NFS unstage

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -149,9 +149,15 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 	shared := isShared(req.GetVolumeCapabilities())
-	if shared && replicas > 1 && quorum == miroirv1alpha1.QuorumLastManStanding {
-		return nil, status.Error(codes.InvalidArgument,
-			"RWX volumes require freeze quorum: last-man-standing risks dual-primary split-brain when the gateway reschedules")
+	if shared {
+		if replicas < 2 {
+			return nil, status.Error(codes.InvalidArgument,
+				"RWX volumes need at least 2 replicas so the NFS gateway can fail over to a surviving node")
+		}
+		if quorum == miroirv1alpha1.QuorumLastManStanding {
+			return nil, status.Error(codes.InvalidArgument,
+				"RWX volumes require freeze quorum: last-man-standing risks two gateways writing during a partition")
+		}
 	}
 
 	snapID := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -207,11 +207,12 @@ func rwxCaps() []*csi.VolumeCapability {
 
 func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	s := newScheme(t)
-	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second, DRBDPortBase: 7000}
 
 	resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name:               volPvc1,
 		VolumeCapabilities: rwxCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
 		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
 	})
 	if err != nil {
@@ -227,6 +228,22 @@ func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	}
 	if vol.Spec.Export == nil || vol.Spec.Export.FSType != "xfs" {
 		t.Fatalf("expected export spec fsType=xfs, got %+v", vol.Spec.Export)
+	}
+}
+
+func TestCreateVolumeRejectsRWXSingleReplica(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes}
+
+	// RWX needs a second replica node for the gateway to fail over to.
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: rwxCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "1"},
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("single-replica RWX must be rejected, got %v", err)
 	}
 }
 

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/sys/unix"
@@ -215,12 +216,30 @@ func (n *Node) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRe
 	return &csi.NodeExpandVolumeResponse{CapacityBytes: req.GetCapacityRange().GetRequiredBytes()}, nil
 }
 
-// NodeUnstageVolume unmounts the staging path. Idempotent.
-func (n *Node) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+// nfsUnmountTimeout bounds a forced NFS unmount so a dead gateway cannot
+// wedge NodeUnstageVolume indefinitely.
+const nfsUnmountTimeout = 30 * time.Second
+
+// NodeUnstageVolume unmounts the staging path. Idempotent. An export
+// volume's staging mount is NFS: if its gateway has died a plain unmount
+// blocks, so force it with a deadline. The volume lookup is best-effort —
+// a volume already deleted falls back to the normal cleanup.
+func (n *Node) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	if req.GetVolumeId() == "" || req.GetStagingTargetPath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id and staging path are required")
 	}
-	if err := mount.CleanupMountPoint(req.GetStagingTargetPath(), n.Mounter, true); err != nil {
+	target := req.GetStagingTargetPath()
+
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := n.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err == nil && vol.Spec.Export != nil {
+		if forcer, ok := n.Mounter.Interface.(mount.MounterForceUnmounter); ok {
+			if err := mount.CleanupMountWithForce(target, forcer, true, nfsUnmountTimeout); err != nil {
+				return nil, status.Errorf(codes.Internal, "unstage: %v", err)
+			}
+			return &csi.NodeUnstageVolumeResponse{}, nil
+		}
+	}
+	if err := mount.CleanupMountPoint(target, n.Mounter, true); err != nil {
 		return nil, status.Errorf(codes.Internal, "unstage: %v", err)
 	}
 	return &csi.NodeUnstageVolumeResponse{}, nil

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -117,6 +117,13 @@ func TestReconcileCreatesWorkloads(t *testing.T) {
 	if want := []string{nodeKharkiv, nodeParis}; !slices.Equal(got, want) {
 		t.Fatalf("affinity nodes = %v, want %v", got, want)
 	}
+	// Fast eviction on node loss (30s, not the 5m default) so a singleton
+	// gateway's failover can start promptly.
+	for _, tol := range dep.Spec.Template.Spec.Tolerations {
+		if tol.Effect == corev1.TaintEffectNoExecute && (tol.TolerationSeconds == nil || *tol.TolerationSeconds != 30) {
+			t.Fatalf("NoExecute toleration %q must be 30s, got %v", tol.Key, tol.TolerationSeconds)
+		}
+	}
 
 	svc := &corev1.Service{}
 	if err := cl.Get(t.Context(), types.NamespacedName{Name: shareName("pvc-abc"), Namespace: testNS}, svc); err != nil {

--- a/internal/export/workloads.go
+++ b/internal/export/workloads.go
@@ -84,6 +84,13 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,
 					Affinity:           nodeAffinity(diskfulNodes(vol)),
+					// Evict 30s after the node goes unreachable, not the 5m
+					// default: the gateway is a singleton, so failover cannot
+					// start until this pod is gone from the dead node.
+					Tolerations: []corev1.Toleration{
+						{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptr.To[int64](30)},
+						{Key: "node.kubernetes.io/unreachable", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptr.To[int64](30)},
+					},
 					Containers: []corev1.Container{{
 						Name:  "gateway",
 						Image: image,

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -204,6 +204,56 @@ pv_b=$(recycle_pvc)
 recycle_destroy "$pv_b"
 ok "recreate under reused claim came up healthy ($pv_a -> $pv_b)"
 
+step "RWX: shared filesystem across two nodes"
+kubectl apply -n "$NS" -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rwx-data
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: $SC
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+pod_manifest rwx-a rwx-data "$node" | kubectl apply -f -
+pod_manifest rwx-b rwx-data "$other" | kubectl apply -f -
+kubectl wait -n "$NS" pod/rwx-a pod/rwx-b --for=condition=Ready --timeout="$TIMEOUT" \
+    || die "RWX pods not ready on both nodes"
+rwx_pv=$(kubectl get pvc -n "$NS" rwx-data -o jsonpath='{.spec.volumeName}')
+ok "RWX PVC bound ($rwx_pv), pods running on $node and $other"
+
+step "RWX: write on one node visible on the other"
+kubectl exec -n "$NS" rwx-a -- sh -c 'echo hello-from-a > /data/shared && sync'
+# NFS close-to-open: rwx-a closed the file, so rwx-b sees the write.
+got=$(kubectl exec -n "$NS" rwx-b -- cat /data/shared)
+[ "$got" = hello-from-a ] || die "RWX cross-node read got '$got', want hello-from-a"
+ok "write on $node read back on $other over NFS"
+
+step "RWX: gateway pod failover"
+gw=$(kubectl get pod -n miroir-system -l miroir.home-operations.com/volume="$rwx_pv" \
+    -o jsonpath='{.items[0].metadata.name}')
+[ -n "$gw" ] || die "no gateway pod found for $rwx_pv"
+kubectl delete pod -n miroir-system "$gw" --wait
+kubectl rollout status -n miroir-system "deploy/miroir-share-$rwx_pv" --timeout="$TIMEOUT" \
+    || die "gateway did not reschedule"
+# Hard mounts stall through the reschedule and NFS grace, then resume. Retry
+# a bounded write until the replacement gateway is serving again.
+deadline=$((SECONDS + 180))
+until kubectl exec -n "$NS" --request-timeout=20s rwx-b -- sh -c 'echo after-failover >> /data/shared && sync' 2>/dev/null; do
+    [ "$SECONDS" -lt "$deadline" ] || die "RWX did not recover after gateway failover"
+    sleep 5
+done
+kubectl exec -n "$NS" rwx-a -- grep -q after-failover /data/shared \
+    || die "post-failover write not visible on $node"
+ok "RWX survived gateway reschedule and stayed writable"
+
+# Clean up the RWX resources so the teardown check below stays about the
+# RWO PVs it already tracks.
+kubectl delete pod -n "$NS" rwx-a rwx-b --wait
+kubectl delete pvc -n "$NS" rwx-data --wait
+
 step "teardown leaves nothing behind"
 pv2=$(kubectl get pvc -n "$NS" smoke-restore -o jsonpath='{.spec.volumeName}')
 kubectl delete namespace "$NS" --wait=true --timeout=120s


### PR DESCRIPTION
Stacked on #164 → #163 → #162 → #161. Merge bottom-up; base retargets to `main` as the stack lands.

## What

Failover and ops hardening for the RWX gateway.

- **Fast eviction:** the gateway Deployment tolerates `not-ready`/`unreachable` for **30s** (`NoExecute`, `tolerationSeconds: 30`) instead of the 5-minute default. The gateway is a singleton, so failover can't start until the old pod is gone from the dead node — 30s is the floor on node-death failover.
- **Unstuck unstage:** `NodeUnstageVolume` force-unmounts an export volume's NFS staging mount (`CleanupMountWithForce`, 30s deadline) — a plain `umount` of a dead gateway's `hard` NFS mount blocks forever. Best-effort volume lookup; a deleted volume falls back to the normal cleanup path.
- **Smoke scenario:** `smoke.sh` gains an RWX case — a `ReadWriteMany` PVC with pods on two different nodes sharing a file over NFS, then a gateway-pod deletion that must reschedule and stay writable (bounded retry through the NFS grace window).

## Design note (LINSTOR comparison)

I checked how LINSTOR/Piraeus does RWX before hardening this. Its **manual** pattern is a per-volume NFS pod exporting an RWO volume — identical to ours. Its **native** path (Operator 2.10.0) uses a shared `linstor-csi-nfs-server` DaemonSet + **DRBD Reactor** for HA, which scales to more volumes and fails over faster, but pulls in DRBD Reactor and dynamic export reconfiguration — the "extra control plane" miroir exists to avoid. For miroir's 2–3-node target the per-volume Deployment is the right trade; `tolerationSeconds: 30` here closes most of the failover-speed gap. DRBD Reactor stays a possible future optimization.

## Test

- `go build`/`vet`/`golangci-lint` clean; `gofmt` clean; `smoke.sh` passes `bash -n`.
- `internal/export` test asserts the 30s `NoExecute` tolerations.
- `stageNFS`/unstage force-unmount and the smoke scenario exercise real NFS behaviour, which runs on a cluster (the `csi` package is Linux-only; its unit tests run in CI).

## Honest caveat

The real-cluster validation this PR is *about* — ganesha grace behaviour on Talos, actual failover timing, the smoke scenario passing against DRBD+ganesha — has **not** been run from here (no cluster access). The code encodes sane defaults (fs recovery backend on the volume, 60s grace, 30s eviction); numbers may need tuning once smoke runs on real hardware. Flagging so this isn't merged as "validated".