### PR TITLE
feat: RWX export readiness metric, verify-staleness alert, and dashboard coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,9 +495,16 @@ Each agent additionally exports its pool capacity
 capacity-aware placement and the `PoolUsageHigh` condition, so pool
 exhaustion is alertable, not just an Event.
 
+For RWX volumes the **controller** exports `miroir_export_ready` — 1
+while the volume's NFS gateway is serving (gateway pod available,
+export address published). This is the signal the per-volume gauges
+cannot give you: DRBD replicas stay healthy while a dead gateway
+leaves every NFS client hanging.
+
 `monitoring.prometheusRule.enabled: true` ships starter alerts for all
 of the above (split-brain, quorum lost, stranded barrier, disk failed,
-degraded replication, sustained out-of-sync, pool and thin-metadata
+degraded replication, sustained out-of-sync, an unavailable RWX
+export, a stale verify schedule, pool and thin-metadata
 usage), and `monitoring.dashboards.enabled: true` installs a Grafana
 dashboard — as a sidecar-labelled ConfigMap, or a grafana-operator
 `GrafanaDashboard` CR via `monitoring.dashboards.grafanaOperator`.

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -103,6 +103,7 @@ Kubernetes: `>=1.31.0`
 | monitoring.prometheusRule.annotations | object | `{}` | PrometheusRule annotations. |
 | monitoring.prometheusRule.enabled | bool | `false` | Create a PrometheusRule with alerting rules (requires the Prometheus Operator CRDs). |
 | monitoring.prometheusRule.labels | object | `{}` | PrometheusRule labels. |
+| monitoring.prometheusRule.verifyStaleDays | int | `8` | Days since the last completed scheduled verify before MiroirVolumeVerifyStale fires. Size it to just over the schedule period (a weekly `drbd.verify.schedule` → 8). The rule is only rendered when `drbd.verify.schedule` is set. |
 | nameOverride | string | `""` | Override the chart name used in labels and default object names. |
 | nodes | object | `{}` |  |
 | overcommitRatio | int | `2` | Thin-provisioning overcommit guardrail: CreateVolume is refused when a node's provisioned total would exceed capacity × this ratio. 2× is the classic CoW headroom; raise it only if you trust your usage to stay sparse, lower it toward 1 to provision conservatively. |

--- a/charts/miroir/dashboards/miroir.json
+++ b/charts/miroir/dashboards/miroir.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "description": "miroir \u2014 DRBD-replicated local storage: volume health, replication, pools, and operator activity.",
+  "description": "miroir — DRBD-replicated local storage: volume health, replication, pools, and operator activity.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -83,7 +83,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Volumes DRBD refuses to reconnect after divergence \u2014 manual resolution required.",
+      "description": "Volumes DRBD refuses to reconnect after divergence — manual resolution required.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -144,7 +144,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Freeze-policy legs with IO suspended awaiting quorum \u2014 workloads are hanging.",
+      "description": "Freeze-policy legs with IO suspended awaiting quorum — workloads are hanging.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -205,7 +205,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Legs latched failed after a backing-disk I/O error \u2014 replace the disk, then remove and re-add.",
+      "description": "Legs latched failed after a backing-disk I/O error — replace the disk, then remove and re-add.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -266,7 +266,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Diskful legs below UpToDate \u2014 resyncing, detached, or disconnected.",
+      "description": "Diskful legs below UpToDate — resyncing, detached, or disconnected.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -525,7 +525,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Worst per-peer out-of-sync amount \u2014 exposure if the healthiest peer is lost; also counts online-verify findings.",
+      "description": "Worst per-peer out-of-sync amount — exposure if the healthiest peer is lost; also counts online-verify findings.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -681,7 +681,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 22
       },
