### PR TITLE
fix(csi): seed Node objects in the RWX CreateVolume test

### DIFF
--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -72,9 +72,10 @@ var testNodes = nodemap.Map{
 
 // readyOnGet flips a created volume to Ready, simulating the agent.
 // NB: depends on the fake client returning the same object pointer.
-func readyOnGet(s *runtime.Scheme) client.WithWatch {
+func readyOnGet(s *runtime.Scheme, objs ...client.Object) client.WithWatch {
 	return fake.NewClientBuilder().
 		WithScheme(s).
+		WithObjects(objs...).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}, &miroirv1alpha1.MiroirSnapshot{}).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -207,7 +208,14 @@ func rwxCaps() []*csi.VolumeCapability {
 
 func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	s := newScheme(t)
-	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second, DRBDPortBase: 7000}
+	// Node objects back the replication-address resolution place() runs
+	// for the 2-replica placement.
+	c := &Controller{
+		Client:           readyOnGet(s, nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)),
+		Nodes:            testNodes,
+		ProvisionTimeout: 2 * time.Second,
+		DRBDPortBase:     7000,
+	}
 
 	resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name:               volPvc1,


### PR DESCRIPTION
`TestCreateVolumeRWXSetsExport` (from #164) places a 2-replica volume, and `place()` resolves replication addresses from Node objects the test's fake client never held — so the test fails and main's Tests workflow is currently red (#164's own push run was cancelled by the concurrency group, which is how it slipped through; the 0.4.12 release commit shows the failure). `readyOnGet` grows a variadic objects parameter and the test seeds the two Nodes.