### PR TITLE
refactor: repair split doc comments, drop dead code, modernize idioms

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -212,16 +212,17 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, nil
 		}
 	} else {
-		// Diskless tie-breaker: join DRBD for quorum only, no backing.
-		// No replica metrics either — the up-to-date/connected series
-		// describe data legs, and a tie-breaker is never UpToDate, so a
-		// series here would permanently trip up_to_date==0 alerts.
-		log.V(1).Info("diskless tie-breaker realized", "volume", vol.Name)
+		// Diskless leg (tie-breaker or client): join DRBD without a
+		// backing device. No replica metrics either — the
+		// up-to-date/connected series describe data legs, and a diskless
+		// leg is never UpToDate, so a series here would permanently trip
+		// up_to_date==0 alerts.
+		log.V(1).Info("diskless leg realized", "volume", vol.Name)
 	}
 
 	// Replicated: layer DRBD on the backing device. Pods attach the DRBD
 	// device, never the backing LV/zvol directly.
-	minor, err := r.assignMinor(ctx, vol)
+	minor, err := r.assignMinor(vol)
 	if err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
@@ -864,10 +865,6 @@ func (r *VolumeReconciler) patchStatus(ctx context.Context, vol *miroirv1alpha1.
 		client.ForceOwnership)
 }
 
-// replicaStatusAC mirrors ReplicaStatus's wire shape: fields without
-// omitempty are always set (SSA must own them even at zero — Connected
-// false is a statement, not an absence), omitempty fields only when
-// non-zero (absent → SSA clears the previous value this manager owned).
 // primarySince keeps a stable timestamp for how long this leg has been
 // Primary: stamped on the first pass that observes the role, carried
 // through subsequent passes, dropped on demotion (the device closed). The
@@ -883,6 +880,10 @@ func primarySince(vol *miroirv1alpha1.MiroirVolume, node string, primary bool) *
 	return &now
 }
 
+// replicaStatusAC mirrors ReplicaStatus's wire shape: fields without
+// omitempty are always set (SSA must own them even at zero — Connected
+// false is a statement, not an absence), omitempty fields only when
+// non-zero (absent → SSA clears the previous value this manager owned).
 func replicaStatusAC(st miroirv1alpha1.ReplicaStatus) *acv1alpha1.ReplicaStatusApplyConfiguration {
 	ac := acv1alpha1.ReplicaStatus().
 		WithDeviceCreated(st.DeviceCreated).
@@ -916,19 +917,13 @@ func replicaStatusAC(st miroirv1alpha1.ReplicaStatus) *acv1alpha1.ReplicaStatusA
 }
 
 // assignMinor returns the DRBD minor for this volume, allocating a free one if unset.
