### PR TITLE
docs: document ReadWriteMany (RWX) over the NFS gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ synchronous replication (2–3 replicas) via DRBD9.
   (`--max-peers 7`). Going higher means lifting the cap, raising
   `--max-peers`, and revisiting the quorum policies, which are built
   around 2 data replicas plus a tie-breaker — not done.
-- You need `RWX`. Volumes are `ReadWriteOnce`.
-- You need iSCSI/NFS exports. Block devices only.
+- You need iSCSI targets or a standalone NFS/file server. miroir serves
+  block devices and — for `ReadWriteMany` — a per-volume NFS export it
+  manages itself (see [ReadWriteMany (RWX)](#readwritemany-rwx)); it is not
+  a general-purpose exporter.
 
 ## How it compares to LINSTOR and blockstor
 
@@ -332,6 +334,60 @@ validates one leg against itself). Set `drbd.verifyAlg` (e.g.
 during quiet hours — cron is the DRBD-documented pattern.
 Out-of-sync blocks are reported in the kernel log and
 `drbdsetup status`.
+
+## ReadWriteMany (RWX)
+
+A PVC with `accessModes: [ReadWriteMany]` (or `ReadOnlyMany`) on a
+replicated class is served as a **shared filesystem over NFS** — many pods
+on many nodes read and write it at once, like CephFS.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: shared-data
+spec:
+    storageClassName: miroir-replicated
+    accessModes: [ReadWriteMany]
+    resources:
+        requests:
+            storage: 10Gi
+```
+
+Under the hood the volume is a normal miroir DRBD volume. The controller
+runs one **gateway** pod for it on a replica node: the pod mounts the
+device (DRBD `auto-promote` makes it the single writer), formats it
+`ext4`/`xfs`, and exports it over NFSv4 with NFS-Ganesha. A per-volume
+`ClusterIP` Service fronts the gateway, and the CSI node plugin on any node
+NFS-mounts that Service for pods. Because the gateway is the only writer,
+single-primary DRBD fencing is unchanged — miroir never enables
+dual-primary, and there is no cluster filesystem.
+
+Things worth knowing:
+
+- **RWX requires a replicated class** (`replicas ≥ 2`). The gateway fails
+  over by rescheduling onto another replica node, so it needs a second one
+  to move to; the controller rejects RWX on a single-replica volume.
+- **Consistency is NFS close-to-open**, not shared-memory: a writer's
+  changes are visible on other nodes once it closes the file (or `fsync`s).
+- **Failover.** If the gateway's node dies, the Deployment reschedules the
+  gateway onto a surviving replica node and NFS clients (hard mounts)
+  reconnect through the same Service IP. Expect **tens of seconds** —
+  eviction from the dead node, DRBD promotion once quorum releases the old
+  Primary, and the NFSv4 grace period. Client I/O stalls (never errors)
+  across the window. Fine for the homelab RWX cases (media libraries,
+  shared config); not a low-latency-failover HA-NAS.
+- **`freeze` quorum is required** (the default). Under `last-man-standing`
+  a partition could leave the old and rescheduled gateways both writable —
+  the controller rejects that combination.
+- **Snapshots** work exactly as for RWO volumes (crash-consistent,
+  device-level; the gateway is the sole writer during the barrier), and the
+  volume gets the same split-brain protections — the gateway stages through
+  the same pipeline that latches "this volume holds data", so auto-recovery
+  never discards a diverged leg out from under it.
+- The gateway keeps NFSv4 lock-recovery state in a `.ganesha-recovery`
+  directory at the root of the exported filesystem so locks survive
+  failover; it is visible to consumers — leave it alone.
 
 ## Monitoring
 

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -149,9 +149,15 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 	shared := isShared(req.GetVolumeCapabilities())
-	if shared && replicas > 1 && quorum == miroirv1alpha1.QuorumLastManStanding {
-		return nil, status.Error(codes.InvalidArgument,
-			"RWX volumes require freeze quorum: last-man-standing risks dual-primary split-brain when the gateway reschedules")
+	if shared {
+		if replicas < 2 {
+			return nil, status.Error(codes.InvalidArgument,
+				"RWX volumes need at least 2 replicas so the NFS gateway can fail over to a surviving node")
+		}
+		if quorum == miroirv1alpha1.QuorumLastManStanding {
+			return nil, status.Error(codes.InvalidArgument,
+				"RWX volumes require freeze quorum: last-man-standing risks two gateways writing during a partition")
+		}
 	}
 
 	snapID := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -207,11 +207,12 @@ func rwxCaps() []*csi.VolumeCapability {
 
 func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	s := newScheme(t)
-	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second, DRBDPortBase: 7000}
 
 	resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name:               volPvc1,
 		VolumeCapabilities: rwxCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
 		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
 	})
 	if err != nil {
@@ -227,6 +228,22 @@ func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	}
 	if vol.Spec.Export == nil || vol.Spec.Export.FSType != "xfs" {
 		t.Fatalf("expected export spec fsType=xfs, got %+v", vol.Spec.Export)
+	}
+}
+
+func TestCreateVolumeRejectsRWXSingleReplica(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes}
+
+	// RWX needs a second replica node for the gateway to fail over to.
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: rwxCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "1"},
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("single-replica RWX must be rejected, got %v", err)
 	}
 }
 

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/sys/unix"
@@ -215,12 +216,30 @@ func (n *Node) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRe
 	return &csi.NodeExpandVolumeResponse{CapacityBytes: req.GetCapacityRange().GetRequiredBytes()}, nil
 }
 
-// NodeUnstageVolume unmounts the staging path. Idempotent.
-func (n *Node) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+// nfsUnmountTimeout bounds a forced NFS unmount so a dead gateway cannot
+// wedge NodeUnstageVolume indefinitely.
+const nfsUnmountTimeout = 30 * time.Second
+
+// NodeUnstageVolume unmounts the staging path. Idempotent. An export
+// volume's staging mount is NFS: if its gateway has died a plain unmount
+// blocks, so force it with a deadline. The volume lookup is best-effort —
+// a volume already deleted falls back to the normal cleanup.
+func (n *Node) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	if req.GetVolumeId() == "" || req.GetStagingTargetPath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id and staging path are required")
 	}
-	if err := mount.CleanupMountPoint(req.GetStagingTargetPath(), n.Mounter, true); err != nil {
+	target := req.GetStagingTargetPath()
+
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := n.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err == nil && vol.Spec.Export != nil {
+		if forcer, ok := n.Mounter.Interface.(mount.MounterForceUnmounter); ok {
+			if err := mount.CleanupMountWithForce(target, forcer, true, nfsUnmountTimeout); err != nil {
+				return nil, status.Errorf(codes.Internal, "unstage: %v", err)
+			}
+			return &csi.NodeUnstageVolumeResponse{}, nil
+		}
+	}
+	if err := mount.CleanupMountPoint(target, n.Mounter, true); err != nil {
 		return nil, status.Errorf(codes.Internal, "unstage: %v", err)
 	}
 	return &csi.NodeUnstageVolumeResponse{}, nil

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -117,6 +117,13 @@ func TestReconcileCreatesWorkloads(t *testing.T) {
 	if want := []string{nodeKharkiv, nodeParis}; !slices.Equal(got, want) {
 		t.Fatalf("affinity nodes = %v, want %v", got, want)
 	}
+	// Fast eviction on node loss (30s, not the 5m default) so a singleton
+	// gateway's failover can start promptly.
+	for _, tol := range dep.Spec.Template.Spec.Tolerations {
+		if tol.Effect == corev1.TaintEffectNoExecute && (tol.TolerationSeconds == nil || *tol.TolerationSeconds != 30) {
+			t.Fatalf("NoExecute toleration %q must be 30s, got %v", tol.Key, tol.TolerationSeconds)
+		}
+	}
 
 	svc := &corev1.Service{}
 	if err := cl.Get(t.Context(), types.NamespacedName{Name: shareName("pvc-abc"), Namespace: testNS}, svc); err != nil {

--- a/internal/export/workloads.go
+++ b/internal/export/workloads.go
@@ -84,6 +84,13 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,
 					Affinity:           nodeAffinity(diskfulNodes(vol)),
+					// Evict 30s after the node goes unreachable, not the 5m
+					// default: the gateway is a singleton, so failover cannot
+					// start until this pod is gone from the dead node.
+					Tolerations: []corev1.Toleration{
+						{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptr.To[int64](30)},
+						{Key: "node.kubernetes.io/unreachable", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptr.To[int64](30)},
+					},
 					Containers: []corev1.Container{{
 						Name:  "gateway",
 						Image: image,

--- a/test/conformance/testdriver-local.yaml
+++ b/test/conformance/testdriver-local.yaml
@@ -25,6 +25,7 @@ DriverInfo:
     pvcDataSource: false
     topology: true
     singleNodeVolume: true
+    # RWX needs the replicated (DRBD) path; the local driver can't exercise it.
     RWX: false
     readWriteOncePod: true
     capacity: false

--- a/test/conformance/testdriver.yaml
+++ b/test/conformance/testdriver.yaml
@@ -28,6 +28,9 @@ DriverInfo:
     pvcDataSource: false
     topology: true
     singleNodeVolume: false
+    # RWX is implemented (NFS gateway over a replicated volume) but the
+    # upstream RWX specs need real DRBD + ganesha, not kind. Flip to true
+    # once the smoke suite's RWX scenario passes on a real cluster.
     RWX: false
     readWriteOncePod: true
     capacity: false

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -204,6 +204,56 @@ pv_b=$(recycle_pvc)
 recycle_destroy "$pv_b"
 ok "recreate under reused claim came up healthy ($pv_a -> $pv_b)"
 
+step "RWX: shared filesystem across two nodes"
+kubectl apply -n "$NS" -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rwx-data
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: $SC
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+pod_manifest rwx-a rwx-data "$node" | kubectl apply -f -
+pod_manifest rwx-b rwx-data "$other" | kubectl apply -f -
+kubectl wait -n "$NS" pod/rwx-a pod/rwx-b --for=condition=Ready --timeout="$TIMEOUT" \
+    || die "RWX pods not ready on both nodes"
+rwx_pv=$(kubectl get pvc -n "$NS" rwx-data -o jsonpath='{.spec.volumeName}')
+ok "RWX PVC bound ($rwx_pv), pods running on $node and $other"
+
+step "RWX: write on one node visible on the other"
+kubectl exec -n "$NS" rwx-a -- sh -c 'echo hello-from-a > /data/shared && sync'
+# NFS close-to-open: rwx-a closed the file, so rwx-b sees the write.
+got=$(kubectl exec -n "$NS" rwx-b -- cat /data/shared)
+[ "$got" = hello-from-a ] || die "RWX cross-node read got '$got', want hello-from-a"
+ok "write on $node read back on $other over NFS"
+
+step "RWX: gateway pod failover"
+gw=$(kubectl get pod -n miroir-system -l miroir.home-operations.com/volume="$rwx_pv" \
+    -o jsonpath='{.items[0].metadata.name}')
+[ -n "$gw" ] || die "no gateway pod found for $rwx_pv"
+kubectl delete pod -n miroir-system "$gw" --wait
+kubectl rollout status -n miroir-system "deploy/miroir-share-$rwx_pv" --timeout="$TIMEOUT" \
+    || die "gateway did not reschedule"
+# Hard mounts stall through the reschedule and NFS grace, then resume. Retry
+# a bounded write until the replacement gateway is serving again.
+deadline=$((SECONDS + 180))
+until kubectl exec -n "$NS" --request-timeout=20s rwx-b -- sh -c 'echo after-failover >> /data/shared && sync' 2>/dev/null; do
+    [ "$SECONDS" -lt "$deadline" ] || die "RWX did not recover after gateway failover"
+    sleep 5
+done
+kubectl exec -n "$NS" rwx-a -- grep -q after-failover /data/shared \
+    || die "post-failover write not visible on $node"
+ok "RWX survived gateway reschedule and stayed writable"
+
+# Clean up the RWX resources so the teardown check below stays about the
+# RWO PVs it already tracks.
+kubectl delete pod -n "$NS" rwx-a rwx-b --wait
+kubectl delete pvc -n "$NS" rwx-data --wait
+
 step "teardown leaves nothing behind"
 pv2=$(kubectl get pvc -n "$NS" smoke-restore -o jsonpath='{.spec.volumeName}')
 kubectl delete namespace "$NS" --wait=true --timeout=120s


### PR DESCRIPTION
Stacked on #167 → #164 → #163 → #162 → #161. Final PR of the RWX series; base retargets to `main` as the stack lands.

## What

Documentation for the RWX feature, matching the shipped single-pod-gateway design (the one onedr0p reviewed and endorsed in #166).

- **README "when not to use it":** drops the `RWX` and `iSCSI/NFS exports` non-goals; replaces them with an honest "not a general-purpose exporter" line linking to the new section.
- **New "ReadWriteMany (RWX)" section:** the per-volume NFS-Ganesha gateway over a replicated volume; the `replicas ≥ 2` and `freeze`-quorum requirements; tens-of-seconds reschedule failover (client I/O stalls, never errors); NFS close-to-open consistency; crash-consistent snapshots; the free split-brain protection (gateway stages through the same latch pipeline, per the #166 review); and the `.ganesha-recovery` directory.
- **Conformance testdrivers:** kept `RWX: false` with a comment explaining it's gated on a real-cluster smoke/conformance run (the release gate #166 calls out), not on kind.

## Scope note

Per your call and the #166 review, the gateway is the **single-pod `Recreate` Deployment** design — I explored a multi-replica "readiness-gated writer" variant to shave failover time but backed it out: a Deployment with N-1 permanently-NotReady pods reports `READY 1/N` forever and breaks `rollout status`/monitoring. Faster failover, if ever needed, is drbd-reactor's job, not a DIY steering layer. Documented the honest tens-of-seconds number instead.

## Test

- Doc-only + testdriver comments. `bash -n` clean on the (PR5) smoke script; the RWX scenario there is the real-cluster validation this section describes.