### PR TITLE
build(image): install drbd-utils from LINBIT's public trixie repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,17 +36,19 @@ ENTRYPOINT ["/usr/local/bin/miroir"]
 #     older than the module is the supported direction, and miroir only
 #     uses ancient ops (create -V/snapshot/clone/promote/volsize).
 FROM debian:trixie-slim AS agent
-# LINBIT's keyring deb installs /etc/apt/trusted.gpg.d/linbit-keyring.gpg.
-ADD https://packages.linbit.com/public/linbit-keyring/trixie/linbit-keyring.deb /tmp/linbit-keyring.deb
-RUN sed -i 's|^Components: main$|Components: main contrib|' /etc/apt/sources.list.d/debian.sources && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    sed -i 's|^Components: main$|Components: main contrib|' /etc/apt/sources.list.d/debian.sources && \
     apt-get update -qq && \
     # ca-certificates: apt needs TLS trust to reach the LINBIT repo. Kept
     # installed — the gateway stage's apt-get update fetches from it too.
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates && \
-    dpkg -i /tmp/linbit-keyring.deb && rm /tmp/linbit-keyring.deb && \
-    echo "deb https://packages.linbit.com/public trixie misc" > /etc/apt/sources.list.d/linbit.list && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://packages.linbit.com/package-signing-pubkey.asc \
+      -o /etc/apt/keyrings/linbit.asc && \
+    echo "deb [signed-by=/etc/apt/keyrings/linbit.asc] https://packages.linbit.com/public trixie misc" \
+      > /etc/apt/sources.list.d/linbit.list && \
     apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-get install -y --no-install-recommends \
     drbd-utils \
     lvm2 \
     zfsutils-linux \
@@ -65,6 +67,9 @@ RUN sed -i 's|^Components: main$|Components: main contrib|' /etc/apt/sources.lis
     util-linux \
     mount \
     coreutils && \
+    # curl was only needed to fetch the signing key above.
+    apt-get purge -y curl && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 # No udevd is reachable from the container: stop libdevmapper from waiting
 # on udev cookies and lvm from querying udev for the device list.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,21 +23,28 @@ ENTRYPOINT ["/usr/local/bin/miroir"]
 # userland; the kernel modules come from the Talos kernel + extensions.
 # Debian (glibc) because the DRBD/ZFS ecosystem — LINBIT, Piraeus,
 # blockstor — builds and tests the storage stack against glibc only.
-# zfsutils-linux lives in contrib. Version notes (trixie, no backports):
-#   - drbd-utils 9.22: every CLI/JSON surface miroir uses predates it
-#     (adjust --skip-disk 8.9.7, status --json 8.9.8, quorum 8.9.11;
-#     peer_devices/percent-in-sync/out-of-sync/peer-disk-state and the
-#     per-peer `drbdsetup disconnect <res> <peer_node_id>` form
-#     (CTX_PEER_NODE) verified in the v9.22.0 source). The birth
-#     generation depends on drbdadm
+# zfsutils-linux lives in contrib. Version notes:
+#   - drbd-utils comes from LINBIT's public apt repo (native trixie
+#     dist), not Debian trixie, which is frozen at 9.22 with no
+#     backports: the 9.34.x line is what LINBIT builds and tests
+#     against the DRBD 9.3.x kernel module the siderolabs extension
+#     ships. The birth generation depends on drbdadm
 #     new-current-uuid --clear-bitmap behavior — re-validate with
 #     smoke.sh + conformance on real DRBD (the kind e2e exercises the
-#     local backend only) before shipping a base bump.
+#     local backend only) before shipping a utils or base bump.
 #   - zfs userland 2.3 against the siderolabs/zfs 2.4 module: userland
 #     older than the module is the supported direction, and miroir only
 #     uses ancient ops (create -V/snapshot/clone/promote/volsize).
 FROM debian:trixie-slim AS agent
+# LINBIT's keyring deb installs /etc/apt/trusted.gpg.d/linbit-keyring.gpg.
+ADD https://packages.linbit.com/public/linbit-keyring/trixie/linbit-keyring.deb /tmp/linbit-keyring.deb
 RUN sed -i 's|^Components: main$|Components: main contrib|' /etc/apt/sources.list.d/debian.sources && \
+    apt-get update -qq && \
+    # ca-certificates: apt needs TLS trust to reach the LINBIT repo. Kept
+    # installed — the gateway stage's apt-get update fetches from it too.
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates && \
+    dpkg -i /tmp/linbit-keyring.deb && rm /tmp/linbit-keyring.deb && \
+    echo "deb https://packages.linbit.com/public trixie misc" > /etc/apt/sources.list.d/linbit.list && \
     apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     drbd-utils \


### PR DESCRIPTION
## What

Install `drbd-utils` in the agent image from LINBIT's public apt repo (native `trixie` dist, component `misc`) instead of Debian trixie, which is frozen at 9.22.0 with no backports. The repo currently resolves to **9.34.3-1**, the utils line LINBIT builds and tests against the DRBD 9.3.x kernel module the siderolabs extension ships.

- The signing key comes from LINBIT's published `package-signing-pubkey.asc`, fetched with curl into `/etc/apt/keyrings/linbit.asc` and scoped to the repo via `signed-by` (verified: its rsa4096 key `4E5385546726D13CB649872CFC05A31DB826FE48` signs the trixie `InRelease`).
- `ca-certificates` is installed first (apt needs TLS trust for the repo) and kept: the gateway stage's own `apt-get update` fetches from it too. curl is purged after the key fetch.
- `DEBIAN_FRONTEND=noninteractive` is exported once for the whole `RUN`.
- `drbd-utils` stays unpinned, matching the rest of the file; apt prefers 9.34.3-1 over Debian's 9.22.0-1.1 by version, so no pinning is needed.
- The version-notes comment now documents the repo choice and keeps the standing warning to re-validate with smoke.sh + conformance on real DRBD before shipping a utils/base bump.

## Why

#195's triage flagged utils 9.22 driving a 9.3.2 kernel module as a suspect. Follow-up analysis on the issue ruled skew out as the teardown-wedge cause (the hang is kernel-side, post-detach), but eliminating the skew removes the variable from every future incident and picks up the 9.3.x-era knobs (`bitmap`, `tie-breaker`) should miroir want them.

Repo facts verified against the live index: `trixie` dist updated 2026-07-10; amd64 + arm64 published (matching the image's platforms); 9.34.3-1 depends only on stock trixie packages (`libc6 >= 2.38`, `libstdc++6 >= 14`, `libkeyutils1`, `mount`, `debconf`).

## Verification

Not build-tested locally (no docker socket access on this machine). The e2e workflow builds both `controller` and `agent` targets on this PR and runs the kind e2e against the agent image, exercising the new apt flow. Per the #118 precedent, a real-hardware smoke test (`drbdsetup --version` in-pod, smoke.sh) should gate the release that ships this.

Refs #195