@@ -713,12 +713,402 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Auto-diskful conversions per interval, by leg kind: a settled remote consumer gained a local replica (client) or a tie-breaker flipped diskful in place (tiebreaker).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (kind) (increase(miroir_autodiskful_conversions_total[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{kind}}"
+        }
+      ],
+      "title": "Auto-diskful conversions",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 30
+      },
+      "id": 22,
+      "panels": [],
+      "title": "Online verify",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Time since the last completed scheduled verify per volume; a line climbing past the schedule period means the verify stopped firing. Volumes that never completed a verify have no series.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "time() - max by (volume) (miroir_volume_verify_last_timestamp_seconds{volume=~\"$volume\"})",
+          "refId": "A",
+          "legendFormat": "{{volume}}"
+        }
+      ],
+      "title": "Last verify age",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Out-of-sync bytes the last scheduled verify found; anything above 0 is silent divergence that needs a disconnect/connect resync to heal.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (volume) (miroir_volume_verify_out_of_sync_bytes{volume=~\"$volume\"})",
+          "refId": "A",
+          "legendFormat": "{{volume}}"
+        }
+      ],
+      "title": "Verify findings",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 25,
+      "panels": [],
+      "title": "RWX exports",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "RWX volumes with an NFS gateway.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 40
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(miroir_export_ready) OR on() vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "RWX exports",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Exports without a serving gateway — their NFS clients are hanging right now.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 44
+      },
+      "id": 27,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(miroir_export_ready == 0) OR on() vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Exports not ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "1 while the volume's NFS gateway is serving (pod available, address published); dips are failovers — clients hang until the line returns to 1.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 20,
+        "x": 4,
+        "y": 40
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "min by (volume) (miroir_export_ready{volume=~\"$volume\"})",
+          "refId": "A",
+          "legendFormat": "{{volume}}"
+        }
+      ],
+      "title": "Export availability",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
       },
       "id": 13,
       "panels": [],
@@ -757,7 +1147,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 31
+        "y": 49
       },
       "id": 14,
       "options": {
@@ -829,7 +1219,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 31
+        "y": 49
       },
       "id": 15,
       "options": {
@@ -892,7 +1282,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 31
+        "y": 49
       },
       "id": 16,
       "options": {
@@ -927,7 +1317,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 57
       },
       "id": 17,
       "panels": [],
@@ -966,7 +1356,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 58
       },
       "id": 18,
       "options": {
@@ -1000,7 +1390,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "A sustained error rate means a wedged reconcile \u2014 check the owning pod's logs.",
+      "description": "A sustained error rate means a wedged reconcile — check the owning pod's logs.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1027,7 +1417,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 58
       },
       "id": 19,
       "options": {
@@ -1106,7 +1496,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "miroir \u2014 replicated storage",
+  "title": "miroir — replicated storage",
   "uid": "miroir-overview",
   "version": 1,
   "weekStart": ""

--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -182,6 +182,34 @@ spec:
             {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.drbd.verify.schedule }}
+
+        # Only rendered when a verify schedule is configured. A schedule
+        # that silently stops firing (agent down over the cron slot, verify
+        # suspended and forgotten) erodes the only cross-leg integrity
+        # check; the last-completed timestamp going stale is the signal.
+        # Volumes that never completed a verify have no series and are not
+        # caught here.
+        - alert: MiroirVolumeVerifyStale
+          expr: >-
+            time() - miroir_volume_verify_last_timestamp_seconds
+            > {{ .Values.monitoring.prometheusRule.verifyStaleDays }} * 86400
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
+          annotations:
+            summary: >-
+              Volume {{ "{{" }} $labels.volume {{ "}}" }} has not completed
+              an online verify in {{ "{{" }} $value | humanizeDuration {{ "}}" }}
+            description: >-
+              The scheduled drbdadm verify has not completed within the
+              expected window — the coordinating agent may have been down
+              over the cron slot, verify may be suspended, or a pass is
+              wedged. Check the agent logs on the volume's first diskful
+              replica node.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
 
     - name: miroir.pools
       rules:
