### PR TITLE
feat(csi): report volume health via CSI VolumeCondition; add al-extents knob

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -51,6 +51,7 @@ Kubernetes: `>=1.31.0`
 | agent.resources.requests.memory | string | `"32Mi"` |  |
 | agent.volumeWorkers | int | `4` | Concurrent volume reconciles per agent. Per-volume work is serialized by controller-runtime regardless; this bounds how many distinct volumes one agent works at once. |
 | autoTieBreaker | bool | `true` | Add a diskless tie-breaker replica to 2-replica freeze volumes when a spare storage node exists, so majority quorum survives a single node loss. Also retrofits existing freeze volumes at controller startup. |
+| drbd.alExtents | string | `""` | al-extents, the DRBD activity-log size (number of 4 MiB extents kept "hot"). DRBD's default (1237) forces frequent metadata updates under a scattered random-write workload; raising it (e.g. 6007) cuts that write amplification at the cost of a longer resync of the active region after a crash. Empty leaves DRBD's default. Must be a prime below 65534. |
 | drbd.net.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count (e.g. "36864"); raises resync throughput on fast links. |
 | drbd.onIoError | string | `"detach"` |  |
 | drbd.portBase | int | `7000` | Lowest TCP port for DRBD replication links, one per replicated volume ascending (7000, 7001, …). The agent runs hostNetwork so these bind on the node's kernel. Ceph mgr dashboard's non-SSL default is also 7000; co-locating with Rook host-network Ceph requires moving one of them (see issue #148). Existing volumes keep their assigned ports. |
@@ -113,6 +114,9 @@ Kubernetes: `>=1.31.0`
 | provisionTimeout | string | `"120s"` | Wait for agents to realise a new volume. Keep sidecars.*.timeout at or above this, or the sidecar RPC deadline fires before this one and the knob has no effect. |
 | replicaCount | int | `1` | Controller replicas. Anything above 1 automatically enables leader election: the extras are warm standbys (failover is lease expiry, ~15s, instead of a full pod reschedule), the rollout strategy switches to RollingUpdate, and a PodDisruptionBudget keeps one replica through voluntary disruptions. Pointless on a single-node cluster (the node is the failure domain); pair with global.affinity (pod anti-affinity) so replicas land on different nodes. |
 | resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | Controller resources. |
+| sidecars.healthMonitor.enabled | bool | `false` |  |
+| sidecars.healthMonitor.image | string | `"registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0"` |  |
+| sidecars.healthMonitor.interval | string | `"1m"` |  |
 | sidecars.provisioner.image | string | `"registry.k8s.io/sig-storage/csi-provisioner:v6.3.0"` |  |
 | sidecars.provisioner.timeout | string | `"120s"` |  |
 | sidecars.resizer.image | string | `"registry.k8s.io/sig-storage/csi-resizer:v2.2.1"` |  |

--- a/charts/miroir/templates/configmap.tpl
+++ b/charts/miroir/templates/configmap.tpl
@@ -36,6 +36,9 @@ data:
         {{- with .Values.drbd.onIoError }}
             on-io-error {{ . }};
         {{- end }}
+        {{- with .Values.drbd.alExtents }}
+            al-extents {{ . }};
+        {{- end }}
         {{- with .Values.drbd.resync }}
         {{- if .planAhead }}
             c-plan-ahead {{ .planAhead }};

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -144,6 +144,20 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        {{- if .Values.sidecars.healthMonitor.enabled }}
+        - name: csi-external-health-monitor-controller
+          image: {{ .Values.sidecars.healthMonitor.image }}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --monitor-interval={{ .Values.sidecars.healthMonitor.interval }}
+            - --leader-election={{ include "miroir.leaderElectionEnabled" . }}
+          resources:
+            requests: { cpu: 10m, memory: 32Mi }
+            limits: { memory: 128Mi }
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        {{- end }}
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -143,6 +143,16 @@
     "drbd": {
       "description": "=============================================================================\nDRBD replication tuning\n=============================================================================\nDRBD replication tuning applied cluster-wide through the common{} section of\nglobal_common.conf; every resource inherits it. Leave a value empty to use\nDRBD's built-in default. Tune to your replication network — see the LINBIT\n\"Tuning the DRBD Resync Controller\" guide.",
       "properties": {
+        "alExtents": {
+          "default": "",
+          "description": "al-extents, the DRBD activity-log size (number of 4 MiB extents kept\n\"hot\"). DRBD's default (1237) forces frequent metadata updates under a\nscattered random-write workload; raising it (e.g. 6007) cuts that write\namplification at the cost of a longer resync of the active region after a\ncrash. Empty leaves DRBD's default. Must be a prime below 65534.",
+          "required": [],
+          "title": "alExtents",
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
         "net": {
           "properties": {
             "maxBuffers": {
@@ -686,6 +696,30 @@
     "sidecars": {
       "description": "=============================================================================\nCSI sidecars (upstream sig-storage images)\n=============================================================================",
       "properties": {
+        "healthMonitor": {
+          "description": "external-health-monitor-controller: polls ControllerGetVolume and raises a\nPVC event when a volume reports split-brain/degraded/disk-failed (the same\nhealth the agents fold into status.phase). Off by default — the\nmiroir_volume_* metrics already carry this; enable for native PVC events.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "image": {
+              "default": "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0",
+              "title": "image",
+              "type": "string"
+            },
+            "interval": {
+              "default": "1m",
+              "description": "How often the monitor re-checks every volume's condition.",
+              "title": "interval",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "healthMonitor",
+          "type": "object"
+        },
         "provisioner": {
           "properties": {
             "image": {

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -111,6 +111,15 @@ sidecars:
     image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
     # Online grow can block on a rebooting node; keep >= provisionTimeout.
     timeout: 120s
+  # external-health-monitor-controller: polls ControllerGetVolume and raises a
+  # PVC event when a volume reports split-brain/degraded/disk-failed (the same
+  # health the agents fold into status.phase). Off by default — the
+  # miroir_volume_* metrics already carry this; enable for native PVC events.
+  healthMonitor:
+    enabled: false
+    image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
+    # How often the monitor re-checks every volume's condition.
+    interval: 1m
 
 # =============================================================================
 # Agent (per-node DaemonSet: storage userland + CSI node service)
@@ -279,6 +288,15 @@ drbd:
   # Diskless and serves reads/writes via the peer instead of surfacing
   # EIO into the pod. Set to pass_on to propagate errors instead.
   onIoError: detach
+  # @schema
+  # type: [integer, string]
+  # @schema
+  # -- al-extents, the DRBD activity-log size (number of 4 MiB extents kept
+  # "hot"). DRBD's default (1237) forces frequent metadata updates under a
+  # scattered random-write workload; raising it (e.g. 6007) cuts that write
+  # amplification at the cost of a longer resync of the active region after a
+  # crash. Empty leaves DRBD's default. Must be a prime below 65534.
+  alExtents: ""
   resync:
     # -- c-plan-ahead in 0.1s units; a value > 0 enables DRBD's variable-rate resync controller.
     planAhead: ""

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -101,6 +101,8 @@ func (c *Controller) ControllerGetCapabilities(_ context.Context, _ *csi.Control
 		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+		csi.ControllerServiceCapability_RPC_GET_VOLUME,
+		csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
 	}
 	resp := &csi.ControllerGetCapabilitiesResponse{}
 	for _, t := range caps {
@@ -829,6 +831,32 @@ func (c *Controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRe
 	return resp, nil
 }
 
+// ControllerGetVolume reports one volume's replication health to the
+// external-health-monitor, which raises it as an event on the PVC. The
+// condition is derived from the same aggregated status the agents publish.
+func (c *Controller) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
+	if req.GetVolumeId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume id is required")
+	}
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "volume %s not found", req.GetVolumeId())
+		}
+		return nil, status.Errorf(codes.Internal, "get volume: %v", err)
+	}
+	return &csi.ControllerGetVolumeResponse{
+		Volume: &csi.Volume{
+			VolumeId:           vol.Name,
+			CapacityBytes:      vol.Spec.SizeBytes,
+			AccessibleTopology: accessibleTopology(vol),
+		},
+		Status: &csi.ControllerGetVolumeResponse_VolumeStatus{
+			VolumeCondition: volumeCondition(vol),
+		},
+	}, nil
+}
+
 // ListVolumes returns all provisioned volumes for external-provisioner reconciliation.
 func (c *Controller) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 	vols := &miroirv1alpha1.MiroirVolumeList{}
@@ -865,6 +893,9 @@ func (c *Controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 				VolumeId:           v.Name,
 				CapacityBytes:      v.Spec.SizeBytes,
 				AccessibleTopology: accessibleTopology(v),
+			},
+			Status: &csi.ListVolumesResponse_VolumeStatus{
+				VolumeCondition: volumeCondition(v),
 			},
 		})
 	}

--- a/internal/csi/health.go
+++ b/internal/csi/health.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+// volumeCondition maps a volume's aggregated CRD status (the same signals the
+// agent folds into Phase and the miroir_volume_* gauges) to a CSI
+// VolumeCondition. The external-health-monitor surfaces it as a PVC event and
+// kubelet as the volume-health metric, so operators see split-brain/degraded
+// without scraping Prometheus. Abnormal states are ranked most-urgent first so
+// the single message names the condition to act on.
+func volumeCondition(vol *miroirv1alpha1.MiroirVolume) *csi.VolumeCondition {
+	// Split-brain: DRBD refused to reconnect diverged legs. Nothing heals it
+	// automatically — an operator must pick the loser.
+	if node, ok := firstNodeWhere(vol, func(s miroirv1alpha1.ReplicaStatus) bool { return s.SplitBrain }); ok {
+		return abnormalf("split-brain on node %s; manual resolution required", node)
+	}
+	// A backing disk DRBD detached on I/O error (on-io-error detach): serving
+	// continues via the peer, but this leg is latched failed and redundancy is
+	// gone until the disk is replaced.
+	if node, ok := firstNodeWhere(vol, func(s miroirv1alpha1.ReplicaStatus) bool { return s.DiskFailed }); ok {
+		return abnormalf("backing disk failed on node %s; replace the disk, then remove and re-add the replica", node)
+	}
+	switch vol.Status.Phase {
+	case miroirv1alpha1.VolumeFailed:
+		return abnormalf("provisioning failed; a backing device never materialized")
+	case miroirv1alpha1.VolumeDegraded:
+		return abnormalf("degraded: a replica is missing current data (resyncing or its peer is unreachable)")
+	}
+	return &csi.VolumeCondition{Abnormal: false, Message: "healthy"}
+}
+
+// firstNodeWhere returns the lexically-first node whose status satisfies pred,
+// so a condition message stays stable across reconciles when several nodes
+// match.
+func firstNodeWhere(vol *miroirv1alpha1.MiroirVolume, pred func(miroirv1alpha1.ReplicaStatus) bool) (string, bool) {
+	best, found := "", false
+	for node, st := range vol.Status.PerNode {
+		if pred(st) && (!found || node < best) {
+			best, found = node, true
+		}
+	}
+	return best, found
+}
+
+func abnormalf(format string, args ...any) *csi.VolumeCondition {
+	return &csi.VolumeCondition{Abnormal: true, Message: fmt.Sprintf(format, args...)}
+}

--- a/internal/csi/health_test.go
+++ b/internal/csi/health_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+func volWithStatus(name string, phase miroirv1alpha1.VolumePhase, perNode map[string]miroirv1alpha1.ReplicaStatus) *miroirv1alpha1.MiroirVolume {
+	return &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     miroirv1alpha1.MiroirVolumeStatus{Phase: phase, PerNode: perNode},
+	}
+}
+
+func TestVolumeCondition(t *testing.T) {
+	tests := []struct {
+		name         string
+		vol          *miroirv1alpha1.MiroirVolume
+		wantAbnormal bool
+		wantContains string
+	}{
+		{
+			name:         "ready is healthy",
+			vol:          volWithStatus("v", miroirv1alpha1.VolumeReady, nil),
+			wantAbnormal: false,
+			wantContains: "healthy",
+		},
+		{
+			name: "split-brain wins over everything",
+			vol: volWithStatus("v", miroirv1alpha1.VolumeDegraded, map[string]miroirv1alpha1.ReplicaStatus{
+				nodeParis:   {DiskFailed: true},
+				nodeKharkiv: {SplitBrain: true},
+			}),
+			wantAbnormal: true,
+			wantContains: "split-brain on node " + nodeKharkiv,
+		},
+		{
+			name: "disk failed when no split-brain",
+			vol: volWithStatus("v", miroirv1alpha1.VolumeReady, map[string]miroirv1alpha1.ReplicaStatus{
+				nodeParis: {DiskFailed: true},
+			}),
+			wantAbnormal: true,
+			wantContains: "backing disk failed on node " + nodeParis,
+		},
+		{
+			name:         "failed phase",
+			vol:          volWithStatus("v", miroirv1alpha1.VolumeFailed, nil),
+			wantAbnormal: true,
+			wantContains: "provisioning failed",
+		},
+		{
+			name:         "degraded phase",
+			vol:          volWithStatus("v", miroirv1alpha1.VolumeDegraded, nil),
+			wantAbnormal: true,
+			wantContains: "degraded",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := volumeCondition(tt.vol)
+			if got.GetAbnormal() != tt.wantAbnormal {
+				t.Fatalf("abnormal = %v, want %v (msg %q)", got.GetAbnormal(), tt.wantAbnormal, got.GetMessage())
+			}
+			if !strings.Contains(got.GetMessage(), tt.wantContains) {
+				t.Fatalf("message %q does not contain %q", got.GetMessage(), tt.wantContains)
+			}
+		})
+	}
+}
+
+// TestVolumeConditionDeterministic pins the message when several nodes match,
+// so a health event doesn't flap between reconciles.
+func TestVolumeConditionDeterministic(t *testing.T) {
+	vol := volWithStatus("v", miroirv1alpha1.VolumeReady, map[string]miroirv1alpha1.ReplicaStatus{
+		nodeParis:   {SplitBrain: true},
+		nodeKharkiv: {SplitBrain: true},
+		nodeOslo:    {SplitBrain: true},
+	})
+	for range 5 {
+		if msg := volumeCondition(vol).GetMessage(); !strings.Contains(msg, nodeKharkiv) {
+			t.Fatalf("expected lexically-first node %s, got %q", nodeKharkiv, msg)
+		}
+	}
+}
+
+func TestControllerGetVolume(t *testing.T) {
+	s := newScheme(t)
+	vol := volWithStatus(volPvc1, miroirv1alpha1.VolumeDegraded, nil)
+	vol.Spec.SizeBytes = 1 << 30
+	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).WithObjects(vol).Build()}
+
+	resp, err := c.ControllerGetVolume(context.Background(), &csi.ControllerGetVolumeRequest{VolumeId: volPvc1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.GetVolume().GetVolumeId() != volPvc1 {
+		t.Fatalf("volume id = %q, want %q", resp.GetVolume().GetVolumeId(), volPvc1)
+	}
+	if resp.GetVolume().GetCapacityBytes() != 1<<30 {
+		t.Fatalf("capacity = %d, want %d", resp.GetVolume().GetCapacityBytes(), 1<<30)
+	}
+	if !resp.GetStatus().GetVolumeCondition().GetAbnormal() {
+		t.Fatal("expected degraded volume to report abnormal")
+	}
+
+	if _, err := c.ControllerGetVolume(context.Background(), &csi.ControllerGetVolumeRequest{}); err == nil {
+		t.Fatal("expected error for empty volume id")
+	}
+	if _, err := c.ControllerGetVolume(context.Background(), &csi.ControllerGetVolumeRequest{VolumeId: "missing"}); err == nil {
+		t.Fatal("expected NotFound for missing volume")
+	}
+}

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -87,6 +87,7 @@ func (n *Node) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabilities
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 		csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
 	}
 	resp := &csi.NodeGetCapabilitiesResponse{}
 	for _, t := range caps {
@@ -503,22 +504,34 @@ func (n *Node) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeSta
 	if req.GetVolumeId() == "" || req.GetVolumePath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id and path are required")
 	}
+	resp := &csi.NodeGetVolumeStatsResponse{VolumeCondition: n.lookupVolumeCondition(ctx, req.GetVolumeId())}
 	// A raw-block publish path is a bind-mounted device file: statfs
 	// there reports the host filesystem backing the target dir, not the
 	// volume. No filesystem, no usage to report.
 	if fi, err := os.Stat(req.GetVolumePath()); err == nil && !fi.IsDir() {
-		return &csi.NodeGetVolumeStatsResponse{}, nil
+		return resp, nil
 	}
 	stats, err := statfsAt(req.GetVolumePath())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "volume stats: %v", err)
 	}
