### PR TITLE
feat(drbd): advertise real discard granularity on client legs

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ Trade-offs to understand:
   floor), so attaching and detaching consumers never moves the
   majority threshold, and a dead consumer node leaves no phantom vote
   behind.
+- **Trims from consumers reach the real backings.** A client leg's
+  device advertises the diskful legs' probed discard granularity
+  (DRBD's diskless default is a 512-byte fiction dm-thin would
+  silently drop), so in-pod `fstrim` and `-o discard` free thin-pool
+  space as if the pod ran on a replica node.
 - **Consumers must run on nodes listed in `nodes`.** Agents only
   start on mapped nodes, so a pod scheduled onto an unmapped node has
   no CSI driver and wedges in `ContainerCreating`. Keep every

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/replicastatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/replicastatus.go
@@ -54,6 +54,12 @@ type ReplicaStatusApplyConfiguration struct {
 	// tie-breaker. Self-reported by the agent so removal handling still
 	// knows after the entry has left spec.replicas.
 	Diskless *bool `json:"diskless,omitempty"`
+	// DiscardGranularityBytes is the discard granularity this diskful
+	// leg probed from its backing device (0: unsupported or unprobed).
+	// Client legs advertise the max over the diskful legs' values, so
+	// trims from remote consumers align with the real backings instead
+	// of the 512-byte default DRBD assumes for diskless devices.
+	DiscardGranularityBytes *int64 `json:"discardGranularityBytes,omitempty"`
 	// DiskFailed latches a diskful leg DRBD detached after a backing I/O
 	// error (on-io-error detach): the agent renders `adjust --skip-disk`
 	// so the next reconcile does not re-attach the failing disk and
@@ -146,6 +152,14 @@ func (b *ReplicaStatusApplyConfiguration) WithSplitBrain(value bool) *ReplicaSta
 // If called multiple times, the Diskless field is set to the value of the last call.
 func (b *ReplicaStatusApplyConfiguration) WithDiskless(value bool) *ReplicaStatusApplyConfiguration {
 	b.Diskless = &value
+	return b
+}
+
+// WithDiscardGranularityBytes sets the DiscardGranularityBytes field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DiscardGranularityBytes field is set to the value of the last call.
+func (b *ReplicaStatusApplyConfiguration) WithDiscardGranularityBytes(value int64) *ReplicaStatusApplyConfiguration {
+	b.DiscardGranularityBytes = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -278,6 +278,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: devicePath
       type:
         scalar: string
+    - name: discardGranularityBytes
+      type:
+        scalar: numeric
     - name: diskFailed
       type:
         scalar: boolean

--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -267,6 +267,13 @@ type ReplicaStatus struct {
 	// knows after the entry has left spec.replicas.
 	// +optional
 	Diskless bool `json:"diskless,omitempty"`
+	// DiscardGranularityBytes is the discard granularity this diskful
+	// leg probed from its backing device (0: unsupported or unprobed).
+	// Client legs advertise the max over the diskful legs' values, so
+	// trims from remote consumers align with the real backings instead
+	// of the 512-byte default DRBD assumes for diskless devices.
+	// +optional
+	DiscardGranularityBytes int64 `json:"discardGranularityBytes,omitempty"`
 	// DiskFailed latches a diskful leg DRBD detached after a backing I/O
 	// error (on-io-error detach): the agent renders `adjust --skip-disk`
 	// so the next reconcile does not re-attach the failing disk and

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -401,6 +401,15 @@ spec:
                         DevicePath is the node-local path pods attach to (backing device for
                         replicas:1; /dev/drbd<minor> when replicated).
                       type: string
+                    discardGranularityBytes:
+                      description: |-
+                        DiscardGranularityBytes is the discard granularity this diskful
+                        leg probed from its backing device (0: unsupported or unprobed).
+                        Client legs advertise the max over the diskful legs' values, so
+                        trims from remote consumers align with the real backings instead
+                        of the 512-byte default DRBD assumes for diskless devices.
+                      format: int64
+                      type: integer
                     diskFailed:
                       description: |-
                         DiskFailed latches a diskful leg DRBD detached after a backing I/O

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -401,6 +401,15 @@ spec:
                         DevicePath is the node-local path pods attach to (backing device for
                         replicas:1; /dev/drbd<minor> when replicated).
                       type: string
+                    discardGranularityBytes:
+                      description: |-
+                        DiscardGranularityBytes is the discard granularity this diskful
+                        leg probed from its backing device (0: unsupported or unprobed).
+                        Client legs advertise the max over the diskful legs' values, so
+                        trims from remote consumers align with the real backings instead
+                        of the 512-byte default DRBD assumes for diskless devices.
+                      format: int64
+                      type: integer
                     diskFailed:
                       description: |-
                         DiskFailed latches a diskful leg DRBD detached after a backing I/O

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -285,17 +285,18 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		recordDisklessMetrics(vol.Name, st.Primary)
 	}
 	if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
-		DeviceCreated: !localDiskless,
-		DevicePath:    drbd.DevicePath(minor),
-		DRBDMinor:     minor,
-		SizeBytes:     reportSize,
-		DiskState:     st.DiskState,
-		Connected:     connected,
-		SplitBrain:    st.SplitBrain,
-		Diskless:      localDiskless,
-		DiskFailed:    diskFailed,
-		Message:       detachedDiskMessage(diskFailed),
-		PrimarySince:  primarySince(vol, r.NodeName, st.Primary),
+		DeviceCreated:           !localDiskless,
+		DevicePath:              drbd.DevicePath(minor),
+		DRBDMinor:               minor,
+		SizeBytes:               reportSize,
+		DiskState:               st.DiskState,
+		Connected:               connected,
+		SplitBrain:              st.SplitBrain,
+		Diskless:                localDiskless,
+		DiskFailed:              diskFailed,
+		DiscardGranularityBytes: discardGranularity,
+		Message:                 detachedDiskMessage(diskFailed),
+		PrimarySince:            primarySince(vol, r.NodeName, st.Primary),
 	}); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -525,6 +526,20 @@ func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string,
 			Client:   true,
 		})
 	}