@@ -219,6 +247,31 @@ spec:
               dm-thin metadata usage crossed 80%; exhausting it corrupts the
               pool even while data space remains. Extend the metadata LV
               (lvextend --poolmetadatasize).
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+    - name: miroir.exports
+      rules:
+        # The gateway is a per-volume singleton: while it is down every NFS
+        # client of the RWX volume hangs, even though the miroir_volume_*
+        # gauges stay green (the DRBD replicas are healthy). 5m rides out a
+        # normal failover — 30s node eviction, reschedule, and DRBD
+        # releasing the dead pod's Primary claim.
+        - alert: MiroirExportUnavailable
+          expr: miroir_export_ready == 0
+          for: 5m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
+          annotations:
+            summary: >-
+              RWX export for volume {{ "{{" }} $labels.volume {{ "}}" }}
+              is unavailable — NFS clients are hanging
+            description: >-
+              The NFS gateway has no available pod (or no published export
+              address). Check the miroir-share-{{ "{{" }} $labels.volume {{ "}}" }}
+              Deployment: a failover stuck this long usually means no
+              schedulable replica node or DRBD refusing promotion.
             {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/miroir/tests/prometheusrule_test.yaml
+++ b/charts/miroir/tests/prometheusrule_test.yaml
@@ -23,13 +23,13 @@ tests:
           path: metadata.namespace
           value: miroir-system
 
-  - it: should have the volume and pool rule groups
+  - it: should have the volume, pool and export rule groups
     set:
       monitoring.prometheusRule.enabled: true
     asserts:
       - lengthEqual:
           path: spec.groups
-          count: 2
+          count: 3
       - equal:
           path: spec.groups[0].name
           value: miroir.volumes
@@ -42,6 +42,34 @@ tests:
       - lengthEqual:
           path: spec.groups[1].rules
           count: 2
+      - equal:
+          path: spec.groups[2].name
+          value: miroir.exports
+      - equal:
+          path: spec.groups[2].rules[0].alert
+          value: MiroirExportUnavailable
+      - equal:
+          path: spec.groups[2].rules[0].labels.severity
+          value: critical
+
+  - it: should render the verify staleness rule only with a verify schedule
+    set:
+      monitoring.prometheusRule.enabled: true
+      drbd.verify.schedule: "0 3 * * 0"
+      monitoring.prometheusRule.verifyStaleDays: 9
+    asserts:
+      - lengthEqual:
+          path: spec.groups[0].rules
+          count: 9
+      - equal:
+          path: spec.groups[0].rules[8].alert
+          value: MiroirVolumeVerifyStale
+      - equal:
+          path: spec.groups[0].rules[8].labels.severity
+          value: warning
+      - equal:
+          path: spec.groups[0].rules[8].expr
+          value: time() - miroir_volume_verify_last_timestamp_seconds > 9 * 86400
 
   - it: should mark IO-freezing conditions critical
     set:

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -581,6 +581,12 @@
               "required": [],
               "title": "labels",
               "type": "object"
+            },
+            "verifyStaleDays": {
+              "default": 8,
+              "description": "Days since the last completed scheduled verify before\nMiroirVolumeVerifyStale fires. Size it to just over the schedule\nperiod (a weekly `drbd.verify.schedule` → 8). The rule is only\nrendered when `drbd.verify.schedule` is set.",
+              "title": "verifyStaleDays",
+              "type": "integer"
             }
           },
           "required": [],

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -364,6 +364,11 @@ monitoring:
     additionalRuleLabels: {}
     # -- Extra annotations added to every alert rule.
     additionalRuleAnnotations: {}
+    # -- Days since the last completed scheduled verify before
+    # MiroirVolumeVerifyStale fires. Size it to just over the schedule
+    # period (a weekly `drbd.verify.schedule` → 8). The rule is only
+    # rendered when `drbd.verify.schedule` is set.
+    verifyStaleDays: 8
 
   dashboards:
     # -- Render the Grafana dashboard ConfigMap (for grafana-operator or the kube-prometheus-stack sidecar).

