### PR TITLE
fix(controller): scope gateway Deployment/Service informers to the namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,8 @@ import (
 	"time"
 
 	"github.com/robfig/cron/v3"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -120,6 +122,25 @@ func setupExport(mgr ctrl.Manager, namespace, image, serviceAccount string) erro
 // client-only agent (CSI node service for RWX/NFS consumers) rather than
 // failing to start.
 var errNodeUnmapped = errors.New("node absent from the storage node map")
+
+// cacheOptions builds the manager cache config. SSA-heavy objects grow a
+// managedFields entry per field manager (every agent + the CSI controller
+// write each volume), so strip them from cached copies — nothing reads
+// them locally (conflict detection is server-side; SSA patches build fresh
+// objects). In controller mode the export reconciler manages gateway
+// Deployments and Services only in its own namespace, so scope those
+// informers there: Owns() otherwise lists them cluster-wide, which the
+// namespaced Role neither grants nor should. Other types stay cluster-scoped.
+func cacheOptions(mode, namespace string) cache.Options {
+	opts := cache.Options{DefaultTransform: cache.TransformStripManagedFields()}
+	if mode == modeController && namespace != "" {
+		opts.ByObject = map[client.Object]cache.ByObject{
+			&appsv1.Deployment{}: {Namespaces: map[string]cache.Config{namespace: {}}},
+			&corev1.Service{}:    {Namespaces: map[string]cache.Config{namespace: {}}},
+		}
+	}
+	return opts
+}
 
 // backendFor resolves this node's storage entry from the node map and
 // builds its backend — shared by setup and agent mode so the two can
@@ -329,12 +350,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: metricsAddr},
-		// SSA-heavy objects grow a managedFields entry per field manager
-		// (every agent + the CSI controller write each volume), and every
-		// agent caches all volumes cluster-wide — strip them from cached
-		// copies. Nothing reads them locally: conflict detection is
-		// server-side, and the SSA patches build fresh objects.
-		Cache: cache.Options{DefaultTransform: cache.TransformStripManagedFields()},
+		Cache:   cacheOptions(mode, podNamespace),
 		// The dedicated health-probe server is disabled; the probes are
 		// co-hosted on the (plain HTTP) metrics listener so each workload
 		// exposes a single operational port — the agent runs hostNetwork,


### PR DESCRIPTION
The deployed controller logs a fatal watch error after the RWX work landed:

```
Failed to watch *v1.Service: services is forbidden: User
"system:serviceaccount:miroir-system:miroir-controller" cannot list
resource "services" in API group "" at the cluster scope
```

**Cause:** the export reconciler `Owns(&appsv1.Deployment{})` / `Owns(&corev1.Service{})`, so controller-runtime's cache sets up a **cluster-scoped** list/watch on both. But the controller only holds a **namespaced** Role for deployments/services (it creates gateway workloads in its own namespace — the least-privilege shape #166 endorsed). So the cluster-wide watch is forbidden and the informer never syncs.

**Fix:** scope just the Deployment/Service informers to the controller's namespace via `cache.Options.ByObject` (in controller mode). The namespaced Role then satisfies the watch, and it's also less work than caching every Service in the cluster. Cluster-scoped types (the CRDs, Nodes) are untouched. No chart change — the namespaced Role already grants `list`/`watch` in the release namespace.

Extracted the cache config into a `cacheOptions(mode, namespace)` helper (also keeps `main()` under the gocyclo limit).

## Test
`GOOS=linux` build + vet + `golangci-lint` clean. Behavioral fix in the manager cache wiring; the real confirmation is the controller starting cleanly on-cluster (no forbidden-watch error) — same off-cluster caveat as the rest of this feature.