### PR TITLE
fix(drbd): disconnect before down to prevent kernel deadlock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,10 @@ ENTRYPOINT ["/usr/local/bin/miroir"]
 # zfsutils-linux lives in contrib. Version notes (trixie, no backports):
 #   - drbd-utils 9.22: every CLI/JSON surface miroir uses predates it
 #     (adjust --skip-disk 8.9.7, status --json 8.9.8, quorum 8.9.11;
-#     peer_devices/percent-in-sync/out-of-sync/peer-disk-state verified
-#     in the v9.22.0 source). The birth generation depends on drbdadm
+#     peer_devices/percent-in-sync/out-of-sync/peer-disk-state and the
+#     per-peer `drbdsetup disconnect <res> <peer_node_id>` form
+#     (CTX_PEER_NODE) verified in the v9.22.0 source). The birth
+#     generation depends on drbdadm
 #     new-current-uuid --clear-bitmap behavior — re-validate with
 #     smoke.sh + conformance on real DRBD (the kind e2e exercises the
 #     local backend only) before shipping a base bump.

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -294,7 +294,7 @@ func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool)
 				if owned(res.Name) {
 					continue
 				}
-				if err := d.downResource(ctx, res.Name); err != nil {
+				if err := d.downResource(ctx, res.Name, res.peerIDs()); err != nil {
 					return fmt.Errorf("down orphan %s: %w", res.Name, err)
 				}
 			}