-	return &csi.NodeGetVolumeStatsResponse{
-		Usage: []*csi.VolumeUsage{
-			{Unit: csi.VolumeUsage_BYTES, Total: stats.total, Used: stats.used, Available: stats.available},
-			{Unit: csi.VolumeUsage_INODES, Total: stats.inodes, Used: stats.inodesUsed, Available: stats.inodesAvail},
-		},
-	}, nil
+	resp.Usage = []*csi.VolumeUsage{
+		{Unit: csi.VolumeUsage_BYTES, Total: stats.total, Used: stats.used, Available: stats.available},
+		{Unit: csi.VolumeUsage_INODES, Total: stats.inodes, Used: stats.inodesUsed, Available: stats.inodesAvail},
+	}
+	return resp, nil
+}
+
+// lookupVolumeCondition reports the volume's replication health for the stats
+// RPC. Best-effort: a lookup failure (volume mid-delete, transient API error)
+// must not fail NodeGetVolumeStats, whose primary job is capacity — the
+// controller's ControllerGetVolume reports the same condition regardless.
+func (n *Node) lookupVolumeCondition(ctx context.Context, volumeID string) *csi.VolumeCondition {
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := n.Client.Get(ctx, types.NamespacedName{Name: volumeID}, vol); err != nil {
+		return nil
+	}
+	return volumeCondition(vol)
 }
 
 type fsStatResult struct {

--- a/internal/csi/node_test.go
+++ b/internal/csi/node_test.go
@@ -117,6 +117,44 @@ func TestDevicePathHealthyReturnsDevice(t *testing.T) {
 	}
 }
 