+	// A client leg's device advertises the diskful legs' real discard
+	// granularity (max: aligned for the coarsest backing works on all)
+	// instead of the 512-byte default DRBD assumes for diskless devices —
+	// dm-thin silently drops sub-chunk discards, so trims sized to the
+	// default under-free thin pools. 0 (peers not yet published) renders
+	// nothing and keeps DRBD's default.
+	var clientDiscard int64
+	if vol.Spec.ClientForNode(localNode) != nil {
+		for _, rep := range vol.Spec.Replicas {
+			if !rep.Diskless {
+				clientDiscard = max(clientDiscard, vol.Status.PerNode[rep.Node].DiscardGranularityBytes)
+			}
+		}
+	}
 	return drbd.Resource{
 		Name:          vol.Name,
 		Minor:         minor,
@@ -537,10 +552,11 @@ func drbdResource(vol *miroirv1alpha1.MiroirVolume, localNode, localDisk string,
 		// Latched failed: render adjust --skip-disk so the failing disk is
 		// not re-attached. Read from prior status, so it lags the detach by
 		// one reconcile. Cleared by a replica re-add (removal drops the slot).
-		SkipDiskAttach:          !localDiskless && vol.Status.PerNode[localNode].DiskFailed,
-		DiscardGranularityBytes: discardGranularity,
-		BitmapGranularityBytes:  vol.Spec.DRBD.BitmapGranularityBytes,
-		Peers:                   peers,
+		SkipDiskAttach:                !localDiskless && vol.Status.PerNode[localNode].DiskFailed,
+		DiscardGranularityBytes:       discardGranularity,
+		ClientDiscardGranularityBytes: clientDiscard,
+		BitmapGranularityBytes:        vol.Spec.DRBD.BitmapGranularityBytes,
+		Peers:                         peers,
 	}
 }
 
@@ -911,6 +927,9 @@ func replicaStatusAC(st miroirv1alpha1.ReplicaStatus) *acv1alpha1.ReplicaStatusA
 	}
 	if st.DiskFailed {
 		ac = ac.WithDiskFailed(true)
+	}
+	if st.DiscardGranularityBytes != 0 {
+		ac = ac.WithDiscardGranularityBytes(st.DiscardGranularityBytes)
 	}
 	if st.Message != "" {
 		ac = ac.WithMessage(st.Message)

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -2151,6 +2151,26 @@ func TestDrbdResourceBitmapGranularity(t *testing.T) {
 	}
 }
 
+// A client leg advertises the max of the diskful legs' published discard
+// granularities (mixed backends: aligned for the coarsest works on all);
+// replicas and tie-breakers advertise nothing.
+func TestDrbdResourceClientDiscardGranularity(t *testing.T) {
+	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeOslo, NodeID: 2, Address: addrOslo}}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DiscardGranularityBytes: 262144}, // lvmthin chunk
+		nodeParis:   {DiscardGranularityBytes: 16384},  // zvol block
+	}
+
+	if r := drbdResource(v, nodeOslo, "", 1000, true, 0); r.ClientDiscardGranularityBytes != 262144 {
+		t.Fatalf("client granularity = %d, want max(peers) 262144", r.ClientDiscardGranularityBytes)
+	}
+	if r := drbdResource(v, nodeKharkiv, "/dev/vg/pvc-1", 1000, false, 262144); r.ClientDiscardGranularityBytes != 0 {
+		t.Fatalf("a replica must not advertise a client granularity, got %d", r.ClientDiscardGranularityBytes)
+	}
+}
+
 // A client leg (spec.clients) realizes exactly like a diskless
 // tie-breaker: no backing device, DRBD adjust with disk none, and a status
 // slot marked Diskless so CSI can gate staging on the peers' health.