--- a/internal/export/metrics.go
+++ b/internal/export/metrics.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// The RWX serving signal. The agents' miroir_volume_* gauges track DRBD
+// replica health and stay green while the gateway — a per-volume singleton —
+// is down and every NFS client hangs, so export health needs its own gauge.
+// Published from the controller (this reconciler owns the gateway workloads
+// and already watches them); the gateway pod has no metrics endpoint.
+var metricExportReady = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "miroir_export_ready",
+	Help: "1 when the RWX volume's NFS gateway is serving (gateway pod available and export address published); 0 while clients cannot reach the export — a failover in progress, or a gateway that cannot run.",
+}, []string{"volume"})
+
+func init() {
+	metrics.Registry.MustRegister(metricExportReady)
+}
+
+func recordExportReady(volume string, ready bool) {
+	var v float64
+	if ready {
+		v = 1
+	}
+	metricExportReady.WithLabelValues(volume).Set(v)
+}
+
+// dropExportMetrics removes a volume's series; a deleted volume must not
+// leave a stale 0 behind (it would fire MiroirExportUnavailable forever).
+func dropExportMetrics(volume string) {
+	metricExportReady.DeleteLabelValues(volume)
+}

--- a/internal/export/reconciler.go
+++ b/internal/export/reconciler.go
@@ -30,6 +30,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,15 +64,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	vol := &miroirv1alpha1.MiroirVolume{}
 	if err := r.Get(ctx, req.NamespacedName, vol); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		if apierrors.IsNotFound(err) {
+			dropExportMetrics(req.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
 	}
 	// Only RWX volumes have a gateway; a volume being deleted keeps its
 	// workloads until GC removes them with the owner.
 	if vol.Spec.Export == nil || !vol.DeletionTimestamp.IsZero() {
+		dropExportMetrics(vol.Name)
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.ensureDeployment(ctx, vol); err != nil {
+	available, err := r.ensureDeployment(ctx, vol)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 	addr, err := r.ensureService(ctx, vol)
@@ -81,13 +88,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := r.publishAddress(ctx, vol, addr); err != nil {
 		return ctrl.Result{}, err
 	}
-	log.Info("reconciled RWX gateway", "volume", vol.Name, "address", addr)
+	// Serving means a gateway pod is up and the address consumers mount is
+	// published; the owned-Deployment watch re-runs this on availability
+	// flips, so the gauge tracks failovers without polling.
+	recordExportReady(vol.Name, available && addr != "")
+	log.Info("reconciled RWX gateway", "volume", vol.Name, "address", addr, "available", available)
 	return ctrl.Result{}, nil
 }
 
 // ensureDeployment creates or updates the gateway Deployment, refreshing
-// its node affinity when the volume's replica set changes.
-func (r *Reconciler) ensureDeployment(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) error {
+// its node affinity when the volume's replica set changes. It reports
+// whether a gateway pod is currently available (the export-ready signal).
+func (r *Reconciler) ensureDeployment(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) (bool, error) {
 	want := buildDeployment(vol, r.Namespace, r.Image, r.ServiceAccount)
 	dep := &appsv1.Deployment{}
 	dep.Name = want.Name
@@ -97,7 +109,10 @@ func (r *Reconciler) ensureDeployment(ctx context.Context, vol *miroirv1alpha1.M
 		dep.Spec = want.Spec
 		return controllerutil.SetControllerReference(vol, dep, r.Scheme())
 	})
-	return err
+	if err != nil {
+		return false, err
+	}
+	return dep.Status.AvailableReplicas > 0, nil
 }
 
 // ensureService creates or adopts the gateway Service and returns its

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 )
@@ -203,6 +204,64 @@ func TestReconcileUpdatesAffinityOnReplicaChange(t *testing.T) {
 	slices.Sort(nodes)
 	if want := []string{nodeKharkiv, nodeOslo}; !slices.Equal(nodes, want) {
 		t.Fatalf("affinity nodes after move = %v, want %v", nodes, want)
+	}
+}
+
+// exportReadyGauge reads miroir_export_ready for a volume from the global
+// registry; ok=false means the series does not exist.
+func exportReadyGauge(t *testing.T, volume string) (float64, bool) {
+	t.Helper()
+	mfs, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "miroir_export_ready" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "volume" && l.GetValue() == volume {
+					return m.GetGauge().GetValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestReconcileExportReadyMetric(t *testing.T) {
+	vol := exportVolume("pvc-metric", nodeKharkiv, nodeParis)
+	// The Service pre-exists with an apiserver-assigned ClusterIP (the fake
+	// client assigns none), so readiness hinges on gateway availability.
+	svc := buildService(vol, testNS)
+	svc.Spec.ClusterIP = testClusterIP
+	r, cl := newReconciler(vol, svc)
+
+	// First reconcile creates the Deployment; no pod is available yet.
+	reconcile(t, r, "pvc-metric")
+	if v, ok := exportReadyGauge(t, "pvc-metric"); !ok || v != 0 {
+		t.Fatalf("gauge = %v (exists=%v), want 0 while no gateway pod is available", v, ok)
+	}
+
+	// The gateway pod comes up.
+	dep := getDeployment(t, cl, "pvc-metric")
+	dep.Status.AvailableReplicas = 1
+	if err := cl.Status().Update(t.Context(), dep); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, "pvc-metric")
+	if v, ok := exportReadyGauge(t, "pvc-metric"); !ok || v != 1 {
+		t.Fatalf("gauge = %v (exists=%v), want 1 with an available gateway and a published address", v, ok)
+	}
+
+	// Volume gone: the series must be dropped, not left at a stale value.
+	if err := cl.Delete(t.Context(), vol); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, "pvc-metric")
+	if _, ok := exportReadyGauge(t, "pvc-metric"); ok {
+		t.Fatal("gauge series must be dropped when the volume is deleted")
 	}
 }
 


### PR DESCRIPTION
## Why

The NFS gateway added with RWX support (#161–#164) had no observability. The per-volume `miroir_volume_*` gauges track DRBD replica health and stay green while the gateway — a per-volume singleton (`replicas: 1`, Recreate) — is down and every NFS client hangs. Nothing scraped the gateway, nothing alerted on it, and nothing on the dashboard showed it.

Two smaller pre-existing gaps closed alongside:

- `miroir_volume_verify_last_timestamp_seconds`' help text has always said *"Alert on staleness to catch a verify schedule that stopped firing"* — no such rule existed, and neither verify metric appeared on the dashboard.
- `miroir_autodiskful_conversions_total` was registered and incremented but consumed nowhere.

## What

**Metric** (controller-side, no gateway changes needed)

- `miroir_export_ready{volume}`: 1 when the gateway Deployment has an available pod **and** the export address is published on status. Set by the export reconciler; the owned-Deployment watch already re-triggers it on availability flips, so the gauge tracks failovers without polling. Series is dropped on volume deletion so a removed volume can't leave a stale 0 firing forever.

**Alerts**

- `MiroirExportUnavailable` (critical, `for: 5m` — rides out a normal failover: 30s eviction + reschedule + DRBD releasing the dead pod's Primary claim) in a new `miroir.exports` group.
- `MiroirVolumeVerifyStale` (warning), rendered only when `drbd.verify.schedule` is set; threshold via new `monitoring.prometheusRule.verifyStaleDays` (default 8, sized for a weekly schedule). Volumes that never completed a verify have no series and are documented as not covered.

**Dashboard**

- New **RWX exports** row: export count, exports-not-ready stat, per-volume availability timeseries.
- New **Online verify** row: last-verify age and verify findings (bytes).
- **Auto-diskful conversions** panel next to *Remote consumers*, closing the loop on the diskless-client story (consumer settles remote → conversion fires → diskless Primary drops).
- Chart README + values.schema.json regenerated via `mise run helm-docs`.

## Testing

- `go test` (all unit packages) — includes a new export-reconciler test covering the gauge lifecycle: 0 while no gateway pod is available, 1 once available with a published address, series dropped on volume deletion.
- `helm unittest charts/miroir` (89 passed) — new assertions for the exports group, the conditional verify-stale rule, and its rendered expression.
- `helm lint`, `golangci-lint run`: clean.
- Dashboard JSON validated; grid layout verified (no overlaps, rows shifted consistently).