-func (r *VolumeReconciler) assignMinor(_ context.Context, vol *miroirv1alpha1.MiroirVolume) (int32, error) {
+func (r *VolumeReconciler) assignMinor(vol *miroirv1alpha1.MiroirVolume) (int32, error) {
 	if m := vol.Status.PerNode[r.NodeName].DRBDMinor; m > 0 {
 		return m, nil
 	}
-	minor, err := r.DRBD.AllocateMinor(vol.Name)
-	if err != nil {
-		return 0, err
-	}
-	return minor, nil
+	return r.DRBD.AllocateMinor(vol.Name)
 }
 
-// computePhase aggregates per-node states into the volume phase the CSI
-// controller waits on (notes/DESIGN.md §4.5.1).
 // growIfCoordinator runs drbdadm resize when this node is the resize
 // coordinator (first diskful replica) and its realized size still trails
 // the spec — first bring-up and expansion. Once its status reaches spec
@@ -995,6 +990,8 @@ func detachedDiskMessage(diskFailed bool) string {
 		"replace the disk, then remove and re-add this replica"
 }
 
+// computePhase aggregates per-node states into the volume phase the CSI
+// controller waits on (notes/DESIGN.md §4.5.1).
 func computePhase(vol *miroirv1alpha1.MiroirVolume) miroirv1alpha1.VolumePhase {
 	diskfulReplicas := vol.Spec.DiskfulReplicas()
 	ready := 0

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -100,7 +100,8 @@ func New(typ miroirv1alpha1.BackendType, cfg Config, exec Exec) (Backend, error)
 
 // Config carries the node-local pool locations, from agent flags.
 // Fields are partitioned by backend: VolumeGroup/ThinPool/Device/PoolSize
-// for lvmthin, Dataset for zfs. New() reads only the relevant ones.
+// for lvmthin, Dataset for zfs, BaseDir for loopfile. New() reads only
+// the relevant ones.
 type Config struct {
 	// VolumeGroup is the LVM VG holding the thin pool (lvmthin).
 	VolumeGroup string

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -194,11 +194,11 @@ func (z *zfsBackend) promoteClones(ctx context.Context, vol string) error {
 	if err != nil {
 		return err
 	}
-	for _, clones := range strings.Fields(out) {
+	for clones := range strings.FieldsSeq(out) {
 		if clones == "-" {
 			continue
 		}
-		for _, clone := range strings.Split(clones, ",") {
+		for clone := range strings.SplitSeq(clones, ",") {
 			if _, err := z.exec(ctx, "zfs", "promote", clone); err != nil {
 				return err
 			}

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -332,7 +332,7 @@ func (c *Controller) resolveSource(ctx context.Context, snapID string, sizeBytes
 	return &miroirv1alpha1.VolumeSource{SnapshotName: snapID}, srcReplicas, snap.Status.SourceFormatted, nil
 }
 
-// allocVolumes lists every volume once// allocVolumes lists every volume once for the allocMu critical section
+// allocVolumes lists every volume once for the allocMu critical section
 // (the overcommit guard and the DRBD port scan share it). Skipped when
 // unneeded — a 1-replica restore does zero volume Lists.
 func (c *Controller) allocVolumes(ctx context.Context, needed bool) ([]miroirv1alpha1.MiroirVolume, error) {
@@ -346,7 +346,7 @@ func (c *Controller) allocVolumes(ctx context.Context, needed bool) ([]miroirv1a
 	return list.Items, nil
 }
 
-// place selects count replica nodes:// place selects count replica nodes: the scheduler's preference first
+// place selects count replica nodes: the scheduler's preference first
 // (WaitForFirstConsumer), then the remaining eligible storage nodes by
 // free space — capacity-aware spread (notes/DESIGN.md §4.6). Nodes whose
 // projected provisioned total would breach the overcommit ratio are
@@ -554,13 +554,10 @@ func (c *Controller) poolStats(ctx context.Context) (map[string]miroirv1alpha1.M
 	return out, nil
 }
 
-// provisionedPerNode sums the provisioned (virtual) size of every volume
-// with a replica on each node, excluding exclude (the volume being
-// (re)created, so an idempotent retry does not count itself). Clones share
-// backing on disk but are counted in full — a conservative overcommit guard.
 // provisionedPerNode sums the provisioned (virtual) bytes per node from a
 // pre-fetched volume list, excluding the named volume (the one being
-// (re)created, so an idempotent retry does not count itself).
+// (re)created, so an idempotent retry does not count itself). Clones share
+// backing on disk but are counted in full — a conservative overcommit guard.
 func provisionedPerNode(vols []miroirv1alpha1.MiroirVolume, exclude string) map[string]int64 {
 	out := map[string]int64{}
 	for _, v := range vols {

--- a/internal/csi/identity.go
+++ b/internal/csi/identity.go
@@ -34,8 +34,6 @@ type Identity struct {
 	// WithController is true only in controller mode: the agent's Identity
 	// must not advertise CONTROLLER_SERVICE (it serves no controller RPCs).
 	WithController bool
-	// Ready reports whether the serving component can handle RPCs.
-	Ready func(ctx context.Context) bool
 }
 
 // GetPluginInfo returns the driver name and version.
@@ -79,10 +77,8 @@ func (s *Identity) GetPluginCapabilities(_ context.Context, _ *csi.GetPluginCapa
 }
 
 // Probe reports liveness/readiness to the livenessprobe sidecar and kubelet.
-func (s *Identity) Probe(ctx context.Context, _ *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	ready := true
-	if s.Ready != nil {
-		ready = s.Ready(ctx)
-	}
-	return &csi.ProbeResponse{Ready: wrapperspb.Bool(ready)}, nil
+// Serving the RPC is the signal: the gRPC server only comes up after the
+// manager's cache has synced (see serveCSI).
+func (s *Identity) Probe(_ context.Context, _ *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	return &csi.ProbeResponse{Ready: wrapperspb.Bool(true)}, nil
 }

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -47,7 +47,6 @@ type Driver struct {
 	Mknod func(path string, mode uint32, dev int) error
 }
 
-// Apply converges the kernel state for one resource: write config when it
 // isMissingMetadata matches drbdadm's complaint when a backing device
 // carries no DRBD metadata (attach against a blank/replaced disk).
 func isMissingMetadata(err error) bool {
@@ -80,6 +79,7 @@ func (d *Driver) ensureMarkedMetadata(ctx context.Context, r Resource) error {
 	return os.WriteFile(marker, nil, 0o640)
 }
 
+// Apply converges the kernel state for one resource: write config when it
 // changed, create metadata once (left at UUID_JUST_CREATED — see
 // ensureMetadata for how the birth generation lands), bring the resource
 // up / adjust.
@@ -257,7 +257,7 @@ const justCreatedUUID = "0000000000000004"
 // operator-recoverable, wiping a live one is not.
 func virginMetadata(dump, name string) bool {
 	current := ""
-	for _, line := range strings.Split(dump, "\n") {
+	for line := range strings.SplitSeq(dump, "\n") {
 		fields := strings.Fields(strings.TrimSuffix(strings.TrimSpace(line), ";"))
 		if len(fields) != 2 {
 			continue
@@ -356,9 +356,6 @@ const drbdMajor = 147
 // volumes. Lower numbers may be reserved for system DRBD resources.
 const minorBase int32 = 1000
 
-// AllocateMinor assigns a DRBD minor to a volume, returning the same
-// minor on future calls. Serialised by an advisory flock the kernel
-// releases on close or process death, then persisted via atomic rename.
 // lockMinors serialises minor.assign access. flock, not an O_EXCL
 // sentinel: a sentinel orphaned by a crash between create and remove would
 // deadlock every future allocation (nothing sweeps minor.lock). LOCK_EX
@@ -398,6 +395,9 @@ func (d *Driver) releaseMinor(volume string) error {
 	return d.writeAssignments(assigned)
 }
 
+// AllocateMinor assigns a DRBD minor to a volume, returning the same
+// minor on future calls. Serialised by an advisory flock the kernel
+// releases on close or process death, then persisted via atomic rename.
 func (d *Driver) AllocateMinor(volume string) (int32, error) {
 	unlock, err := d.lockMinors()
 	if err != nil {
@@ -473,7 +473,7 @@ func (d *Driver) readAssignments() (map[string]int32, error) {
 		return nil, err
 	}
 	m := map[string]int32{}
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -491,22 +491,11 @@ func (d *Driver) readAssignments() (map[string]int32, error) {
 }
 
 func (d *Driver) writeAssignments(m map[string]int32) error {
-	path := d.path("minor.assign")
-	tmp := path + ".tmp"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
+	var buf bytes.Buffer
 	for name, minor := range m {
-		if _, err := fmt.Fprintf(f, "%s %d\n", name, minor); err != nil {
-			return err
-		}
+		fmt.Fprintf(&buf, "%s %d\n", name, minor)
 	}
-	if err := f.Sync(); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return writeFileAtomic(d.path("minor.assign"), buf.Bytes(), 0o640)
 }
 
 func (d *Driver) scanUsedMinors(assigned map[string]int32) map[int32]bool {
@@ -803,7 +792,7 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 	res := parsed[0]
 
 	s := Status{
-		Primary:       res.Role == "Primary",
+		Primary:       res.Role == rolePrimary,
 		Suspended:     res.SuspendedUser,
 		PeerConnected: make(map[int32]bool, len(res.Connections)),
 		PeerDiskState: make(map[int32]string, len(res.Connections)),
@@ -814,7 +803,7 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 		s.Quorum = res.Devices[0].Quorum
 	}
 	for _, c := range res.Connections {
-		if c.PeerRole == "Primary" {
+		if c.PeerRole == rolePrimary {
 			s.PeerPrimary = true
 		}
 		// replication-state / percent-in-sync live per peer-device.
@@ -959,8 +948,7 @@ func (d *Driver) writeConfig(r Resource) error {
 	}
 	// Atomic write: StateDir is drbdadm's include directory, and a crash
 	// mid-write would leave a truncated .res that makes drbdadm adjust fail
-	// for EVERY resource on the node, not just this one. Same tmp+sync+rename
-	// as writeAssignments.
+	// for EVERY resource on the node, not just this one.
 	return writeFileAtomic(path, rendered, 0o640)
 }
 

--- a/internal/drbd/res.go
+++ b/internal/drbd/res.go
@@ -52,8 +52,9 @@ type Resource struct {
 	// LocalDisk is the local backing device path. Empty/unused when
 	// LocalDiskless is true.
 	LocalDisk string
-	// LocalDiskless is true when the local node is a diskless tie-breaker:
-	// Apply skips create-md and the local peer renders "disk none".
+	// LocalDiskless is true when the local node holds a diskless leg — a
+	// tie-breaker replica or a client leg (spec.clients): Apply skips
+	// create-md and the local peer renders "disk none".
 	LocalDiskless bool
 	// Secret authenticates peers (cram-hmac challenge-response). Empty
 	// renders no auth — volumes created before secrets existed.
@@ -79,8 +80,9 @@ type Peer struct {
 	Node    string
 	NodeID  int32
 	Address string
-	// Diskless marks a quorum-only tie-breaker peer: renders "disk none",
-	// no meta-disk, no backend.
+	// Diskless marks a peer with no backing device — a quorum-only
+	// tie-breaker or a client leg: renders "disk none", no meta-disk,
+	// no backend.
 	Diskless bool
 }
 

--- a/internal/membership/autodiskful.go
+++ b/internal/membership/autodiskful.go
@@ -18,6 +18,7 @@ package membership
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -114,18 +115,15 @@ type candidate struct {
 // so no client leg ever exists). Only legs on storage nodes qualify.
 func candidates(vol *miroirv1alpha1.MiroirVolume, nodes nodemap.Map) []candidate {
 	var out []candidate
-	for i := range vol.Spec.Clients {
-		cl := vol.Spec.Clients[i]
+	for i, cl := range vol.Spec.Clients {
 		entry, storage := nodes[cl.Node]
 		if !storage || cl.Address == "" || cl.AddedAt == nil {
 			continue
 		}
-		idx := i
 		out = append(out, candidate{node: cl.Node, kind: "client", since: cl.AddedAt.Time,
-			apply: func(v *miroirv1alpha1.MiroirVolume) { convertClient(v, idx, entry.Backend) }})
+			apply: func(v *miroirv1alpha1.MiroirVolume) { convertClient(v, i, entry.Backend) }})
 	}
-	for i := range vol.Spec.Replicas {
-		rep := vol.Spec.Replicas[i]
+	for i, rep := range vol.Spec.Replicas {
 		if !rep.Diskless {
 			continue
 		}
@@ -134,9 +132,8 @@ func candidates(vol *miroirv1alpha1.MiroirVolume, nodes nodemap.Map) []candidate
 		if !storage || since == nil {
 			continue
 		}
-		idx := i
 		out = append(out, candidate{node: rep.Node, kind: "tiebreaker", since: since.Time,
-			apply: func(v *miroirv1alpha1.MiroirVolume) { convertTieBreaker(v, idx, entry.Backend) }})
+			apply: func(v *miroirv1alpha1.MiroirVolume) { convertTieBreaker(v, i, entry.Backend) }})
 	}
 	return out
 }
@@ -165,7 +162,7 @@ func convertClient(vol *miroirv1alpha1.MiroirVolume, clientIdx int, backend miro
 		FullSync: true,
 	})
 	vol.Spec.Replicas = replicas
-	vol.Spec.Clients = append(vol.Spec.Clients[:clientIdx], vol.Spec.Clients[clientIdx+1:]...)
+	vol.Spec.Clients = slices.Delete(vol.Spec.Clients, clientIdx, clientIdx+1)
 }
 
 // convertTieBreaker flips a tie-breaker leg diskful in place (the CEL

--- a/internal/nodemap/nodemap.go
+++ b/internal/nodemap/nodemap.go
@@ -40,7 +40,8 @@ import (
 // creation and persisted in the CRD; `address` overrides that for a
 // dedicated replication NIC.
 type Node struct {
-	// Backend selects the storage implementation: "lvmthin" | "zfs".
+	// Backend selects the storage implementation: "lvmthin" | "zfs" |
+	// "loopfile".
 	Backend miroirv1alpha1.BackendType `json:"backend"`
 	// Zone is an optional failure domain (rack, host group, AZ). When set,
 	// the controller spreads a volume's replicas across distinct zones;


### PR DESCRIPTION
## What

A cleanup pass over the whole Go tree (~9.5k non-test lines, every package read): dead code, dead/inaccurate comments, idiom, DRY. No behavior changes.

### Mangled doc comments (the main find)

Six doc comments were broken by later edits — a function inserted mid-comment left half the text attached to the wrong declaration, or a reworded comment was stacked on top of the old one and both survived:

| Location | Damage |
|---|---|
| `drbd.Apply` / `isMissingMetadata` | Apply's first line was welded to isMissingMetadata; Apply started at "changed, create metadata once…" |
| `drbd.AllocateMinor` / `lockMinors` | AllocateMinor's comment sat on lockMinors; AllocateMinor had none |
| `agent.computePhase` / `growIfCoordinator` | computePhase's comment stranded on growIfCoordinator |
| `agent.replicaStatusAC` / `primarySince` | both comments fused above primarySince |
| `csi.allocVolumes`, `csi.place` | literal duplicated text glued mid-line (`…lists every volume once// allocVolumes lists every volume once for…`) |
| `csi.provisionedPerNode` | old and new versions of its own comment stacked |

All reassembled onto the right declarations, keeping the richer wording.

### Stale comments (pre-#165 wording)

- `drbd.Resource.LocalDiskless`, `drbd.Peer.Diskless`, and the agent's diskless-realize branch said "diskless tie-breaker" — since #165 the same fields/paths carry client legs; comments and the `diskless tie-breaker realized` log line updated.
- `nodemap.Node.Backend` and `backend.Config` claimed `lvmthin | zfs` only; loopfile is a validated third backend.

### Dead code

- `csi.Identity.Ready` was never assigned anywhere (prod or tests): field removed, `Probe` returns a constant ready with a comment explaining why that is correct (the gRPC server only starts after cache sync).

### Idiom / DRY / Go modernization

- `drbd.writeAssignments` now uses the shared `writeFileAtomic` instead of hand-rolling the identical tmp+fsync+rename (and `writeConfig`'s now-stale cross-reference is gone).
- `drbd.Status` compares against the existing `rolePrimary` const instead of two `"Primary"` literals.
- `strings.SplitSeq`/`FieldsSeq` in `virginMetadata`, `readAssignments`, and zfs `promoteClones` — the rest of the tree already uses the iterator forms.
- `agent.assignMinor` drops its unused `ctx` parameter and a redundant `err` dance.
- membership: `slices.Delete` for client-leg removal (matching `csi/node`), and Go 1.22 per-iteration loop variables replace the manual `idx := i` closure copies in `candidates`.

### Verified clean, deliberately untouched

- `x/tools deadcode ./cmd/...`: nothing unreachable.
- gopls `modernize`: one remaining finding, `ptr.To(false)` → `new(bool)` in main.go — kept as-is; `ptr.To(false)` states "explicitly disabled" where `new(bool)` hides it.
- `CreateVolume`'s explicit allocMu lock/unlock branches: a closure/defer refactor would conflate alloc errors with the Create error that `handleCreateErr` needs raw.
- Interface use is already right-sized (`backend.Backend`, `backend.Exec`, `stage.DRBDStatus`); no new abstractions warranted.

## Testing

- `go build ./...`, `go vet ./...`, full unit suite: pass. The two refactored behavior paths have dedicated tests (`drbd/minor_test.go`, `membership/autodiskful_test.go`).
- `golangci-lint run`: 0 issues.