@@ -2163,6 +2183,11 @@ func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
 	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeOslo, NodeID: 2, Address: addrOslo}}
 	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeOslo)
+	// A diskful peer has published its backing's discard granularity; the
+	// client's device must advertise it (see the .res assertion below).
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeKharkiv: {DiscardGranularityBytes: 262144},
+	}
 
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateDiskless + `"}],
@@ -2185,13 +2210,18 @@ func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 	fe.notCalledWith(t, "drbdmeta")
 
 	// The rendered config must exclude the client from quorum voting —
-	// exactly once, on the client's own entry, never on the replicas.
+	// exactly once, on the client's own entry, never on the replicas —
+	// and advertise the diskful peers' discard granularity (the status
+	// fixture publishes kharkiv's 262144) on the local device.
 	res, err := os.ReadFile(filepath.Join(r.DRBD.StateDir, volPvc1+".res"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if n := strings.Count(string(res), "tiebreaker no;"); n != 1 {
 		t.Fatalf("client leg must render tiebreaker no exactly once, got %d:\n%s", n, res)
+	}
+	if !strings.Contains(string(res), "discard-granularity 262144;") {
+		t.Fatalf("client leg must advertise the peers' discard granularity:\n%s", res)
 	}
 
 	got := &miroirv1alpha1.MiroirVolume{}

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -36,6 +36,7 @@ const (
 	addrKharkiv        = "192.168.1.41"
 	addrParis          = "192.168.1.42"
 	addrOslo           = "192.168.1.43"
+	nodeWorker1        = "worker-1"
 )
 
 func testResource(local string) Resource {
@@ -120,7 +121,7 @@ func TestRenderClientLegNoTiebreaker(t *testing.T) {
 	r := testResource(nodeKharkiv)
 	r.Peers = append(r.Peers,
 		Peer{Node: "tiebreak-1", NodeID: 2, Address: addrOslo, Diskless: true},
-		Peer{Node: "worker-1", NodeID: 3, Address: "192.168.1.44", Diskless: true, Client: true},
+		Peer{Node: nodeWorker1, NodeID: 3, Address: "192.168.1.44", Diskless: true, Client: true},
 	)
 	out := Render(r)
 	if n := strings.Count(out, "tiebreaker no;"); n != 1 {
@@ -129,6 +130,41 @@ func TestRenderClientLegNoTiebreaker(t *testing.T) {
 	client := out[strings.Index(out, `on "worker-1"`):]
 	if !strings.Contains(client[:strings.Index(client, "}")+1], "tiebreaker no;") {
 		t.Fatalf("tiebreaker no must sit in the client's volume block:\n%s", out)
+	}
+}
+
+// A client leg rendered on its own node advertises the diskful legs'
+// discard granularity; rendered anywhere else (or unset) it must not.
+func TestRenderClientDiscardGranularity(t *testing.T) {
+	r := testResource(nodeKharkiv)
+	r.Peers = append(r.Peers,
+		Peer{Node: nodeWorker1, NodeID: 2, Address: addrOslo, Diskless: true, Client: true},
+	)
+	r.ClientDiscardGranularityBytes = 65536
+
+	// Rendered on a replica node: the option belongs to the client's
+	// device, not this one — nothing renders even with the value set.
+	if out := Render(r); strings.Contains(out, "discard-granularity") {
+		t.Fatalf("non-client local must not render discard-granularity:\n%s", out)
+	}
+
+	r.LocalNode = nodeWorker1
+	r.LocalDiskless = true
+	r.LocalDisk = ""
+	// The resync knob must stay diskful-only even when its value is set.
+	r.DiscardGranularityBytes = 4096
+	out := Render(r)
+	if !strings.Contains(out, "discard-granularity 65536;") {
+		t.Fatalf("client local must advertise the peers' granularity:\n%s", out)
+	}
+	if strings.Contains(out, "rs-discard-granularity") {
+		t.Fatalf("diskless local must not render the resync knob:\n%s", out)
+	}
+	r.DiscardGranularityBytes = 0
+
+	r.ClientDiscardGranularityBytes = 0
+	if out := Render(r); strings.Contains(out, "discard-granularity") {
+		t.Fatalf("zero must render nothing (keep the kernel heuristic):\n%s", out)
 	}
 }
 

--- a/internal/drbd/res.go
+++ b/internal/drbd/res.go
@@ -70,6 +70,13 @@ type Resource struct {
 	// Probed from the backing device; never set for loopfile (loop devices
 	// mishandle it). Overrides the cluster-wide common{} knob.
 	DiscardGranularityBytes int64
+	// ClientDiscardGranularityBytes renders discard-granularity in the
+	// local client leg's disk{} options: the diskless device advertises
+	// this to the filesystem instead of DRBD's 512-byte diskless default,
+	// so consumer-side mkfs/fstrim discards align with the diskful legs'
+	// real backings. 0 renders nothing (keeps the kernel heuristic).
+	// Needs kmod ≥ 9.3.1 / utils ≥ 9.34 — the agent's startup floor.
+	ClientDiscardGranularityBytes int64
 	// BitmapGranularityBytes is passed to create-md as
 	// --bitmap-block-size (0 passes nothing, DRBD defaults to 4k). Not
 	// rendered into the .res: it is an on-disk metadata property fixed
@@ -162,6 +169,14 @@ func Render(r Resource) string {
 				// replicas keep the default yes. Needs drbd-utils ≥ 9.34
 				// and kmod ≥ 9.3.1 — the agent's startup floor.
 				b.WriteString("            tiebreaker no;\n")
+			}
+			// A second disk statement is legal: the string form (none)
+			// and the options form fill different config fields — the
+			// same shape the diskful branch uses for rs-discard-granularity.
+			if p.Node == r.LocalNode && r.ClientDiscardGranularityBytes > 0 {
+				b.WriteString("            disk {\n")
+				fmt.Fprintf(&b, "                discard-granularity %d;\n", r.ClientDiscardGranularityBytes)
+				b.WriteString("            }\n")
 			}
 		} else {
 			disk := peerDiskPlaceholder


### PR DESCRIPTION
Implements the final #197 item, per the evaluation posted there (https://github.com/home-operations/miroir/issues/197#issuecomment-4975736801).

## Problem

A diskless DRBD device advertises discards at a hardcoded **512-byte granularity** (`drbd_nl.c` legacy heuristic: peers speak `DRBD_FF_TRIM` → granularity 512; a diskful device stacks its real backing limits on top, a diskless device has nothing to stack). That's a fiction for thin backings — dm-thin silently drops discards smaller than its chunk — so consumer-side `mkfs`, `-o discard`, and in-pod `fstrim` over a client leg under-free thin pools. Inefficiency, not corruption, but it means remote consumers quietly defeat trim.

## What

- Diskful agents publish their probed backing discard granularity (the existing lsblk probe that feeds `rs-discard-granularity`) in the volume's per-node status slot: `ReplicaStatus.discardGranularityBytes`.
- A client leg's render sets the DRBD 9.3.1 **device option** `discard-granularity` to the **max** over the diskful legs' published values — aligned for the coarsest backing works on all, which is what mixed clusters (lvmthin + zfs) need. The kernel comment for this option names the exact use case: "LINSTOR knows the real granularity from storage pool info and configures it for diskless primaries."
- Absent/zero values render nothing, keeping the kernel heuristic — rendering `0` would disable discards outright, which is worse.

The evaluation's open question is settled from the drbdadm parser source: a second `disk` statement in a volume block is legal (the string form and the options-block form fill different config fields — the same shape the diskful branch already uses for `rs-discard-granularity`), so `disk none;` + `disk { discard-granularity N; }` parses fine.

## Rollout

- Applies live: existing client legs pick it up at the next adjust; no migration.
- Post-upgrade transient: a client leg created before its volume's replicas have re-reconciled on this version renders without the option (peers haven't published yet) and keeps the 512-byte heuristic — the pre-existing behavior, self-healing on the next generation bump.
- kmod >= 9.3.1 / utils >= 9.34 required — guaranteed by the #198 floor and #196 image.

## Verification

- Render test: option appears only on the client's own node's render (a replica rendering the same volume emits nothing), `rs-discard-granularity` stays diskful-only, zero renders nothing.
- `drbdResource` test: max over per-node published values (262144 lvmthin vs 16384 zvol → 262144), replicas never advertise a client granularity.
- The end-to-end client-leg reconciler test now also asserts the written `.res` contains `discard-granularity 262144;` from a published peer slot.
- Full `go test ./...`, `golangci-lint` (0 issues), chart tests pass; CRDs/applyconfigurations regenerated. README "Remote consumers" gains the corresponding bullet.

Closes the last #197 checklist item. Refs #197.
