### PR TITLE
docs(readme): refresh for recent features; lean pass and layout examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ go.work
 .vscode
 .remember/
 *.sock
-notes/

--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -21,9 +21,14 @@ exclude = ["charts/miroir/README.md"]
 [pre-commit.commands.format-json]
 exclude = ["charts/miroir/values.schema.json"]
 
+# Generated CRD/RBAC YAMLs are .prettierignore'd; exclude them here too, or a
+# commit staging only generated YAML feeds oxfmt an all-ignored input list and
+# it exits 2. (An earlier `run = "... || true"` override stopped working when
+# lefthook v2 dropped shell interpretation of run strings.)
 [pre-commit.commands.format-yaml]
-glob = ["*.yaml", "*.yml"]
-# Generated CRD YAMLs are .prettierignore'd (oxfmt respects them); override
-# run so oxfmt doesn't error when its only inputs are all ignored files.
-run = "oxfmt {staged_files} || true"
-stage_fixed = true
+exclude = [
+  "charts/miroir/crds/*.yaml",
+  "config/crd/bases/*.yaml",
+  "config/rbac/role.yaml",
+  "config/webhook/manifests.yaml",
+]

--- a/README.md
+++ b/README.md
@@ -396,24 +396,19 @@ Trade-offs to understand:
   preference: PV node affinity is all-or-nothing, so the scheduler is
   blind to replica locations. Keep locality-sensitive workloads on a
   pinned class, or steer them with their own node/pod affinity.
-- **An attached client shifts quorum math.** DRBD counts every peer's
-  vote: a 2+1 volume with a client attached has 4 votes, so majority
-  becomes 3. While the client is connected this is neutral-to-helpful
-  (the client's vote replaces a lost node's); the regression window
-  is two simultaneous failures, which majority-of-4 freezes where
-  majority-of-3 tolerated one loss. Client legs come and go with
-  pods, so the math shifts at stage/unstage, not permanently.
+- **An attached client shifts quorum math.** Its DRBD vote raises the
+  majority threshold while attached (a 2+1 volume becomes 4 votes,
+  majority 3); neutral-to-helpful for a single failure, stricter for
+  two simultaneous ones.
 - **Consumers must run on nodes listed in `nodes`.** Agents only
   start on mapped nodes, so a pod scheduled onto an unmapped node has
-  no CSI driver to mount with and wedges in `ContainerCreating`, and
-  with no PV affinity nothing steers the scheduler away. Keep every
+  no CSI driver and wedges in `ContainerCreating`. Keep every
   schedulable node in the map (a `loopfile` entry with a few spare GB
   is enough) or set `allowRemoteVolumeAccess: "false"`.
-- **A lost node can strand its client leg.** If a node dies without
-  unstaging, its entry in `spec.clients` (and teardown finalizer)
-  lingers, holding a quorum vote and blocking volume deletion until
-  the node returns or the entry is removed by hand; the same
-  semantics as a dead replica node.
+- **A lost node can strand its client leg.** Like a dead replica
+  node, its `spec.clients` entry holds a quorum vote and blocks
+  volume deletion until the node returns or the entry is removed by
+  hand.
 
 #### Auto-diskful
 
@@ -593,11 +588,6 @@ and `monitoring.dashboards.enabled: true` installs a Grafana
 dashboard, either a sidecar-labelled ConfigMap or a grafana-operator
 `GrafanaDashboard` CR via `monitoring.dashboards.grafanaOperator`.
 
-Both processes also expose controller-runtime metrics
-(`controller_runtime_reconcile_errors_total` is the wedged-reconcile
-signal), and mounted volumes get `kubelet_volume_stats_*` for free
-via CSI.
-
 ## Coexistence with other provisioners
 
 - **OpenEBS LocalPV-ZFS**: keep your pool and let `openebs-zfs` stay
@@ -626,19 +616,13 @@ via CSI.
 - **Replicated volume stuck in `Degraded`**: one leg isn't
   `UpToDate`. `kubectl describe miroirvolume <name>` shows per-node
   status; usually a transient DRBD sync.
