### PR TITLE
test(csi): fix RWX create test missing Node fixtures

### DIFF
--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -207,7 +207,15 @@ func rwxCaps() []*csi.VolumeCapability {
 
 func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	s := newScheme(t)
-	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second, DRBDPortBase: 7000}
+	// RWX is replicated (>=2), so placement resolves each replica's address
+	// from its Node's InternalIP — the fake client needs the Node objects.
+	cl := readyOnGet(s)
+	for _, n := range []*corev1.Node{nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)} {
+		if err := cl.Create(t.Context(), n); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c := &Controller{Client: cl, Nodes: testNodes, ProvisionTimeout: 2 * time.Second, DRBDPortBase: 7000}
 
 	resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name:               volPvc1,


### PR DESCRIPTION
`TestCreateVolumeRWXSetsExport` (merged in #164) fails on `main`:

```
controller_test.go: rpc error: code = Internal desc = get node kharkiv: nodes "kharkiv" not found
FAIL github.com/home-operations/miroir/internal/csi
```

RWX requires `replicas >= 2`, so the test provisions a replicated volume, and placement resolves each replica's address from its Node's `InternalIP`. The test used the bare `readyOnGet` client, which has no `Node` objects. Seed the `Node` fixtures the same way `TestCreateVolumeReplicated` already does.

This slipped through because the `internal/csi` package is Linux-only (`unix.Statfs_t`), so its tests can't run on the maintainer's macOS dev box — only `go build`/`vet`/`golangci-lint` do, and it type-checks fine. It surfaced on the first Linux `go test` run. Verified `vet` + `golangci-lint` clean; the fix is the same node-seeding pattern the passing replicated-create test uses.