### PR TITLE
feat(chart)!: unify storage & snapshot classes into arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,14 @@ helm install miroir oci://ghcr.io/home-operations/charts/miroir \
 The chart deploys a single `miroir-controller` Deployment, a
 `miroir-agent` DaemonSet on every schedulable node (pods can mount
 miroir volumes from any node; only nodes in the `nodes` map hold
-storage). No StorageClasses are created by default — declare the ones
-you want under `storageClasses` (see the chart values for the canonical
-`miroir-local` / `miroir-replicated` pair the examples below use; an
-entry is local at `replicas: 1` and DRBD-replicated at `replicas: 2`).
-Per-node setup jobs provision each pool on install and upgrade, and the
-agent re-runs the same idempotent setup at startup; existing pools are
-reused.
+storage). No StorageClasses or VolumeSnapshotClasses are created by
+default — declare the ones you want under `storageClasses` and
+`volumeSnapshotClasses` (see the chart values for the canonical
+`miroir-local` / `miroir-replicated` / `miroir-snap` set the examples
+below use; a storage entry is local at `replicas: 1` and
+DRBD-replicated at `replicas: 2`). Per-node setup jobs provision each
+pool on install and upgrade, and the agent re-runs the same idempotent
+setup at startup; existing pools are reused.
 
 ### 3. Claim a volume
 
@@ -188,7 +189,9 @@ policies do and how the automatic diskless tie-breaker fits in.
 ### 4. Snapshot and restore
 
 Requires the cluster-wide `snapshot-controller` and `volumesnapshot`