-- **Replicated volume stuck `Connecting`, no split-brain, PVC hangs
-  in `ContainerCreating`**: the DRBD replication port (default 7000,
-  allocated per volume ascending) is likely occupied by a
-  host-network tenant, most commonly the Ceph mgr dashboard. The
-  agent runs `hostNetwork: true`, so the collision is silent: `dmesg`
-  on the node shows `Failed to initiate connection, err=-98`
-  (EADDRINUSE), and peers dialing in log
-  `Wrong magic value 0x48545450` (`"HTTP"` in ASCII).
-  `curl -sI http://<node>:7000/` identifies the squatter. Fix by
-  setting `drbd.portBase` (e.g. `7100`), or move the Ceph dashboard
-  (`cephClusterSpec.dashboard.port: 8081`). Existing volumes keep
-  their assigned ports; only new allocations use the new base
-  ([#148](https://github.com/home-operations/miroir/issues/148)).
+- **Replicated volume stuck `Connecting`, no split-brain**: a
+  host-network tenant (commonly the Ceph mgr dashboard) occupies the
+  DRBD replication port; `dmesg` shows
+  `Failed to initiate connection, err=-98`. Set `drbd.portBase` (e.g.
+  `7100`) to move miroir's range; existing volumes keep their ports.
+  Full forensics in
+  [#148](https://github.com/home-operations/miroir/issues/148).
 
 ## Uninstall
 
@@ -654,37 +638,9 @@ what is stuck, and the agent log on the affected node
 (`kubectl logs -n miroir-system -l app.kubernetes.io/component=agent`)
 shows the failing call to clean up manually.
 
-## Roadmap
-
-**Should land soon**
-
-- [x] Capacity-aware placement
-- [x] CSI `CSIStorageCapacity` reporting per pool (opt-in:
-      `storageCapacity.enabled`)
-- [x] Per-volume DRBD state metrics (`miroir_volume_up_to_date` /
-      `connected` / `split_brain` / `suspended` / `resync_ratio`;
-      opt-in PodMonitor via `monitoring.podMonitor.enabled`)
-- [x] Per-volume quorum / failed-disk / out-of-sync gauges and pool
-      capacity metrics
-
-**Natural extensions**
-
-- [ ] Online volume migration (node-to-node, backend-to-backend)
-- [ ] Thick LVM volumes
-- [ ] Read-only clones
-- [ ] Pool hot-resize
-
-**Waiting on upstream**
-
-- [ ] `VolumeGroupSnapshot` (Kubernetes 1.36 GA)
-- [ ] CBT-based incremental backups (`thin_delta` / `zfs diff`)
-
-**Nice-to-have**
-
-- [ ] `mctl` CLI wrapping the CRDs
-
 ## Development
 
-Architecture: [notes/DESIGN.md](notes/DESIGN.md). Tooling pinned with
-[mise](https://mise.jdx.dev); `mise run test`, `mise run lint`,
-`mise run build`, `mise run manifests`.
+Architecture: [notes/DESIGN.md](notes/DESIGN.md). Planned work lives
+in the [issue tracker](https://github.com/home-operations/miroir/issues).
+Tooling pinned with [mise](https://mise.jdx.dev); `mise run test`,
+`mise run lint`, `mise run build`, `mise run manifests`.

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ shows the failing call to clean up manually.
 
 ## Development
 
-Architecture: [notes/DESIGN.md](notes/DESIGN.md). Planned work lives
-in the [issue tracker](https://github.com/home-operations/miroir/issues).
+Planned work lives in the
+[issue tracker](https://github.com/home-operations/miroir/issues).
 Tooling pinned with [mise](https://mise.jdx.dev); `mise run test`,
 `mise run lint`, `mise run build`, `mise run manifests`.

--- a/README.md
+++ b/README.md
@@ -21,46 +21,12 @@ synchronous replication (2-3 replicas) via DRBD9.
   serves block devices, plus a per-volume NFS export for
   `ReadWriteMany` (see [ReadWriteMany (RWX)](#readwritemany-rwx)); it
   is not a general-purpose exporter.
-
-## How it compares to LINSTOR and blockstor
-
-miroir runs the same data plane as [LINSTOR][linstor] and
-[blockstor][blockstor]: DRBD 9 replicating thin LVM or ZFS volumes,
-synchronous protocol C, quorum with diskless tie-breakers. The
-difference is the control plane.
-
-- **LINSTOR** is the reference DRBD orchestrator and the right choice
-  at fleet scale: resource groups with placement counts, automatic
-  eviction and rebalancing, many storage backends, WAN replication
-  via DRBD Proxy. That power rides on a Java controller with its own
-  database and a satellite RPC protocol; on Kubernetes the Piraeus
-  stack adds an operator, controller, per-node satellites, CSI
-  drivers, and an HA controller, each its own workload to run and
-  upgrade.
-- **blockstor** is a clean-room Go reimplementation of the LINSTOR
-  model for Cozystack: the resource-definition / resource-group
-  abstractions (plus auto-evict and rebalancing) with CRDs in place
-  of the JVM and database. Architecturally it is miroir's closest
-  relative.
-- **miroir** cuts the scope to what 2-3 nodes actually need. The
-  Kubernetes API is the _only_ control plane: the controller writes
-  MiroirVolume objects and node agents realize them; no controller
-  database, no inter-node RPC protocol, no operator managing an
-  operator. One small static image serves as both the controller
-  Deployment and the agent DaemonSet, and the Helm chart is the
-  entire configuration surface. Placement, quorum tie-breakers, and
-  barrier-consistent snapshots are automated; resource groups,
-  auto-evict, and multi-site replication deliberately are not. If you
-  need those, run LINSTOR.
-
-Where the bigger projects encode operational wisdom, miroir adopts it
-instead of relearning it: `on-io-error detach`, the resync,
-activity-log, and discard tuning knobs, and the
-majority-quorum-plus-tie-breaker default all follow what LINSTOR and
-blockstor ship.
-
-[linstor]: https://github.com/LINBIT/linstor-server
-[blockstor]: https://github.com/cozystack/blockstor
+- You're at fleet scale. Resource groups, automatic eviction and
+  rebalancing, and multi-site replication are
+  [LINSTOR](https://github.com/LINBIT/linstor-server)'s territory;
+  miroir runs the same DRBD9 data plane but deliberately stops at
+  what 2-3 nodes need, with the Kubernetes API as its only control
+  plane.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Replicated block storage for small Kubernetes clusters. CSI driver
 on top of LVM thin, ZFS, or loopfile backends, with optional
-synchronous replication (2–3 replicas) via DRBD9.
+synchronous replication (2-3 replicas) via DRBD9.
 
 ## When to use it
 
 - You want replicated block storage without running Ceph.
-- You're on 2–3 nodes and either have a spare disk per node (LVM), a
+- You're on 2-3 nodes and either have a spare disk per node (LVM), a
   ZFS pool (ZFS), or a few GB on the root filesystem (loopfile).
 - You want snapshots that actually work for replicated volumes
   (both legs cut in lockstep, not whichever finishes first).
@@ -15,14 +15,12 @@ synchronous replication (2–3 replicas) via DRBD9.
 ## When _not_ to use it
 
 - You need >3 replicas. DRBD9 itself supports more, but the
-  controller validates `1..3` and reserves DRBD metadata slots for 7
-  (`--max-peers 7`). Going higher means lifting the cap, raising
-  `--max-peers`, and revisiting the quorum policies, which are built
-  around 2 data replicas plus a tie-breaker — not done.
-- You need iSCSI targets or a standalone NFS/file server. miroir serves
-  block devices and — for `ReadWriteMany` — a per-volume NFS export it
-  manages itself (see [ReadWriteMany (RWX)](#readwritemany-rwx)); it is not
-  a general-purpose exporter.
+  controller validates `1..3`, metadata reserves `--max-peers 7`, and
+  the quorum policies assume 2 data replicas plus a tie-breaker.
+- You need iSCSI targets or a standalone NFS/file server. miroir
+  serves block devices, plus a per-volume NFS export for
+  `ReadWriteMany` (see [ReadWriteMany (RWX)](#readwritemany-rwx)); it
+  is not a general-purpose exporter.
 
 ## How it compares to LINSTOR and blockstor
 
@@ -33,32 +31,33 @@ difference is the control plane.
 
 - **LINSTOR** is the reference DRBD orchestrator and the right choice
   at fleet scale: resource groups with placement counts, automatic
-  eviction and rebalancing, many storage backends, WAN replication via
-  DRBD Proxy. That power rides on a Java controller with its own
+  eviction and rebalancing, many storage backends, WAN replication
+  via DRBD Proxy. That power rides on a Java controller with its own
   database and a satellite RPC protocol; on Kubernetes the Piraeus
   stack adds an operator, controller, per-node satellites, CSI
-  controller and node drivers, and an HA controller — each its own
-  workload to run and upgrade.
+  drivers, and an HA controller, each its own workload to run and
+  upgrade.
 - **blockstor** is a clean-room Go reimplementation of the LINSTOR
-  model for Cozystack: it keeps the resource-definition /
-  resource-group abstractions (plus auto-evict and rebalancing) while
-  replacing the JVM and database with CRDs. Architecturally it is
-  miroir's closest relative.
-- **miroir** cuts the scope to what 2–3 nodes actually need. The
+  model for Cozystack: the resource-definition / resource-group
+  abstractions (plus auto-evict and rebalancing) with CRDs in place
+  of the JVM and database. Architecturally it is miroir's closest
+  relative.
+- **miroir** cuts the scope to what 2-3 nodes actually need. The
   Kubernetes API is the _only_ control plane: the controller writes
-  MiroirVolume objects, node agents watch and realize them — no
-  controller database, no inter-node RPC protocol, no operator
-  managing an operator. One small static image serves as both the
-  controller Deployment and the agent DaemonSet, and the Helm chart is
-  the entire configuration surface. Placement, quorum tie-breakers,
-  and barrier-consistent snapshots are automated; resource groups,
-  auto-evict, and multi-site replication deliberately are not — if
-  you need those, run LINSTOR.
+  MiroirVolume objects and node agents realize them; no controller
+  database, no inter-node RPC protocol, no operator managing an
+  operator. One small static image serves as both the controller
+  Deployment and the agent DaemonSet, and the Helm chart is the
+  entire configuration surface. Placement, quorum tie-breakers, and
+  barrier-consistent snapshots are automated; resource groups,
+  auto-evict, and multi-site replication deliberately are not. If you
+  need those, run LINSTOR.
 
 Where the bigger projects encode operational wisdom, miroir adopts it
-instead of relearning it: `on-io-error detach`, the resync and
-discard tuning knobs, and the majority-quorum-plus-tie-breaker
-default all follow what LINSTOR and blockstor ship.
+instead of relearning it: `on-io-error detach`, the resync,
+activity-log, and discard tuning knobs, and the
+majority-quorum-plus-tie-breaker default all follow what LINSTOR and
+blockstor ship.
 
 [linstor]: https://github.com/LINBIT/linstor-server
 [blockstor]: https://github.com/cozystack/blockstor
@@ -67,19 +66,19 @@ default all follow what LINSTOR and blockstor ship.
 
 - Kubernetes ≥ 1.31.
 - A `kubelet` directory the agent can `hostPath`-mount (default
-  `/var/lib/kubelet`; override `kubeletDir` in Helm values).
+  `/var/lib/kubelet`; override `agent.kubeletDir` in Helm values).
 - Storage kernel module(s) on each storage node:
-    - `lvmthin` — `dm_thin_pool`.
-    - `zfs` — userland + kernel module on the same minor. On Talos
+    - `lvmthin`: the `dm_thin_pool` module.
+    - `zfs`: userland + kernel module on the same minor. On Talos
       that's the `siderolabs/zfs` extension; otherwise install ZFS
       however you normally do.
-    - `loopfile` — the `loop` module and a reflink-capable filesystem
+    - `loopfile`: the `loop` module and a reflink-capable filesystem
       for `baseDir` (XFS `reflink=1`, e.g. Talos `/var`, or btrfs).
 - For DRBD9 replication: `drbd` and `drbd_transport_tcp` kernel
   modules, plus `drbd-utils` (`drbdadm`, `drbdsetup`, `drbdmeta`).
-- Kubelet [graceful node shutdown][gns] so the agent (a
+- Kubelet [graceful node shutdown][gns], so the agent (a
   `system-node-critical` pod) is stopped _after_ workloads on reboot
-  and can release DRBD backings before the backend pool exports —
+  and can release DRBD backings before the backend pool exports;
   otherwise a node reboot can wedge unmounting the pool. On Talos it
   is on by default; give critical pods enough of the window via
   `machine.kubelet.extraConfig.shutdownGracePeriodCriticalPods` (≥ the
@@ -93,40 +92,87 @@ Talos-specific.
 
 ## Quickstart
 
-### 1. Declare your storage topology
+### 1. Pick a storage layout
+
+`nodes` declares which nodes hold storage and how; `storageClasses`
+declares the classes to create (`replicas: 1` is node-local,
+`replicas: 2` is DRBD-replicated). Pods can mount miroir volumes from
+any schedulable node; only nodes in the map hold data.
+
+**Two nodes, a spare partition each.** The common pair: one local and
+one replicated class. Add a third storage node later and existing
+replicated volumes pick it up as a quorum tie-breaker automatically.
 
 ```yaml
 # values.yaml
 nodes:
+    node-a:
+        backend: lvmthin
+        device: /dev/disk/by-partlabel/r-miroir
+    node-b:
+        backend: lvmthin
+        device: /dev/disk/by-partlabel/r-miroir
+storageClasses:
+    - name: miroir-local
+      replicas: 1
+    - name: miroir-replicated
+      replicas: 2
+volumeSnapshotClasses:
+    - name: miroir-snap
+```
+
+**Three nodes, mixed backends.** DRBD replicates whatever device each
+backend provides, so one volume can pair a ZFS zvol with an LVM thin
+LV. `zone` (optional) spreads replicas and the tie-breaker across
+failure domains; `address` (optional) pins replication to a dedicated
+storage NIC/VLAN, IPv4 or IPv6 (default: the node's `InternalIP`;
+applies to volumes created afterwards).
+
+```yaml
+nodes:
     kharkiv:
         backend: lvmthin
         device: /dev/disk/by-partlabel/r-miroir
-        zone: rack-a # optional failure domain
-        address: 10.0.100.11 # optional: replicate over a dedicated NIC
+        zone: rack-a
+        address: 10.0.100.11
     paris:
         backend: zfs
         zfsDataset: data-pool/miroir
         zone: rack-b
     le-havre:
         backend: loopfile
-        baseDir: /var/lib/miroir # reflink-capable fs (XFS reflink=1, btrfs)
+        baseDir: /var/lib/miroir
         zone: rack-c
+storageClasses:
+    - name: miroir-replicated
+      replicas: 2
+      quorum: freeze
 ```
 
-`zone` is optional: when set, replicas — and the quorum tie-breaker —
-prefer distinct zones (rack, room, AZ). Nodes without a zone are
-unconstrained.
+**One node, no dedicated disk.** Dev clusters: loopfile backs volumes
+with sparse files on an existing filesystem.
 
-`address` is optional: it pins DRBD replication to a dedicated storage
-NIC/VLAN (IPv4 or IPv6); without it, the node's `InternalIP` is used. It
-applies to volumes created afterwards — existing volumes keep the address
-resolved at creation.
+```yaml
+nodes:
+    solo:
+        backend: loopfile
+        baseDir: /var/lib/miroir
+storageClasses:
+    - name: miroir-local
+      replicas: 1
+      isDefault: true
+```
 
 | Backend    | You provide                            | Notes                                  |
 | ---------- | -------------------------------------- | -------------------------------------- |
 | `lvmthin`  | A partition or disk for the thin pool  | `dm_thin_pool` kernel module           |
 | `zfs`      | A ZFS pool, you specify the dataset    | Userland and kmod on the same minor    |
 | `loopfile` | A path on a reflink-capable filesystem | `loop` module; XFS `reflink=1` / btrfs |
+
+The [chart README](charts/miroir/README.md) documents every value:
+per-class `fsType`, `reclaimPolicy`, and `allowRemoteVolumeAccess`,
+`thinPoolSize` for VGs shared with other tenants, DRBD tuning, and
+more.
 
 ### 2. Install
 
@@ -135,63 +181,36 @@ helm install miroir oci://ghcr.io/home-operations/charts/miroir \
   -n miroir-system --create-namespace -f values.yaml
 ```
 
-The chart deploys a single `miroir-controller` Deployment, a
-`miroir-agent` DaemonSet on every schedulable node (pods can mount
-miroir volumes from any node; only nodes in the `nodes` map hold
-storage). No StorageClasses or VolumeSnapshotClasses are created by
-default — declare the ones you want under `storageClasses` and
-`volumeSnapshotClasses` (see the chart values for the canonical
-`miroir-local` / `miroir-replicated` / `miroir-snap` set the examples
-below use; a storage entry is local at `replicas: 1` and
-DRBD-replicated at `replicas: 2`). Per-node setup jobs provision each
-pool on install and upgrade, and the agent re-runs the same idempotent
-setup at startup; existing pools are reused.
+The chart deploys one `miroir-controller` Deployment and a
+`miroir-agent` DaemonSet on every schedulable node. Per-node setup
+jobs provision each pool on install and upgrade, the agent re-runs
+the same idempotent setup at startup, and existing pools are reused.
 
 ### 3. Claim a volume
 
-Single-node:
-
 ```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
     name: my-data
 spec:
-    storageClassName: miroir-local
+    storageClassName: miroir-replicated # or miroir-local
     accessModes: [ReadWriteOnce]
     resources:
         requests:
             storage: 10Gi
 ```
 
-Replicated:
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-    name: my-data
-spec:
-    storageClassName: miroir-replicated
-    accessModes: [ReadWriteOnce]
-    resources:
-        requests:
-            storage: 10Gi
-```
-
-| Parameter                           | Values                        | Default  |
-| ----------------------------------- | ----------------------------- | -------- |
-| `miroir.home-operations.com/quorum` | `freeze`, `last-man-standing` | `freeze` |
-
-See [Replication and quorum](#replication-and-quorum) for what the two
-policies do and how the automatic diskless tie-breaker fits in.
+See [Replication and quorum](#replication-and-quorum) for what the
+per-class `quorum` policies do and how the automatic diskless
+tie-breaker fits in.
 
 ### 4. Snapshot and restore
 
 Requires the cluster-wide `snapshot-controller` and `volumesnapshot`
 CRDs (see the [CSI snapshot docs](https://kubernetes-csi.github.io/docs/snapshots.html)),
-and a VolumeSnapshotClass declared under `volumeSnapshotClasses` (the
-`miroir-snap` below is the example name).
+plus a class under `volumeSnapshotClasses` (the `miroir-snap` example
+above).
 
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1
@@ -238,29 +257,29 @@ the filesystem in place if the volume is mounted.
 Replicated volumes are 2-way synchronous (DRBD protocol C): a write
 completes only once both legs have it. The quorum policy decides what
 happens when the nodes can no longer see each other, and is set per
-StorageClass via the `miroir.home-operations.com/quorum` parameter
-(the `quorum` field on a `storageClasses` entry with `replicas > 1`).
+StorageClass via the `quorum` field on a `storageClasses` entry with
+`replicas > 1` (the `miroir.home-operations.com/quorum` parameter).
 
 ### `freeze` (default)
 
 DRBD majority quorum with `on-no-quorum io-error`: a replica that
-cannot reach a majority of the volume's peers refuses writes — the
-workload sees I/O errors — instead of carrying on alone. Two isolated
+cannot reach a majority of the volume's peers refuses writes (the
+workload sees I/O errors) instead of carrying on alone. Two isolated
 sides can never both write, so there is nothing to un-diverge later;
 when connectivity returns, the stale side simply resyncs. Expect the
 filesystem on top to have gone read-only in the meantime, so the pod
 usually needs a restart once the volume recovers.
 
 Two data replicas on their own are only 2 votes, and majority of 2 is
-2 — _any_ disconnect would halt writes on both sides. That is what
-the tie-breaker fixes.
+2: _any_ disconnect would halt writes on both sides. That is what the
+tie-breaker fixes.
 
 ### The diskless tie-breaker
 
 When a 2-replica `freeze` volume is created and a third storage node
 in the `nodes` map holds neither leg, the controller adds that node
 as a diskless tie-breaker: a DRBD peer rendered with `disk none` that
-joins quorum voting but stores nothing — no backing device, no
+joins quorum voting but stores nothing; no backing device, no
 capacity used, no part in snapshots or CSI topology. With 3 votes,
 losing any single node (a data leg _or_ the tie-breaker) leaves a
 majority of 2 and the volume keeps serving.
@@ -278,16 +297,16 @@ Behavior and knobs:
 - **No spare node, no tie-breaker.** On a 2-node cluster the volume
   is created with majority quorum on 2 votes: never diverges, but a
   single node loss stops I/O until the node returns. If availability
-  matters more, use `last-man-standing` — or add a third node and let
+  matters more, use `last-man-standing`, or add a third node and let
   the retrofit pick it up.
-- **Opt out** with `controller.autoTieBreaker=false` in Helm values.
-  This disables both placement at create time and the retrofit;
+- **Opt out** with `autoTieBreaker: false` in Helm values. This
+  disables both placement at create time and the retrofit;
   tie-breakers can still be added manually by appending
   `{node: <name>, diskless: true}` to a volume's `spec.replicas`.
 - **Remove or move one** by deleting its entry from
   `spec.replicas`; the node's agent detaches and cleans up (removal
   waits until both data legs are connected and `UpToDate`). A
-  diskful replica can never become diskless in place — remove and
+  diskful replica can never become diskless in place; remove and
   re-add the entry instead. The other direction is allowed: flipping
   `diskless: false` on a tie-breaker makes its agent attach a fresh
   backing device to the live leg and full-sync it (this is how
@@ -296,7 +315,7 @@ Behavior and knobs:
 ### `last-man-standing`
 
 `quorum off`: the surviving replica keeps accepting writes even with
-no peers in sight. Maximum availability — but if both sides run while
+no peers in sight. Maximum availability, but if both sides run while
 partitioned they diverge. DRBD detects the split-brain on reconnect
 and deliberately stays disconnected (`after-sb-* disconnect`, never
 auto-resolve); an operator inspects both legs and picks the loser.
@@ -307,71 +326,69 @@ Volumes with this policy never get a tie-breaker.
 Replicated volumes are consumable from any node by default (matching
 LINSTOR): the PV carries no node affinity, and a pod scheduled on a
 node without a replica consumes the volume through an ephemeral
-**diskless client leg** — a DRBD peer with `disk none` that the CSI
+**diskless client leg**, a DRBD peer with `disk none` that the CSI
 node service adds to `spec.clients` at stage time and removes at
 unstage. The membership reconciler completes it (node id, address)
 exactly like an operator-added replica, and a pod landing on the
 tie-breaker's node stages through the tie-breaker leg directly.
 
-Set `allowRemoteVolumeAccess: false` on a `storageClasses` entry (the
-`miroir.home-operations.com/allowRemoteVolumeAccess` StorageClass
-parameter) to opt that class out: its PVs then pin pods to the diskful
-replica nodes, guaranteeing local reads.
+Set `allowRemoteVolumeAccess: false` on a `storageClasses` entry to
+opt that class out: its PVs then pin pods to the diskful replica
+nodes, guaranteeing local reads.
 
 Trade-offs to understand:
 
-- **Every remote read and write crosses the replication network.** A
-  remote consumer runs at network speed; pin latency-sensitive
-  workloads with `allowRemoteVolumeAccess: "false"` so a replica is
-  always under the pod.
+- **Every remote read and write crosses the replication network.**
+  Pin latency-sensitive workloads with
+  `allowRemoteVolumeAccess: "false"` so a replica is always under the
+  pod.
 - **Replica nodes are only preferred at first use.** The first
   consumer's node is pinned as a replica when it is a storage node
-  (falling back to capacity-ranked placement when it is not). After
-  that there is no soft preference: PV node affinity is all-or-nothing
-  in Kubernetes, so the scheduler is blind to replica locations. Keep
-  locality-sensitive workloads on the default class, or pin them with
-  their own node/pod affinity.
+  (capacity-ranked placement otherwise). After that there is no soft
+  preference: PV node affinity is all-or-nothing, so the scheduler is
+  blind to replica locations. Keep locality-sensitive workloads on a
+  pinned class, or steer them with their own node/pod affinity.
 - **An attached client shifts quorum math.** DRBD counts every peer's
   vote: a 2+1 volume with a client attached has 4 votes, so majority
   becomes 3. While the client is connected this is neutral-to-helpful
-  (the client's vote replaces a lost node's); the regression window is
-  two simultaneous failures, which majority-of-4 freezes where
-  majority-of-3 tolerated one loss. Client legs come and go with pods,
-  so the math shifts at stage/unstage, not permanently.
-- **Consumers must run on nodes listed in `nodes`.** Agents only start
-  on mapped nodes, so a pod scheduled onto an unmapped node has no CSI
-  driver to mount with and wedges in `ContainerCreating` — and with no
-  PV affinity, nothing steers the scheduler away. Until a
-  client-capable agent for unmapped nodes lands, keep every
+  (the client's vote replaces a lost node's); the regression window
+  is two simultaneous failures, which majority-of-4 freezes where
+  majority-of-3 tolerated one loss. Client legs come and go with
+  pods, so the math shifts at stage/unstage, not permanently.
+- **Consumers must run on nodes listed in `nodes`.** Agents only
+  start on mapped nodes, so a pod scheduled onto an unmapped node has
+  no CSI driver to mount with and wedges in `ContainerCreating`, and
+  with no PV affinity nothing steers the scheduler away. Keep every
   schedulable node in the map (a `loopfile` entry with a few spare GB
   is enough) or set `allowRemoteVolumeAccess: "false"`.
 - **A lost node can strand its client leg.** If a node dies without
   unstaging, its entry in `spec.clients` (and teardown finalizer)
-  lingers, holding a quorum vote and blocking volume deletion until the
-  node returns or the entry is removed by hand — the same semantics as
-  a dead replica node. Remove it by deleting the `spec.clients` entry.
+  lingers, holding a quorum vote and blocking volume deletion until
+  the node returns or the entry is removed by hand; the same
+  semantics as a dead replica node.
 
 #### Auto-diskful
 
-Set `autoDiskfulAfter` (e.g. `"10m"`) to convert a client leg that has
-stayed attached past the threshold into a diskful replica on its node —
-LINSTOR's auto-diskful. The consumer evidently lives there, so it gets
-a local replica and stops paying network I/O: the entry moves from
-`spec.clients` to `spec.replicas`, membership completes it as a
+Set `autoDiskfulAfter` (e.g. `"10m"`) to convert a client leg that
+has stayed attached past the threshold into a diskful replica on its
+node (LINSTOR's auto-diskful). The consumer evidently lives there, so
+it gets a local replica and stops paying network I/O: the entry moves
+from `spec.clients` to `spec.replicas`, membership completes it as a
 FullSync joiner, and the agent attaches a backing device to the live
-resource while the pod keeps running. Conversion requires the client's
-node in the `nodes` map with fresh pool stats and room for the volume's
-full size, and a Ready volume; a 2+1 volume's tie-breaker is replaced
-by the third data copy (three diskful votes need no tie-breaker).
-Volumes already at 3 diskful replicas are left alone — evicting a
-replica is an operator decision. Empty (the default) disables it.
+resource while the pod keeps running. Conversion requires the
+client's node in the `nodes` map with fresh pool stats and room for
+the volume's full size, and a Ready volume; a 2+1 volume's
+tie-breaker is replaced by the third data copy (three diskful votes
+need no tie-breaker). Volumes already at 3 diskful replicas are left
+alone; evicting a replica is an operator decision. Empty (the
+default) disables it.
 
 On a fully-mapped cluster (every node in `nodes`) the volume's
 non-replica node is its tie-breaker, so a settled consumer stages
 through that leg and no client leg ever exists. Auto-diskful covers
 this too: a tie-breaker leg whose device has been held Primary past
 the threshold (the agent stamps `primarySince` from the kernel role)
-is flipped diskful **in place** — node id and address kept, a fresh
+is flipped diskful **in place**: node id and address kept, a fresh
 backing device attached to the live resource, full-synced under the
 running pod.
 
@@ -384,9 +401,9 @@ running pod.
 | Two nodes down               | remaining node refuses writes                              | I/O errors                  | survivor keeps writing                             |
 
 The default was `last-man-standing` before v0.3. Volumes keep
-whatever `quorumPolicy` is stored in their spec — nothing is
-rewritten on upgrade; the new default only applies to volumes created
-after it.
+whatever `quorumPolicy` is stored in their spec; nothing is rewritten
+on upgrade, and the new default only applies to volumes created after
+it.
 
 ### Disk failures, node rebuilds, and verification
 
@@ -395,32 +412,37 @@ config defaults to `on-io-error detach` (`drbd.onIoError`): a leg
 whose backing device errors drops to Diskless and the volume keeps
 serving through the peer instead of surfacing EIO into the pod. The
 detached leg shows as `DiskState: Diskless` in
-`kubectl describe miroirvolume` and `miroir_volume_up_to_date` goes 0
-for that node — replace the disk, then remove and re-add the replica.
+`kubectl describe miroirvolume` and `miroir_volume_disk_failed` goes
+1 for that node: replace the disk, then remove and re-add the
+replica.
 
 **Rebuilding a node is safe.** A reinstall (e.g. Talos wipe) destroys
 the backing devices and miroir's node-local state together; when the
 node rejoins, the agent detects the wipe and makes each recreated leg
-a full sync target rather than trusting its empty disk. Full
-syncs stay thin automatically: the agent probes each lvmthin/zfs
-backing device's discard granularity and renders it per leg, so zero
-runs are sent as discards and a re-synced leg consumes what the data
-needs, not the volume's virtual size (loopfile legs are skipped — loop
+a full sync target rather than trusting its empty disk. Full syncs
+stay thin automatically: the agent probes each lvmthin/zfs backing
+device's discard granularity and renders it per leg, so zero runs are
+sent as discards and a re-synced leg consumes what the data needs,
+not the volume's virtual size (loopfile legs are skipped, loop
 devices mishandle it; `drbd.resync.discardGranularity` remains as a
 manual cluster-wide fallback).
 
 **Verification** is the only cross-leg integrity check (a ZFS scrub
-validates one leg against itself). Set `drbd.verifyAlg` (e.g.
-`crc32c`) and run `drbdadm verify <resource>` on a storage node
-during quiet hours — cron is the DRBD-documented pattern.
-Out-of-sync blocks are reported in the kernel log and
-`drbdsetup status`.
+validates one leg against itself). `drbd.verifyAlg` (default
+`crc32c`) arms it, and `drbd.verify.schedule` (5-field cron, e.g.
+`"0 4 * * 0"`) runs an online verify of every replicated volume on
+that cadence, serialized per node and skipping volumes that are
+resyncing. Findings land in the volume's status
+(`lastVerifyOutOfSyncBytes`), the `miroir_volume_verify_*` metrics,
+and a `VerifyOutOfSync` event; the starter alerts flag both findings
+and a schedule that stopped firing. `drbdadm verify <resource>` on a
+storage node does the same by hand.
 
 ## ReadWriteMany (RWX)
 
 A PVC with `accessModes: [ReadWriteMany]` (or `ReadOnlyMany`) on a
-replicated class is served as a **shared filesystem over NFS** — many pods
-on many nodes read and write it at once, like CephFS.
+replicated class is served as a **shared filesystem over NFS**: many
+pods on many nodes read and write it at once, like CephFS.
 
 ```yaml
 apiVersion: v1
@@ -435,40 +457,46 @@ spec:
             storage: 10Gi
 ```
 
-Under the hood the volume is a normal miroir DRBD volume. The controller
-runs one **gateway** pod for it on a replica node: the pod mounts the
-device (DRBD `auto-promote` makes it the single writer), formats it
-`ext4`/`xfs`, and exports it over NFSv4 with NFS-Ganesha. A per-volume
-`ClusterIP` Service fronts the gateway, and the CSI node plugin on any node
-NFS-mounts that Service for pods. Because the gateway is the only writer,
-single-primary DRBD fencing is unchanged — miroir never enables
-dual-primary, and there is no cluster filesystem.
+Under the hood the volume is a normal miroir DRBD volume. The
+controller runs one **gateway** pod for it on a replica node: the pod
+mounts the device (DRBD `auto-promote` makes it the single writer),
+formats it `ext4`/`xfs`, and exports it over NFSv4 with NFS-Ganesha.
+A per-volume `ClusterIP` Service fronts the gateway, and the CSI node
+plugin on any node NFS-mounts that Service for pods. Because the
+gateway is the only writer, single-primary DRBD fencing is unchanged:
+miroir never enables dual-primary, and there is no cluster
+filesystem.
 
 Things worth knowing:
 
-- **RWX requires a replicated class** (`replicas ≥ 2`). The gateway fails
-  over by rescheduling onto another replica node, so it needs a second one
-  to move to; the controller rejects RWX on a single-replica volume.
+- **RWX requires a replicated class** (`replicas ≥ 2`). The gateway
+  fails over by rescheduling onto another replica node, so it needs a
+  second one to move to; the controller rejects RWX on a
+  single-replica volume.
 - **Consistency is NFS close-to-open**, not shared-memory: a writer's
-  changes are visible on other nodes once it closes the file (or `fsync`s).
-- **Failover.** If the gateway's node dies, the Deployment reschedules the
-  gateway onto a surviving replica node and NFS clients (hard mounts)
-  reconnect through the same Service IP. Expect **tens of seconds** —
-  eviction from the dead node, DRBD promotion once quorum releases the old
-  Primary, and the NFSv4 grace period. Client I/O stalls (never errors)
-  across the window. Fine for the homelab RWX cases (media libraries,
-  shared config); not a low-latency-failover HA-NAS.
-- **`freeze` quorum is required** (the default). Under `last-man-standing`
-  a partition could leave the old and rescheduled gateways both writable —
-  the controller rejects that combination.
+  changes are visible on other nodes once it closes the file (or
+  `fsync`s).
+- **Failover.** If the gateway's node dies, the Deployment
+  reschedules the gateway onto a surviving replica node and NFS
+  clients (hard mounts) reconnect through the same Service IP. Expect
+  **tens of seconds**: eviction from the dead node, DRBD promotion
+  once quorum releases the old Primary, and the NFSv4 grace period.
+  Client I/O stalls (never errors) across the window. Fine for the
+  homelab RWX cases (media libraries, shared config); not a
+  low-latency-failover HA-NAS.
+- **`freeze` quorum is required** (the default). Under
+  `last-man-standing` a partition could leave the old and rescheduled
+  gateways both writable; the controller rejects that combination.
 - **Snapshots** work exactly as for RWO volumes (crash-consistent,
-  device-level; the gateway is the sole writer during the barrier), and the
-  volume gets the same split-brain protections — the gateway stages through
-  the same pipeline that latches "this volume holds data", so auto-recovery
-  never discards a diverged leg out from under it.
-- The gateway keeps NFSv4 lock-recovery state in a `.ganesha-recovery`
-  directory at the root of the exported filesystem so locks survive
-  failover; it is visible to consumers — leave it alone.
+  device-level; the gateway is the sole writer during the barrier),
+  and the volume gets the same split-brain protections: the gateway
+  stages through the same pipeline that latches "this volume holds
+  data", so auto-recovery never discards a diverged leg out from
+  under it.
+- The gateway keeps NFSv4 lock-recovery state in a
+  `.ganesha-recovery` directory at the root of the exported
+  filesystem so locks survive failover; it is visible to consumers.
+  Leave it alone.
 
 ## Monitoring
 
@@ -478,35 +506,43 @@ PodMonitor scraping the controller **and every agent** on their
 each storage node; a `node` label is added to every series). The
 agent exports, per volume on that node:
 
-| Metric                            | Meaning                                                                                                                                     |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `miroir_volume_up_to_date`        | 1 when this node's replica is UpToDate (unreplicated volumes are always 1 once created)                                                     |
-| `miroir_volume_connected`         | 1 when all replication links to diskful peers are established (tie-breaker links excluded)                                                  |
-| `miroir_volume_split_brain`       | 1 when DRBD refused to reconnect after divergence — manual resolution required                                                              |
-| `miroir_volume_suspended`         | 1 while the snapshot write barrier freezes IO; sustained means a stranded barrier                                                           |
-| `miroir_volume_resync_ratio`      | fraction (0-1) in sync of the least-synced diskful peer; 1 when fully in sync                                                               |
-| `miroir_volume_quorum`            | 0 while a `freeze` volume has lost quorum and its IO is suspended — the "workloads are hanging" signal (always 1 under `last-man-standing`) |
-| `miroir_volume_disk_failed`       | 1 when this leg's disk was detached after an I/O error and latched failed — replace the disk, then remove and re-add the replica            |
-| `miroir_volume_out_of_sync_bytes` | worst per-peer out-of-sync bytes: the exposure if the healthiest peer is lost; also counts online-verify findings                           |
+| Metric                                        | Meaning                                                                                                                                    |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `miroir_volume_up_to_date`                    | 1 when this node's replica is UpToDate (unreplicated volumes are always 1 once created)                                                    |
+| `miroir_volume_connected`                     | 1 when all replication links to diskful peers are established (tie-breaker links excluded)                                                 |
+| `miroir_volume_split_brain`                   | 1 when DRBD refused to reconnect after divergence; manual resolution required                                                              |
+| `miroir_volume_suspended`                     | 1 while the snapshot write barrier freezes IO; sustained means a stranded barrier                                                          |
+| `miroir_volume_resync_ratio`                  | fraction (0-1) in sync of the least-synced diskful peer; 1 when fully in sync                                                              |
+| `miroir_volume_quorum`                        | 0 while a `freeze` volume has lost quorum and its IO is suspended, the "workloads are hanging" signal (always 1 under `last-man-standing`) |
+| `miroir_volume_disk_failed`                   | 1 when this leg's disk was detached after an I/O error and latched failed; replace the disk, then remove and re-add the replica            |
+| `miroir_volume_out_of_sync_bytes`             | worst per-peer out-of-sync bytes: the exposure if the healthiest peer is lost; also counts online-verify findings                          |
+| `miroir_volume_diskless_primary`              | 1 while a diskless leg (client or tie-breaker) is Primary here: the consumer pays network I/O; see auto-diskful                            |
+| `miroir_volume_verify_last_timestamp_seconds` | unix time of the last completed scheduled verify; alert on staleness to catch a schedule that stopped firing                               |
+| `miroir_volume_verify_out_of_sync_bytes`      | out-of-sync bytes the last scheduled verify found (0 = clean)                                                                              |
 
 Each agent additionally exports its pool capacity
 (`miroir_pool_capacity_bytes` / `miroir_pool_allocated_bytes` /
-`miroir_pool_meta_used_ratio`) — the same sample that feeds
+`miroir_pool_meta_used_ratio`), the same sample that feeds
 capacity-aware placement and the `PoolUsageHigh` condition, so pool
 exhaustion is alertable, not just an Event.
 
-For RWX volumes the **controller** exports `miroir_export_ready` — 1
+For RWX volumes the **controller** exports `miroir_export_ready`: 1
 while the volume's NFS gateway is serving (gateway pod available,
 export address published). This is the signal the per-volume gauges
 cannot give you: DRBD replicas stay healthy while a dead gateway
 leaves every NFS client hanging.
 
-`monitoring.prometheusRule.enabled: true` ships starter alerts for all
-of the above (split-brain, quorum lost, stranded barrier, disk failed,
-degraded replication, sustained out-of-sync, an unavailable RWX
-export, a stale verify schedule, pool and thin-metadata
-usage), and `monitoring.dashboards.enabled: true` installs a Grafana
-dashboard — as a sidecar-labelled ConfigMap, or a grafana-operator
+Prometheus is not the only surface. Volume health also flows through
+the CSI `VolumeCondition`: enable `sidecars.healthMonitor.enabled`
+and split-brain, failed-disk, and degraded volumes surface as events
+on their PVCs (`kubectl describe pvc`).
+
+`monitoring.prometheusRule.enabled: true` ships starter alerts for
+all of the above (split-brain, quorum lost, stranded barrier, disk
+failed, degraded replication, sustained out-of-sync, an unavailable
+RWX export, a stale verify schedule, pool and thin-metadata usage),
+and `monitoring.dashboards.enabled: true` installs a Grafana
+dashboard, either a sidecar-labelled ConfigMap or a grafana-operator
 `GrafanaDashboard` CR via `monitoring.dashboards.grafanaOperator`.
 
 Both processes also expose controller-runtime metrics
@@ -532,8 +568,8 @@ via CSI.
 
 - **Agent pod `CrashLoopBackOff` on lvmthin**: partition or disk
   missing, or `dm_thin_pool` not loaded. Check
-  `kubectl logs -n miroir-system -l app.kubernetes.io/component=agent` and
-  `lsmod | grep dm_thin` on the node.
+  `kubectl logs -n miroir-system -l app.kubernetes.io/component=agent`
+  and `lsmod | grep dm_thin` on the node.
 - **Agent pod `CrashLoopBackOff` on loopfile**: `baseDir` isn't
   reflink-capable. The agent refuses to start so the failure shows
   up immediately.
@@ -542,21 +578,18 @@ via CSI.
 - **Replicated volume stuck in `Degraded`**: one leg isn't
   `UpToDate`. `kubectl describe miroirvolume <name>` shows per-node
   status; usually a transient DRBD sync.
-- **Replicated volume stuck `Connecting`, no split-brain, PVC hangs in
-  `ContainerCreating`**: the DRBD replication port (default 7000,
-  allocated per volume ascending) may be occupied by a host-network
-  tenant — most commonly the Ceph mgr dashboard, whose non-SSL default
-  is also 7000. The agent runs `hostNetwork: true`, so DRBD binds on the
-  node's kernel and the collision is silent (no split-brain, so the
-  recovery path never engages). Check `dmesg` on the node for
-  `Failed to initiate connection, err=-98` (EADDRINUSE); peers dialing
-  in reach the dashboard instead and log
-  `Wrong magic value 0x48545450` (`"HTTP"` in ASCII). Identify the
-  squatter with `curl -sI http://<node>:7000/` — a `Ceph-Dashboard`
-  server header confirms it. Fix by setting `drbd.portBase` (e.g.
-  `7100`) in Helm values, or moving the Ceph dashboard
-  (`cephClusterSpec.dashboard.port: 8081`). Existing volumes keep their
-  assigned ports — only new allocations use the new base
+- **Replicated volume stuck `Connecting`, no split-brain, PVC hangs
+  in `ContainerCreating`**: the DRBD replication port (default 7000,
+  allocated per volume ascending) is likely occupied by a
+  host-network tenant, most commonly the Ceph mgr dashboard. The
+  agent runs `hostNetwork: true`, so the collision is silent: `dmesg`
+  on the node shows `Failed to initiate connection, err=-98`
+  (EADDRINUSE), and peers dialing in log
+  `Wrong magic value 0x48545450` (`"HTTP"` in ASCII).
+  `curl -sI http://<node>:7000/` identifies the squatter. Fix by
+  setting `drbd.portBase` (e.g. `7100`), or move the Ceph dashboard
+  (`cephClusterSpec.dashboard.port: 8081`). Existing volumes keep
+  their assigned ports; only new allocations use the new base
   ([#148](https://github.com/home-operations/miroir/issues/148)).
 
 ## Uninstall
@@ -578,7 +611,8 @@ shows the failing call to clean up manually.
 **Should land soon**
 
 - [x] Capacity-aware placement
-- [ ] CSI `CSIStorageCapacity` reporting per pool
+- [x] CSI `CSIStorageCapacity` reporting per pool (opt-in:
+      `storageCapacity.enabled`)
 - [x] Per-volume DRBD state metrics (`miroir_volume_up_to_date` /
       `connected` / `split_brain` / `suspended` / `resync_ratio`;
       opt-in PodMonitor via `monitoring.podMonitor.enabled`)

--- a/README.md
+++ b/README.md
@@ -67,28 +67,76 @@ blockstor ship.
 - Kubernetes ≥ 1.31.
 - A `kubelet` directory the agent can `hostPath`-mount (default
   `/var/lib/kubelet`; override `agent.kubeletDir` in Helm values).
-- Storage kernel module(s) on each storage node:
-    - `lvmthin`: the `dm_thin_pool` module.
-    - `zfs`: userland + kernel module on the same minor. On Talos
-      that's the `siderolabs/zfs` extension; otherwise install ZFS
-      however you normally do.
-    - `loopfile`: the `loop` module and a reflink-capable filesystem
-      for `baseDir` (XFS `reflink=1`, e.g. Talos `/var`, or btrfs).
-- For DRBD9 replication: `drbd` and `drbd_transport_tcp` kernel
-  modules, plus `drbd-utils` (`drbdadm`, `drbdsetup`, `drbdmeta`).
+- Kernel modules on each storage node (per-OS notes below):
+  `dm_thin_pool` (lvmthin), ZFS (zfs), `loop` plus a reflink-capable
+  filesystem for `baseDir` (loopfile), and, for replication, the
+  DRBD9 `drbd` and `drbd_transport_tcp` modules.
 - Kubelet [graceful node shutdown][gns], so the agent (a
   `system-node-critical` pod) is stopped _after_ workloads on reboot
   and can release DRBD backings before the backend pool exports;
-  otherwise a node reboot can wedge unmounting the pool. On Talos it
-  is on by default; give critical pods enough of the window via
-  `machine.kubelet.extraConfig.shutdownGracePeriodCriticalPods` (≥ the
-  agent's `terminationGracePeriodSeconds`, default 60s).
+  otherwise a node reboot can wedge unmounting the pool.
+
+All storage userland (`drbdadm`, `lvm`, `zfs`, `mkfs`, `mount.nfs`)
+ships inside the agent image; nodes only provide kernel modules.
 
 [gns]: https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown
 
-Talos Linux is the primary target because it ships these modules
-ready to go, but nothing in the controller or agent is
-Talos-specific.
+### Talos
+
+Talos is the primary target. The stock kernel ships `dm_thin_pool`
+and `loop` (the agent loads them on demand), and `/var` is XFS with
+`reflink=1`, so `lvmthin` and `loopfile` work out of the box. DRBD
+and ZFS modules come from [Image Factory][factory] system extensions;
+build the install image with:
+
+- `siderolabs/drbd` for replication
+- `siderolabs/zfs` for the zfs backend
+
+Load DRBD with its usermode helper disabled: the kernel side
+otherwise calls out to `/sbin/drbdadm` on the host, which does not
+exist on Talos. Graceful node shutdown is on by default; size the
+critical-pod window to cover the agent's
+`terminationGracePeriodSeconds` (default 60s):
+
+```yaml
+machine:
+    kernel:
+        modules:
+            - name: drbd
+              parameters:
+                  - usermode_helper=disabled
+            - name: drbd_transport_tcp
+    kubelet:
+        extraConfig:
+            shutdownGracePeriod: 120s
+            shutdownGracePeriodCriticalPods: 60s
+```
+
+[factory]: https://factory.talos.dev
+
+### Debian/Ubuntu
+
+Stock kernels ship `dm_thin_pool` and `loop`, so `lvmthin` and
+`loopfile` need nothing extra. For the rest:
+
+- **DRBD9**: the in-tree `drbd.ko` is the 8.4 API and does **not**
+  work with miroir's DRBD9 configuration. Install `drbd-dkms` and
+  kernel headers from the [LINBIT PPA][ppa] (Ubuntu) or LINBIT's
+  Debian repositories. Unless the host has a matching `drbd-utils`
+  installed, disable the usermode helper for the same reason as on
+  Talos: `options drbd usermode_helper=disabled` in
+  `/etc/modprobe.d/drbd.conf`.
+- **zfs backend**: Ubuntu kernels ship the ZFS module
+  (`linux-modules-extra`); on Debian install `zfs-dkms` (contrib).
+  The agent's ZFS userland is 2.3, and userland older than the
+  node's module is the supported direction.
+- Enable kubelet graceful node shutdown (`shutdownGracePeriod` /
+  `shutdownGracePeriodCriticalPods` in the kubelet config) with a
+  critical-pod window ≥ the agent's grace period (default 60s).
+
+[ppa]: https://launchpad.net/~linbit/+archive/ubuntu/linbit-drbd9-stack
+
+Nothing in the controller or agent is otherwise OS-specific.
 
 ## Quickstart
 
@@ -166,7 +214,7 @@ storageClasses:
 | Backend    | You provide                            | Notes                                  |
 | ---------- | -------------------------------------- | -------------------------------------- |
 | `lvmthin`  | A partition or disk for the thin pool  | `dm_thin_pool` kernel module           |
-| `zfs`      | A ZFS pool, you specify the dataset    | Userland and kmod on the same minor    |
+| `zfs`      | A ZFS pool, you specify the dataset    | ZFS module on the node (Requirements)  |
 | `loopfile` | A path on a reflink-capable filesystem | `loop` module; XFS `reflink=1` / btrfs |
 
 The [chart README](charts/miroir/README.md) documents every value:

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodestatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodestatus.go
@@ -27,7 +27,7 @@ import (
 // with apply.
 //
 // MiroirNodeStatus is the pool capacity this node's agent publishes for
-// capacity-aware placement and overcommit guardrails (DESIGN.md §4.6).
+// capacity-aware placement and overcommit guardrails.
 // On a shared pool (e.g. ZFS shared with OpenEBS) the figures are
 // pool-level, so a co-tenant's growth correctly shrinks miroir's headroom.
 type MiroirNodeStatusApplyConfiguration struct {

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirsnapshotstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirsnapshotstatus.go
@@ -29,7 +29,7 @@ import (
 //
 // MiroirSnapshotStatus is the observed state aggregated from node agents.
 // The snapshot exists as a backend CoW snapshot on every replica of the
-// source volume (DESIGN.md §4.5.4).
+// source volume.
 type MiroirSnapshotStatusApplyConfiguration struct {
 	// ReadyToUse is true once every replica holds the snapshot.
 	ReadyToUse *bool `json:"readyToUse,omitempty"`

--- a/api/v1alpha1/miroirnode_types.go
+++ b/api/v1alpha1/miroirnode_types.go
@@ -13,7 +13,7 @@ type MiroirNodeSpec struct {
 }
 
 // MiroirNodeStatus is the pool capacity this node's agent publishes for
-// capacity-aware placement and overcommit guardrails (DESIGN.md §4.6).
+// capacity-aware placement and overcommit guardrails.
 // On a shared pool (e.g. ZFS shared with OpenEBS) the figures are
 // pool-level, so a co-tenant's growth correctly shrinks miroir's headroom.
 type MiroirNodeStatus struct {

--- a/api/v1alpha1/miroirsnapshot_types.go
+++ b/api/v1alpha1/miroirsnapshot_types.go
@@ -25,7 +25,7 @@ type MiroirSnapshotSpec struct {
 
 // MiroirSnapshotStatus is the observed state aggregated from node agents.
 // The snapshot exists as a backend CoW snapshot on every replica of the
-// source volume (DESIGN.md §4.5.4).
+// source volume.
 type MiroirSnapshotStatus struct {
 	// ReadyToUse is true once every replica holds the snapshot.
 	// +optional

--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -16,7 +16,7 @@ const (
 	BackendLoopfile BackendType = "loopfile"
 )
 
-// QuorumPolicy selects the 2-node consistency mode (DESIGN.md §3.2).
+// QuorumPolicy selects the 2-node consistency mode.
 // +kubebuilder:validation:Enum=last-man-standing;freeze
 type QuorumPolicy string
 

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -50,6 +50,7 @@ Kubernetes: `>=1.31.0`
 | agent.resources.requests.cpu | string | `"10m"` |  |
 | agent.resources.requests.memory | string | `"32Mi"` |  |
 | agent.volumeWorkers | int | `4` | Concurrent volume reconciles per agent. Per-volume work is serialized by controller-runtime regardless; this bounds how many distinct volumes one agent works at once. |
+| autoDiskfulAfter | string | `""` | Convert a diskless leg (client or tie-breaker) that has stayed DRBD Primary past this duration into a local diskful replica on its node, so a settled consumer stops paying network I/O (LINSTOR's auto-diskful; Go duration, e.g. "10m"). Conversion needs the leg's node in `nodes` with fresh pool stats and room for the volume's full size. Empty disables it. See the root README, "Auto-diskful". |
 | autoTieBreaker | bool | `true` | Add a diskless tie-breaker replica to 2-replica freeze volumes when a spare storage node exists, so majority quorum survives a single node loss. Also retrofits existing freeze volumes at controller startup. |
 | drbd.alExtents | string | `""` | al-extents, the DRBD activity-log size (number of 4 MiB extents kept "hot"). DRBD's default (1237) forces frequent metadata updates under a scattered random-write workload; raising it (e.g. 6007) cuts that write amplification at the cost of a longer resync of the active region after a crash. Empty leaves DRBD's default. Must be a prime below 65534. |
 | drbd.net.maxBuffers | string | `""` | max-buffers, the DRBD receive-buffer count (e.g. "36864"); raises resync throughput on fast links. |

--- a/charts/miroir/crds/miroir.home-operations.com_miroirnodes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirnodes.yaml
@@ -70,7 +70,7 @@ spec:
           status:
             description: |-
               MiroirNodeStatus is the pool capacity this node's agent publishes for
-              capacity-aware placement and overcommit guardrails (DESIGN.md §4.6).
+              capacity-aware placement and overcommit guardrails.
               On a shared pool (e.g. ZFS shared with OpenEBS) the figures are
               pool-level, so a co-tenant's growth correctly shrinks miroir's headroom.
             properties:

--- a/charts/miroir/crds/miroir.home-operations.com_miroirsnapshots.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirsnapshots.yaml
@@ -66,7 +66,7 @@ spec:
             description: |-
               MiroirSnapshotStatus is the observed state aggregated from node agents.
               The snapshot exists as a backend CoW snapshot on every replica of the
-              source volume (DESIGN.md §4.5.4).
+              source volume.
             properties:
               conditions:
                 description: Conditions follow the standard Kubernetes condition conventions.

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -457,3 +457,18 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].env[1].name
           value: POD_NAME
+
+  - it: omits auto-diskful-after by default
+    documentIndex: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --auto-diskful-after=10m
+  - it: passes auto-diskful-after when autoDiskfulAfter is set
+    documentIndex: 0
+    set:
+      autoDiskfulAfter: 10m
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --auto-diskful-after=10m

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -134,6 +134,12 @@
       "title": "agent",
       "type": "object"
     },
+    "autoDiskfulAfter": {
+      "default": "",
+      "description": "Convert a diskless leg (client or tie-breaker) that has stayed DRBD\nPrimary past this duration into a local diskful replica on its node, so a\nsettled consumer stops paying network I/O (LINSTOR's auto-diskful; Go\nduration, e.g. \"10m\"). Conversion needs the leg's node in `nodes` with\nfresh pool stats and room for the volume's full size. Empty disables it.\nSee the root README, \"Auto-diskful\".",
+      "title": "autoDiskfulAfter",
+      "type": "string"
+    },
     "autoTieBreaker": {
       "default": true,
       "description": "Add a diskless tie-breaker replica to 2-replica freeze volumes when a\nspare storage node exists, so majority quorum survives a single node\nloss. Also retrofits existing freeze volumes at controller startup.",

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -57,6 +57,13 @@ overcommitRatio: 2
 # spare storage node exists, so majority quorum survives a single node
 # loss. Also retrofits existing freeze volumes at controller startup.
 autoTieBreaker: true
+# -- Convert a diskless leg (client or tie-breaker) that has stayed DRBD
+# Primary past this duration into a local diskful replica on its node, so a
+# settled consumer stops paying network I/O (LINSTOR's auto-diskful; Go
+# duration, e.g. "10m"). Conversion needs the leg's node in `nodes` with
+# fresh pool stats and room for the volume's full size. Empty disables it.
+# See the root README, "Auto-diskful".
+autoDiskfulAfter: ""
 # Storage-capacity-aware scheduling. When enabled, the external-provisioner
 # publishes CSIStorageCapacity objects from the driver's GetCapacity RPC
 # (capacity × overcommitRatio − provisioned, per storage node) and the

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // miroir is a low-resource replicated block storage driver for Kubernetes.
-// One binary, several modes (notes/DESIGN.md §4.2):
+// One binary, several modes:
 //
 //	--mode=controller  CSI Identity+Controller services (Deployment)
 //	--mode=agent       CSI Identity+Node services + node reconciler (DaemonSet)
@@ -465,8 +465,8 @@ func main() {
 			setupLog.Error(err, "unable to build the node's backend")
 			os.Exit(1)
 		}
-		// Bootstrap the node-local pool before serving anything
-		// (notes/DESIGN.md §7.2): first start on a fresh node creates
+		// Bootstrap the node-local pool before serving anything: first
+		// start on a fresh node creates
 		// PV/VG/thin-pool (lvmthin) or the parent dataset (zfs).
 		if err := be.Setup(context.Background()); err != nil {
 			setupLog.Error(err, "backend pool setup failed")
@@ -546,8 +546,7 @@ func main() {
 			setupLog.Error(err, "unable to set up snapshot reconciler")
 			os.Exit(1)
 		}
-		// Publishes this node's pool capacity for capacity-aware placement
-		// (notes/DESIGN.md §4.6).
+		// Publishes this node's pool capacity for capacity-aware placement.
 		if err := mgr.Add(&agent.PoolStatsPublisher{
 			Client:      mgr.GetClient(),
 			NodeName:    nodeName,

--- a/config/crd/bases/miroir.home-operations.com_miroirnodes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirnodes.yaml
@@ -70,7 +70,7 @@ spec:
           status:
             description: |-
               MiroirNodeStatus is the pool capacity this node's agent publishes for
-              capacity-aware placement and overcommit guardrails (DESIGN.md §4.6).
+              capacity-aware placement and overcommit guardrails.
               On a shared pool (e.g. ZFS shared with OpenEBS) the figures are
               pool-level, so a co-tenant's growth correctly shrinks miroir's headroom.
             properties:

--- a/config/crd/bases/miroir.home-operations.com_miroirsnapshots.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirsnapshots.yaml
@@ -66,7 +66,7 @@ spec:
             description: |-
               MiroirSnapshotStatus is the observed state aggregated from node agents.
               The snapshot exists as a backend CoW snapshot on every replica of the
-              source volume (DESIGN.md §4.5.4).
+              source volume.
             properties:
               conditions:
                 description: Conditions follow the standard Kubernetes condition conventions.

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Exposed on the agent's metrics endpoint; the split-brain gauge is the
-// alerting hook for the last-man-standing failure mode (DESIGN §3.2).
+// alerting hook for the last-man-standing failure mode.
 const volumeLabel = "volume"
 
 var (

--- a/internal/agent/poolstats.go
+++ b/internal/agent/poolstats.go
@@ -38,19 +38,19 @@ import (
 
 const (
 	// DefaultPoolStatsInterval is how often the agent republishes pool
-	// capacity (DESIGN.md §4.6 — "every ~60s").
+	// capacity (every ~60s).
 	DefaultPoolStatsInterval = 60 * time.Second
 	// ConditionPoolUsageHigh fires on a MiroirNode once data or metadata
 	// usage crosses poolUsageWarnPercent.
 	ConditionPoolUsageHigh = "PoolUsageHigh"
 	// poolUsageWarnPercent is the warn line for both data and dm-thin
-	// metadata; ZFS also degrades badly past ~85% full (DESIGN.md §4.6).
+	// metadata; ZFS also degrades badly past ~85% full.
 	poolUsageWarnPercent = 80
 )
 
 // PoolStatsPublisher samples this node's backend pool capacity on an
 // interval and publishes it to the node's MiroirNode object, where the
-// controller reads it for capacity-aware placement (DESIGN.md §4.6).
+// controller reads it for capacity-aware placement.
 type PoolStatsPublisher struct {
 	Client      client.Client
 	NodeName    string

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package agent realizes MiroirVolume desired state on one node: it creates,
 // resizes, and deletes backing devices via the node's Backend and reports
-// observed state back through the CRD status (notes/DESIGN.md §4.2).
+// observed state back through the CRD status.
 package agent
 
 import (
@@ -48,7 +48,7 @@ import (
 )
 
 // VolumeReconciler converges local state for volumes that place a replica on
-// NodeName. Level-triggered: safe to restart at any point (notes/DESIGN.md §4.2).
+// NodeName. Level-triggered: safe to restart at any point.
 type VolumeReconciler struct {
 	client.Client
 	NodeName string
@@ -142,7 +142,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if !present {
 		// Not placed here, but a held finalizer means this replica (or
 		// client leg) was removed from the spec: tear down the local leg
-		// once it is safe (notes/DESIGN.md §4.2).
+		// once it is safe.
 		return r.reconcileRemoval(ctx, vol)
 	}
 	if vol.Spec.DRBD != nil && incomplete {
@@ -991,7 +991,7 @@ func detachedDiskMessage(diskFailed bool) string {
 }
 
 // computePhase aggregates per-node states into the volume phase the CSI
-// controller waits on (notes/DESIGN.md §4.5.1).
+// controller waits on.
 func computePhase(vol *miroirv1alpha1.MiroirVolume) miroirv1alpha1.VolumePhase {
 	diskfulReplicas := vol.Spec.DiskfulReplicas()
 	ready := 0

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package backend abstracts the node-local thin-provisioned storage layer
-// (notes/DESIGN.md §4.1a). DRBD replicates whatever block device a Backend
-// provides, so replicas of one volume may use different backends on
-// different nodes (ZFS zvol on paris, LVM thin LV on kharkiv).
+// Package backend abstracts the node-local thin-provisioned storage
+// layer. DRBD replicates whatever block device a Backend provides, so
+// replicas of one volume may use different backends on different nodes
+// (ZFS zvol on paris, LVM thin LV on kharkiv).
 package backend
 
 import (
@@ -48,9 +48,9 @@ type PoolStats struct {
 // Implementations are thin wrappers over the lvm/zfs CLIs; all methods are
 // idempotent so reconcilers can retry safely.
 type Backend interface {
-	// Setup bootstraps the node-local pool on first start if absent
-	// (notes/DESIGN.md §7.2): lvmthin creates PV/VG/thin-pool on the configured
-	// device; zfs creates the parent dataset. Idempotent.
+	// Setup bootstraps the node-local pool on first start if absent:
+	// lvmthin creates PV/VG/thin-pool on the configured device; zfs
+	// creates the parent dataset. Idempotent.
 	Setup(ctx context.Context) error
 	// Create provisions a thin device of the given virtual size and
 	// returns its device path. Succeeds without re-checking size when the

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -165,7 +165,7 @@ func TestZFSCreate(t *testing.T) {
 	if dev != "/dev/zvol/tank/miroir/pvc-1" {
 		t.Fatalf("unexpected device path %q", dev)
 	}
-	// Sparse + 4k volblocksize per notes/DESIGN.md §4.1a / SPIKE P0-1, lz4.
+	// Sparse + 4k volblocksize plus lz4.
 	fe.calledWith(t, "zfs create -s -b 4096 -o compression=lz4 -V 10737418240 tank/miroir/pvc-1")
 }
 

--- a/internal/backend/loopfile.go
+++ b/internal/backend/loopfile.go
@@ -27,7 +27,7 @@ import (
 
 // loopfile provisions volumes as sparse files on a node's existing
 // filesystem, each attached as a loop device — no dedicated disk and no
-// LVM/ZFS pool to format (notes/DESIGN.md §4.1a). It is the "use whatever's
+// LVM/ZFS pool to format. It is the "use whatever's
 // already mounted" backend: Longhorn's sparse-file replicas, but replicated
 // by in-kernel DRBD instead of a userspace engine.
 //
@@ -316,7 +316,7 @@ func (lf *loopfile) sizeOf(ctx context.Context, file string) (int64, error) {
 
 func (lf *loopfile) Stats(ctx context.Context) (PoolStats, error) {
 	// The "pool" is the filesystem holding the base directory; headroom must
-	// account for everything on it, not only miroir files (notes/DESIGN.md §4.6).
+	// account for everything on it, not only miroir files.
 	out, err := lf.exec(ctx, "df", "-B1", "-P", lf.baseDir)
 	if err != nil {
 		return PoolStats{}, err

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -41,7 +41,7 @@ func newLVMThin(cfg Config, e Exec) *lvmThin {
 }
 
 // Setup creates PV → VG → thin pool on the configured device if the VG does
-// not exist yet (notes/DESIGN.md §7.2: kharkiv's r-miroir raw partition). Metadata
+// not exist yet (kharkiv's r-miroir raw partition). Metadata
 // LV is sized 1 GiB per dm-thin guidance (§4.6).
 func (l *lvmThin) Setup(ctx context.Context) error {
 	if _, err := l.lvm(ctx, "vgs", l.vg); err == nil {
@@ -198,7 +198,7 @@ func (l *lvmThin) CreateFromSnapshot(ctx context.Context, vol, _ /* sourceVol */
 	}
 	if !ok {
 		// A writable thin snapshot of the snapshot is the clone: instant
-		// CoW within the same pool, no data copy (notes/DESIGN.md §4.5.5).
+		// CoW within the same pool, no data copy.
 		_, err = l.lvm(ctx, "lvcreate",
 			"--snapshot",
 			"--name", vol,

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -24,7 +24,7 @@ import (
 )
 
 // zfsBackend provisions sparse zvols under a dedicated dataset (paris's
-// backend; pool shared with OpenEBS LocalPV-ZFS — notes/DESIGN.md §4.1a).
+// backend; pool shared with OpenEBS LocalPV-ZFS).
 // volblocksize is fixed at 4k to align with the LVM-thin peer leg.
 type zfsBackend struct {
 	dataset string
@@ -37,7 +37,7 @@ func newZFS(cfg Config, e Exec) *zfsBackend {
 
 // Setup creates the parent dataset (e.g. tank/miroir) if absent — the
 // namespace separating miroir zvols from OpenEBS datasets in the shared
-// pool (notes/DESIGN.md §4.1a).
+// pool.
 func (z *zfsBackend) Setup(ctx context.Context) error {
 	ok, err := z.exists(ctx, z.dataset)
 	if err != nil || ok {
@@ -242,7 +242,7 @@ func (z *zfsBackend) volSize(ctx context.Context, vol string) (int64, error) {
 
 func (z *zfsBackend) Stats(ctx context.Context) (PoolStats, error) {
 	// Pool-level stats: the pool is shared with OpenEBS, so headroom must
-	// account for everything in it, not only miroir zvols (notes/DESIGN.md §4.6).
+	// account for everything in it, not only miroir zvols.
 	pool := z.pool()
 	out, err := z.exec(ctx, "zpool", "get", "-Hpo", "value", "size,allocated", pool)
 	if err != nil {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -29,7 +29,7 @@ const (
 	DriverName = "miroir.home-operations.com"
 
 	// TopologyKey is the CSI topology key reported by NodeGetInfo; its
-	// value is the Kubernetes node name (notes/DESIGN.md §6.5).
+	// value is the Kubernetes node name.
 	TopologyKey = "miroir.home-operations.com/node"
 
 	// FinalizerPrefix + node name blocks MiroirVolume deletion until that

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -44,7 +44,7 @@ import (
 	"github.com/home-operations/miroir/internal/stage"
 )
 
-// Controller implements csi.ControllerServer (notes/DESIGN.md §6.1). It translates
+// Controller implements csi.ControllerServer. It translates
 // CSI RPCs into MiroirVolume objects and waits for node agents to realize
 // them — the Kubernetes API is the only channel to the data plane (§4.2).
 type Controller struct {
@@ -62,7 +62,7 @@ type Controller struct {
 	ProvisionTimeout time.Duration
 	// OvercommitRatio bounds thin-provisioning overcommit: CreateVolume is
 	// refused when a node's provisioned total would exceed
-	// capacity×ratio (notes/DESIGN.md §4.6). Zero → defaultOvercommitRatio.
+	// capacity×ratio. Zero → defaultOvercommitRatio.
 	OvercommitRatio float64
 	// AutoTieBreaker adds a diskless tie-breaker replica to new 2-replica
 	// freeze volumes when a spare storage node exists (#70).
@@ -82,8 +82,8 @@ type Controller struct {
 
 const (
 	defaultProvisionTimeout = 120 * time.Second // matches sidecars.provisioner.timeout
-	// defaultOvercommitRatio caps provisioned-over-capacity per pool
-	// (notes/DESIGN.md §4.6); 2× is the documented default.
+	// defaultOvercommitRatio caps provisioned-over-capacity per pool;
+	// 2× is the documented default.
 	defaultOvercommitRatio = 2.0
 	// defaultDRBDPortBase is the lowest DRBD replication port when
 	// DRBDPortBase is unset (zero). Ceph mgr dashboard's non-SSL default
@@ -117,7 +117,7 @@ func (c *Controller) ControllerGetCapabilities(_ context.Context, _ *csi.Control
 }
 
 // CreateVolume provisions a MiroirVolume and waits until its agents report
-// Ready (notes/DESIGN.md §4.5.1). Idempotent by volume name.
+// Ready. Idempotent by volume name.
 func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	if req.GetName() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume name is required")
@@ -261,7 +261,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 }
 
 // DeleteVolume removes the MiroirVolume; agents tear down local state via
-// the finalizer before it disappears (notes/DESIGN.md §4.5.7). Idempotent.
+// the finalizer before it disappears. Idempotent.
 func (c *Controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id is required")
@@ -351,7 +351,7 @@ func (c *Controller) allocVolumes(ctx context.Context, needed bool) ([]miroirv1a
 
 // place selects count replica nodes: the scheduler's preference first
 // (WaitForFirstConsumer), then the remaining eligible storage nodes by
-// free space — capacity-aware spread (notes/DESIGN.md §4.6). Nodes whose
+// free space — capacity-aware spread. Nodes whose
 // projected provisioned total would breach the overcommit ratio are
 // excluded, and a chosen node breaching it (e.g. a topology-pinned one)
 // fails the request so the scheduler retries elsewhere. Pools without
@@ -539,7 +539,7 @@ func (c *Controller) reader() client.Reader {
 }
 
 // poolStats returns the fresh pool capacity each storage node's agent
-// published (notes/DESIGN.md §4.6). Stale or never-published nodes are
+// published. Stale or never-published nodes are
 // omitted — placement treats them as unknown (eligible, no free-space
 // signal) so a cold cluster still provisions.
 func (c *Controller) poolStats(ctx context.Context) (map[string]miroirv1alpha1.MiroirNodeStatus, error) {

--- a/internal/csi/identity.go
+++ b/internal/csi/identity.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Identity implements csi.IdentityServer for both the controller and the
-// agent (notes/DESIGN.md §6.1).
+// agent.
 type Identity struct {
 	csi.UnimplementedIdentityServer
 	// Version is injected from main's ldflags.

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -41,7 +41,7 @@ import (
 	"github.com/home-operations/miroir/internal/stage"
 )
 
-// Node implements csi.NodeServer (notes/DESIGN.md §4.5.2). It looks the volume up
+// Node implements csi.NodeServer. It looks the volume up
 // in the CRD (the source of truth) and stages its node-local device.
 type Node struct {
 	csi.UnimplementedNodeServer

--- a/internal/csi/server.go
+++ b/internal/csi/server.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package csi implements the miroir.home-operations.com CSI driver services (notes/DESIGN.md §6).
+// Package csi implements the miroir.home-operations.com CSI driver services.
 package csi
 
 import (

--- a/internal/drbd/res.go
+++ b/internal/drbd/res.go
@@ -44,7 +44,7 @@ type Resource struct {
 	Minor int32
 	// Port is the TCP port for all of this resource's connections.
 	Port int32
-	// Quorum selects the 2-node consistency mode (DESIGN §3.2).
+	// Quorum selects the 2-node consistency mode.
 	Quorum miroirv1alpha1.QuorumPolicy
 	// LocalNode is the node this config is rendered on; its peer entry
 	// gets the real backing path, all others the placeholder.
@@ -120,8 +120,8 @@ func Render(r Resource) string {
 		b.WriteString("        cram-hmac-alg sha1;\n")
 		fmt.Fprintf(&b, "        shared-secret %q;\n", r.Secret)
 	}
-	// Never auto-resolve diverged data: an operator picks the loser
-	// (DESIGN §3.2). discard-zero-changes and consensus let DRBD pick
+	// Never auto-resolve diverged data: an operator picks the loser.
+	// discard-zero-changes and consensus let DRBD pick
 	// one — a zero-changes verdict trusts generation identifiers that
 	// day0-seeded clones share without sharing history.
 	b.WriteString("        after-sb-0pri disconnect;\n")

--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -185,7 +185,7 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 		}
 
 		// FormatAndMount formats only when the device has no filesystem —
-		// the mkfs-if-blank step of notes/DESIGN.md §4.5.2.
+		// the mkfs-if-blank step.
 		if err := d.Mounter.FormatAndMount(dev, target, fsType, flags); err != nil {
 			return status.Errorf(codes.Internal, "format/mount %s: %v", dev, err)
 		}

--- a/test/e2e/placement_test.go
+++ b/test/e2e/placement_test.go
@@ -12,7 +12,7 @@ import (
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 )
 
-// Capacity-aware placement surface (DESIGN.md §4.6): each storage agent
+// Capacity-aware placement surface: each storage agent
 // publishes its pool capacity to a MiroirNode the controller reads at
 // placement. Provisioning itself exercises the placement path in the
 // lifecycle spec; here we assert the stats the decision rests on.


### PR DESCRIPTION
Documentation-only pass over the root README: catch it up with recently shipped features, fix stale/incorrect references, and refactor per three goals - keep it lean, no em dashes, copy-pasteable Helm examples for different storage layouts.

## Catching up with shipped features

- **Verification section rewritten** - it still described hand-run `drbdadm verify` via external cron and kernel-log-only findings, while the alerts paragraph two sections later referenced "a stale verify schedule". Now documents the built-in scheduled verify (`drbd.verify.schedule`), findings in volume status (`lastVerifyOutOfSyncBytes`), the `miroir_volume_verify_*` metrics, the `VerifyOutOfSync` event, and the starter alerts; hand-run verify kept as the manual path.
- **Metrics table completed** - adds the three exported-but-undocumented gauges: `miroir_volume_diskless_primary`, `miroir_volume_verify_last_timestamp_seconds`, `miroir_volume_verify_out_of_sync_bytes`.
- **Monitoring mentions the CSI health surface** (#187) - `sidecars.healthMonitor.enabled` surfaces split-brain/failed-disk/degraded as PVC events, for clusters without Prometheus.
- **Roadmap**: `CSIStorageCapacity` reporting checked off (#189), noted as opt-in via `storageCapacity.enabled`.
- **Corrected value paths**: `autoTieBreaker` (was documented as `controller.autoTieBreaker`) and `agent.kubeletDir` (was `kubeletDir`).
- Disk-failure paragraph now points at `miroir_volume_disk_failed` (the latched signal) rather than `miroir_volume_up_to_date`.

## Refactor

- **Quickstart restructured around three storage layouts**, each a complete copy-pasteable `values.yaml` including `storageClasses` (previously the example had no classes and deferred to chart values):
  - two nodes with a spare partition each (the common local + replicated pair),
  - three nodes with mixed backends, zones, and a dedicated replication NIC,
  - single-node loopfile for dev clusters.
- Dropped the redundant second PVC example and the quorum parameter table (now visible in the class examples); added a pointer to the chart README for the full value reference.
- Removed all em/en dashes; general prose tightening throughout (comparison bullets, remote-consumer trade-offs, troubleshooting port-collision entry - all content preserved, wording condensed).

Net: +34 lines despite the added examples.

## Per-OS node setup (second commit)

Requirements now has **Talos** and **Debian/Ubuntu** subsections instead of the abstract module list:

- **Talos**: Image Factory extensions (`siderolabs/drbd`, `siderolabs/zfs`) and a machine-config snippet loading `drbd` with `usermode_helper=disabled` (the kernel side otherwise calls out to `/sbin/drbdadm` on the host, absent on Talos - the same pattern the Piraeus Talos guide documents) plus `drbd_transport_tcp`, and graceful-shutdown window sizing.
- **Debian/Ubuntu**: the in-tree `drbd.ko` is the 8.4 API and does not work with miroir's DRBD9 configuration (the same fact #125 records for CI); `drbd-dkms` + kernel headers from the LINBIT PPA/repos, with the same usermode-helper caveat via modprobe.d. ZFS module from `linux-modules-extra` (Ubuntu) or `zfs-dkms` (Debian); userland-older-than-module noted as the supported direction.
- States explicitly that all storage userland ships inside the agent image and nodes provide only kernel modules; the old wording implied `drbd-utils` was a node prerequisite.

## Lean pass (third commit)

- **Roadmap section removed.** Half its entries were checked-off (changelog territory; release-please already maintains `CHANGELOG.md`), the rest belong in the issue tracker; README roadmaps rot silently (this PR fixed one stale checkbox already). Development now links to the issue tracker.
- Compressed below-README-altitude passages: remote-consumer quorum-math and stranded-client bullets, the troubleshooting port-collision walkthrough (symptom → cause → fix; full forensics stay in #148, which it links), and the generic controller-runtime metrics paragraph.

## notes/ removal (fourth commit)

`notes/` is gitignored and local to the maintainer, so the README's `notes/DESIGN.md` link 404s for everyone else and ~45 section pointers in code comments cited a document readers cannot open. This commit strips every citation (keeping each comment's substance), drops the `notes/` gitignore entry, and regenerates the CRDs + apply-configurations whose descriptions carried them (`mise run generate` / `helm-crds`). No functional change; full `go test` + lint + helm unittest green.

## format-yaml hook fix (fifth commit)

Removing the notes references surfaced a broken pre-commit hook: a commit staging only prettierignored generated YAML (the CRDs) feeds oxfmt an all-ignored input list and it exits 2. The old `run = "oxfmt {staged_files} || true"` override relied on shell interpretation of run strings, which lefthook v2 dropped, so the hook hard-failed such commits. Fixed by `exclude`-ing the generated paths (CRDs, `config/rbac/role.yaml`, `config/webhook/manifests.yaml`), matching the format-markdown/format-json pattern; verified by staging only a generated CRD and running the hook (now skips cleanly).

## LINSTOR comparison folded away (sixth commit)

The 39-line three-way LINSTOR/blockstor comparison restated positioning carried elsewhere in the README; its one actionable takeaway (fleet-scale features are LINSTOR's territory, miroir stops at 2-3 nodes) is now a bullet in "When not to use it". Final size: 612 lines (was 609 before the PR, with the per-OS setup section and layout examples added and the roadmap/comparison removed).

## autoDiskfulAfter declared (seventh commit)

`controller.tpl` has read `.Values.autoDiskfulAfter` since the auto-diskful feature landed, but the value was never declared in `values.yaml` - absent from the generated chart README and `values.schema.json` even though the root README documents it. Now declared (empty = disabled, matching the flag default), docs/schema regenerated, and both render states pinned in the chart tests (96 helm-unittest cases, +2).