@@ -342,7 +342,7 @@ func (d *Driver) DownSecondaries(ctx context.Context) error {
 		if res.Role == rolePrimary {
 			continue
 		}
-		if err := d.downResource(ctx, res.Name); err != nil {
+		if err := d.downResource(ctx, res.Name, res.peerIDs()); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -654,35 +654,26 @@ func (d *Driver) WipeMetadata(ctx context.Context, name, disk string, minor int3
 	return nil
 }
 
-// downTimeout bounds drbdsetup down. A device stuck in Detaching (kernel
-// ref-count corruption, put_ldev assertion) makes down hang in D-state
-// forever; without a bound it pins the reconcile worker and head-of-line-
-// blocks every other volume on the node. Shorter than execTimeout because
-// down on healthy hardware completes in milliseconds.
+// downTimeout tightens RealExec's 2-minute bound for drbdsetup down. A
+// device wedged mid-teardown (stuck Detaching) leaves down in D-state, and
+// teardown retries every ~10s — a 2-minute pin per attempt head-of-line-
+// blocks the reconcile worker. 30s is generous: down on healthy hardware
+// completes in milliseconds. The bound frees the worker, not the device —
+// a D-state child ignores the SIGKILL and keeps its holds.
 const downTimeout = 30 * time.Second
 
-// downResource disconnects each peer connection then downs the resource.
-// Disconnecting first avoids a kernel deadlock when the peer is mid-resync:
-// drbdsetup down can enter uninterruptible sleep negotiating teardown with
-// an active connection. drbdsetup disconnect requires a peer_node_id, so
-// the peers are enumerated from status. Best-effort: a resource already
-// StandAlone or not configured has no connections to disconnect.
-// drbdsetup, not drbdadm: drbdadm refuses conflicting .res files, and
-// teardown is how a conflict gets removed.
-func (d *Driver) downResource(ctx context.Context, name string) error {
-	if out, err := d.Exec(ctx, "drbdsetup", "status", "--json", name); err == nil {
-		var parsed []jsonStatus
-		if json.Unmarshal([]byte(out), &parsed) == nil {
-			for _, res := range parsed {
-				if res.Name != name {
-					continue
-				}
-				for _, conn := range res.Connections {
-					_, _ = d.Exec(ctx, "drbdsetup", "disconnect", name,
-						strconv.Itoa(int(conn.PeerNodeID)))
-				}
-			}
-		}
+// downResource disconnects each peer connection, then downs the resource.
+// Disconnecting first avoids a kernel deadlock: drbdsetup down on a
+// resource with an active resync connection can enter uninterruptible
+// sleep negotiating teardown with the peer. Disconnects are best-effort
+// (a StandAlone or unconfigured connection errors harmlessly); drbdsetup
+// needs no config, takes peers by node id, and down exits 0 for unknown
+// names, keeping teardown idempotent. drbdsetup, not drbdadm: drbdadm
+// refuses conflicting .res files, and teardown is how a conflict gets
+// removed.
+func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32) error {
+	for _, id := range peerIDs {
+		_, _ = d.Exec(ctx, "drbdsetup", "disconnect", name, strconv.Itoa(int(id)))
 	}
 	downCtx, cancel := context.WithTimeout(ctx, downTimeout)
 	defer cancel()
@@ -692,12 +683,33 @@ func (d *Driver) downResource(ctx context.Context, name string) error {
 	return nil
 }
 
+// livePeerIDs reports the resource's DRBD peer node ids per the kernel's
+// live view — the ids downResource must disconnect. Empty when the
+// resource is down or the status is unreadable (nothing to disconnect).
+func (d *Driver) livePeerIDs(ctx context.Context, name string) []int32 {
+	out, err := d.Exec(ctx, "drbdsetup", "status", "--json", name)
+	if err != nil {
+		return nil
+	}
+	var parsed []jsonStatus
+	if json.Unmarshal([]byte(out), &parsed) != nil {
+		return nil
+	}
+	var ids []int32
+	for _, res := range parsed {
+		if res.Name == name {
+			ids = append(ids, res.peerIDs()...)
+		}
+	}
+	return ids
+}
+
 // Down stops the resource and removes its rendered state. Idempotent.
 func (d *Driver) Down(ctx context.Context, name string) error {
 	if _, err := os.Stat(d.path(name + ".res")); os.IsNotExist(err) {
 		return nil // never configured here
 	}
-	if err := d.downResource(ctx, name); err != nil {
+	if err := d.downResource(ctx, name, d.livePeerIDs(ctx, name)); err != nil {
 		return err
 	}
 	for _, suffix := range stateSuffixes {
@@ -809,6 +821,16 @@ type jsonStatus struct {
 			OutOfSyncKiB     int64   `json:"out-of-sync"`
 		} `json:"peer_devices"`
 	} `json:"connections"`
+}
+
+// peerIDs lists the entry's connection peer node ids — the handles
+// drbdsetup disconnect takes.
+func (s jsonStatus) peerIDs() []int32 {
+	ids := make([]int32, 0, len(s.Connections))
+	for _, c := range s.Connections {
+		ids = append(ids, c.PeerNodeID)
+	}
+	return ids
 }
 
 // Status parses `drbdsetup status --json <res>`.

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -293,8 +294,7 @@ func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool)
 				if owned(res.Name) {
 					continue
 				}
-				// drbdsetup down works without a .res file.
-				if _, err := d.Exec(ctx, "drbdsetup", "down", res.Name); err != nil {
+				if err := d.downResource(ctx, res.Name); err != nil {
 					return fmt.Errorf("down orphan %s: %w", res.Name, err)
 				}
 			}
@@ -342,8 +342,8 @@ func (d *Driver) DownSecondaries(ctx context.Context) error {
 		if res.Role == rolePrimary {
 			continue
 		}
-		if _, err := d.Exec(ctx, "drbdsetup", "down", res.Name); err != nil {
-			errs = append(errs, fmt.Errorf("down %s: %w", res.Name, err))
+		if err := d.downResource(ctx, res.Name); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
@@ -654,16 +654,51 @@ func (d *Driver) WipeMetadata(ctx context.Context, name, disk string, minor int3
 	return nil
 }
 
+// downTimeout bounds drbdsetup down. A device stuck in Detaching (kernel
+// ref-count corruption, put_ldev assertion) makes down hang in D-state
+// forever; without a bound it pins the reconcile worker and head-of-line-
+// blocks every other volume on the node. Shorter than execTimeout because
+// down on healthy hardware completes in milliseconds.
+const downTimeout = 30 * time.Second
+
+// downResource disconnects each peer connection then downs the resource.
+// Disconnecting first avoids a kernel deadlock when the peer is mid-resync:
+// drbdsetup down can enter uninterruptible sleep negotiating teardown with
+// an active connection. drbdsetup disconnect requires a peer_node_id, so
+// the peers are enumerated from status. Best-effort: a resource already
+// StandAlone or not configured has no connections to disconnect.
+// drbdsetup, not drbdadm: drbdadm refuses conflicting .res files, and
+// teardown is how a conflict gets removed.
+func (d *Driver) downResource(ctx context.Context, name string) error {
+	if out, err := d.Exec(ctx, "drbdsetup", "status", "--json", name); err == nil {
+		var parsed []jsonStatus
+		if json.Unmarshal([]byte(out), &parsed) == nil {
+			for _, res := range parsed {
+				if res.Name != name {
+					continue
+				}
+				for _, conn := range res.Connections {
+					_, _ = d.Exec(ctx, "drbdsetup", "disconnect", name,
+						strconv.Itoa(int(conn.PeerNodeID)))
+				}
+			}
+		}
+	}
+	downCtx, cancel := context.WithTimeout(ctx, downTimeout)
+	defer cancel()
+	if _, err := d.Exec(downCtx, "drbdsetup", "down", name); err != nil {
+		return fmt.Errorf("down %s: %w", name, err)
+	}
+	return nil
+}
+
 // Down stops the resource and removes its rendered state. Idempotent.
-// drbdsetup, not drbdadm: drbdadm refuses to do anything while any two
-// .res files in the directory conflict, and teardown is how a conflict
-// gets removed. drbdsetup needs no config and exits 0 for unknown names.
 func (d *Driver) Down(ctx context.Context, name string) error {
 	if _, err := os.Stat(d.path(name + ".res")); os.IsNotExist(err) {
 		return nil // never configured here
 	}
-	if _, err := d.Exec(ctx, "drbdsetup", "down", name); err != nil {
-		return fmt.Errorf("down %s: %w", name, err)
+	if err := d.downResource(ctx, name); err != nil {
+		return err
 	}
 	for _, suffix := range stateSuffixes {
 		if err := os.Remove(d.path(name + suffix)); err != nil && !os.IsNotExist(err) {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -586,7 +586,9 @@ func TestVirginMetadata(t *testing.T) {
 }
 
 func TestDownRemovesState(t *testing.T) {
-	fe := &fakeExec{}
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"pvc-1","connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
+	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 	r := testResource(nodeKharkiv)
 
@@ -596,7 +598,21 @@ func TestDownRemovesState(t *testing.T) {
 	if err := d.Down(t.Context(), volPvc1); err != nil {
 		t.Fatal(err)
 	}
+	// Disconnect must precede down, with the peer_node_id from status.
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
 	fe.calledWith(t, "drbdsetup down pvc-1")
+	discIdx, downIdx := -1, -1
+	for i, c := range fe.calls {
+		if strings.Contains(c, "drbdsetup disconnect pvc-1") {
+			discIdx = i
+		}
+		if strings.Contains(c, "drbdsetup down pvc-1") {
+			downIdx = i
+		}
+	}
+	if discIdx < 0 || downIdx < 0 || discIdx > downIdx {
+		t.Fatalf("disconnect must precede down, got calls: %v", fe.calls)
+	}
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.res")); !os.IsNotExist(err) {
 		t.Fatal("res file must be removed")
 	}
@@ -675,8 +691,8 @@ func TestStatusPerPeerDiskState(t *testing.T) {
 func TestDownSecondariesSkipsPrimary(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{
 		cmdDrbdsetupStatus: `[
-			{"name":"pvc-1","role":"Primary"},
-			{"name":"pvc-2","role":"Secondary"}]`,
+			{"name":"pvc-1","role":"Primary","connections":[{"peer-node-id":1,"connection-state":"Connected"}]},
+			{"name":"pvc-2","role":"Secondary","connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 
@@ -685,6 +701,8 @@ func TestDownSecondariesSkipsPrimary(t *testing.T) {
 	}
 	// Primary legs are still open — skipped.
 	fe.notCalledWith(t, "drbdsetup down pvc-1")
+	fe.notCalledWith(t, "drbdsetup disconnect pvc-1")
+	fe.calledWith(t, "drbdsetup disconnect pvc-2 1")
 	fe.calledWith(t, "drbdsetup down pvc-2")
 }
 
@@ -692,8 +710,8 @@ func TestDownSecondariesContinuesOnError(t *testing.T) {
 	fe := &fakeExec{
 		responses: map[string]string{
 			cmdDrbdsetupStatus: `[
-				{"name":"pvc-2","role":"Secondary"},
-				{"name":"pvc-3","role":"Secondary"}]`,
+				{"name":"pvc-2","role":"Secondary","connections":[{"peer-node-id":1,"connection-state":"Connected"}]},
+				{"name":"pvc-3","role":"Secondary","connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
 		},
 		errOn: map[string]error{"down pvc-2": errors.New("Device is held open by someone")},
 	}
@@ -704,6 +722,7 @@ func TestDownSecondariesContinuesOnError(t *testing.T) {
 		t.Fatalf("want a joined error naming pvc-2, got %v", err)
 	}
 	// One stuck resource must not strand the rest of the sweep.
+	fe.calledWith(t, "drbdsetup disconnect pvc-3 1")
 	fe.calledWith(t, "drbdsetup down pvc-3")
 }
 

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -704,6 +704,17 @@ func TestDownSecondariesSkipsPrimary(t *testing.T) {
 	fe.notCalledWith(t, "drbdsetup disconnect pvc-1")
 	fe.calledWith(t, "drbdsetup disconnect pvc-2 1")
 	fe.calledWith(t, "drbdsetup down pvc-2")
+	// Peer ids come from the sweep's own status parse — no per-resource
+	// re-fetch (shutdown is time-bounded; see cmd/main.go).
+	statusCalls := 0
+	for _, c := range fe.calls {
+		if strings.Contains(c, cmdDrbdsetupStatus) {
+			statusCalls++
+		}
+	}
+	if statusCalls != 1 {
+		t.Fatalf("want exactly 1 status call, got %d: %v", statusCalls, fe.calls)
+	}
 }
 
 func TestDownSecondariesContinuesOnError(t *testing.T) {


### PR DESCRIPTION
## Problem

`drbdsetup down` on a resource with an active resync connection (peer in Inconsistent state) can enter uninterruptible sleep (D-state), deadlocking the node:

- The stuck process holds the block device, blocking all LVM commands
- The agent can't start (`be.Setup()` calls LVM that hangs forever)
- D-state processes are unkillable, only a node reboot clears them

This was observed in production: a volume created from a snapshot was deleted before the peer finished syncing. `drbdsetup down` deadlocked, cascading into a full node freeze.

## Root cause

All three `drbdsetup down` call sites (`Down`, `DownSecondaries`, `SweepOrphans`) called `down` directly without first disconnecting the peer connection. `ResolveSplitBrain` already does disconnect-first — the `down` paths did not.

## Fix

Route all three down paths through a shared `downResource` helper that calls `drbdsetup disconnect` (best-effort) before `drbdsetup down`.

## Checklist

- [x] Tests pass (`go test ./internal/drbd/`)
- [x] `go vet` clean
- [x] `gofmt` clean
- [x] Lefthook pre-commit passed