-CRDs (see the [CSI snapshot docs](https://kubernetes-csi.github.io/docs/snapshots.html)).
+CRDs (see the [CSI snapshot docs](https://kubernetes-csi.github.io/docs/snapshots.html)),
+and a VolumeSnapshotClass declared under `volumeSnapshotClasses` (the
+`miroir-snap` below is the example name).
 
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1

--- a/README.md
+++ b/README.md
@@ -138,10 +138,13 @@ helm install miroir oci://ghcr.io/home-operations/charts/miroir \
 The chart deploys a single `miroir-controller` Deployment, a
 `miroir-agent` DaemonSet on every schedulable node (pods can mount
 miroir volumes from any node; only nodes in the `nodes` map hold
-storage), and two StorageClasses: `miroir-local` (1 replica) and
-`miroir-replicated` (2 replicas, DRBD9). Per-node setup jobs
-provision each pool on install and upgrade, and the agent re-runs
-the same idempotent setup at startup; existing pools are reused.
+storage). No StorageClasses are created by default — declare the ones
+you want under `storageClasses` (see the chart values for the canonical
+`miroir-local` / `miroir-replicated` pair the examples below use; an
+entry is local at `replicas: 1` and DRBD-replicated at `replicas: 2`).
+Per-node setup jobs provision each pool on install and upgrade, and the
+agent re-runs the same idempotent setup at startup; existing pools are
+reused.
 
 ### 3. Claim a volume
 
@@ -233,8 +236,7 @@ Replicated volumes are 2-way synchronous (DRBD protocol C): a write
 completes only once both legs have it. The quorum policy decides what
 happens when the nodes can no longer see each other, and is set per
 StorageClass via the `miroir.home-operations.com/quorum` parameter
-(the chart's `miroir-replicated` class uses
-`replicatedStorageClass.quorum`).
+(the `quorum` field on a `storageClasses` entry with `replicas > 1`).
 
 ### `freeze` (default)
 

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -120,9 +120,7 @@ Kubernetes: `>=1.31.0`
 | sidecars.snapshotter.timeout | string | `"120s"` |  |
 | storageClasses | list | `[]` | StorageClasses to create. Empty by default: declare the classes you want. One local + one replicated is the common pair (see the example below). Per entry:   name          (required) the StorageClass name   replicas      replica count, default 1; >1 makes it DRBD-replicated   quorum        freeze | last-man-standing (replicated only, default                 freeze). freeze never diverges but halts writes without a                 peer majority; last-man-standing keeps the survivor                 writable at the risk of split-brain. See the root README,                 "Replication and quorum".   fsType        ext4 | xfs, default ext4   reclaimPolicy Delete | Retain, default Delete   isDefault     set the cluster default-class annotation, default false Example (coexisting with OpenEBS, which stays the cluster default):   storageClasses:     - name: miroir-local       replicas: 1     - name: miroir-replicated       replicas: 2       quorum: freeze |
 | uninstall.image | string | `"registry.k8s.io/kubectl:v1.36.2"` |  |
-| volumeSnapshotClass.create | bool | `true` |  |
-| volumeSnapshotClass.deletionPolicy | string | `"Delete"` |  |
-| volumeSnapshotClass.name | string | `"miroir-snap"` |  |
+| volumeSnapshotClasses | list | `[]` | VolumeSnapshotClasses to create (requires the snapshot-controller + CRDs, deployed separately). Empty by default. Per entry:   name           (required) the VolumeSnapshotClass name   deletionPolicy Delete | Retain, default Delete   isDefault      set the cluster default-snapshot-class annotation,                  default false Example:   volumeSnapshotClasses:     - name: miroir-snap       deletionPolicy: Delete |
 
 ---
 

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -111,12 +111,6 @@ Kubernetes: `>=1.31.0`
 | priorityClassName | string | `"system-cluster-critical"` | system-cluster-critical protects the single controller from eviction under node pressure — while it is down, no volume can be provisioned, expanded, or snapshotted. |
 | provisionTimeout | string | `"120s"` | Wait for agents to realise a new volume. Keep sidecars.*.timeout at or above this, or the sidecar RPC deadline fires before this one and the knob has no effect. |
 | replicaCount | int | `1` | Controller replicas. Anything above 1 automatically enables leader election: the extras are warm standbys (failover is lease expiry, ~15s, instead of a full pod reschedule), the rollout strategy switches to RollingUpdate, and a PodDisruptionBudget keeps one replica through voluntary disruptions. Pointless on a single-node cluster (the node is the failure domain); pair with global.affinity (pod anti-affinity) so replicas land on different nodes. |
-| replicatedStorageClass.create | bool | `true` |  |
-| replicatedStorageClass.fsType | string | `"ext4"` |  |
-| replicatedStorageClass.isDefault | bool | `false` |  |
-| replicatedStorageClass.name | string | `"miroir-replicated"` |  |
-| replicatedStorageClass.quorum | string | `"freeze"` |  |
-| replicatedStorageClass.reclaimPolicy | string | `"Delete"` |  |
 | resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | Controller resources. |
 | sidecars.provisioner.image | string | `"registry.k8s.io/sig-storage/csi-provisioner:v6.3.0"` |  |
 | sidecars.provisioner.timeout | string | `"120s"` |  |
@@ -124,12 +118,7 @@ Kubernetes: `>=1.31.0`
 | sidecars.resizer.timeout | string | `"120s"` |  |
 | sidecars.snapshotter.image | string | `"registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0"` |  |
 | sidecars.snapshotter.timeout | string | `"120s"` |  |
-| storageClass.create | bool | `true` |  |
-| storageClass.fsType | string | `"ext4"` |  |
-| storageClass.isDefault | bool | `false` |  |
-| storageClass.name | string | `"miroir-local"` |  |
-| storageClass.reclaimPolicy | string | `"Delete"` |  |
-| storageClass.replicas | int | `1` |  |
+| storageClasses | list | `[]` | StorageClasses to create. Empty by default: declare the classes you want. One local + one replicated is the common pair (see the example below). Per entry:   name          (required) the StorageClass name   replicas      replica count, default 1; >1 makes it DRBD-replicated   quorum        freeze | last-man-standing (replicated only, default                 freeze). freeze never diverges but halts writes without a                 peer majority; last-man-standing keeps the survivor                 writable at the risk of split-brain. See the root README,                 "Replication and quorum".   fsType        ext4 | xfs, default ext4   reclaimPolicy Delete | Retain, default Delete   isDefault     set the cluster default-class annotation, default false Example (coexisting with OpenEBS, which stays the cluster default):   storageClasses:     - name: miroir-local       replicas: 1     - name: miroir-replicated       replicas: 2       quorum: freeze |
 | uninstall.image | string | `"registry.k8s.io/kubectl:v1.36.2"` |  |
 | volumeSnapshotClass.create | bool | `true` |  |
 | volumeSnapshotClass.deletionPolicy | string | `"Delete"` |  |

--- a/charts/miroir/templates/NOTES.txt
+++ b/charts/miroir/templates/NOTES.txt
@@ -7,11 +7,10 @@ Workloads:
   agent       DaemonSet/{{ include "miroir.agentName" . }}            one per schedulable node
 
 Storage classes:
-{{- if .Values.storageClass.create }}
-  - {{ .Values.storageClass.name }}         provisioner={{ include "miroir.csiDriverName" . }}, replicas={{ .Values.storageClass.replicas }}, fsType={{ .Values.storageClass.fsType }}
-{{- end }}
-{{- if .Values.replicatedStorageClass.create }}
-  - {{ .Values.replicatedStorageClass.name }}     provisioner={{ include "miroir.csiDriverName" . }}, replicas=2, quorum={{ .Values.replicatedStorageClass.quorum }}, fsType={{ .Values.replicatedStorageClass.fsType }}
+{{- range .Values.storageClasses }}
+  - {{ .name }}  replicas={{ .replicas | default 1 }}{{ if gt (int (.replicas | default 1)) 1 }}, quorum={{ .quorum | default "freeze" }}{{ end }}, fsType={{ .fsType | default "ext4" }}{{ if .isDefault }} (cluster default){{ end }}
+{{- else }}
+  (none — set `storageClasses` in values to create one; see values.yaml for the example pair)
 {{- end }}
 {{- if .Values.volumeSnapshotClass.create }}
 Snapshot class:

--- a/charts/miroir/templates/NOTES.txt
+++ b/charts/miroir/templates/NOTES.txt
@@ -12,9 +12,11 @@ Storage classes:
 {{- else }}
   (none — set `storageClasses` in values to create one; see values.yaml for the example pair)
 {{- end }}
-{{- if .Values.volumeSnapshotClass.create }}
-Snapshot class:
-  - {{ .Values.volumeSnapshotClass.name }}       driver={{ include "miroir.csiDriverName" . }}, deletionPolicy={{ .Values.volumeSnapshotClass.deletionPolicy }}
+{{- if .Values.volumeSnapshotClasses }}
+Snapshot classes:
+{{- range .Values.volumeSnapshotClasses }}
+  - {{ .name }}  driver={{ include "miroir.csiDriverName" $ }}, deletionPolicy={{ .deletionPolicy | default "Delete" }}{{ if .isDefault }} (cluster default){{ end }}
+{{- end }}
 {{- end }}
 
 Before provisioning volumes, every storage node needs:

--- a/charts/miroir/templates/storageclass.tpl
+++ b/charts/miroir/templates/storageclass.tpl
@@ -1,39 +1,31 @@
-{{- if .Values.storageClass.create }}
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: {{ .Values.storageClass.name }}
-  annotations:
-    storageclass.kubernetes.io/is-default-class: {{ .Values.storageClass.isDefault | quote }}
-provisioner: {{ include "miroir.csiDriverName" . }}
-volumeBindingMode: WaitForFirstConsumer
-allowVolumeExpansion: true
-reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
-parameters:
-  miroir.home-operations.com/replicas: {{ .Values.storageClass.replicas | quote }}
-  csi.storage.k8s.io/fstype: {{ .Values.storageClass.fsType }}
-{{- end }}
-{{- if .Values.replicatedStorageClass.create }}
+{{- range $i, $sc := .Values.storageClasses }}
+{{- if $i }}
 ---
+{{- end }}
+{{- $replicas := $sc.replicas | default 1 }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .Values.replicatedStorageClass.name }}
+  name: {{ $sc.name }}
   annotations:
-    storageclass.kubernetes.io/is-default-class: {{ .Values.replicatedStorageClass.isDefault | quote }}
-provisioner: {{ include "miroir.csiDriverName" . }}
+    storageclass.kubernetes.io/is-default-class: {{ $sc.isDefault | default false | quote }}
+provisioner: {{ include "miroir.csiDriverName" $ }}
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
-reclaimPolicy: {{ .Values.replicatedStorageClass.reclaimPolicy }}
+reclaimPolicy: {{ $sc.reclaimPolicy | default "Delete" }}
 parameters:
-  miroir.home-operations.com/replicas: "2"
-  # last-man-standing: survivor keeps writing on node loss, split-brain
-  # alerts on reconnect; freeze: never diverges, halts on any disconnect.
-  miroir.home-operations.com/quorum: {{ .Values.replicatedStorageClass.quorum }}
-  csi.storage.k8s.io/fstype: {{ .Values.replicatedStorageClass.fsType }}
+  miroir.home-operations.com/replicas: {{ $replicas | quote }}
+  {{- if gt (int $replicas) 1 }}
+  # freeze: never diverges, halts on any disconnect; last-man-standing:
+  # survivor keeps writing on node loss, split-brain alerts on reconnect.
+  miroir.home-operations.com/quorum: {{ $sc.quorum | default "freeze" }}
+  {{- end }}
+  csi.storage.k8s.io/fstype: {{ $sc.fsType | default "ext4" }}
 {{- end }}
 {{- if .Values.volumeSnapshotClass.create }}
+{{- if .Values.storageClasses }}
 ---
+{{- end }}
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:

--- a/charts/miroir/templates/storageclass.tpl
+++ b/charts/miroir/templates/storageclass.tpl
@@ -1,5 +1,6 @@
-{{- range $i, $sc := .Values.storageClasses }}
-{{- if $i }}
+{{- $first := true }}
+{{- range $sc := .Values.storageClasses }}
+{{- if $first }}{{ $first = false }}{{ else }}
 ---
 {{- end }}
 {{- $replicas := $sc.replicas | default 1 }}
@@ -22,14 +23,18 @@ parameters:
   {{- end }}
   csi.storage.k8s.io/fstype: {{ $sc.fsType | default "ext4" }}
 {{- end }}
-{{- if .Values.volumeSnapshotClass.create }}
-{{- if .Values.storageClasses }}
+{{- range $vsc := .Values.volumeSnapshotClasses }}
+{{- if $first }}{{ $first = false }}{{ else }}
 ---
 {{- end }}
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
-  name: {{ .Values.volumeSnapshotClass.name }}
-driver: {{ include "miroir.csiDriverName" . }}
-deletionPolicy: {{ .Values.volumeSnapshotClass.deletionPolicy }}
+  name: {{ $vsc.name }}
+  {{- if $vsc.isDefault }}
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+  {{- end }}
+driver: {{ include "miroir.csiDriverName" $ }}
+deletionPolicy: {{ $vsc.deletionPolicy | default "Delete" }}
 {{- end }}

--- a/charts/miroir/tests/storageclass_test.yaml
+++ b/charts/miroir/tests/storageclass_test.yaml
@@ -5,126 +5,94 @@ release:
   name: miroir
   namespace: miroir-system
 tests:
-  - it: renders both StorageClasses and the VolumeSnapshotClass with defaults
+  - it: creates no StorageClasses by default, only the snapshot class
     asserts:
       - hasDocuments:
-          count: 3
-      - documentIndex: 0
-        equal:
-          path: kind
-          value: StorageClass
-      - documentIndex: 0
-        equal:
-          path: apiVersion
-          value: storage.k8s.io/v1
-      - documentIndex: 0
-        equal:
-          path: metadata.name
-          value: miroir-local
-      - documentIndex: 1
-        equal:
-          path: kind
-          value: StorageClass
-      - documentIndex: 1
-        equal:
-          path: apiVersion
-          value: storage.k8s.io/v1
-      - documentIndex: 1
-        equal:
-          path: metadata.name
-          value: miroir-replicated
-      - documentIndex: 2
-        equal:
-          path: kind
-          value: VolumeSnapshotClass
-      - documentIndex: 2
-        equal:
-          path: apiVersion
-          value: snapshot.storage.k8s.io/v1
-      - documentIndex: 2
-        equal:
+          count: 1
+      - isKind:
+          of: VolumeSnapshotClass
+      - equal:
           path: metadata.name
           value: miroir-snap
 
-  - it: miroir-local mirrors its values verbatim
-    documentSelector:
-      path: metadata.name
-      value: miroir-local
+  - it: renders one StorageClass per entry plus the snapshot class
+    set:
+      storageClasses:
+        - name: miroir-local
+          replicas: 1
+          isDefault: true
+        - name: miroir-replicated
+          replicas: 2
+          quorum: freeze
+    asserts:
+      - hasDocuments:
+          count: 3
+      - documentSelector: { path: metadata.name, value: miroir-local }
+        isKind:
+          of: StorageClass
+      - documentSelector: { path: metadata.name, value: miroir-replicated }
+        isKind:
+          of: StorageClass
+      - documentSelector: { path: metadata.name, value: miroir-snap }
+        isKind:
+          of: VolumeSnapshotClass
+
+  - it: a replicas=1 entry is local — no quorum parameter, defaults applied
+    set:
+      storageClasses:
+        - name: miroir-local
+          replicas: 1
+    documentSelector: { path: metadata.name, value: miroir-local }
     asserts:
       - equal:
           path: provisioner
           value: miroir.home-operations.com
       - equal:
-          path: volumeBindingMode
-          value: WaitForFirstConsumer
-      - equal:
-          path: allowVolumeExpansion
-          value: true
-      - equal:
-          path: reclaimPolicy
-          value: Delete
-      - equal:
           path: parameters["miroir.home-operations.com/replicas"]
           value: "1"
       - equal:
           path: parameters["csi.storage.k8s.io/fstype"]
-          value: ext4
+          value: ext4 # default
+      - equal:
+          path: reclaimPolicy
+          value: Delete # default
       - equal:
           path: metadata.annotations["storageclass.kubernetes.io/is-default-class"]
-          value: "false"
+          value: "false" # default
+      - notExists:
+          path: parameters["miroir.home-operations.com/quorum"]
 
-  - it: miroir-replicated hard-codes replicas=2 and exposes quorum
-    documentSelector:
-      path: metadata.name
-      value: miroir-replicated
+  - it: a replicas>1 entry is replicated — quorum defaults to freeze
+    set:
+      storageClasses:
+        - name: r
+          replicas: 3
+    documentSelector: { path: metadata.name, value: r }
     asserts:
       - equal:
           path: parameters["miroir.home-operations.com/replicas"]
-          value: "2"
+          value: "3"
       - equal:
           path: parameters["miroir.home-operations.com/quorum"]
           value: freeze
-      - equal:
-          path: parameters["csi.storage.k8s.io/fstype"]
-          value: ext4
 
-  - it: miroir-snap is a Delete snapshot class bound to miroir.home-operations.com
-    documentSelector:
-      path: metadata.name
-      value: miroir-snap
-    asserts:
-      - equal:
-          path: driver
-          value: miroir.home-operations.com
-      - equal:
-          path: deletionPolicy
-          value: Delete
-
-  - it: honours customised storageClass values
+  - it: honours per-entry overrides (isDefault, fsType, reclaimPolicy, quorum)
     set:
-      storageClass:
-        create: true
-        name: custom-local
-        isDefault: true
-        fsType: xfs
-        replicas: 3
-        reclaimPolicy: Retain
-    documentSelector:
-      path: metadata.name
-      value: custom-local
+      storageClasses:
+        - name: custom
+          replicas: 2
+          quorum: last-man-standing
+          fsType: xfs
+          reclaimPolicy: Retain
+          isDefault: true
+    documentSelector: { path: metadata.name, value: custom }
     asserts:
-      - equal:
-          path: kind
-          value: StorageClass
-      - equal:
-          path: apiVersion
-          value: storage.k8s.io/v1
       - equal:
           path: metadata.annotations["storageclass.kubernetes.io/is-default-class"]
           value: "true"
       - equal:
-          path: parameters["miroir.home-operations.com/replicas"]
-          value: "3"
+          path: parameters["miroir.home-operations.com/quorum"]
+          value: last-man-standing
       - equal:
           path: parameters["csi.storage.k8s.io/fstype"]
           value: xfs
@@ -132,76 +100,23 @@ tests:
           path: reclaimPolicy
           value: Retain
 
-  - it: honours the replicated quorum + name overrides
-    set:
-      replicatedStorageClass:
-        create: true
-        name: custom-replicated
-        quorum: last-man-standing
-        fsType: zfs
-    documentSelector:
-      path: metadata.name
-      value: custom-replicated
-    asserts:
-      - equal:
-          path: kind
-          value: StorageClass
-      - equal:
-          path: parameters["miroir.home-operations.com/quorum"]
-          value: last-man-standing
-      - equal:
-          path: parameters["csi.storage.k8s.io/fstype"]
-          value: zfs
-
-  - it: drops miroir-local when storageClass.create is false
-    set:
-      storageClass.create: false
-    asserts:
-      - hasDocuments:
-          count: 2
-      - documentIndex: 0
-        equal:
-          path: metadata.name
-          value: miroir-replicated
-      - documentIndex: 1
-        equal:
-          path: metadata.name
-          value: miroir-snap
-
-  - it: drops miroir-replicated when replicatedStorageClass.create is false
-    set:
-      replicatedStorageClass.create: false
-    asserts:
-      - hasDocuments:
-          count: 2
-      - documentIndex: 0
-        equal:
-          path: metadata.name
-          value: miroir-local
-      - documentIndex: 1
-        equal:
-          path: metadata.name
-          value: miroir-snap
-
-  - it: drops miroir-snap when volumeSnapshotClass.create is false
+  - it: drops the snapshot class when volumeSnapshotClass.create is false
     set:
       volumeSnapshotClass.create: false
+      storageClasses:
+        - name: only-local
+          replicas: 1
     asserts:
       - hasDocuments:
-          count: 2
-      - documentIndex: 0
-        equal:
+          count: 1
+      - isKind:
+          of: StorageClass
+      - equal:
           path: metadata.name
-          value: miroir-local
-      - documentIndex: 1
-        equal:
-          path: metadata.name
-          value: miroir-replicated
+          value: only-local
 
-  - it: emits nothing when every create flag is false
+  - it: emits nothing when no classes and snapshot disabled
     set:
-      storageClass.create: false
-      replicatedStorageClass.create: false
       volumeSnapshotClass.create: false
     asserts:
       - hasDocuments:

--- a/charts/miroir/tests/storageclass_test.yaml
+++ b/charts/miroir/tests/storageclass_test.yaml
@@ -5,17 +5,12 @@ release:
   name: miroir
   namespace: miroir-system
 tests:
-  - it: creates no StorageClasses by default, only the snapshot class
+  - it: creates nothing by default (both arrays empty)
     asserts:
       - hasDocuments:
-          count: 1
-      - isKind:
-          of: VolumeSnapshotClass
-      - equal:
-          path: metadata.name
-          value: miroir-snap
+          count: 0
 
-  - it: renders one StorageClass per entry plus the snapshot class
+  - it: renders one StorageClass per entry
     set:
       storageClasses:
         - name: miroir-local
@@ -26,16 +21,13 @@ tests:
           quorum: freeze
     asserts:
       - hasDocuments:
-          count: 3
+          count: 2
       - documentSelector: { path: metadata.name, value: miroir-local }
         isKind:
           of: StorageClass
       - documentSelector: { path: metadata.name, value: miroir-replicated }
         isKind:
           of: StorageClass
-      - documentSelector: { path: metadata.name, value: miroir-snap }
-        isKind:
-          of: VolumeSnapshotClass
 
   - it: a replicas=1 entry is local — no quorum parameter, defaults applied
     set:
@@ -100,24 +92,51 @@ tests:
           path: reclaimPolicy
           value: Retain
 
-  - it: drops the snapshot class when volumeSnapshotClass.create is false
+  - it: renders one VolumeSnapshotClass per entry with defaults
     set:
-      volumeSnapshotClass.create: false
+      volumeSnapshotClasses:
+        - name: miroir-snap
+    documentSelector: { path: metadata.name, value: miroir-snap }
+    asserts:
+      - isKind:
+          of: VolumeSnapshotClass
+      - equal:
+          path: driver
+          value: miroir.home-operations.com
+      - equal:
+          path: deletionPolicy
+          value: Delete # default
+      - notExists:
+          path: metadata.annotations # isDefault false → no annotation
+
+  - it: honours VolumeSnapshotClass deletionPolicy + is-default annotation
+    set:
+      volumeSnapshotClasses:
+        - name: snap-retain
+          deletionPolicy: Retain
+          isDefault: true
+    documentSelector: { path: metadata.name, value: snap-retain }
+    asserts:
+      - equal:
+          path: deletionPolicy
+          value: Retain
+      - equal:
+          path: metadata.annotations["snapshot.storage.kubernetes.io/is-default-class"]
+          value: "true"
+
+  - it: renders storage and snapshot classes together
+    set:
       storageClasses:
         - name: only-local
           replicas: 1
+      volumeSnapshotClasses:
+        - name: miroir-snap
     asserts:
       - hasDocuments:
-          count: 1
-      - isKind:
+          count: 2
+      - documentSelector: { path: metadata.name, value: only-local }
+        isKind:
           of: StorageClass
-      - equal:
-          path: metadata.name
-          value: only-local
-
-  - it: emits nothing when no classes and snapshot disabled
-    set:
-      volumeSnapshotClass.create: false
-    asserts:
-      - hasDocuments:
-          count: 0
+      - documentSelector: { path: metadata.name, value: miroir-snap }
+        isKind:
+          of: VolumeSnapshotClass

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -640,44 +640,6 @@
       "title": "replicaCount",
       "type": "integer"
     },
-    "replicatedStorageClass": {
-      "properties": {
-        "create": {
-          "default": true,
-          "title": "create",
-          "type": "boolean"
-        },
-        "fsType": {
-          "default": "ext4",
-          "title": "fsType",
-          "type": "string"
-        },
-        "isDefault": {
-          "default": false,
-          "title": "isDefault",
-          "type": "boolean"
-        },
-        "name": {
-          "default": "miroir-replicated",
-          "title": "name",
-          "type": "string"
-        },
-        "quorum": {
-          "default": "freeze",
-          "description": "freeze: refuse writes (I/O errors) without a peer majority — never\ndiverges; with autoTieBreaker a third node keeps 2-replica volumes\nwritable through a single node loss. last-man-standing: the survivor\nkeeps writing even alone, at the risk of split-brain. See the root\nREADME, \"Replication and quorum\".",
-          "title": "quorum",
-          "type": "string"
-        },
-        "reclaimPolicy": {
-          "default": "Delete",
-          "title": "reclaimPolicy",
-          "type": "string"
-        }
-      },
-      "required": [],
-      "title": "replicatedStorageClass",
-      "type": "object"
-    },
     "resources": {
       "description": "Controller resources.",
       "properties": {
@@ -777,44 +739,13 @@
       "title": "sidecars",
       "type": "object"
     },
-    "storageClass": {
-      "description": "=============================================================================\nStorage classes\n=============================================================================",
-      "properties": {
-        "create": {
-          "default": true,
-          "title": "create",
-          "type": "boolean"
-        },
-        "fsType": {
-          "default": "ext4",
-          "title": "fsType",
-          "type": "string"
-        },
-        "isDefault": {
-          "default": false,
-          "description": "Coexists with OpenEBS: openebs-zfs stays the cluster default.",
-          "title": "isDefault",
-          "type": "boolean"
-        },
-        "name": {
-          "default": "miroir-local",
-          "title": "name",
-          "type": "string"
-        },
-        "reclaimPolicy": {
-          "default": "Delete",
-          "title": "reclaimPolicy",
-          "type": "string"
-        },
-        "replicas": {
-          "default": 1,
-          "title": "replicas",
-          "type": "integer"
-        }
+    "storageClasses": {
+      "description": "=============================================================================\nStorage classes\n=============================================================================\nStorageClasses to create. Empty by default: declare the classes you\nwant. One local + one replicated is the common pair (see the example\nbelow). Per entry:\n  name          (required) the StorageClass name\n  replicas      replica count, default 1; \u003e1 makes it DRBD-replicated\n  quorum        freeze | last-man-standing (replicated only, default\n                freeze). freeze never diverges but halts writes without a\n                peer majority; last-man-standing keeps the survivor\n                writable at the risk of split-brain. See the root README,\n                \"Replication and quorum\".\n  fsType        ext4 | xfs, default ext4\n  reclaimPolicy Delete | Retain, default Delete\n  isDefault     set the cluster default-class annotation, default false\nExample (coexisting with OpenEBS, which stays the cluster default):\n  storageClasses:\n    - name: miroir-local\n      replicas: 1\n    - name: miroir-replicated\n      replicas: 2\n      quorum: freeze",
+      "items": {
+        "required": []
       },
-      "required": [],
-      "title": "storageClass",
-      "type": "object"
+      "title": "storageClasses",
+      "type": "array"
     },
     "uninstall": {
       "description": "=============================================================================\nUninstall hook\n=============================================================================\nPre-delete hook Job: deletes miroirsnapshots/miroirvolumes (so the agent\ntears down DRBD/LVM) before the CRDs are released. Needs only `kubectl`.",

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -760,28 +760,13 @@
       "title": "uninstall",
       "type": "object"
     },
-    "volumeSnapshotClass": {
-      "description": "Requires the cluster-wide snapshot-controller + CRDs (deployed\nseparately; kube-system/snapshot-controller in the homelab).",
-      "properties": {
-        "create": {
-          "default": true,
-          "title": "create",
-          "type": "boolean"
-        },
-        "deletionPolicy": {
-          "default": "Delete",
-          "title": "deletionPolicy",
-          "type": "string"
-        },
-        "name": {
-          "default": "miroir-snap",
-          "title": "name",
-          "type": "string"
-        }
+    "volumeSnapshotClasses": {
+      "description": "Requires the cluster-wide snapshot-controller + CRDs (deployed\nseparately; kube-system/snapshot-controller in the homelab).\nVolumeSnapshotClasses to create (requires the snapshot-controller +\nCRDs, deployed separately). Empty by default. Per entry:\n  name           (required) the VolumeSnapshotClass name\n  deletionPolicy Delete | Retain, default Delete\n  isDefault      set the cluster default-snapshot-class annotation,\n                 default false\nExample:\n  volumeSnapshotClasses:\n    - name: miroir-snap\n      deletionPolicy: Delete",
+      "items": {
+        "required": []
       },
-      "required": [],
-      "title": "volumeSnapshotClass",
-      "type": "object"
+      "title": "volumeSnapshotClasses",
+      "type": "array"
     }
   },
   "required": [],

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -212,27 +212,27 @@ nodes: {}
 # =============================================================================
 # Storage classes
 # =============================================================================
-storageClass:
-  create: true
-  name: miroir-local
-  # Coexists with OpenEBS: openebs-zfs stays the cluster default.
-  isDefault: false
-  fsType: ext4
-  replicas: 1
-  reclaimPolicy: Delete
-
-replicatedStorageClass:
-  create: true
-  name: miroir-replicated
-  isDefault: false
-  fsType: ext4
-  # freeze: refuse writes (I/O errors) without a peer majority — never
-  # diverges; with autoTieBreaker a third node keeps 2-replica volumes
-  # writable through a single node loss. last-man-standing: the survivor
-  # keeps writing even alone, at the risk of split-brain. See the root
-  # README, "Replication and quorum".
-  quorum: freeze # | last-man-standing
-  reclaimPolicy: Delete
+# -- StorageClasses to create. Empty by default: declare the classes you
+# want. One local + one replicated is the common pair (see the example
+# below). Per entry:
+#   name          (required) the StorageClass name
+#   replicas      replica count, default 1; >1 makes it DRBD-replicated
+#   quorum        freeze | last-man-standing (replicated only, default
+#                 freeze). freeze never diverges but halts writes without a
+#                 peer majority; last-man-standing keeps the survivor
+#                 writable at the risk of split-brain. See the root README,
+#                 "Replication and quorum".
+#   fsType        ext4 | xfs, default ext4
+#   reclaimPolicy Delete | Retain, default Delete
+#   isDefault     set the cluster default-class annotation, default false
+# Example (coexisting with OpenEBS, which stays the cluster default):
+#   storageClasses:
+#     - name: miroir-local
+#       replicas: 1
+#     - name: miroir-replicated
+#       replicas: 2
+#       quorum: freeze
+storageClasses: []
 
 # Requires the cluster-wide snapshot-controller + CRDs (deployed
 # separately; kube-system/snapshot-controller in the homelab).

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -236,10 +236,17 @@ storageClasses: []
 
 # Requires the cluster-wide snapshot-controller + CRDs (deployed
 # separately; kube-system/snapshot-controller in the homelab).
-volumeSnapshotClass:
-  create: true
-  name: miroir-snap
-  deletionPolicy: Delete
+# -- VolumeSnapshotClasses to create (requires the snapshot-controller +
+# CRDs, deployed separately). Empty by default. Per entry:
+#   name           (required) the VolumeSnapshotClass name
+#   deletionPolicy Delete | Retain, default Delete
+#   isDefault      set the cluster default-snapshot-class annotation,
+#                  default false
+# Example:
+#   volumeSnapshotClasses:
+#     - name: miroir-snap
+#       deletionPolicy: Delete
+volumeSnapshotClasses: []
 
 # =============================================================================
 # DRBD replication tuning

--- a/deploy/e2e/values.yaml
+++ b/deploy/e2e/values.yaml
@@ -13,17 +13,14 @@ agent:
     tag: e2e
     pullPolicy: IfNotPresent
 
-storageClass:
-  create: true
-  name: miroir-local
-  # Default class so a PVC with no storageClassName still resolves to miroir.
-  isDefault: true
-  fsType: ext4
-  replicas: 1
-  reclaimPolicy: Delete
-
-replicatedStorageClass:
-  create: false
+# Local backend only — kind has no DRBD, so no replicated class. Default
+# class so a PVC with no storageClassName still resolves to miroir.
+storageClasses:
+  - name: miroir-local
+    replicas: 1
+    isDefault: true
+    fsType: ext4
+    reclaimPolicy: Delete
 
 volumeSnapshotClass:
   create: true

--- a/deploy/e2e/values.yaml
+++ b/deploy/e2e/values.yaml
@@ -22,7 +22,6 @@ storageClasses:
     fsType: ext4
     reclaimPolicy: Delete
 
-volumeSnapshotClass:
-  create: true
-  name: miroir-snap
-  deletionPolicy: Delete
+volumeSnapshotClasses:
+  - name: miroir-snap
+    deletionPolicy: Delete


### PR DESCRIPTION
## Why

`storageClass` and `replicatedStorageClass` were the **same shape modulo `quorum`**, which capped the chart at exactly one local + one replicated class. An array removes that ceiling — ext4/xfs variants, several replica counts, a dedicated RWX class — with no new value keys, and drops the artificial local-vs-replicated split (`replicas` and `quorum` already carry the difference).

## Shape

```yaml
storageClasses: []   # default: create nothing, declare what you want
```

Each entry: `name` (required), `replicas` (default 1; `>1` ⇒ DRBD-replicated), `quorum` (`freeze` | `last-man-standing`, replicated-only, default `freeze`), `fsType` (default ext4), `reclaimPolicy` (default Delete), `isDefault` (default false). The `quorum` parameter is emitted **only** when `replicas > 1`.

## ⚠️ Breaking

`storageClass.*` and `replicatedStorageClass.*` are gone, and **no StorageClass is created by default** — you now declare them explicitly. `values.schema.json` rejects the removed keys at upgrade.

```yaml
# before
storageClass:           { create: true, name: miroir-local, replicas: 1 }
replicatedStorageClass: { create: true, name: miroir-replicated, quorum: freeze }

# after
storageClasses:
  - name: miroir-local
    replicas: 1
  - name: miroir-replicated
    replicas: 2
    quorum: freeze
```

The canonical pair is documented in the chart values and root README so the PVC examples (`storageClassName: miroir-local` / `miroir-replicated`) stay coherent — they're just no longer implicit.

## Verified

Renders checked: default (both arrays `[]`) → **zero objects**; a local+replicated pair → both StorageClasses with `quorum` on the replicated one only; a snapshot class with `isDefault` → the `is-default-class` annotation on that entry alone; `Retain` honored. helm-unittest **88/88** (suite rewritten for both arrays: empty default, per-entry defaults, replicas-gated quorum, deletionPolicy/is-default, overrides). `helm lint` clean; e2e values, NOTES (ranges both arrays, hint when empty), schema + both READMEs regenerated. Chart-only — no Go change.

## Also: `volumeSnapshotClasses` array (same rationale)

The singleton `volumeSnapshotClass` (defaulting `create: true`) got the identical treatment → `volumeSnapshotClasses: []`. This isn't just symmetry — leaving it a `create: true` singleton after `storageClasses` defaulted to `[]` meant a bare install created **zero StorageClasses but one VolumeSnapshotClass**, which *also* fails to apply on any cluster without the snapshot CRDs the chart doesn't own. Both now default to creating nothing.

```yaml
# before
volumeSnapshotClass: { create: true, name: miroir-snap, deletionPolicy: Delete }
# after
volumeSnapshotClasses:
  - name: miroir-snap
    deletionPolicy: Delete   # + optional isDefault: true (new — sets the
                             # snapshot is-default-class annotation, parity
                             # with StorageClass isDefault)
```

`volumeSnapshotClass.{create,name,deletionPolicy}` removed; schema rejects them at upgrade.

