### PR TITLE
feat!: enforce the DRBD kernel module floor at agent startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ synchronous replication (2-3 replicas) via DRBD9.
 - Kernel modules on each storage node (per-OS notes below):
   `dm_thin_pool` (lvmthin), ZFS (zfs), `loop` plus a reflink-capable
   filesystem for `baseDir` (loopfile), and, for replication, the
-  DRBD9 `drbd` and `drbd_transport_tcp` modules.
+  DRBD9 `drbd` and `drbd_transport_tcp` modules, **version ≥ 9.3.1**
+  (on Talos: shipped by ≥ 1.13.0). The agent refuses to start on a
+  node whose module is older — the drbd-utils in the agent image
+  render options an older module rejects. Nodes without the module at
+  all are fine (local-only).
 - Kubelet [graceful node shutdown][gns], so the agent (a
   `system-node-critical` pod) is stopped _after_ workloads on reboot
   and can release DRBD backings before the backend pool exports;
@@ -49,7 +53,9 @@ ships inside the agent image; nodes only provide kernel modules.
 
 ### Talos
 
-Talos is the primary target. The stock kernel ships `dm_thin_pool`
+Talos is the primary target — **≥ 1.13.0** for replication (its
+`siderolabs/drbd` extension ships the DRBD 9.3.1 module the agent
+requires). The stock kernel ships `dm_thin_pool`
 and `loop` (the agent loads them on demand), and `/var` is XFS with
 `reflink=1`, so `lvmthin` and `loopfile` work out of the box. DRBD
 and ZFS modules come from [Image Factory][factory] system extensions;

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodestatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodestatus.go
@@ -39,6 +39,11 @@ type MiroirNodeStatusApplyConfiguration struct {
 	// otherwise), rounded — exhausting metadata wedges the pool
 	// independently of data space.
 	MetaUsedPercent *int32 `json:"metaUsedPercent,omitempty"`
+	// DRBDVersion is the DRBD kernel module version the agent probed at
+	// startup (e.g. "9.3.2"); absent on nodes without the module. The
+	// module ships with the host, not the agent image, so this is the
+	// per-node view that makes mixed clusters visible mid-upgrade.
+	DRBDVersion *string `json:"drbdVersion,omitempty"`
 	// ObservedAt is when these figures were last sampled; the controller
 	// ignores stats older than a few poll intervals as unknown.
 	ObservedAt *v1.Time `json:"observedAt,omitempty"`
@@ -74,6 +79,14 @@ func (b *MiroirNodeStatusApplyConfiguration) WithAllocatedBytes(value int64) *Mi
 // If called multiple times, the MetaUsedPercent field is set to the value of the last call.
 func (b *MiroirNodeStatusApplyConfiguration) WithMetaUsedPercent(value int32) *MiroirNodeStatusApplyConfiguration {
 	b.MetaUsedPercent = &value
+	return b
+}
+
+// WithDRBDVersion sets the DRBDVersion field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DRBDVersion field is set to the value of the last call.
+func (b *MiroirNodeStatusApplyConfiguration) WithDRBDVersion(value string) *MiroirNodeStatusApplyConfiguration {
+	b.DRBDVersion = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -101,6 +101,9 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Condition
           elementRelationship: atomic
+    - name: drbdVersion
+      type:
+        scalar: string
     - name: metaUsedPercent
       type:
         scalar: numeric

--- a/api/v1alpha1/miroirnode_types.go
+++ b/api/v1alpha1/miroirnode_types.go
@@ -28,6 +28,12 @@ type MiroirNodeStatus struct {
 	// independently of data space.
 	// +optional
 	MetaUsedPercent int32 `json:"metaUsedPercent,omitempty"`
+	// DRBDVersion is the DRBD kernel module version the agent probed at
+	// startup (e.g. "9.3.2"); absent on nodes without the module. The
+	// module ships with the host, not the agent image, so this is the
+	// per-node view that makes mixed clusters visible mid-upgrade.
+	// +optional
+	DRBDVersion string `json:"drbdVersion,omitempty"`
 	// ObservedAt is when these figures were last sampled; the controller
 	// ignores stats older than a few poll intervals as unknown.
 	// +optional
@@ -44,6 +50,7 @@ type MiroirNodeStatus struct {
 // +kubebuilder:printcolumn:name="Backend",type=string,JSONPath=`.spec.backend`
 // +kubebuilder:printcolumn:name="Capacity",type=integer,JSONPath=`.status.capacityBytes`
 // +kubebuilder:printcolumn:name="Allocated",type=integer,JSONPath=`.status.allocatedBytes`
+// +kubebuilder:printcolumn:name="DRBD",type=string,JSONPath=`.status.drbdVersion`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MiroirNode publishes one storage node's pool capacity. Named after the

--- a/charts/miroir/crds/miroir.home-operations.com_miroirnodes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirnodes.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.allocatedBytes
       name: Allocated
       type: integer
+    - jsonPath: .status.drbdVersion
+      name: DRBD
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -142,6 +145,13 @@ spec:
                   - type
                   type: object
                 type: array
+              drbdVersion:
+                description: |-
+                  DRBDVersion is the DRBD kernel module version the agent probed at
+                  startup (e.g. "9.3.2"); absent on nodes without the module. The
+                  module ships with the host, not the agent image, so this is the
+                  per-node view that makes mixed clusters visible mid-upgrade.
+                type: string
               metaUsedPercent:
                 description: |-
                   MetaUsedPercent is the dm-thin metadata usage (lvmthin only; 0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -457,7 +457,11 @@ func main() {
 		be, backendType, err := backendFor(nodeName, nodesConfig, vg, thinPool)
 		if errors.Is(err, errNodeUnmapped) {
 			setupLog.Info("node not in the storage map; running client-only node service", "node", nodeName)
-			node := csi.NewNode(mgr.GetClient(), nodeName, &drbd.Driver{StateDir: drbdStateDir, Exec: backend.RealExec})
+			// Client legs get DRBD configs rendered here too, so the
+			// kernel floor binds on client-only nodes as well.
+			clientDRBD := &drbd.Driver{StateDir: drbdStateDir, Exec: backend.RealExec}
+			probeDRBD(clientDRBD)
+			node := csi.NewNode(mgr.GetClient(), nodeName, clientDRBD)
 			serveCSI(mgr, csiSocket, identity, nil, node)
 			break
 		}
@@ -478,7 +482,7 @@ func main() {
 		// it proactively on nodes that ship it) and run without the DRBD
 		// machinery when the kernel side is absent — otherwise the events
 		// watcher hot-loops "exit status 20" every 5s forever.
-		drbdReady := drbdDriver.KernelAvailable(context.Background())
+		drbdKernel, drbdReady := probeDRBD(drbdDriver)
 		if !drbdReady {
 			setupLog.Info("DRBD kernel module unavailable; running local-only " +
 				"(no events watcher, no orphan/barrier/shutdown sweeps)")
@@ -554,6 +558,7 @@ func main() {
 			BackendType: backendType,
 			Interval:    poolStatsInterval,
 			Recorder:    mgr.GetEventRecorder("miroir-agent"),
+			DRBDVersion: drbdKernel,
 		}); err != nil {
 			setupLog.Error(err, "unable to add pool stats publisher")
 			os.Exit(1)
@@ -728,6 +733,30 @@ func resumeStaleBarriers(driver *drbd.Driver, apiBudget time.Duration) error {
 		}
 	}
 	return nil
+}
+
+// probeDRBD reports whether the DRBD kernel side is usable and, when it
+// is, the module version — exiting below drbd.KernelFloor: a 9.3.1-era
+// option rendered against an older module errors drbdadm for every
+// resource on the node, so failing fast here beats poisoning them all
+// later. Talos ≥ 1.13.0 ships a module at the floor.
+func probeDRBD(driver *drbd.Driver) (version string, ready bool) {
+	if !driver.KernelAvailable(context.Background()) {
+		return "", false
+	}
+	v, err := driver.KernelVersion(context.Background())
+	if err != nil {
+		// The module answered but the version read flaked; running
+		// unchecked beats refusing a working node.
+		setupLog.Error(err, "cannot read DRBD kernel module version; skipping floor check")
+		return "", true
+	}
+	if drbd.BelowKernelFloor(v) {
+		setupLog.Error(nil, "DRBD kernel module is below the supported floor; upgrade the node (Talos >= 1.13.0)",
+			"version", v, "floor", drbd.KernelFloor)
+		os.Exit(1)
+	}
+	return v, true
 }
 
 // csiRunnable marks the CSI server as running on every replica rather than

--- a/config/crd/bases/miroir.home-operations.com_miroirnodes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirnodes.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.allocatedBytes
       name: Allocated
       type: integer
+    - jsonPath: .status.drbdVersion
+      name: DRBD
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -142,6 +145,13 @@ spec:
                   - type
                   type: object
                 type: array
+              drbdVersion:
+                description: |-
+                  DRBDVersion is the DRBD kernel module version the agent probed at
+                  startup (e.g. "9.3.2"); absent on nodes without the module. The
+                  module ships with the host, not the agent image, so this is the
+                  per-node view that makes mixed clusters visible mid-upgrade.
+                type: string
               metaUsedPercent:
                 description: |-
                   MetaUsedPercent is the dm-thin metadata usage (lvmthin only; 0

--- a/internal/agent/poolstats.go
+++ b/internal/agent/poolstats.go
@@ -60,6 +60,10 @@ type PoolStatsPublisher struct {
 	Interval time.Duration
 	// Recorder emits the PoolUsageHigh event; optional.
 	Recorder events.EventRecorder
+	// DRBDVersion is the kernel module version probed at agent startup;
+	// empty on nodes without the module. A module change means a node
+	// reboot and thus an agent restart, so startup is current enough.
+	DRBDVersion string
 }
 
 // Start publishes once promptly, then on the interval until ctx is done.
@@ -112,6 +116,7 @@ func (p *PoolStatsPublisher) publish(ctx context.Context) error {
 		cur.Status.CapacityBytes = stats.SizeBytes
 		cur.Status.AllocatedBytes = stats.UsedBytes
 		cur.Status.MetaUsedPercent = int32(math.Round(stats.MetaUsedPercent))
+		cur.Status.DRBDVersion = p.DRBDVersion
 		now := metav1.Now()
 		cur.Status.ObservedAt = &now
 

--- a/internal/agent/poolstats_test.go
+++ b/internal/agent/poolstats_test.go
@@ -60,6 +60,7 @@ func TestPoolStatsPublisherPublishes(t *testing.T) {
 	fb := newFakeBackend()
 	fb.stats = backend.PoolStats{SizeBytes: 100 * poolGiB, UsedBytes: 50 * poolGiB}
 	p, get := newPublisher(t, fb, nil)
+	p.DRBDVersion = "9.3.2"
 
 	if err := p.publish(t.Context()); err != nil {
 		t.Fatal(err)
@@ -70,6 +71,9 @@ func TestPoolStatsPublisherPublishes(t *testing.T) {
 	}
 	if n.Status.CapacityBytes != 100*poolGiB || n.Status.AllocatedBytes != 50*poolGiB {
 		t.Fatalf("unexpected capacity figures: %+v", n.Status)
+	}
+	if n.Status.DRBDVersion != "9.3.2" {
+		t.Fatalf("drbdVersion = %q, want 9.3.2", n.Status.DRBDVersion)
 	}
 	if n.Status.ObservedAt == nil {
 		t.Fatal("ObservedAt must be set")

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -903,6 +903,53 @@ func (d *Driver) KernelAvailable(ctx context.Context) bool {
 	return err == nil
 }
 
+// KernelFloor is the minimum DRBD kernel module version the agent runs
+// against (Talos ≥ 1.13.0 ships it via the siderolabs/drbd extension).
+// Rendering a 9.3.1-era option (peer-tiebreaker, bitmap granularity)
+// against an older module errors drbdadm for every resource on the node,
+// so the floor is enforced once at startup instead of gating each option.
+const KernelFloor = "9.3.1"
+
+// KernelVersion reports the loaded module's version via drbdadm's
+// DRBD_KERNEL_VERSION (sourced from /proc/drbd). Only meaningful after
+// KernelAvailable: with no module loaded drbdadm falls back to a
+// compile-time guess.
+func (d *Driver) KernelVersion(ctx context.Context) (string, error) {
+	out, err := d.Exec(ctx, "drbdadm", "--version")
+	if err != nil {
+		return "", fmt.Errorf("drbdadm --version: %w", err)
+	}
+	for line := range strings.SplitSeq(out, "\n") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), "DRBD_KERNEL_VERSION="); ok {
+			return strings.TrimSpace(v), nil
+		}
+	}
+	return "", errors.New("no DRBD_KERNEL_VERSION in drbdadm --version output")
+}
+
+// BelowKernelFloor reports whether a module version sorts below
+// KernelFloor, comparing dotted components numerically ("9.10" is newer
+// than "9.3"). A version that does not parse reads as below: refusing an
+// unknown platform beats rendering options it may reject.
+func BelowKernelFloor(version string) bool {
+	floor := strings.Split(KernelFloor, ".")
+	parts := strings.Split(strings.TrimSpace(version), ".")
+	for i, f := range floor {
+		want, _ := strconv.Atoi(f)
+		if i >= len(parts) {
+			return true // shorter than the floor: "9.3" < "9.3.1"
+		}
+		got, err := strconv.Atoi(parts[i])
+		if err != nil {
+			return true
+		}
+		if got != want {
+			return got < want
+		}
+	}
+	return false
+}
+
 // DiscardGranularity probes the backing device's discard granularity
 // (lsblk DISC-GRAN, bytes), clamped to [4096, 1MiB] — DRBD's sane range
 // for rs-discard-granularity. 0 means the device does not support

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -30,6 +30,7 @@ import (
 const (
 	volPvc1            = "pvc-1"
 	cmdDrbdsetupStatus = "drbdsetup status"
+	cmdAdmVersion      = "drbdadm --version"
 	cmdDumpMD          = "dump-md"
 	mockCurrentUUID    = "current-uuid 0xDEADBEEF00000001;"
 	addrKharkiv        = "192.168.1.41"
@@ -290,6 +291,62 @@ func TestKernelAvailable(t *testing.T) {
 	d = &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 	if d.KernelAvailable(t.Context()) {
 		t.Fatal("module-less node must read as unavailable")
+	}
+}
+
+// KernelVersion pulls DRBD_KERNEL_VERSION out of drbdadm --version; the
+// other lines (utils version, api codes) must not be mistaken for it.
+func TestKernelVersion(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdAdmVersion: "DRBDADM_BUILDTAG=GIT-hash\n" +
+			"DRBDADM_API_VERSION=2\n" +
+			"DRBD_KERNEL_VERSION_CODE=0x090302\n" +
+			"DRBD_KERNEL_VERSION=9.3.2\n" +
+			"DRBDADM_VERSION_CODE=0x092203\n" +
+			"DRBDADM_VERSION=9.34.3\n",
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	v, err := d.KernelVersion(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != "9.3.2" {
+		t.Fatalf("version = %q, want 9.3.2", v)
+	}
+
+	fe = &fakeExec{responses: map[string]string{cmdAdmVersion: "DRBDADM_VERSION=9.34.3\n"}}
+	d = &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if _, err := d.KernelVersion(t.Context()); err == nil {
+		t.Fatal("missing DRBD_KERNEL_VERSION line must error, not match DRBDADM_VERSION")
+	}
+
+	fe = &fakeExec{errOn: map[string]error{cmdAdmVersion: errors.New("exit status 1")}}
+	d = &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if _, err := d.KernelVersion(t.Context()); err == nil {
+		t.Fatal("exec failure must surface as an error")
+	}
+}
+
+// The floor compare is numeric per dotted component — "9.10" is newer
+// than "9.3" — and anything unparseable reads as below the floor.
+func TestBelowKernelFloor(t *testing.T) {
+	cases := map[string]bool{
+		"9.3.1":   false, // the floor itself
+		"9.3.2":   false,
+		"9.4.0":   false,
+		"9.10.0":  false, // numeric, not lexicographic
+		"10.0.0":  false,
+		"9.3.0":   true,
+		"9.2.18":  true,
+		"8.4.11":  true,
+		"9.3":     true, // shorter than the floor
+		"":        true,
+		"unknown": true,
+	}
+	for version, want := range cases {
+		if got := BelowKernelFloor(version); got != want {
+			t.Errorf("BelowKernelFloor(%q) = %v, want %v", version, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
First checklist item of #197: kmod version read + `MiroirNode` status surfacing + startup floor check + README Requirements floor.

## What

- **`internal/drbd`**: `KernelVersion()` parses `DRBD_KERNEL_VERSION=` from `drbdadm --version` (sourced from `/proc/drbd`; only meaningful after `KernelAvailable`). `KernelFloor = "9.3.1"`. `BelowKernelFloor()` compares dotted components numerically (`9.10` > `9.3`) and fails closed on anything unparseable.
- **`cmd/main.go`**: a `probeDRBD` helper wraps the existing `KernelAvailable` probe. Module absent stays the graceful local-only downgrade, unchanged. Module present but below 9.3.1 exits with a clear "upgrade the node (Talos >= 1.13.0)" error. A flaked version read logs and skips the check rather than refusing a working node. The probe runs on the storage-node path **and the client-only path** — client legs get DRBD configs rendered there too, so the floor binds on consumer nodes as well. (Helper rather than inline: `main.main` sits at the gocyclo limit.)
- **`MiroirNode.status.drbdVersion`** + a `DRBD` printcolumn, published by `PoolStatsPublisher` from the startup probe (a module change means a node reboot and agent restart, so startup is current enough). `kubectl get miroirnodes` now shows per-node module versions, making mixed clusters visible mid-upgrade.
- **README**: Requirements states the >= 9.3.1 module floor and that Talos >= 1.13.0 ships it; the Talos section leads with the version.
- Regenerated CRD (config + chart copy), deepcopy, applyconfigurations.

## Why the floor is a hard startup failure

Rendering a 9.3.1-era option (`peer-tiebreaker`, bitmap granularity — the #197 follow-ups) against an older module errors drbdadm for every resource on the node. Enforcing the floor once at startup keeps later PRs free to render those options unconditionally, and a crash-looping agent with an explicit log line beats N wedged volumes with obscure drbdadm errors.

**Breaking**: agents refuse to start on nodes with a DRBD module older than 9.3.1. Upgrade Talos to >= 1.13.0 before upgrading miroir on replicated clusters. Nodes without the module at all (local-only) are unaffected.

## Verification

- New unit tests: version parse (including not mismatching `DRBDADM_VERSION`), numeric floor compare (11 cases incl. `9.10.0`, short, and garbage versions), published status field.
- Full `go test ./...`, `golangci-lint`, `go vet`, helm unit tests pass.
- The module-absent startup path is exercised for real by the kind e2e (no DRBD module on kind nodes). The floor-exit path needs real hardware with an old module; it is unit-tested piecewise with thin glue in `probeDRBD`.

Refs #197.