+// NodeGetVolumeStats attaches the volume's replication health so kubelet's
+// volume-health metric reflects a degraded leg alongside the capacity stats.
+func TestNodeGetVolumeStatsReportsCondition(t *testing.T) {
+	v := stagedVolume()
+	v.Status.Phase = miroirv1alpha1.VolumeDegraded
+	n := newNode(t, v, fakeDRBDStatus{st: drbd.Status{DiskState: drbd.DiskUpToDate}})
+
+	resp, err := n.NodeGetVolumeStats(t.Context(), &csi.NodeGetVolumeStatsRequest{
+		VolumeId:   volPvc1,
+		VolumePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.GetVolumeCondition().GetAbnormal() {
+		t.Fatalf("degraded volume must report abnormal condition, got %+v", resp.GetVolumeCondition())
+	}
+	if len(resp.GetUsage()) == 0 {
+		t.Fatal("expected capacity usage alongside the condition")
+	}
+}
+
+// A stats call for a volume that has been deleted must still succeed — the
+// condition is best-effort, capacity is the contract.
+func TestNodeGetVolumeStatsMissingVolume(t *testing.T) {
+	n := newNode(t, stagedVolume(), fakeDRBDStatus{})
+	resp, err := n.NodeGetVolumeStats(t.Context(), &csi.NodeGetVolumeStatsRequest{
+		VolumeId:   "missing",
+		VolumePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.GetVolumeCondition() != nil {
+		t.Fatalf("missing volume should carry no condition, got %+v", resp.GetVolumeCondition())
+	}
+}
+
 // A diskless tie-breaker node must never stage the volume: it holds no
 // data leg, only a quorum vote.
 func TestDevicePathRefusesDisklessNode(t *testing.T) {


### PR DESCRIPTION
Two low-hanging improvements informed by LINSTOR/blockstor parity.

## 1. Volume health via CSI `VolumeCondition`

miroir already tracks rich per-volume replication health (`status.phase`, per-node `splitBrain`/`diskFailed`) but only exposes it through the `miroir_volume_*` Prometheus gauges. This wires the same signals through the standard CSI health channel so they surface as a **PVC event** and a kubelet volume-health metric.

- **`internal/csi/health.go`** — shared `volumeCondition()` mapping aggregated CRD status → `csi.VolumeCondition`, ranked most-urgent-first (split-brain → disk-failed → failed → degraded → healthy), with deterministic node selection so the message doesn't flap between reconciles.
- **Controller** — new `ControllerGetVolume` RPC; advertises `GET_VOLUME` and `VOLUME_CONDITION`; also attaches the condition to `ListVolumes` entries.
- **Node** — `NodeGetVolumeStats` returns the condition alongside capacity (best-effort: a missing/mid-delete volume never fails the stats call); advertises the node `VOLUME_CONDITION` capability.
- **Chart** — optional `external-health-monitor-controller` sidecar (`sidecars.healthMonitor.enabled`, **default off** — the metrics already carry this; enable for native PVC events). Existing controller RBAC (PVs/PVCs/events/nodes) already covers it, so no new rules.

Notes:
- The node-side `VOLUME_CONDITION` only yields a metric where kubelet's `CSIVolumeHealth` gate is on (alpha); the controller sidecar is the always-on path. Both are wired.
- The sidecar was left opt-in given the metric overlap — easy to flip to default-on if preferred.

## 2. `al-extents` DRBD knob

Exposes the DRBD activity-log size as `drbd.alExtents`, rendered into the cluster-wide `common{} disk {}` section (empty = DRBD default of 1237). Raising it (e.g. 6007) cuts metadata write amplification under scattered random writes at the cost of a longer active-region resync after a crash — a well-known LINSTOR/blockstor tuning. Follows the existing resync/net knob pattern.

## Verification

- `go build ./...`, full `go test ./...`, `golangci-lint run ./...` (cache-cleared) — all pass. Added `health_test.go` (mapping + `ControllerGetVolume`) and two `NodeGetVolumeStats` tests.
- `helm template` confirms `al-extents` renders and the health-monitor container appears only when enabled; `helm lint` + `helm unittest` (89 tests) pass; `values.schema.json`/chart README regenerated (idempotent).
- Not exercised locally: the health-monitor sidecar end-to-end (no cluster available); the driver RPCs it calls are unit-tested against a fake client.

A third candidate (dm-thin `-Z n` chunk-zeroing perf) was deliberately left out pending a decision on its stale-remainder tradeoff.