### PR TITLE
refactor: semver-based kernel floor compare, generic test node names

### DIFF
--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -8,7 +8,7 @@ tests:
   - it: renders a DaemonSet with the agent + node-driver-registrar
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     asserts:
@@ -42,7 +42,7 @@ tests:
   - it: agent container runs with mode=agent and a privileged securityContext
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     documentIndex: 0
@@ -84,7 +84,7 @@ tests:
   - it: pod runs with hostNetwork, hostPID and ClusterFirstWithHostNet
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     documentIndex: 0
@@ -117,7 +117,7 @@ tests:
     set:
       agent.kubeletDir: /var/snap/kubelet
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     documentIndex: 0
@@ -141,10 +141,10 @@ tests:
   - it: with no loopfile nodes, no loopfile mount or volume is rendered
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
-        paris:
+        node-b:
           backend: zfs
           zfsDataset: data-pool/miroir
     documentIndex: 0
@@ -159,13 +159,13 @@ tests:
   - it: adds one identity-mounted loopfile mount and hostPath volume per baseDir
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
-        paris:
+        node-b:
           backend: zfs
           zfsDataset: data-pool/miroir
-        le-havre:
+        node-c:
           backend: loopfile
           baseDir: /var/lib/miroir
         backup:
@@ -237,7 +237,7 @@ tests:
   - it: pins the agent image by digest when set, overriding the tag
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       agent:
@@ -253,7 +253,7 @@ tests:
   - it: applies global pull secrets but not global scheduling (agent runs everywhere)
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       global:
@@ -272,7 +272,7 @@ tests:
   - it: wires agent pod metadata and extra args/env after NODE_NAME
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       agent:
@@ -301,7 +301,7 @@ tests:
   - it: omits --verify-schedule by default
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     documentIndex: 0
@@ -313,7 +313,7 @@ tests:
   - it: passes --verify-schedule when a schedule is set
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       drbd:
@@ -328,7 +328,7 @@ tests:
   - it: omits --verify-schedule while suspended
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       drbd:
@@ -344,7 +344,7 @@ tests:
   - it: fails when a verify schedule is set without an algorithm
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       drbd:

--- a/charts/miroir/tests/configmap_test.yaml
+++ b/charts/miroir/tests/configmap_test.yaml
@@ -15,10 +15,10 @@ tests:
   - it: renders the nodes ConfigMap and the drbd ConfigMap
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
-        paris:
+        node-b:
           backend: zfs
           zfsDataset: data-pool/miroir
     asserts:
@@ -52,10 +52,10 @@ tests:
   - it: embeds the per-node topology in miroir-nodes as YAML
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
-        paris:
+        node-b:
           backend: zfs
           zfsDataset: data-pool/miroir
     documentIndex: 0
@@ -76,7 +76,7 @@ tests:
   - it: keeps the drbd global config to usage-count no and an empty common{}
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     documentIndex: 1
@@ -113,7 +113,7 @@ tests:
   - it: renders cluster-wide resync tuning into common{} when set
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       drbd:
@@ -145,7 +145,7 @@ tests:
   - it: renders discard granularity and verify-alg when set
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       drbd:
@@ -165,7 +165,7 @@ tests:
   - it: default emits no discard granularity (loopfile-unsafe, opt-in)
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     documentIndex: 1
@@ -180,7 +180,7 @@ tests:
       namespace: storage
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     asserts:
@@ -196,7 +196,7 @@ tests:
   - it: fails loudly when the pre-0.7 drbd.verifyAlg key is still set
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
       drbd:

--- a/charts/miroir/tests/helpers_test.yaml
+++ b/charts/miroir/tests/helpers_test.yaml
@@ -11,7 +11,7 @@ tests:
     set:
       nameOverride: alt
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: csidriver.tpl
@@ -25,7 +25,7 @@ tests:
     set:
       nameOverride: alt
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: controller.tpl
@@ -39,7 +39,7 @@ tests:
     set:
       nameOverride: alt
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: agent.tpl
@@ -53,7 +53,7 @@ tests:
     set:
       fullnameOverride: storage
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: controller.tpl
@@ -67,7 +67,7 @@ tests:
     set:
       fullnameOverride: storage
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: agent.tpl
@@ -93,7 +93,7 @@ tests:
       namespace: miroir-system
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: controller.tpl
@@ -109,7 +109,7 @@ tests:
       namespace: miroir-system
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: agent.tpl
@@ -122,7 +122,7 @@ tests:
   - it: every workload carries the standard label set
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: controller.tpl
@@ -147,7 +147,7 @@ tests:
   - it: Deployment matchLabels only carry the immutable selector set
     set:
       nodes:
-        kharkiv:
+        node-a:
           backend: lvmthin
           device: /dev/disk/by-partlabel/r-miroir
     template: controller.tpl

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/home-operations/miroir
 go 1.26.3
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.32.0
@@ -23,7 +24,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/agent/cordon_test.go
+++ b/internal/agent/cordon_test.go
@@ -33,16 +33,16 @@ func TestCordonWatcherTracksUnschedulable(t *testing.T) {
 		t.Fatal(err)
 	}
 	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeKharkiv},
+		ObjectMeta: metav1.ObjectMeta{Name: nodeA},
 		Spec:       corev1.NodeSpec{Unschedulable: true},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(node).Build()
-	w := &CordonWatcher{Client: c, NodeName: nodeKharkiv}
+	w := &CordonWatcher{Client: c, NodeName: nodeA}
 
 	if w.Cordoned() {
 		t.Fatal("must default to not cordoned before any observation")
 	}
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: nodeKharkiv}}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: nodeA}}
 	if _, err := w.Reconcile(t.Context(), req); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/poolstats_test.go
+++ b/internal/agent/poolstats_test.go
@@ -41,14 +41,14 @@ func newPublisher(t *testing.T, fb *fakeBackend, rec events.EventRecorder) (*Poo
 		Build()
 	p := &PoolStatsPublisher{
 		Client:      c,
-		NodeName:    nodeKharkiv,
+		NodeName:    nodeA,
 		Backend:     fb,
 		BackendType: miroirv1alpha1.BackendLVMThin,
 		Recorder:    rec,
 	}
 	get := func() *miroirv1alpha1.MiroirNode {
 		n := &miroirv1alpha1.MiroirNode{}
-		if err := c.Get(t.Context(), types.NamespacedName{Name: nodeKharkiv}, n); err != nil {
+		if err := c.Get(t.Context(), types.NamespacedName{Name: nodeA}, n); err != nil {
 			t.Fatal(err)
 		}
 		return n

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -44,17 +44,17 @@ import (
 )
 
 const (
-	nodeKharkiv           = "kharkiv"
-	nodeParis             = "paris"
-	addrKharkiv           = "192.168.1.41"
-	addrParis             = "192.168.1.42"
+	nodeA                 = "node-a"
+	nodeB                 = "node-b"
+	addrA                 = "192.168.1.41"
+	addrB                 = "192.168.1.42"
 	volPvc1               = "pvc-1"
 	snapSnap1             = "snap-1"
 	diskStateUpToDate     = "UpToDate"
 	diskStateInconsistent = "Inconsistent"
 	diskStateDiskless     = "Diskless"
-	nodeOslo              = "oslo"
-	addrOslo              = "192.168.1.43"
+	nodeC                 = "node-c"
+	addrC                 = "192.168.1.43"
 )
 
 // fakeBackend records calls and simulates a thin pool in memory.
@@ -179,10 +179,10 @@ func TestReconcileRealizesReplica(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(vol(volPvc1, nodeKharkiv)).
+		WithObjects(vol(volPvc1, nodeA)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	reconcile(t, r, volPvc1)
 
@@ -196,7 +196,7 @@ func TestReconcileRealizesReplica(t *testing.T) {
 	if got.Status.Phase != miroirv1alpha1.VolumeReady {
 		t.Fatalf("phase = %s, want Ready (status %+v)", got.Status.Phase, got.Status.PerNode)
 	}
-	if got.Status.PerNode[nodeKharkiv].DevicePath != "/dev/fake/pvc-1" {
+	if got.Status.PerNode[nodeA].DevicePath != "/dev/fake/pvc-1" {
 		t.Fatalf("unexpected status %+v", got.Status.PerNode)
 	}
 	// No peers means fully in sync: the zero value would perma-fire any
@@ -210,10 +210,10 @@ func TestReconcileIgnoresForeignVolume(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(vol(volPvc1, "paris")).
+		WithObjects(vol(volPvc1, "node-b")).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	reconcile(t, r, volPvc1)
 
@@ -227,10 +227,10 @@ func TestReconcileReportsBackendError(t *testing.T) {
 	fb := newFakeBackend()
 	fb.failOn = "create"
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(vol(volPvc1, nodeKharkiv)).
+		WithObjects(vol(volPvc1, nodeA)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	_, err := r.Reconcile(t.Context(),
 		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
@@ -245,7 +245,7 @@ func TestReconcileReportsBackendError(t *testing.T) {
 	if got.Status.Phase != miroirv1alpha1.VolumeFailed {
 		t.Fatalf("phase = %s, want Failed", got.Status.Phase)
 	}
-	if got.Status.PerNode[nodeKharkiv].Message == "" {
+	if got.Status.PerNode[nodeA].Message == "" {
 		t.Fatal("error message must be reported in status")
 	}
 }
@@ -256,14 +256,14 @@ func TestReconcileSourceSnapshotGoneRecoversBacking(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true // backing survived the reboot
-	v := vol(volPvc1, nodeKharkiv)
+	v := vol(volPvc1, nodeA)
 	v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-deleted"}
 	// No MiroirSnapshot object in the client: it has been garbage-collected.
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	reconcile(t, r, volPvc1)
 
@@ -280,7 +280,7 @@ func TestReconcileSourceSnapshotGoneRecoversBacking(t *testing.T) {
 	if got.Status.Phase != miroirv1alpha1.VolumeReady {
 		t.Fatalf("phase = %s, want Ready (status %+v)", got.Status.Phase, got.Status.PerNode)
 	}
-	if got.Status.PerNode[nodeKharkiv].DevicePath != "/dev/fake/pvc-1" {
+	if got.Status.PerNode[nodeA].DevicePath != "/dev/fake/pvc-1" {
 		t.Fatalf("backing not recovered: %+v", got.Status.PerNode)
 	}
 }
@@ -290,13 +290,13 @@ func TestReconcileSourceSnapshotGoneRecoversBacking(t *testing.T) {
 func TestReconcileSourceSnapshotGoneAndDeviceMissingFails(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend() // no existing device
-	v := vol(volPvc1, nodeKharkiv)
+	v := vol(volPvc1, nodeA)
 	v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-deleted"}
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	_, err := r.Reconcile(t.Context(),
 		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
@@ -312,19 +312,19 @@ func TestReconcileSourceSnapshotGoneAndDeviceMissingFails(t *testing.T) {
 func TestReconcileReplicatedVolume(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, "paris")
+	v := vol(volPvc1, nodeA, "node-b")
 	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 
 	stateDir := t.TempDir()
 	// Pre-seed .res so assignMinor → AllocateMinor picks minor 1000.
 	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
 		"resource \"pvc-1\" {\n"+
-			"    on \"kharkiv\" {\n"+
+			"    on \"node-a\" {\n"+
 			"        device minor 1000;\n"+
 			"    }\n"+
 			"}\n",
@@ -340,7 +340,7 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -361,7 +361,7 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	st := got.Status.PerNode[nodeKharkiv]
+	st := got.Status.PerNode[nodeA]
 	if st.DevicePath != "/dev/drbd1000" {
 		t.Fatalf("pods must attach the DRBD device, got %q", st.DevicePath)
 	}
@@ -379,7 +379,7 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 	// Peer reports its leg; the next coordinator pass grows DRBD and
 	// publishes the size.
 	base := got.DeepCopy()
-	got.Status.PerNode["paris"] = miroirv1alpha1.ReplicaStatus{
+	got.Status.PerNode["node-b"] = miroirv1alpha1.ReplicaStatus{
 		DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true,
 	}
 	if err := c.Status().Patch(t.Context(), got, client.MergeFrom(base)); err != nil {
@@ -393,8 +393,8 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Status.PerNode[nodeKharkiv].SizeBytes != 1<<30 {
-		t.Fatalf("size must publish after DRBD resize, got %d", got.Status.PerNode[nodeKharkiv].SizeBytes)
+	if got.Status.PerNode[nodeA].SizeBytes != 1<<30 {
+		t.Fatalf("size must publish after DRBD resize, got %d", got.Status.PerNode[nodeA].SizeBytes)
 	}
 	if got.Status.Phase != miroirv1alpha1.VolumeReady {
 		t.Fatalf("phase = %s, want Ready with both legs UpToDate", got.Status.Phase)
@@ -410,22 +410,22 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 func TestReconcile_StatusApplyScopedToOwnSlot(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 	// A peer slot and a CSI-owned Formatted flag this agent must not touch.
 	v.Status.Formatted = true
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeParis: {DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true},
+		nodeB: {DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true},
 	}
 
 	stateDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
-		"resource \"pvc-1\" {\n    on \"kharkiv\" {\n        device minor 1000;\n    }\n}\n",
+		"resource \"pvc-1\" {\n    on \"node-a\" {\n        device minor 1000;\n    }\n}\n",
 	), 0o640); err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +448,7 @@ func TestReconcile_StatusApplyScopedToOwnSlot(t *testing.T) {
 		}).
 		Build()
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -461,10 +461,10 @@ func TestReconcile_StatusApplyScopedToOwnSlot(t *testing.T) {
 		t.Fatal("expected at least one server-side apply of status")
 	}
 	for i, st := range applies {
-		if _, ok := st.PerNode[nodeKharkiv]; !ok {
+		if _, ok := st.PerNode[nodeA]; !ok {
 			t.Errorf("apply %d omits this node's slot: %+v", i, st.PerNode)
 		}
-		if _, ok := st.PerNode[nodeParis]; ok {
+		if _, ok := st.PerNode[nodeB]; ok {
 			t.Errorf("apply %d names the peer's slot (would force-own it): %+v", i, st.PerNode)
 		}
 		if st.Formatted != nil {
@@ -476,17 +476,17 @@ func TestReconcile_StatusApplyScopedToOwnSlot(t *testing.T) {
 func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, "paris")
+	v := vol(volPvc1, nodeA, "node-b")
 	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 
 	stateDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
-		"resource \"pvc-1\" {\n    on \"kharkiv\" {\n        device minor 1000;\n    }\n}\n",
+		"resource \"pvc-1\" {\n    on \"node-a\" {\n        device minor 1000;\n    }\n}\n",
 	), 0o640); err != nil {
 		t.Fatal(err)
 	}
@@ -501,7 +501,7 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -511,7 +511,7 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 	}
 	base := got.DeepCopy()
 	got.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		"paris": {DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true},
+		"node-b": {DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true},
 	}
 	if err := c.Status().Patch(t.Context(), got, client.MergeFrom(base)); err != nil {
 		t.Fatal(err)
@@ -525,8 +525,8 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Status.PerNode[nodeKharkiv].SizeBytes != 0 {
-		t.Fatalf("size must be withheld while resyncing, got %d", got.Status.PerNode[nodeKharkiv].SizeBytes)
+	if got.Status.PerNode[nodeA].SizeBytes != 0 {
+		t.Fatalf("size must be withheld while resyncing, got %d", got.Status.PerNode[nodeA].SizeBytes)
 	}
 
 	// Resync completes: the next pass grows DRBD and publishes the size.
@@ -541,25 +541,25 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Status.PerNode[nodeKharkiv].SizeBytes != 1<<30 {
-		t.Fatalf("size must publish once the resync clears, got %d", got.Status.PerNode[nodeKharkiv].SizeBytes)
+	if got.Status.PerNode[nodeA].SizeBytes != 1<<30 {
+		t.Fatalf("size must publish once the resync clears, got %d", got.Status.PerNode[nodeA].SizeBytes)
 	}
 }
 
 func TestReconcile_ResizeRaceWithResyncIsTransient(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, "paris")
+	v := vol(volPvc1, nodeA, "node-b")
 	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 
 	stateDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
-		"resource \"pvc-1\" {\n    on \"kharkiv\" {\n        device minor 1000;\n    }\n}\n",
+		"resource \"pvc-1\" {\n    on \"node-a\" {\n        device minor 1000;\n    }\n}\n",
 	), 0o640); err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +579,7 @@ func TestReconcile_ResizeRaceWithResyncIsTransient(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -589,7 +589,7 @@ func TestReconcile_ResizeRaceWithResyncIsTransient(t *testing.T) {
 	}
 	base := got.DeepCopy()
 	got.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		"paris": {DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true},
+		"node-b": {DeviceCreated: true, SizeBytes: 1 << 30, DiskState: diskStateUpToDate, Connected: true},
 	}
 	if err := c.Status().Patch(t.Context(), got, client.MergeFrom(base)); err != nil {
 		t.Fatal(err)
@@ -607,8 +607,8 @@ func TestReconcile_ResizeRaceWithResyncIsTransient(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Status.PerNode[nodeKharkiv].SizeBytes != 0 {
-		t.Fatalf("size must be withheld until the resize succeeds, got %d", got.Status.PerNode[nodeKharkiv].SizeBytes)
+	if got.Status.PerNode[nodeA].SizeBytes != 0 {
+		t.Fatalf("size must be withheld until the resize succeeds, got %d", got.Status.PerNode[nodeA].SizeBytes)
 	}
 }
 
@@ -676,14 +676,14 @@ func (f *fakeDRBDExec) notCalledWith(t *testing.T, substr string) {
 func TestReconcileForeignAgentLeavesFinalizerOnDelete(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, "paris") // replica on paris...
+	v := vol(volPvc1, "node-b") // replica on node-b...
 	now := metav1.NewTime(time.Now())
 	v.DeletionTimestamp = &now
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb} // ...agent on kharkiv
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb} // ...agent on node-a
 
 	reconcile(t, r, volPvc1)
 
@@ -699,14 +699,14 @@ func TestReconcileForeignAgentLeavesFinalizerOnDelete(t *testing.T) {
 func TestReconcileTeardownOnDelete(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv)
+	v := vol(volPvc1, nodeA)
 	now := metav1.NewTime(time.Now())
 	v.DeletionTimestamp = &now
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	// Pre-create the device so teardown has something to remove.
 	if _, err := fb.Create(t.Context(), volPvc1, 1<<30); err != nil {
@@ -733,17 +733,17 @@ func TestReconcileTeardownOnDelete(t *testing.T) {
 func TestReconcileTeardownDeletesDespiteDetachedDiskState(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv)
+	v := vol(volPvc1, nodeA)
 	now := metav1.NewTime(time.Now())
 	v.DeletionTimestamp = &now
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateDiskless},
+		nodeA: {DeviceCreated: true, DiskState: diskStateDiskless},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	if _, err := fb.Create(t.Context(), volPvc1, 1<<30); err != nil {
 		t.Fatal(err)
@@ -762,12 +762,12 @@ func TestReconcileTeardownDeletesDespiteDetachedDiskState(t *testing.T) {
 func TestReconcileTeardownWipesMetadata(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	now := metav1.NewTime(time.Now())
 	v.DeletionTimestamp = &now
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DRBDMinor: 1000},
+		nodeA: {DeviceCreated: true, DRBDMinor: 1000},
 	}
 	stateDir := t.TempDir()
 	// A .res must exist or Down short-circuits as never-configured.
@@ -778,7 +778,7 @@ func TestReconcileTeardownWipesMetadata(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
 	fe := &fakeDRBDExec{}
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 	if _, err := fb.Create(t.Context(), volPvc1, 1<<30); err != nil {
@@ -798,12 +798,12 @@ func TestReconcileTeardownWipesMetadata(t *testing.T) {
 func TestReconcileTeardownDisklessSkipsWipe(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	now := metav1.NewTime(time.Now())
 	v.DeletionTimestamp = &now
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {Diskless: true},
+		nodeA: {Diskless: true},
 	}
 	stateDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte("resource \"pvc-1\" {}\n"), 0o640); err != nil {
@@ -813,7 +813,7 @@ func TestReconcileTeardownDisklessSkipsWipe(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
 	fe := &fakeDRBDExec{}
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -829,7 +829,7 @@ func TestReconcileTeardownDisklessSkipsWipe(t *testing.T) {
 func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	now := metav1.NewTime(time.Now())
 	v.DeletionTimestamp = &now
@@ -844,7 +844,7 @@ func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 		"drbdsetup down pvc-1": errors.New("pvc-1: State change failed: Device is held open by someone"),
 	}}
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeKharkiv, Backend: fb,
+		Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -868,13 +868,13 @@ func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 // Degraded, not hard-Failed.
 func TestReconcileDetachedDiskGetsActionableMessage(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	// The leg was UpToDate before the disk errored.
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
 	}
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
@@ -884,7 +884,7 @@ func TestReconcileDetachedDiskGetsActionableMessage(t *testing.T) {
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"Diskless"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
@@ -893,7 +893,7 @@ func TestReconcileDetachedDiskGetsActionableMessage(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	st := got.Status.PerNode[nodeKharkiv]
+	st := got.Status.PerNode[nodeA]
 	if !strings.Contains(st.Message, "detached") {
 		t.Fatalf("detached leg must carry an actionable message: %q", st.Message)
 	}
@@ -916,13 +916,13 @@ func TestReconcileDetachedDiskGetsActionableMessage(t *testing.T) {
 // Diskless, and clears only on a replica re-add.
 func TestReconcileLatchedDiskSkipsReAttach(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	// Already latched by a prior reconcile: Diskless and DiskFailed.
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateDiskless, DiskFailed: true, SizeBytes: 1 << 30},
+		nodeA: {DeviceCreated: true, DiskState: diskStateDiskless, DiskFailed: true, SizeBytes: 1 << 30},
 	}
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
@@ -931,7 +931,7 @@ func TestReconcileLatchedDiskSkipsReAttach(t *testing.T) {
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"Diskless"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
@@ -943,7 +943,7 @@ func TestReconcileLatchedDiskSkipsReAttach(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if st := got.Status.PerNode[nodeKharkiv]; !st.DiskFailed {
+	if st := got.Status.PerNode[nodeA]; !st.DiskFailed {
 		t.Fatalf("latch must stay set while the leg is Diskless: %+v", st)
 	}
 	// The latch is the actionable hardware-failure alert signal.
@@ -957,16 +957,16 @@ func TestReconcileLatchedDiskSkipsReAttach(t *testing.T) {
 // reconcile error-loops on a resize the diskless node can never do.
 func TestReconcileLatchedCoordinatorSkipsResize(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.SizeBytes = 2 << 30 // grown; the coordinator is behind
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
-	// kharkiv is replicas[0] (coordinator), latched failed and still at the
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
+	// node-a is replicas[0] (coordinator), latched failed and still at the
 	// old size.
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateDiskless, DiskFailed: true, SizeBytes: 1 << 30},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 2 << 30},
+		nodeA: {DeviceCreated: true, DiskState: diskStateDiskless, DiskFailed: true, SizeBytes: 1 << 30},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 2 << 30},
 	}
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
@@ -975,7 +975,7 @@ func TestReconcileLatchedCoordinatorSkipsResize(t *testing.T) {
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"Diskless"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
@@ -987,12 +987,12 @@ func TestReconcileLatchedCoordinatorSkipsResize(t *testing.T) {
 // workloads hanging" from a benign peer outage. The gauge must go 0.
 func TestReconcileQuorumLostExportsGauge(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
 	}
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
@@ -1001,7 +1001,7 @@ func TestReconcileQuorumLostExportsGauge(t *testing.T) {
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"UpToDate","quorum":false}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connecting"}]}]`}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
@@ -1019,14 +1019,14 @@ func TestReconcileQuorumLostExportsGauge(t *testing.T) {
 // size already matches the spec — the steady state, every poll.
 func TestReconcileResizeCoordinatorSkipsWhenAtSize(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
-	// kharkiv is replicas[0] (the coordinator) and already at spec size.
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
+	// node-a is replicas[0] (the coordinator) and already at spec size.
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
 	}
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
@@ -1035,7 +1035,7 @@ func TestReconcileResizeCoordinatorSkipsWhenAtSize(t *testing.T) {
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
@@ -1048,13 +1048,13 @@ func TestReconcileResizeCoordinatorSkipsWhenAtSize(t *testing.T) {
 // never-written and auto-discard a leg.
 func TestReconcilePrimaryLatchesActivated(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
 	}
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
@@ -1064,7 +1064,7 @@ func TestReconcilePrimaryLatchesActivated(t *testing.T) {
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected",
 		"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
@@ -1082,10 +1082,10 @@ func TestReconcilePrimaryLatchesActivated(t *testing.T) {
 // split-brain auto-recovery.
 func TestReconcileSecondaryDoesNotLatchActivated(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
@@ -1094,7 +1094,7 @@ func TestReconcileSecondaryDoesNotLatchActivated(t *testing.T) {
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected",
 		"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
@@ -1115,12 +1115,12 @@ func TestReconcileSecondaryDoesNotLatchActivated(t *testing.T) {
 // be gone entirely), and DRBD full-syncs its content anyway.
 func TestRealizeBackingFullSyncJoinerCreatesFresh(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-gone"}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
 	fb := newFakeBackend()
-	r := &VolumeReconciler{Client: c, NodeName: nodeParis, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeB, Backend: fb}
 
 	if _, err := r.realizeBacking(t.Context(), v, true); err != nil {
 		t.Fatal(err)
@@ -1139,15 +1139,15 @@ func TestRealizeBackingFullSyncJoinerCreatesFresh(t *testing.T) {
 // first handshake instead of posing as the peers' identical twin.
 func TestReconcileWipedNodeForcesFullSync(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
 	v.Spec.Replicas[1].Address = "192.168.1.42"
 	// The pre-wipe agent had realized the backing and said so in status.
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DevicePath: "/dev/mapper/x"},
+		nodeA: {DeviceCreated: true, DevicePath: "/dev/mapper/x"},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
@@ -1163,7 +1163,7 @@ func TestReconcileWipedNodeForcesFullSync(t *testing.T) {
 	fb := newFakeBackend() // Exists() == false: the wipe took the device
 	r := &VolumeReconciler{
 		Client:   c,
-		NodeName: nodeKharkiv,
+		NodeName: nodeA,
 		Backend:  fb,
 		DRBD:     &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
@@ -1176,16 +1176,16 @@ func TestReconcileWipedNodeForcesFullSync(t *testing.T) {
 func TestReconcileDisklessTieBreaker(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 	v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
-		Node: nodeOslo, NodeID: 2, Address: addrOslo, Diskless: true,
+		Node: nodeC, NodeID: 2, Address: addrC, Diskless: true,
 	})
-	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeOslo)
+	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeC)
 
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateDiskless + `"}],
@@ -1195,7 +1195,7 @@ func TestReconcileDisklessTieBreaker(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeOslo, Backend: fb,
+		Client: c, NodeName: nodeC, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -1217,7 +1217,7 @@ func TestReconcileDisklessTieBreaker(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	st := got.Status.PerNode[nodeOslo]
+	st := got.Status.PerNode[nodeC]
 	if st.DeviceCreated {
 		t.Fatal("tie-breaker must not report DeviceCreated (blocks CSI staging)")
 	}
@@ -1229,22 +1229,22 @@ func TestReconcileDisklessTieBreaker(t *testing.T) {
 // Status.Connected scopes to diskful peers: a downed tie-breaker link
 // must not read as degraded replication, while a downed data leg must.
 func TestDiskfulPeersConnected(t *testing.T) {
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 	v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
-		Node: nodeOslo, NodeID: 2, Address: addrOslo, Diskless: true,
+		Node: nodeC, NodeID: 2, Address: addrC, Diskless: true,
 	})
 
 	tieBreakerDown := drbd.Status{PeerConnected: map[int32]bool{1: true, 2: false}}
-	if !diskfulPeersConnected(tieBreakerDown, v, nodeKharkiv) {
+	if !diskfulPeersConnected(tieBreakerDown, v, nodeA) {
 		t.Fatal("a downed tie-breaker link must not count as disconnected")
 	}
 	dataLegDown := drbd.Status{PeerConnected: map[int32]bool{1: false, 2: true}}
-	if diskfulPeersConnected(dataLegDown, v, nodeKharkiv) {
+	if diskfulPeersConnected(dataLegDown, v, nodeA) {
 		t.Fatal("a downed data leg must count as disconnected")
 	}
 }
@@ -1254,25 +1254,25 @@ func TestDiskfulPeersConnected(t *testing.T) {
 // status marker decides — the entry is already gone from spec.
 func TestRemovalSnapshotGateSkipsTieBreaker(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis) // oslo already removed from spec
+	v := vol(volPvc1, nodeA, nodeB) // node-c already removed from spec
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, Connected: true},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate, Connected: true},
-		nodeOslo:    {DiskState: diskStateDiskless, Diskless: true},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate, Connected: true},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate, Connected: true},
+		nodeC: {DiskState: diskStateDiskless, Diskless: true},
 	}
-	snap := snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)
+	snap := snapObj(snapSnap1, volPvc1, nodeA, nodeB)
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snap).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}, &miroirv1alpha1.MiroirSnapshot{}).
 		Build()
 
-	rO := &VolumeReconciler{Client: c, NodeName: nodeOslo, Backend: newFakeBackend()}
+	rO := &VolumeReconciler{Client: c, NodeName: nodeC, Backend: newFakeBackend()}
 	if reason := rO.removalBlocked(t.Context(), v); reason != "" {
 		t.Fatalf("tie-breaker removal must not be pinned by snapshots: %s", reason)
 	}
 	// A removed diskful replica (no Diskless marker) stays pinned.
-	rK := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend()}
+	rK := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: newFakeBackend()}
 	if reason := rK.removalBlocked(t.Context(), v); !strings.Contains(reason, "snapshot") {
 		t.Fatalf("diskful removal must stay pinned by snapshots, got %q", reason)
 	}
@@ -1406,14 +1406,14 @@ func TestReportErrorPreservesObservedState(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(vol(volPvc1, nodeKharkiv)).
+		WithObjects(vol(volPvc1, nodeA)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 	if err := c.Status().Patch(t.Context(), &miroirv1alpha1.MiroirVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
 	}, client.RawPatch(types.MergePatchType, []byte(`{
-		"status": {"perNode": {"`+nodeKharkiv+`": {
+		"status": {"perNode": {"`+nodeA+`": {
 			"deviceCreated": true, "sizeBytes": 1073741824, "connected": true
 		}}}
 	}`))); err != nil {
@@ -1429,7 +1429,7 @@ func TestReportErrorPreservesObservedState(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	st := got.Status.PerNode[nodeKharkiv]
+	st := got.Status.PerNode[nodeA]
 	if !st.DeviceCreated || st.SizeBytes != 1<<30 || !st.Connected {
 		t.Fatalf("reportError wiped observed state: %+v", st)
 	}
@@ -1438,11 +1438,11 @@ func TestReportErrorPreservesObservedState(t *testing.T) {
 	}
 }
 
-// removedReplicaVol builds a 2-replica volume on paris+oslo whose kharkiv
+// removedReplicaVol builds a 2-replica volume on node-b+node-c whose node-a
 // leg was just removed from spec.replicas (finalizer still held).
 func removedReplicaVol() *miroirv1alpha1.MiroirVolume {
-	v := vol(volPvc1, "paris", nodeOslo)
-	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeKharkiv)
+	v := vol(volPvc1, "node-b", nodeC)
+	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeA)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	for i := range v.Spec.Replicas {
 		v.Spec.Replicas[i].NodeID = int32(i)
@@ -1457,9 +1457,9 @@ func patchPeersUpToDate(t *testing.T, c client.Client, diskState string) {
 		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
 	}, client.RawPatch(types.MergePatchType, []byte(`{
 		"status": {"perNode": {
-			"paris": {"deviceCreated": true, "diskState": "`+diskState+`", "connected": true},
-			"`+nodeOslo+`": {"deviceCreated": true, "diskState": "`+diskStateUpToDate+`", "connected": true},
-			"`+nodeKharkiv+`": {"deviceCreated": true, "diskState": "`+diskStateUpToDate+`", "connected": true}
+			"node-b": {"deviceCreated": true, "diskState": "`+diskState+`", "connected": true},
+			"`+nodeC+`": {"deviceCreated": true, "diskState": "`+diskStateUpToDate+`", "connected": true},
+			"`+nodeA+`": {"deviceCreated": true, "diskState": "`+diskStateUpToDate+`", "connected": true}
 		}}
 	}`)))
 	if err != nil {
@@ -1481,7 +1481,7 @@ func TestReconcileRemovedReplicaTearsDown(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 	patchPeersUpToDate(t, c, diskStateUpToDate)
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run}}
 
 	reconcile(t, r, volPvc1)
@@ -1495,11 +1495,11 @@ func TestReconcileRemovedReplicaTearsDown(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, f := range got.Finalizers {
-		if f == constants.FinalizerPrefix+nodeKharkiv {
+		if f == constants.FinalizerPrefix+nodeA {
 			t.Fatal("finalizer not released after removal teardown")
 		}
 	}
-	if _, ok := got.Status.PerNode[nodeKharkiv]; ok {
+	if _, ok := got.Status.PerNode[nodeA]; ok {
 		t.Fatal("removed replica's status slot not cleared")
 	}
 }
@@ -1516,7 +1516,7 @@ func TestReconcileRemovalBlockedBySnapshot(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 	patchPeersUpToDate(t, c, diskStateUpToDate)
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	res, err := r.Reconcile(t.Context(),
 		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
@@ -1533,8 +1533,8 @@ func TestReconcileRemovalBlockedBySnapshot(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(got.Status.PerNode[nodeKharkiv].Message, "snapshot") {
-		t.Fatalf("blocked reason not surfaced: %+v", got.Status.PerNode[nodeKharkiv])
+	if !strings.Contains(got.Status.PerNode[nodeA].Message, "snapshot") {
+		t.Fatalf("blocked reason not surfaced: %+v", got.Status.PerNode[nodeA])
 	}
 }
 
@@ -1546,8 +1546,8 @@ func TestReconcileRemovalBlockedByDegradedPeer(t *testing.T) {
 		WithObjects(removedReplicaVol()).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	patchPeersUpToDate(t, c, diskStateInconsistent) // paris still syncing
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	patchPeersUpToDate(t, c, diskStateInconsistent) // node-b still syncing
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	res, err := r.Reconcile(t.Context(),
 		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
@@ -1565,16 +1565,16 @@ func TestReconcileRemovalBlockedByDegradedPeer(t *testing.T) {
 func TestReconcileWaitsForIncompleteEntry(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, "paris")
+	v := vol(volPvc1, nodeA, "node-b")
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
-	// kharkiv's entry was just added by an operator: no address yet.
+	v.Spec.Replicas[1].Address = addrB
+	// node-a's entry was just added by an operator: no address yet.
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	res, err := r.Reconcile(t.Context(),
 		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
@@ -1593,10 +1593,10 @@ func TestReconcileWaitsForIncompleteEntry(t *testing.T) {
 // thin backend; loopfile never probes (loop devices mishandle the option).
 func TestReconcileRendersDiscardGranularity(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	fb := newFakeBackend()
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
@@ -1607,7 +1607,7 @@ func TestReconcileRendersDiscardGranularity(t *testing.T) {
 		responses: map[string]string{"lsblk": "65536\n"},
 	}
 	stateDir := t.TempDir()
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		BackendType: miroirv1alpha1.BackendLVMThin,
 		DRBD:        &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
@@ -1625,10 +1625,10 @@ func TestReconcileRendersDiscardGranularity(t *testing.T) {
 
 func TestReconcileLoopfileSkipsDiscardProbe(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	fb := newFakeBackend()
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
@@ -1636,7 +1636,7 @@ func TestReconcileLoopfileSkipsDiscardProbe(t *testing.T) {
 		"devices":[{"disk-state":"UpToDate"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
 		responses: map[string]string{"lsblk": "65536\n"}}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		BackendType: miroirv1alpha1.BackendLoopfile,
 		DRBD:        &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
@@ -1660,12 +1660,12 @@ func countCalls(fe *fakeDRBDExec, substr string) int {
 func steadyVolume(t *testing.T) (*miroirv1alpha1.MiroirVolume, *fakeDRBDExec, *VolumeReconciler) {
 	t.Helper()
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30},
 	}
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
@@ -1674,7 +1674,7 @@ func steadyVolume(t *testing.T) (*miroirv1alpha1.MiroirVolume, *fakeDRBDExec, *V
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `","quorum":true}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		BackendType: miroirv1alpha1.BackendLVMThin,
 		DRBD:        &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 	return v, fe, r
@@ -1781,25 +1781,25 @@ func TestReconcileFastPathDeepCheckExpiry(t *testing.T) {
 	}
 }
 
-// splitBrainSetup builds a 2-replica DRBD volume (kharkiv node id 0 = seed
-// winner, paris node id 1) whose kernel status reports a connState
+// splitBrainSetup builds a 2-replica DRBD volume (node-a node id 0 = seed
+// winner, node-b node id 1) whose kernel status reports a connState
 // connection to peerNodeID, plus a reconciler running on nodeName. activated
 // latches Status.Activated (the auto-recovery gate).
 func splitBrainSetup(t *testing.T, nodeName, peerNodeID, connState string, activated bool) (*VolumeReconciler, *fakeDRBDExec) {
 	t.Helper()
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 	v.Status.Activated = activated
 
 	stateDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
-		"resource \"pvc-1\" {\n    on \"kharkiv\" {\n        device minor 1000;\n    }\n}\n",
+		"resource \"pvc-1\" {\n    on \"node-a\" {\n        device minor 1000;\n    }\n}\n",
 	), 0o640); err != nil {
 		t.Fatal(err)
 	}
@@ -1818,20 +1818,20 @@ func splitBrainSetup(t *testing.T, nodeName, peerNodeID, connState string, activ
 }
 
 // A never-activated volume that comes up split-brain self-heals: the seed
-// winner (kharkiv, node id 0) reconnects as the sync source and never
+// winner (node-a, node id 0) reconnects as the sync source and never
 // discards data (issue #139).
 func TestReconcileSplitBrainWinnerReconnectsWhenNeverActivated(t *testing.T) {
-	r, fe := splitBrainSetup(t, nodeKharkiv, "1", "StandAlone", false)
+	r, fe := splitBrainSetup(t, nodeA, "1", "StandAlone", false)
 	reconcile(t, r, volPvc1)
 	fe.calledWith(t, "drbdadm disconnect pvc-1")
 	fe.calledWith(t, "drbdadm connect pvc-1")
 	fe.notCalledWith(t, "discard-my-data")
 }
 
-// The losing leg (paris, node id 1) discards its own generation so it
+// The losing leg (node-b, node id 1) discards its own generation so it
 // full-syncs from the winner.
 func TestReconcileSplitBrainLoserDiscardsWhenNeverActivated(t *testing.T) {
-	r, fe := splitBrainSetup(t, nodeParis, "0", "StandAlone", false)
+	r, fe := splitBrainSetup(t, nodeB, "0", "StandAlone", false)
 	reconcile(t, r, volPvc1)
 	fe.calledWith(t, "drbdadm disconnect pvc-1")
 	fe.calledWith(t, "drbdadm connect --discard-my-data pvc-1")
@@ -1840,7 +1840,7 @@ func TestReconcileSplitBrainLoserDiscardsWhenNeverActivated(t *testing.T) {
 // An activated volume may hold data: split-brain is never auto-resolved, it
 // is left for an operator.
 func TestReconcileSplitBrainNoAutoRecoveryWhenActivated(t *testing.T) {
-	r, fe := splitBrainSetup(t, nodeParis, "0", "StandAlone", true)
+	r, fe := splitBrainSetup(t, nodeB, "0", "StandAlone", true)
 	reconcile(t, r, volPvc1)
 	fe.notCalledWith(t, "discard-my-data")
 	fe.notCalledWith(t, "drbdadm disconnect")
@@ -1850,7 +1850,7 @@ func TestReconcileSplitBrainNoAutoRecoveryWhenActivated(t *testing.T) {
 // grow-to-fill after mkfs/mount) carries data and must not be auto-discarded,
 // even though Activated is still false.
 func TestReconcileSplitBrainNoAutoRecoveryWhenFormatted(t *testing.T) {
-	r, fe := splitBrainSetup(t, nodeParis, "0", "StandAlone", false)
+	r, fe := splitBrainSetup(t, nodeB, "0", "StandAlone", false)
 	var v miroirv1alpha1.MiroirVolume
 	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, &v); err != nil {
 		t.Fatal(err)
@@ -1887,8 +1887,8 @@ func reportPeerSplitBrain(t *testing.T, r *VolumeReconciler, node string) {
 // sits Connecting while the survivor refuses the handshake — so it must take
 // the winner's reported split-brain as its trigger and discard (issue #144).
 func TestReconcileSplitBrainLoserDiscardsOnPeerReport(t *testing.T) {
-	r, fe := splitBrainSetup(t, nodeParis, "0", "Connecting", false)
-	reportPeerSplitBrain(t, r, nodeKharkiv)
+	r, fe := splitBrainSetup(t, nodeB, "0", "Connecting", false)
+	reportPeerSplitBrain(t, r, nodeA)
 	reconcile(t, r, volPvc1)
 	fe.calledWith(t, "drbdadm disconnect pvc-1")
 	fe.calledWith(t, "drbdadm connect --discard-my-data pvc-1")
@@ -1897,8 +1897,8 @@ func TestReconcileSplitBrainLoserDiscardsOnPeerReport(t *testing.T) {
 // A stale peer split-brain report on a healthy, fully connected leg (the
 // survivor's status patch lags its recovery) must not churn the volume.
 func TestReconcileSplitBrainPeerReportIgnoredWhenConnected(t *testing.T) {
-	r, fe := splitBrainSetup(t, nodeParis, "0", "Connected", false)
-	reportPeerSplitBrain(t, r, nodeKharkiv)
+	r, fe := splitBrainSetup(t, nodeB, "0", "Connected", false)
+	reportPeerSplitBrain(t, r, nodeA)
 	reconcile(t, r, volPvc1)
 	fe.notCalledWith(t, "discard-my-data")
 	fe.notCalledWith(t, "drbdadm disconnect")
@@ -1908,7 +1908,7 @@ func TestReconcileSplitBrainPeerReportIgnoredWhenConnected(t *testing.T) {
 // the volume — attempts must be floored to one per poll interval or the
 // agent thrashes several times per second (issue #144).
 func TestReconcileSplitBrainRecoveryDebounced(t *testing.T) {
-	r, fe := splitBrainSetup(t, nodeKharkiv, "1", "StandAlone", false)
+	r, fe := splitBrainSetup(t, nodeA, "1", "StandAlone", false)
 	reconcile(t, r, volPvc1)
 	attempts := countCalls(fe, "drbdadm connect pvc-1")
 	if attempts != 1 {
@@ -1924,7 +1924,7 @@ func TestReconcileSplitBrainRecoveryDebounced(t *testing.T) {
 // kernel state is a steady Connecting that never invalidates the fingerprint,
 // so only the peers' status can route it into recovery (issue #144).
 func TestFastPathMissesOnPeerReportedSplitBrain(t *testing.T) {
-	r, fe := splitBrainSetup(t, nodeParis, "0", "Connecting", false)
+	r, fe := splitBrainSetup(t, nodeB, "0", "Connecting", false)
 	var v miroirv1alpha1.MiroirVolume
 	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, &v); err != nil {
 		t.Fatal(err)
@@ -1932,8 +1932,8 @@ func TestFastPathMissesOnPeerReportedSplitBrain(t *testing.T) {
 	// Prime the fast path: settled size in this node's slot, the winner's
 	// split-brain report, and a fingerprint matching the live kernel state.
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeParis:   {DeviceCreated: true, SizeBytes: 1 << 30},
-		nodeKharkiv: {DeviceCreated: true, SplitBrain: true},
+		nodeB: {DeviceCreated: true, SizeBytes: 1 << 30},
+		nodeA: {DeviceCreated: true, SplitBrain: true},
 	}
 	if err := r.Status().Update(t.Context(), &v); err != nil {
 		t.Fatal(err)
@@ -1961,19 +1961,19 @@ const (
 			"peer_devices":[{"peer-disk-state":"UpToDate"}]}]}]`
 )
 
-// birthSetup builds a fresh 2-diskful volume (kharkiv node id 0 = winner,
-// paris node id 1) and a reconciler on nodeName whose kernel answers the
+// birthSetup builds a fresh 2-diskful volume (node-a node id 0 = winner,
+// node-b node id 1) and a reconciler on nodeName whose kernel answers the
 // queued --json statuses (peerNodeID fills the connection entries).
 func birthSetup(t *testing.T, nodeName string, peerNodeID int, statusSeq ...string) (*VolumeReconciler, *fakeDRBDExec, *miroirv1alpha1.MiroirVolume) {
 	t.Helper()
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 
 	stateDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
@@ -2008,7 +2008,7 @@ func birthSetup(t *testing.T, nodeName string, peerNodeID int, statusSeq ...stri
 // Inconsistent over established connections, and the same pass proceeds
 // against the resulting UpToDate state.
 func TestReconcileBirthWinnerMintsInitialUUID(t *testing.T) {
-	r, fe, _ := birthSetup(t, nodeKharkiv, 1, birthReadyJSON, birthDoneJSON)
+	r, fe, _ := birthSetup(t, nodeA, 1, birthReadyJSON, birthDoneJSON)
 	reconcile(t, r, volPvc1)
 	// The full fresh path: metadata created and left just-created, then the
 	// one replicated generation minted over the live connections.
@@ -2020,14 +2020,14 @@ func TestReconcileBirthWinnerMintsInitialUUID(t *testing.T) {
 	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if st := got.Status.PerNode[nodeKharkiv]; st.DiskState != diskStateUpToDate {
+	if st := got.Status.PerNode[nodeA]; st.DiskState != diskStateUpToDate {
 		t.Fatalf("winner must report the post-birth state, got %+v", st)
 	}
 }
 
 // The loser waits: only the winner may mint, or two generations could race.
 func TestReconcileBirthLoserWaits(t *testing.T) {
-	r, fe, _ := birthSetup(t, nodeParis, 0, birthReadyJSON)
+	r, fe, _ := birthSetup(t, nodeB, 0, birthReadyJSON)
 	reconcile(t, r, volPvc1)
 	fe.notCalledWith(t, "new-current-uuid")
 }
@@ -2045,7 +2045,7 @@ func TestReconcileBirthWaitsForPeers(t *testing.T) {
 			"connections":[{"peer-node-id":%d,"connection-state":"Connected",
 				"peer_devices":[{"peer-disk-state":"DUnknown"}]}]}]`,
 	} {
-		r, fe, _ := birthSetup(t, nodeKharkiv, 1, status)
+		r, fe, _ := birthSetup(t, nodeA, 1, status)
 		reconcile(t, r, volPvc1)
 		if n := countCalls(fe, "new-current-uuid"); n != 0 {
 			t.Fatalf("%s: must not mint, got %d calls", name, n)
@@ -2056,7 +2056,7 @@ func TestReconcileBirthWaitsForPeers(t *testing.T) {
 // A FullSync joiner means the volume already has a generation elsewhere:
 // never mint over it.
 func TestReconcileBirthSkipsFullSyncJoiner(t *testing.T) {
-	r, fe, v := birthSetup(t, nodeKharkiv, 1, birthReadyJSON)
+	r, fe, v := birthSetup(t, nodeA, 1, birthReadyJSON)
 	got := &miroirv1alpha1.MiroirVolume{}
 	if err := r.Get(t.Context(), types.NamespacedName{Name: v.Name}, got); err != nil {
 		t.Fatal(err)
@@ -2072,7 +2072,7 @@ func TestReconcileBirthSkipsFullSyncJoiner(t *testing.T) {
 // An Activated volume held data: an all-Inconsistent state is then a real
 // incident, never something to paper over with a fresh generation.
 func TestReconcileBirthSkipsActivatedVolume(t *testing.T) {
-	r, fe, _ := birthSetup(t, nodeKharkiv, 1, birthReadyJSON)
+	r, fe, _ := birthSetup(t, nodeA, 1, birthReadyJSON)
 	got := &miroirv1alpha1.MiroirVolume{}
 	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
@@ -2089,7 +2089,7 @@ func TestReconcileBirthSkipsActivatedVolume(t *testing.T) {
 // keeps DeviceCreated so the phase never reads as a hard provisioning
 // failure.
 func TestReconcileBirthMintErrorRetries(t *testing.T) {
-	r, fe, _ := birthSetup(t, nodeKharkiv, 1, birthReadyJSON)
+	r, fe, _ := birthSetup(t, nodeA, 1, birthReadyJSON)
 	fe.errOn = map[string]error{"new-current-uuid": errors.New("exit status 1")}
 	if _, err := r.Reconcile(t.Context(),
 		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err == nil {
@@ -2099,7 +2099,7 @@ func TestReconcileBirthMintErrorRetries(t *testing.T) {
 	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if !got.Status.PerNode[nodeKharkiv].DeviceCreated {
+	if !got.Status.PerNode[nodeA].DeviceCreated {
 		t.Fatal("DeviceCreated must survive a failed mint")
 	}
 }
@@ -2109,7 +2109,7 @@ func TestReconcileBirthMintErrorRetries(t *testing.T) {
 // miss on it, or the winner never re-enters the pipeline and the volume
 // parks Creating forever.
 func TestFastPathMissesOnPeerDiskStateChange(t *testing.T) {
-	r, fe, v := birthSetup(t, nodeKharkiv, 1)
+	r, fe, v := birthSetup(t, nodeA, 1)
 	fe.statusJSON = `[{"name":"pvc-1","role":"Secondary",
 		"devices":[{"disk-state":"Inconsistent"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected",
@@ -2124,7 +2124,7 @@ func TestFastPathMissesOnPeerDiskStateChange(t *testing.T) {
 		t.Fatal(err)
 	}
 	got.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, SizeBytes: 1 << 30},
+		nodeA: {DeviceCreated: true, SizeBytes: 1 << 30},
 	}
 	if err := r.Status().Update(t.Context(), got); err != nil {
 		t.Fatal(err)
@@ -2143,9 +2143,9 @@ func TestFastPathMissesOnPeerDiskStateChange(t *testing.T) {
 // The spec's bitmap granularity reaches the render input; create-md picks
 // it up from there (drbd.TestApplyBitmapGranularity pins the argv).
 func TestDrbdResourceBitmapGranularity(t *testing.T) {
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000, BitmapGranularityBytes: 65536}
-	r := drbdResource(v, nodeKharkiv, "/dev/vg/pvc-1", 1000, false, 0)
+	r := drbdResource(v, nodeA, "/dev/vg/pvc-1", 1000, false, 0)
 	if r.BitmapGranularityBytes != 65536 {
 		t.Fatalf("granularity = %d, want 65536", r.BitmapGranularityBytes)
 	}
@@ -2155,18 +2155,18 @@ func TestDrbdResourceBitmapGranularity(t *testing.T) {
 // granularities (mixed backends: aligned for the coarsest works on all);
 // replicas and tie-breakers advertise nothing.
 func TestDrbdResourceClientDiscardGranularity(t *testing.T) {
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeOslo, NodeID: 2, Address: addrOslo}}
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeC, NodeID: 2, Address: addrC}}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DiscardGranularityBytes: 262144}, // lvmthin chunk
-		nodeParis:   {DiscardGranularityBytes: 16384},  // zvol block
+		nodeA: {DiscardGranularityBytes: 262144}, // lvmthin chunk
+		nodeB: {DiscardGranularityBytes: 16384},  // zvol block
 	}
 
-	if r := drbdResource(v, nodeOslo, "", 1000, true, 0); r.ClientDiscardGranularityBytes != 262144 {
+	if r := drbdResource(v, nodeC, "", 1000, true, 0); r.ClientDiscardGranularityBytes != 262144 {
 		t.Fatalf("client granularity = %d, want max(peers) 262144", r.ClientDiscardGranularityBytes)
 	}
-	if r := drbdResource(v, nodeKharkiv, "/dev/vg/pvc-1", 1000, false, 262144); r.ClientDiscardGranularityBytes != 0 {
+	if r := drbdResource(v, nodeA, "/dev/vg/pvc-1", 1000, false, 262144); r.ClientDiscardGranularityBytes != 0 {
 		t.Fatalf("a replica must not advertise a client granularity, got %d", r.ClientDiscardGranularityBytes)
 	}
 }
@@ -2177,16 +2177,16 @@ func TestDrbdResourceClientDiscardGranularity(t *testing.T) {
 func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
-	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeOslo, NodeID: 2, Address: addrOslo}}
-	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeOslo)
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeC, NodeID: 2, Address: addrC}}
+	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeC)
 	// A diskful peer has published its backing's discard granularity; the
 	// client's device must advertise it (see the .res assertion below).
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DiscardGranularityBytes: 262144},
+		nodeA: {DiscardGranularityBytes: 262144},
 	}
 
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
@@ -2197,7 +2197,7 @@ func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeOslo, Backend: fb,
+		Client: c, NodeName: nodeC, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -2212,7 +2212,7 @@ func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 	// The rendered config must exclude the client from quorum voting —
 	// exactly once, on the client's own entry, never on the replicas —
 	// and advertise the diskful peers' discard granularity (the status
-	// fixture publishes kharkiv's 262144) on the local device.
+	// fixture publishes node-a's 262144) on the local device.
 	res, err := os.ReadFile(filepath.Join(r.DRBD.StateDir, volPvc1+".res"))
 	if err != nil {
 		t.Fatal(err)
@@ -2228,7 +2228,7 @@ func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	st := got.Status.PerNode[nodeOslo]
+	st := got.Status.PerNode[nodeC]
 	if st.DeviceCreated || !st.Diskless {
 		t.Fatalf("client slot must be diskless without a device: %+v", st)
 	}
@@ -2256,11 +2256,11 @@ func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 func TestReconcileClientLegWaitsForMembership(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
-	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeOslo}}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeC}}
 
 	fe := &fakeDRBDExec{}
 	c := fake.NewClientBuilder().WithScheme(s).
@@ -2268,7 +2268,7 @@ func TestReconcileClientLegWaitsForMembership(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 	r := &VolumeReconciler{
-		Client: c, NodeName: nodeOslo, Backend: fb,
+		Client: c, NodeName: nodeC, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 
@@ -2287,10 +2287,10 @@ func TestReconcileClientLegWaitsForMembership(t *testing.T) {
 // passes, and clears on demotion — the auto-diskful tie-breaker signal.
 func TestReconcilePrimarySinceLifecycle(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	fb := newFakeBackend()
 	fb.existing[volPvc1] = true
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
@@ -2300,7 +2300,7 @@ func TestReconcilePrimarySinceLifecycle(t *testing.T) {
 		"connections":[{"peer-node-id":1,"connection-state":"Connected",
 		"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`
 	fe := &fakeDRBDExec{statusJSON: primary}
-	r := &VolumeReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
@@ -2308,7 +2308,7 @@ func TestReconcilePrimarySinceLifecycle(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	stamped := got.Status.PerNode[nodeKharkiv].PrimarySince
+	stamped := got.Status.PerNode[nodeA].PrimarySince
 	if stamped == nil {
 		t.Fatal("Primary leg must stamp PrimarySince")
 	}
@@ -2318,7 +2318,7 @@ func TestReconcilePrimarySinceLifecycle(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if since := got.Status.PerNode[nodeKharkiv].PrimarySince; since == nil || !since.Equal(stamped) {
+	if since := got.Status.PerNode[nodeA].PrimarySince; since == nil || !since.Equal(stamped) {
 		t.Fatalf("PrimarySince must be stable while Primary: %v vs %v", since, stamped)
 	}
 
@@ -2331,7 +2331,7 @@ func TestReconcilePrimarySinceLifecycle(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Status.PerNode[nodeKharkiv].PrimarySince != nil {
+	if got.Status.PerNode[nodeA].PrimarySince != nil {
 		t.Fatal("PrimarySince must clear on demotion")
 	}
 }

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -70,10 +70,10 @@ func TestSnapshotUnreplicatedReadyImmediately(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(vol(volPvc1, nodeKharkiv), snapObj(snapSnap1, volPvc1, nodeKharkiv)).
+		WithObjects(vol(volPvc1, nodeA), snapObj(snapSnap1, volPvc1, nodeA)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: fb}
 
 	reconcileSnap(t, r, snapSnap1)
 
@@ -92,32 +92,32 @@ func TestSnapshotUnreplicatedReadyImmediately(t *testing.T) {
 // every future snapshot of the volume queues behind it.
 func TestSnapshotCoordinatorFailsOverFromDeadReplica0(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis) // kharkiv = replicas[0]
+	v := vol(volPvc1, nodeA, nodeB) // node-a = replicas[0]
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrKharkiv
-	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrParis
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
-	snap := snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)
+	snap := snapObj(snapSnap1, volPvc1, nodeA, nodeB)
 	expired := metav1.NewTime(time.Now().Add(-2 * SuspendDeadline))
 	snap.Status.IOSuspended = true
 	snap.Status.SuspendedAt = &expired
 	snap.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{
-		nodeParis: miroirv1alpha1.SnapshotSuspended,
+		nodeB: miroirv1alpha1.SnapshotSuspended,
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snap).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
-	// paris: Secondary, no Primary anywhere, and its link to kharkiv
-	// (node-id 0) is down — paris is now the lowest reachable diskful leg.
+	// node-b: Secondary, no Primary anywhere, and its link to node-a
+	// (node-id 0) is down — node-b is now the lowest reachable diskful leg.
 	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":0,"connection-state":"Connecting"}]}]`}
-	rP := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
 	reconcileSnap(t, rP, snapSnap1)
 
@@ -133,42 +133,42 @@ func TestSnapshotCoordinatorFailsOverFromDeadReplica0(t *testing.T) {
 
 func TestSnapshotReplicatedBarrier(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
-	// kharkiv is Primary → coordinator: raises its barrier first.
+	// node-a is Primary → coordinator: raises its barrier first.
 	feK := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`}
 	fbK := newFakeBackend()
-	rK := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: fbK,
+	rK := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: fbK,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feK.run}}
 	reconcileSnap(t, rK, snapSnap1)
 	feK.calledWith(t, "drbdadm suspend-io pvc-1")
 
 	got := &miroirv1alpha1.MiroirSnapshot{}
 	_ = c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got)
-	if !got.Status.IOSuspended || got.Status.PerNode[nodeKharkiv] != miroirv1alpha1.SnapshotSuspended {
+	if !got.Status.IOSuspended || got.Status.PerNode[nodeA] != miroirv1alpha1.SnapshotSuspended {
 		t.Fatalf("coordinator must raise the barrier before cutting: %+v", got.Status)
 	}
 	if len(fbK.snapCalls) != 0 {
 		t.Fatalf("no leg may be cut before every barrier is up: %v", fbK.snapCalls)
 	}
 
-	// paris (Secondary peer) raises its own barrier too.
+	// node-b (Secondary peer) raises its own barrier too.
 	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`}
 	fbP := newFakeBackend()
-	rP := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: fbP,
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: fbP,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
 	reconcileSnap(t, rP, snapSnap1)
 	feP.calledWith(t, "drbdadm suspend-io pvc-1")
@@ -206,36 +206,36 @@ func TestSnapshotReplicatedBarrier(t *testing.T) {
 // deletion path releases the finalizer without touching the backend.
 func TestSnapshotBarrierWithTieBreaker(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
-		Node: nodeOslo, NodeID: 2, Address: addrOslo, Diskless: true,
+		Node: nodeC, NodeID: 2, Address: addrC, Diskless: true,
 	})
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeOslo:    {DiskState: diskStateDiskless},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeC: {DiskState: diskStateDiskless},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis, nodeOslo)).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB, nodeC)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
 	feK := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected"}]}]`}
-	rK := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend(),
+	rK := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feK.run}}
 	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected"}]}]`}
-	rP := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
 	fbO := newFakeBackend()
 	feO := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateDiskless + `"}],
 		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected"}]}]`}
-	rO := &SnapshotReconciler{Client: c, NodeName: nodeOslo, Backend: fbO,
+	rO := &SnapshotReconciler{Client: c, NodeName: nodeC, Backend: fbO,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feO.run}}
 
 	// Round: coordinator raises, peer raises, both cut, coordinator
@@ -270,7 +270,7 @@ func TestSnapshotBarrierWithTieBreaker(t *testing.T) {
 	if err := c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got); err != nil {
 		t.Fatal(err)
 	}
-	if slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeOslo) {
+	if slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeC) {
 		t.Fatal("tie-breaker must release its snapshot finalizer on delete")
 	}
 	if len(fbO.snapCalls) != 0 {
@@ -284,25 +284,25 @@ func TestSnapshotBarrierWithTieBreaker(t *testing.T) {
 // The old aggregate-Connected gate blocked every round here.
 func TestSnapshotProceedsWithTieBreakerDown(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	// Full addresses + node ids so the diskful-connectivity check
 	// actually consults the per-peer map (address-less entries are
 	// skipped as not-yet-rendered).
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 	v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
-		Node: nodeOslo, NodeID: 2, Address: addrOslo, Diskless: true,
+		Node: nodeC, NodeID: 2, Address: addrC, Diskless: true,
 	})
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeOslo:    {DiskState: diskStateDiskless},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeC: {DiskState: diskStateDiskless},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis, nodeOslo)).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB, nodeC)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
@@ -311,13 +311,13 @@ func TestSnapshotProceedsWithTieBreakerDown(t *testing.T) {
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"},
 			{"peer-node-id":2,"connection-state":"Connecting"}]}]`}
-	rK := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend(),
+	rK := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feK.run}}
 	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":0,"connection-state":"Connected"},
 			{"peer-node-id":2,"connection-state":"Connecting"}]}]`}
-	rP := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
 
 	reconcileSnap(t, rK, snapSnap1)
@@ -341,20 +341,20 @@ func TestSnapshotProceedsWithTieBreakerDown(t *testing.T) {
 // void the coordinator raced, re-freezing IO or resurrecting a stale leg.
 func TestSnapshotPeerRecordsOnlyOwnSlot(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
-	// The coordinator has opened the round; paris has not raised its barrier.
-	snap := snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)
+	// The coordinator has opened the round; node-b has not raised its barrier.
+	snap := snapObj(snapSnap1, volPvc1, nodeA, nodeB)
 	now := metav1.Now()
 	snap.Status.IOSuspended = true
 	snap.Status.SuspendedAt = &now
 	snap.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{
-		nodeKharkiv: miroirv1alpha1.SnapshotSuspended,
-		nodeParis:   miroirv1alpha1.SnapshotPending,
+		nodeA: miroirv1alpha1.SnapshotSuspended,
+		nodeB: miroirv1alpha1.SnapshotPending,
 	}
 
 	var patchTypes []types.PatchType
@@ -376,7 +376,7 @@ func TestSnapshotPeerRecordsOnlyOwnSlot(t *testing.T) {
 	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`}
-	rP := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
 
 	reconcileSnap(t, rP, snapSnap1)
@@ -392,7 +392,7 @@ func TestSnapshotPeerRecordsOnlyOwnSlot(t *testing.T) {
 		if strings.Contains(data, "ioSuspended") || strings.Contains(data, "suspendedAt") {
 			t.Errorf("patch %d touches the coordinator's barrier fields: %s", i, data)
 		}
-		if !strings.Contains(data, nodeParis) {
+		if !strings.Contains(data, nodeB) {
 			t.Errorf("patch %d does not record this node's slot: %s", i, data)
 		}
 	}
@@ -405,7 +405,7 @@ func TestSnapshotPeerRecordsOnlyOwnSlot(t *testing.T) {
 	if !got.Status.IOSuspended {
 		t.Fatal("peer must not clear the coordinator's barrier")
 	}
-	if got.Status.PerNode[nodeParis] != miroirv1alpha1.SnapshotSuspended {
+	if got.Status.PerNode[nodeB] != miroirv1alpha1.SnapshotSuspended {
 		t.Fatalf("peer's own slot not recorded: %+v", got.Status.PerNode)
 	}
 }
@@ -414,24 +414,24 @@ func TestSnapshotPeerRecordsOnlyOwnSlot(t *testing.T) {
 // Primary — two coordinators livelock the snapshot.
 func TestSnapshotSecondaryDefersToPeerPrimary(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeParis, nodeKharkiv) // paris is replicas[0]...
+	v := vol(volPvc1, nodeB, nodeA) // node-b is replicas[0]...
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeParis, nodeKharkiv)).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeB, nodeA)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
-	// ...but kharkiv holds the device open: the barrier only blocks
-	// writes where they originate, so kharkiv owns it.
+	// ...but node-a holds the device open: the barrier only blocks
+	// writes where they originate, so node-a owns it.
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected","peer-role":"Primary"}]}]`}
 	fb := newFakeBackend()
-	r := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: fb,
+	r := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, snapSnap1)
 
@@ -443,18 +443,18 @@ func TestSnapshotSecondaryDefersToPeerPrimary(t *testing.T) {
 // stale legs must never pair with fresh ones.
 func TestSnapshotExpiredRoundResetsPeersAndRecuts(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
-	snap := snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)
+	snap := snapObj(snapSnap1, volPvc1, nodeA, nodeB)
 	expired := metav1.NewTime(time.Now().Add(-2 * SuspendDeadline))
 	snap.Status.IOSuspended = true
 	snap.Status.SuspendedAt = &expired
 	snap.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{
-		nodeKharkiv: miroirv1alpha1.SnapshotDone, // cut under the dead barrier
+		nodeA: miroirv1alpha1.SnapshotDone, // cut under the dead barrier
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snap).
@@ -465,7 +465,7 @@ func TestSnapshotExpiredRoundResetsPeersAndRecuts(t *testing.T) {
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`}
 	fb := newFakeBackend()
-	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 
 	// Expiry: resume, void every leg, mark the coordinator Error.
@@ -478,8 +478,8 @@ func TestSnapshotExpiredRoundResetsPeersAndRecuts(t *testing.T) {
 	if got.Status.IOSuspended || got.Status.ReadyToUse {
 		t.Fatalf("expired round must resume without going ready: %+v", got.Status)
 	}
-	if got.Status.PerNode[nodeParis] != miroirv1alpha1.SnapshotPending ||
-		got.Status.PerNode[nodeKharkiv] != miroirv1alpha1.SnapshotError {
+	if got.Status.PerNode[nodeB] != miroirv1alpha1.SnapshotPending ||
+		got.Status.PerNode[nodeA] != miroirv1alpha1.SnapshotError {
 		t.Fatalf("expired legs must be voided: %+v", got.Status.PerNode)
 	}
 
@@ -495,7 +495,7 @@ func TestSnapshotExpiredRoundResetsPeersAndRecuts(t *testing.T) {
 	// lands late and must be voided again when the next round opens.
 	aged := metav1.NewTime(time.Now().Add(-2 * suspendRetryBackoff))
 	got.Status.SuspendedAt = &aged
-	got.Status.PerNode[nodeParis] = miroirv1alpha1.SnapshotDone
+	got.Status.PerNode[nodeB] = miroirv1alpha1.SnapshotDone
 	if err := c.Status().Update(t.Context(), got); err != nil {
 		t.Fatal(err)
 	}
@@ -506,13 +506,13 @@ func TestSnapshotExpiredRoundResetsPeersAndRecuts(t *testing.T) {
 		t.Fatalf("no recut before every barrier is up: %v", fb.snapCalls)
 	}
 	_ = c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got)
-	if got.Status.PerNode[nodeParis] != miroirv1alpha1.SnapshotPending {
+	if got.Status.PerNode[nodeB] != miroirv1alpha1.SnapshotPending {
 		t.Fatalf("opening a round must void stale peer legs: %+v", got.Status.PerNode)
 	}
 	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`}
-	rP := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
 	reconcileSnap(t, rP, snapSnap1)
 	reconcileSnap(t, r, snapSnap1)
@@ -526,21 +526,21 @@ func TestSnapshotExpiredRoundResetsPeersAndRecuts(t *testing.T) {
 // off) — no barrier and no cut until replication is healthy again.
 func TestSnapshotWaitsForHealthyReplication(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	// Addresses + node ids: the health gate checks the links to diskful
 	// peers by node id, and skips entries the membership reconciler has
 	// not completed yet.
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
@@ -549,7 +549,7 @@ func TestSnapshotWaitsForHealthyReplication(t *testing.T) {
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connecting"}]}]`}
 	fb := newFakeBackend()
-	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, snapSnap1)
 
@@ -565,9 +565,9 @@ func TestSnapshotWaitsForHealthyReplication(t *testing.T) {
 // (a peer's barrier outliving the coordinator's void).
 func TestSnapshotDeleteResumesStrandedBarrier(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	snap := snapObj("snap-del", volPvc1, nodeKharkiv)
+	snap := snapObj("snap-del", volPvc1, nodeA)
 	now := metav1.NewTime(time.Now())
 	snap.DeletionTimestamp = &now
 	c := fake.NewClientBuilder().WithScheme(s).
@@ -578,7 +578,7 @@ func TestSnapshotDeleteResumesStrandedBarrier(t *testing.T) {
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","suspended-user":true,
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}]}]`}
 	fb := newFakeBackend()
-	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: fb,
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, "snap-del")
 
@@ -609,9 +609,9 @@ func assertFinalizerReleased(t *testing.T, c client.Client, name, node string) {
 // teardown's ErrBusy retry then completes. (Deadlock regression.)
 func TestSnapshotDeleteToleratesDownedResource(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	snap := snapObj("snap-del", volPvc1, nodeKharkiv)
+	snap := snapObj("snap-del", volPvc1, nodeA)
 	now := metav1.NewTime(time.Now())
 	snap.DeletionTimestamp = &now
 	snap.Status.IOSuspended = true // stranded by the dead round
@@ -621,12 +621,12 @@ func TestSnapshotDeleteToleratesDownedResource(t *testing.T) {
 		Build()
 
 	fe := &fakeDRBDExec{errOn: map[string]error{"status": errors.New("no such resource")}}
-	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend(),
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, "snap-del")
 
 	fe.notCalledWith(t, "resume-io")
-	assertFinalizerReleased(t, c, "snap-del", nodeKharkiv)
+	assertFinalizerReleased(t, c, "snap-del", nodeA)
 }
 
 // A node that left spec.replicas after the snapshot was cut still holds
@@ -634,9 +634,9 @@ func TestSnapshotDeleteToleratesDownedResource(t *testing.T) {
 // Terminating and blocks every later replica removal on the volume.
 func TestSnapshotDeleteReleasesDepartedNode(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis) // oslo already removed
+	v := vol(volPvc1, nodeA, nodeB) // node-c already removed
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	snap := snapObj("snap-del", volPvc1, nodeKharkiv, nodeParis, nodeOslo)
+	snap := snapObj("snap-del", volPvc1, nodeA, nodeB, nodeC)
 	now := metav1.NewTime(time.Now())
 	snap.DeletionTimestamp = &now
 	c := fake.NewClientBuilder().WithScheme(s).
@@ -645,11 +645,11 @@ func TestSnapshotDeleteReleasesDepartedNode(t *testing.T) {
 		Build()
 
 	fe := &fakeDRBDExec{errOn: map[string]error{"status": errors.New("no such resource")}}
-	r := &SnapshotReconciler{Client: c, NodeName: nodeOslo, Backend: newFakeBackend(),
+	r := &SnapshotReconciler{Client: c, NodeName: nodeC, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, "snap-del")
 
-	assertFinalizerReleased(t, c, "snap-del", nodeOslo)
+	assertFinalizerReleased(t, c, "snap-del", nodeC)
 }
 
 // The kernel suspend flag is shared per resource: while a sibling
@@ -657,12 +657,12 @@ func TestSnapshotDeleteReleasesDepartedNode(t *testing.T) {
 // barrier out from under it — but it still deletes its leg and departs.
 func TestSnapshotDeleteSkipsSiblingRoundBarrier(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
-	snap := snapObj("snap-del", volPvc1, nodeKharkiv)
+	snap := snapObj("snap-del", volPvc1, nodeA)
 	now := metav1.NewTime(time.Now())
 	snap.DeletionTimestamp = &now
-	sibling := snapObj("snap-live", volPvc1, nodeKharkiv, nodeParis)
+	sibling := snapObj("snap-live", volPvc1, nodeA, nodeB)
 	sibling.Status.IOSuspended = true
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snap, sibling).
@@ -671,26 +671,26 @@ func TestSnapshotDeleteSkipsSiblingRoundBarrier(t *testing.T) {
 
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","suspended-user":true,
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}]}]`}
-	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend(),
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, "snap-del")
 
 	fe.notCalledWith(t, "resume-io")
-	assertFinalizerReleased(t, c, "snap-del", nodeKharkiv)
+	assertFinalizerReleased(t, c, "snap-del", nodeA)
 }
 
 // One round per volume: a coordinator must not open a round while a
 // sibling snapshot of the same volume is mid-round.
 func TestSnapshotRoundWaitsForSibling(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
-	fresh := snapObj("snap-b", volPvc1, nodeKharkiv, nodeParis)
-	sibling := snapObj("snap-a", volPvc1, nodeKharkiv, nodeParis)
+	fresh := snapObj("snap-b", volPvc1, nodeA, nodeB)
+	sibling := snapObj("snap-a", volPvc1, nodeA, nodeB)
 	sibling.Status.IOSuspended = true
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, fresh, sibling).
@@ -700,7 +700,7 @@ func TestSnapshotRoundWaitsForSibling(t *testing.T) {
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`}
-	r := &SnapshotReconciler{Client: c, NodeName: nodeKharkiv, Backend: newFakeBackend(),
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	res := reconcileSnap(t, r, "snap-b")
 
@@ -714,25 +714,25 @@ func TestSnapshotRoundWaitsForSibling(t *testing.T) {
 // owns it — the sibling's own protocol lifts it.
 func TestSnapshotVoidedResumeDefersToSiblingRound(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
-	voided := snapObj("snap-a", volPvc1, nodeKharkiv, nodeParis) // round voided
-	sibling := snapObj("snap-b", volPvc1, nodeKharkiv, nodeParis)
+	voided := snapObj("snap-a", volPvc1, nodeA, nodeB) // round voided
+	sibling := snapObj("snap-b", volPvc1, nodeA, nodeB)
 	sibling.Status.IOSuspended = true
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, voided, sibling).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
-	// paris: Secondary, not replicas[0] → not coordinator; barrier up.
+	// node-b: Secondary, not replicas[0] → not coordinator; barrier up.
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`}
-	r := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: newFakeBackend(),
+	r := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: newFakeBackend(),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, "snap-a")
 
@@ -741,29 +741,29 @@ func TestSnapshotVoidedResumeDefersToSiblingRound(t *testing.T) {
 
 func TestSnapshotPeerWaitsForBarrier(t *testing.T) {
 	s := newScheme(t)
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DiskState: diskStateUpToDate},
-		nodeParis:   {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeKharkiv, nodeParis)).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 
-	// paris, Secondary, barrier not raised → must not snapshot yet.
+	// node-b, Secondary, barrier not raised → must not snapshot yet.
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`}
 	fb := newFakeBackend()
-	r := &SnapshotReconciler{Client: c, NodeName: nodeParis, Backend: fb,
+	r := &SnapshotReconciler{Client: c, NodeName: nodeB, Backend: fb,
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, snapSnap1)
 
 	got := &miroirv1alpha1.MiroirSnapshot{}
 	_ = c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got)
-	if got.Status.PerNode[nodeParis] == miroirv1alpha1.SnapshotDone {
+	if got.Status.PerNode[nodeB] == miroirv1alpha1.SnapshotDone {
 		t.Fatal("peer must wait for the IO barrier")
 	}
 }

--- a/internal/agent/verify_test.go
+++ b/internal/agent/verify_test.go
@@ -64,14 +64,14 @@ const statusAborted = `[{"name":"pvc-1",
 		"peer_devices":[{"replication-state":"Off","out-of-sync":512}]}]}]`
 
 func replicatedVol() *miroirv1alpha1.MiroirVolume {
-	v := vol(volPvc1, nodeKharkiv, nodeParis)
+	v := vol(volPvc1, nodeA, nodeB)
 	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
 	v.Spec.Replicas[0].NodeID = 0
-	v.Spec.Replicas[0].Address = addrKharkiv
+	v.Spec.Replicas[0].Address = addrA
 	v.Spec.Replicas[1].NodeID = 1
-	v.Spec.Replicas[1].Address = addrParis
+	v.Spec.Replicas[1].Address = addrB
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true},
+		nodeA: {DeviceCreated: true},
 	}
 	return v
 }
@@ -108,9 +108,9 @@ func TestVerifySkipsNonCoordinator(t *testing.T) {
 	v := replicatedVol()
 	c := newClient(t, v)
 	fe := &fakeDRBDExec{statusJSON: statusUpToDate}
-	// Scheduler runs on paris, but the coordinator (first diskful replica) is
-	// kharkiv — paris must not initiate.
-	vs := newVerifyScheduler(t, nodeParis, c, fe, nil)
+	// Scheduler runs on node-b, but the coordinator (first diskful replica) is
+	// node-a — node-b must not initiate.
+	vs := newVerifyScheduler(t, nodeB, c, fe, nil)
 
 	if err := vs.runOnce(t.Context()); err != nil {
 		t.Fatal(err)
@@ -119,11 +119,11 @@ func TestVerifySkipsNonCoordinator(t *testing.T) {
 }
 
 func TestVerifySkipsUnreplicated(t *testing.T) {
-	v := vol(volPvc1, nodeKharkiv) // no DRBD
-	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{nodeKharkiv: {DeviceCreated: true}}
+	v := vol(volPvc1, nodeA) // no DRBD
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{nodeA: {DeviceCreated: true}}
 	c := newClient(t, v)
 	fe := &fakeDRBDExec{statusJSON: statusUpToDate}
-	vs := newVerifyScheduler(t, nodeKharkiv, c, fe, nil)
+	vs := newVerifyScheduler(t, nodeA, c, fe, nil)
 
 	if err := vs.runOnce(t.Context()); err != nil {
 		t.Fatal(err)
@@ -153,13 +153,13 @@ func TestVerifySkipsUnhealthy(t *testing.T) {
 			v := replicatedVol()
 			c := newClient(t, v)
 			fe := &fakeDRBDExec{statusJSON: tc.status}
-			vs := newVerifyScheduler(t, nodeKharkiv, c, fe, nil)
+			vs := newVerifyScheduler(t, nodeA, c, fe, nil)
 
 			if err := vs.runOnce(t.Context()); err != nil {
 				t.Fatal(err)
 			}
 			fe.notCalledWith(t, "drbdadm verify")
-			if got := getVol(t, c).Status.PerNode[nodeKharkiv].LastVerifyTime; got != nil {
+			if got := getVol(t, c).Status.PerNode[nodeA].LastVerifyTime; got != nil {
 				t.Fatalf("skipped verify must not record a result, got %v", got)
 			}
 		})
@@ -172,14 +172,14 @@ func TestVerifyHappyPathRecordsCleanResult(t *testing.T) {
 	// gate → in-flight → complete-clean.
 	fe := &fakeDRBDExec{statusSeq: []string{statusUpToDate, statusVerifying, statusClean}}
 	rec := events.NewFakeRecorder(4)
-	vs := newVerifyScheduler(t, nodeKharkiv, c, fe, rec)
+	vs := newVerifyScheduler(t, nodeA, c, fe, rec)
 
 	if err := vs.runOnce(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm verify pvc-1")
 
-	st := getVol(t, c).Status.PerNode[nodeKharkiv]
+	st := getVol(t, c).Status.PerNode[nodeA]
 	if st.LastVerifyTime == nil {
 		t.Fatal("a completed verify must record LastVerifyTime")
 	}
@@ -201,13 +201,13 @@ func TestVerifyOutOfSyncRecordsAndEvents(t *testing.T) {
 	c := newClient(t, v)
 	fe := &fakeDRBDExec{statusSeq: []string{statusUpToDate, statusVerifying, statusDone}}
 	rec := events.NewFakeRecorder(4)
-	vs := newVerifyScheduler(t, nodeKharkiv, c, fe, rec)
+	vs := newVerifyScheduler(t, nodeA, c, fe, rec)
 
 	if err := vs.runOnce(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 
-	st := getVol(t, c).Status.PerNode[nodeKharkiv]
+	st := getVol(t, c).Status.PerNode[nodeA]
 	if st.LastVerifyOutOfSyncBytes == nil || *st.LastVerifyOutOfSyncBytes != 256*1024 {
 		t.Fatalf("verify must record 256 KiB out of sync, got %v", st.LastVerifyOutOfSyncBytes)
 	}
@@ -229,14 +229,14 @@ func TestVerifyDiscardsResultWhenPeerDropsMidPass(t *testing.T) {
 	c := newClient(t, v)
 	fe := &fakeDRBDExec{statusSeq: []string{statusUpToDate, statusVerifying, statusAborted}}
 	rec := events.NewFakeRecorder(4)
-	vs := newVerifyScheduler(t, nodeKharkiv, c, fe, rec)
+	vs := newVerifyScheduler(t, nodeA, c, fe, rec)
 
 	if err := vs.runOnce(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm verify pvc-1")
 
-	if got := getVol(t, c).Status.PerNode[nodeKharkiv].LastVerifyTime; got != nil {
+	if got := getVol(t, c).Status.PerNode[nodeA].LastVerifyTime; got != nil {
 		t.Fatalf("an aborted verify must not record a result, got %v", got)
 	}
 	select {
@@ -251,7 +251,7 @@ func TestVerifyContextCancelStopsCleanly(t *testing.T) {
 	c := newClient(t, v)
 	// Always in-flight: the poll loop only leaves via ctx cancellation.
 	fe := &fakeDRBDExec{statusJSON: statusVerifying, statusSeq: []string{statusUpToDate}}
-	vs := newVerifyScheduler(t, nodeKharkiv, c, fe, nil)
+	vs := newVerifyScheduler(t, nodeA, c, fe, nil)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancelled before the poll loop runs
@@ -264,7 +264,7 @@ func TestVerifyContextCancelStopsCleanly(t *testing.T) {
 	// a disconnect, which would resync.
 	fe.notCalledWith(t, "disconnect")
 	fe.notCalledWith(t, "drbdadm down")
-	if got := getVol(t, c).Status.PerNode[nodeKharkiv].LastVerifyTime; got != nil {
+	if got := getVol(t, c).Status.PerNode[nodeA].LastVerifyTime; got != nil {
 		t.Fatalf("an interrupted verify must not record a result, got %v", got)
 	}
 }

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -41,18 +41,18 @@ import (
 )
 
 const (
-	nodeKharkiv = "kharkiv"
-	nodeParis   = "paris"
-	nodeOslo    = "oslo"
-	addrKharkiv = "192.168.1.41"
-	addrParis   = "192.168.1.42"
-	addrOslo    = "192.168.1.43"
-	volPvc1     = "pvc-1"
-	paramTrue   = "true"
-	paramFalse  = "false"
-	volSrc      = "pvc-src"
-	volNew      = "pvc-new"
-	snapSnap1   = "snap-1"
+	nodeA      = "node-a"
+	nodeB      = "node-b"
+	nodeC      = "node-c"
+	addrA      = "192.168.1.41"
+	addrB      = "192.168.1.42"
+	addrC      = "192.168.1.43"
+	volPvc1    = "pvc-1"
+	paramTrue  = "true"
+	paramFalse = "false"
+	volSrc     = "pvc-src"
+	volNew     = "pvc-new"
+	snapSnap1  = "snap-1"
 )
 
 func newScheme(t *testing.T) *runtime.Scheme {
@@ -68,8 +68,8 @@ func newScheme(t *testing.T) *runtime.Scheme {
 }
 
 var testNodes = nodemap.Map{
-	nodeKharkiv: nodemap.Node{Backend: miroirv1alpha1.BackendLVMThin, Device: "/dev/disk/by-partlabel/r-miroir"},
-	nodeParis:   nodemap.Node{Backend: miroirv1alpha1.BackendZFS, ZFSDataset: "data-pool/miroir"},
+	nodeA: nodemap.Node{Backend: miroirv1alpha1.BackendLVMThin, Device: "/dev/disk/by-partlabel/r-miroir"},
+	nodeB: nodemap.Node{Backend: miroirv1alpha1.BackendZFS, ZFSDataset: "data-pool/miroir"},
 }
 
 // readyOnGet flips a created volume to Ready, simulating the agent.
@@ -133,7 +133,7 @@ func TestCreateVolumePlacesOnPreferredNode(t *testing.T) {
 		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
 		AccessibilityRequirements: &csi.TopologyRequirement{
 			Preferred: []*csi.Topology{
-				{Segments: map[string]string{constants.TopologyKey: nodeKharkiv}},
+				{Segments: map[string]string{constants.TopologyKey: nodeA}},
 			},
 		},
 	})
@@ -143,8 +143,8 @@ func TestCreateVolumePlacesOnPreferredNode(t *testing.T) {
 	if resp.Volume.VolumeId != volPvc1 || resp.Volume.CapacityBytes != 5<<30 {
 		t.Fatalf("unexpected volume %+v", resp.Volume)
 	}
-	if got := resp.Volume.AccessibleTopology[0].Segments[constants.TopologyKey]; got != nodeKharkiv {
-		t.Fatalf("expected placement on kharkiv, got %s", got)
+	if got := resp.Volume.AccessibleTopology[0].Segments[constants.TopologyKey]; got != nodeA {
+		t.Fatalf("expected placement on node-a, got %s", got)
 	}
 
 	// The CR must exist with the right backend for the chosen node.
@@ -213,7 +213,7 @@ func TestCreateVolumeRWXSetsExport(t *testing.T) {
 	// Node objects back the replication-address resolution place() runs
 	// for the 2-replica placement.
 	c := &Controller{
-		Client:           readyOnGet(s, nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)),
+		Client:           readyOnGet(s, nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)),
 		Nodes:            testNodes,
 		ProvisionTimeout: 2 * time.Second,
 		DRBDPortBase:     7000,
@@ -304,7 +304,7 @@ func TestValidateVolumeCapabilitiesRWXMismatch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
-			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv}},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA}},
 		},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(vol).Build()
@@ -347,7 +347,7 @@ func TestCreateVolumeReplicated(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: fake.NewClientBuilder().WithScheme(s).
-			WithObjects(nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, "192.168.1.42")).
+			WithObjects(nodeObj(nodeA, addrA), nodeObj(nodeB, "192.168.1.42")).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					if err := cl.Get(ctx, key, obj, opts...); err != nil {
@@ -375,7 +375,7 @@ func TestCreateVolumeReplicated(t *testing.T) {
 		},
 		AccessibilityRequirements: &csi.TopologyRequirement{
 			Preferred: []*csi.Topology{
-				{Segments: map[string]string{constants.TopologyKey: nodeParis}},
+				{Segments: map[string]string{constants.TopologyKey: nodeB}},
 			},
 		},
 	})
@@ -393,12 +393,12 @@ func TestCreateVolumeReplicated(t *testing.T) {
 	if len(vol.Spec.Replicas) != 2 {
 		t.Fatalf("replicas = %d", len(vol.Spec.Replicas))
 	}
-	// Scheduler preference first → paris is replicas[0] (the GI winner).
-	if vol.Spec.Replicas[0].Node != nodeParis || vol.Spec.Replicas[0].NodeID != 0 {
+	// Scheduler preference first → node-b is replicas[0] (the GI winner).
+	if vol.Spec.Replicas[0].Node != nodeB || vol.Spec.Replicas[0].NodeID != 0 {
 		t.Fatalf("unexpected first replica %+v", vol.Spec.Replicas[0])
 	}
 	if vol.Spec.Replicas[0].Address != "192.168.1.42" ||
-		vol.Spec.Replicas[1].Address != addrKharkiv {
+		vol.Spec.Replicas[1].Address != addrA {
 		t.Fatalf("InternalIPs not resolved: %+v", vol.Spec.Replicas)
 	}
 	if vol.Spec.DRBD == nil || vol.Spec.DRBD.Port != 7000 {
@@ -433,12 +433,12 @@ func TestCreateVolumeReplicated(t *testing.T) {
 func TestCreateVolumeReplicatedAddressOverride(t *testing.T) {
 	s := newScheme(t)
 	nodes := maps.Clone(testNodes)
-	paris := nodes[nodeParis]
-	paris.Address = "10.0.100.42"
-	nodes[nodeParis] = paris
+	entry := nodes[nodeB]
+	entry.Address = "10.0.100.42"
+	nodes[nodeB] = entry
 	c := &Controller{
 		Client: fake.NewClientBuilder().WithScheme(s).
-			WithObjects(nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)).
+			WithObjects(nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					if err := cl.Get(ctx, key, obj, opts...); err != nil {
@@ -461,7 +461,7 @@ func TestCreateVolumeReplicatedAddressOverride(t *testing.T) {
 		Parameters:         map[string]string{constants.ParamReplicas: "2"},
 		AccessibilityRequirements: &csi.TopologyRequirement{
 			Preferred: []*csi.Topology{
-				{Segments: map[string]string{constants.TopologyKey: nodeParis}},
+				{Segments: map[string]string{constants.TopologyKey: nodeB}},
 			},
 		},
 	}); err != nil {
@@ -472,9 +472,9 @@ func TestCreateVolumeReplicatedAddressOverride(t *testing.T) {
 	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: "pvc-ovr"}, vol); err != nil {
 		t.Fatal(err)
 	}
-	// paris preferred → replicas[0]; its override wins, kharkiv falls back.
+	// node-b preferred → replicas[0]; its override wins, node-a falls back.
 	if vol.Spec.Replicas[0].Address != "10.0.100.42" ||
-		vol.Spec.Replicas[1].Address != addrKharkiv {
+		vol.Spec.Replicas[1].Address != addrA {
 		t.Fatalf("override/fallback not applied: %+v", vol.Spec.Replicas)
 	}
 }
@@ -485,7 +485,7 @@ func tieBreakerController(t *testing.T, autoTieBreaker bool) *Controller {
 	t.Helper()
 	return &Controller{
 		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).
-			WithObjects(nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis), nodeObj(nodeOslo, addrOslo)).
+			WithObjects(nodeObj(nodeA, addrA), nodeObj(nodeB, addrB), nodeObj(nodeC, addrC)).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					if err := cl.Get(ctx, key, obj, opts...); err != nil {
@@ -498,9 +498,9 @@ func tieBreakerController(t *testing.T, autoTieBreaker bool) *Controller {
 				},
 			}).Build(),
 		Nodes: nodemap.Map{
-			nodeKharkiv: {Backend: miroirv1alpha1.BackendLVMThin},
-			nodeParis:   {Backend: miroirv1alpha1.BackendZFS, ZFSDataset: "data-pool/miroir"},
-			nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin},
+			nodeA: {Backend: miroirv1alpha1.BackendLVMThin},
+			nodeB: {Backend: miroirv1alpha1.BackendZFS, ZFSDataset: "data-pool/miroir"},
+			nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 		},
 		ProvisionTimeout: 2 * time.Second,
 		AutoTieBreaker:   autoTieBreaker,
@@ -522,8 +522,8 @@ func TestCreateVolumeAutoTieBreaker(t *testing.T) {
 		},
 		AccessibilityRequirements: &csi.TopologyRequirement{
 			Preferred: []*csi.Topology{
-				{Segments: map[string]string{constants.TopologyKey: nodeKharkiv}},
-				{Segments: map[string]string{constants.TopologyKey: nodeParis}},
+				{Segments: map[string]string{constants.TopologyKey: nodeA}},
+				{Segments: map[string]string{constants.TopologyKey: nodeB}},
 			},
 		},
 	})
@@ -545,7 +545,7 @@ func TestCreateVolumeAutoTieBreaker(t *testing.T) {
 		t.Fatalf("want 2 diskful + 1 tie-breaker, got %+v", vol.Spec.Replicas)
 	}
 	tb := vol.Spec.Replicas[2]
-	if tb.Node != nodeOslo || !tb.Diskless || tb.NodeID != 2 || tb.Address != addrOslo {
+	if tb.Node != nodeC || !tb.Diskless || tb.NodeID != 2 || tb.Address != addrC {
 		t.Fatalf("unexpected tie-breaker %+v", tb)
 	}
 	if tb.Backend != "" {
@@ -560,7 +560,7 @@ func TestCreateVolumeAutoTieBreaker(t *testing.T) {
 // a node map override pins its replication address too.
 func TestCreateVolumeAutoTieBreakerAddressOverride(t *testing.T) {
 	c := tieBreakerController(t, true)
-	c.Nodes[nodeOslo] = nodemap.Node{Backend: miroirv1alpha1.BackendLVMThin, Address: "10.0.100.44"}
+	c.Nodes[nodeC] = nodemap.Node{Backend: miroirv1alpha1.BackendLVMThin, Address: "10.0.100.44"}
 
 	if _, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name:               "pvc-tbo",
@@ -568,8 +568,8 @@ func TestCreateVolumeAutoTieBreakerAddressOverride(t *testing.T) {
 		Parameters:         map[string]string{constants.ParamReplicas: "2"},
 		AccessibilityRequirements: &csi.TopologyRequirement{
 			Preferred: []*csi.Topology{
-				{Segments: map[string]string{constants.TopologyKey: nodeKharkiv}},
-				{Segments: map[string]string{constants.TopologyKey: nodeParis}},
+				{Segments: map[string]string{constants.TopologyKey: nodeA}},
+				{Segments: map[string]string{constants.TopologyKey: nodeB}},
 			},
 		},
 	}); err != nil {
@@ -580,7 +580,7 @@ func TestCreateVolumeAutoTieBreakerAddressOverride(t *testing.T) {
 	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: "pvc-tbo"}, vol); err != nil {
 		t.Fatal(err)
 	}
-	if tb := vol.Spec.Replicas[2]; tb.Node != nodeOslo || tb.Address != "10.0.100.44" {
+	if tb := vol.Spec.Replicas[2]; tb.Node != nodeC || tb.Address != "10.0.100.44" {
 		t.Fatalf("tie-breaker did not take the override address: %+v", tb)
 	}
 }
@@ -626,7 +626,7 @@ func TestCreateVolumeAutoTieBreakerSkips(t *testing.T) {
 // tie-breaker on — the volume is created without one.
 func TestCreateVolumeAutoTieBreakerNoSpareNode(t *testing.T) {
 	c := tieBreakerController(t, true)
-	c.Nodes = testNodes // kharkiv + paris only
+	c.Nodes = testNodes // node-a + node-b only
 
 	if _, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name:               "pvc-nospare",
@@ -656,14 +656,14 @@ func TestControllerExpandRetryWaitsForRealization(t *testing.T) {
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 10 << 30, // a prior attempt already grew the spec
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin},
-				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS},
 			},
 		},
 		Status: miroirv1alpha1.MiroirVolumeStatus{
 			PerNode: map[string]miroirv1alpha1.ReplicaStatus{
-				nodeKharkiv: {SizeBytes: 5 << 30},
-				nodeParis:   {SizeBytes: 5 << 30},
+				nodeA: {SizeBytes: 5 << 30},
+				nodeB: {SizeBytes: 5 << 30},
 			},
 		},
 	}
@@ -689,12 +689,12 @@ func TestControllerExpandSucceedsOnceRealized(t *testing.T) {
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 10 << 30,
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin},
 			},
 		},
 		Status: miroirv1alpha1.MiroirVolumeStatus{
 			PerNode: map[string]miroirv1alpha1.ReplicaStatus{
-				nodeKharkiv: {SizeBytes: 10 << 30},
+				nodeA: {SizeBytes: 10 << 30},
 			},
 		},
 	}
@@ -741,9 +741,9 @@ func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
 			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "10.0.0.1"},
-				// paris joined after creation: FullSync stuck in the spec.
-				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "10.0.0.2", FullSync: true},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "10.0.0.1"},
+				// node-b joined after creation: FullSync stuck in the spec.
+				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "10.0.0.2", FullSync: true},
 			},
 		},
 	}
@@ -752,13 +752,13 @@ func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{
-				nodeKharkiv: miroirv1alpha1.SnapshotDone,
-				nodeParis:   miroirv1alpha1.SnapshotDone,
+				nodeA: miroirv1alpha1.SnapshotDone,
+				nodeB: miroirv1alpha1.SnapshotDone,
 			}},
 	}
 	cl := readyOnGet(s)
 	for _, obj := range []client.Object{srcVol, srcSnap,
-		nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)} {
+		nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)} {
 		if err := cl.Create(t.Context(), obj); err != nil {
 			t.Fatal(err)
 		}
@@ -791,7 +791,7 @@ func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 			t.Fatalf("clone must not inherit FullSync: %+v", rep)
 		}
 	}
-	if got.Spec.Replicas[0].Address != addrKharkiv || got.Spec.Replicas[1].Address != addrParis {
+	if got.Spec.Replicas[0].Address != addrA || got.Spec.Replicas[1].Address != addrB {
 		t.Fatalf("addresses must be re-resolved: %+v", got.Spec.Replicas)
 	}
 }
@@ -808,8 +808,8 @@ func TestCreateVolumeFromSnapshotAddressOverride(t *testing.T) {
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
 			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "192.0.2.1"},
-				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "192.0.2.2"},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "192.0.2.1"},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "192.0.2.2"},
 			},
 		},
 	}
@@ -818,13 +818,13 @@ func TestCreateVolumeFromSnapshotAddressOverride(t *testing.T) {
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{
-				nodeKharkiv: miroirv1alpha1.SnapshotDone,
-				nodeParis:   miroirv1alpha1.SnapshotDone,
+				nodeA: miroirv1alpha1.SnapshotDone,
+				nodeB: miroirv1alpha1.SnapshotDone,
 			}},
 	}
 	cl := readyOnGet(s)
 	for _, obj := range []client.Object{srcVol, srcSnap,
-		nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)} {
+		nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)} {
 		if err := cl.Create(t.Context(), obj); err != nil {
 			t.Fatal(err)
 		}
@@ -833,9 +833,9 @@ func TestCreateVolumeFromSnapshotAddressOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 	nodes := maps.Clone(testNodes)
-	kharkiv := nodes[nodeKharkiv]
-	kharkiv.Address = "10.0.100.1"
-	nodes[nodeKharkiv] = kharkiv
+	entry := nodes[nodeA]
+	entry.Address = "10.0.100.1"
+	nodes[nodeA] = entry
 	c := &Controller{Client: cl, ProvisionTimeout: 2 * time.Second, Nodes: nodes}
 
 	if _, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
@@ -856,7 +856,7 @@ func TestCreateVolumeFromSnapshotAddressOverride(t *testing.T) {
 	if err := cl.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Spec.Replicas[0].Address != "10.0.100.1" || got.Spec.Replicas[1].Address != addrParis {
+	if got.Spec.Replicas[0].Address != "10.0.100.1" || got.Spec.Replicas[1].Address != addrB {
 		t.Fatalf("clone did not re-resolve through the override: %+v", got.Spec.Replicas)
 	}
 }
@@ -874,21 +874,21 @@ func TestCreateVolumeFromSnapshotFullSyncsPostSnapshotReplica(t *testing.T) {
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
 			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "10.0.0.1"},
-				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "10.0.0.2"},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "10.0.0.1"},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "10.0.0.2"},
 			},
 		},
 	}
-	// The snapshot captured only kharkiv Done; paris was added afterward.
+	// The snapshot captured only node-a Done; node-b was added afterward.
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
-			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone}},
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
 	cl := readyOnGet(s)
 	for _, obj := range []client.Object{srcVol, srcSnap,
-		nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)} {
+		nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)} {
 		if err := cl.Create(t.Context(), obj); err != nil {
 			t.Fatal(err)
 		}
@@ -919,11 +919,11 @@ func TestCreateVolumeFromSnapshotFullSyncsPostSnapshotReplica(t *testing.T) {
 	for _, r := range got.Spec.Replicas {
 		byNode[r.Node] = r
 	}
-	if byNode[nodeKharkiv].FullSync {
-		t.Fatalf("the Done seed leg must clone, not full-sync: %+v", byNode[nodeKharkiv])
+	if byNode[nodeA].FullSync {
+		t.Fatalf("the Done seed leg must clone, not full-sync: %+v", byNode[nodeA])
 	}
-	if !byNode[nodeParis].FullSync {
-		t.Fatalf("the post-snapshot leg must full-sync (no local snapshot): %+v", byNode[nodeParis])
+	if !byNode[nodeB].FullSync {
+		t.Fatalf("the post-snapshot leg must full-sync (no local snapshot): %+v", byNode[nodeB])
 	}
 }
 
@@ -938,7 +938,7 @@ func TestCreateVolumeAlreadyExistsCacheLagIsUnavailable(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
-			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin}},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 	}
 	apiReader := fake.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
@@ -970,7 +970,7 @@ func TestMarkVolumeFormattedReadsThroughAPIReader(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
-			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin}},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 	}
 	// One store: reads through the cached client 404 (informer lag), while
@@ -1016,14 +1016,14 @@ func TestCreateVolumeFromSnapshotEchoesContentSource(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
-			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin}},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 	}
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
-			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone}},
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
 	cl := readyOnGet(s)
 	if err := cl.Create(t.Context(), srcVol); err != nil {
@@ -1064,7 +1064,7 @@ func TestCreateVolumeFromSnapshotEchoesContentSource(t *testing.T) {
 	if vol.Spec.Source == nil || vol.Spec.Source.SnapshotName != snapSnap1 {
 		t.Fatalf("new volume must record source snapshot, got %+v", vol.Spec.Source)
 	}
-	if len(vol.Spec.Replicas) != 1 || vol.Spec.Replicas[0].Node != nodeKharkiv {
+	if len(vol.Spec.Replicas) != 1 || vol.Spec.Replicas[0].Node != nodeA {
 		t.Fatalf("placement must follow source volume, got %+v", vol.Spec.Replicas)
 	}
 }
@@ -1077,7 +1077,7 @@ func TestCreateVolumeFromSnapshotInheritsFormatted(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
-			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin}},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 	}
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
@@ -1085,7 +1085,7 @@ func TestCreateVolumeFromSnapshotInheritsFormatted(t *testing.T) {
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{
 			ReadyToUse: true, SizeBytes: 5 << 30, SourceFormatted: true,
-			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone},
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone},
 		},
 	}
 	cl := readyOnGet(s)
@@ -1145,7 +1145,7 @@ func TestCreateVolumeIdempotentRejectsSourceChange(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
-			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendLVMThin}},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 	}
 	cl := readyOnGet(s)
@@ -1156,13 +1156,13 @@ func TestCreateVolumeIdempotentRejectsSourceChange(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
-			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone}},
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
 	snap2 := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: "snap-2"},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
-			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeKharkiv: miroirv1alpha1.SnapshotDone}},
+			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
 	if err := cl.Create(t.Context(), snap1); err != nil {
 		t.Fatal(err)
@@ -1207,7 +1207,7 @@ func TestCreateVolumeRemoteAccessDropsTopology(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: fake.NewClientBuilder().WithScheme(s).
-			WithObjects(nodeObj(nodeKharkiv, addrKharkiv), nodeObj(nodeParis, addrParis)).
+			WithObjects(nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					if err := cl.Get(ctx, key, obj, opts...); err != nil {

--- a/internal/csi/health_test.go
+++ b/internal/csi/health_test.go
@@ -51,19 +51,19 @@ func TestVolumeCondition(t *testing.T) {
 		{
 			name: "split-brain wins over everything",
 			vol: volWithStatus("v", miroirv1alpha1.VolumeDegraded, map[string]miroirv1alpha1.ReplicaStatus{
-				nodeParis:   {DiskFailed: true},
-				nodeKharkiv: {SplitBrain: true},
+				nodeB: {DiskFailed: true},
+				nodeA: {SplitBrain: true},
 			}),
 			wantAbnormal: true,
-			wantContains: "split-brain on node " + nodeKharkiv,
+			wantContains: "split-brain on node " + nodeA,
 		},
 		{
 			name: "disk failed when no split-brain",
 			vol: volWithStatus("v", miroirv1alpha1.VolumeReady, map[string]miroirv1alpha1.ReplicaStatus{
-				nodeParis: {DiskFailed: true},
+				nodeB: {DiskFailed: true},
 			}),
 			wantAbnormal: true,
-			wantContains: "backing disk failed on node " + nodeParis,
+			wantContains: "backing disk failed on node " + nodeB,
 		},
 		{
 			name:         "failed phase",
@@ -95,13 +95,13 @@ func TestVolumeCondition(t *testing.T) {
 // so a health event doesn't flap between reconciles.
 func TestVolumeConditionDeterministic(t *testing.T) {
 	vol := volWithStatus("v", miroirv1alpha1.VolumeReady, map[string]miroirv1alpha1.ReplicaStatus{
-		nodeParis:   {SplitBrain: true},
-		nodeKharkiv: {SplitBrain: true},
-		nodeOslo:    {SplitBrain: true},
+		nodeB: {SplitBrain: true},
+		nodeA: {SplitBrain: true},
+		nodeC: {SplitBrain: true},
 	})
 	for range 5 {
-		if msg := volumeCondition(vol).GetMessage(); !strings.Contains(msg, nodeKharkiv) {
-			t.Fatalf("expected lexically-first node %s, got %q", nodeKharkiv, msg)
+		if msg := volumeCondition(vol).GetMessage(); !strings.Contains(msg, nodeA) {
+			t.Fatalf("expected lexically-first node %s, got %q", nodeA, msg)
 		}
 	}
 }

--- a/internal/csi/node_test.go
+++ b/internal/csi/node_test.go
@@ -47,7 +47,7 @@ func (f fakeDRBDStatus) Status(context.Context, string) (drbd.Status, error) {
 	return f.st, f.err
 }
 
-// stagedVolume is a single-replica-on-kharkiv replicated volume whose agent
+// stagedVolume is a single-replica-on-node-a replicated volume whose agent
 // has already created the local DRBD device.
 func stagedVolume() *miroirv1alpha1.MiroirVolume {
 	v := &miroirv1alpha1.MiroirVolume{
@@ -55,11 +55,11 @@ func stagedVolume() *miroirv1alpha1.MiroirVolume {
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			DRBD:      &miroirv1alpha1.DRBDSpec{Port: 7000},
-			Replicas:  []miroirv1alpha1.Replica{{Node: nodeKharkiv, Address: addrKharkiv}},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Address: addrA}},
 		},
 	}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DeviceCreated: true, DevicePath: devDrbd1000},
+		nodeA: {DeviceCreated: true, DevicePath: devDrbd1000},
 	}
 	return v
 }
@@ -69,7 +69,7 @@ func newNode(t *testing.T, vol *miroirv1alpha1.MiroirVolume, d stage.DRBDStatus)
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		WithObjects(vol).Build()
-	return &Node{Client: c, NodeName: nodeKharkiv, DRBD: d}
+	return &Node{Client: c, NodeName: nodeA, DRBD: d}
 }
 
 // A split-brain leg must never be staged: mkfs/mount on divergent data
@@ -159,11 +159,11 @@ func TestNodeGetVolumeStatsMissingVolume(t *testing.T) {
 // data leg, only a quorum vote.
 func TestDevicePathRefusesDisklessNode(t *testing.T) {
 	v := stagedVolume()
-	// paris + oslo hold the data; kharkiv (this node) is the tie-breaker.
+	// node-b + node-c hold the data; node-a (this node) is the tie-breaker.
 	v.Spec.Replicas = []miroirv1alpha1.Replica{
-		{Node: nodeParis, NodeID: 0, Address: addrParis},
-		{Node: nodeOslo, NodeID: 1, Address: "192.168.1.43"},
-		{Node: nodeKharkiv, NodeID: 2, Address: addrKharkiv, Diskless: true},
+		{Node: nodeB, NodeID: 0, Address: addrB},
+		{Node: nodeC, NodeID: 1, Address: "192.168.1.43"},
+		{Node: nodeA, NodeID: 2, Address: addrA, Diskless: true},
 	}
 	n := newNode(t, v, fakeDRBDStatus{
 		st: drbd.Status{DiskState: "Diskless"},
@@ -173,14 +173,14 @@ func TestDevicePathRefusesDisklessNode(t *testing.T) {
 	}
 }
 
-// twoLegVolume extends stagedVolume with a second diskful replica on paris
+// twoLegVolume extends stagedVolume with a second diskful replica on node-b
 // (node id 1) whose slot records a split-brain — the recovery-in-progress
 // signal the staging hold keys on.
 func twoLegVolume() *miroirv1alpha1.MiroirVolume {
 	v := stagedVolume()
 	v.Spec.Replicas = append(v.Spec.Replicas,
-		miroirv1alpha1.Replica{Node: nodeParis, NodeID: 1, Address: addrParis})
-	v.Status.PerNode[nodeKharkiv] = miroirv1alpha1.ReplicaStatus{
+		miroirv1alpha1.Replica{Node: nodeB, NodeID: 1, Address: addrB})
+	v.Status.PerNode[nodeA] = miroirv1alpha1.ReplicaStatus{
 		DeviceCreated: true, DevicePath: devDrbd1000, SplitBrain: true,
 	}
 	return v
@@ -192,7 +192,7 @@ func twoLegVolume() *miroirv1alpha1.MiroirVolume {
 // the auto-recovery that heals the loser — hold it.
 func TestDevicePathHoldsNeverActivatedRecoveringSplitBrain(t *testing.T) {
 	n := newNode(t, twoLegVolume(), fakeDRBDStatus{
-		st: drbd.Status{DiskState: drbd.DiskUpToDate}, // paris link down: no PeerConnected entry
+		st: drbd.Status{DiskState: drbd.DiskUpToDate}, // node-b link down: no PeerConnected entry
 	})
 	if _, _, err := n.devicePath(t.Context(), volPvc1); status.Code(err) != codes.Unavailable {
 		t.Fatalf("recovering split-brain must hold staging as Unavailable, got %v", err)
@@ -256,7 +256,7 @@ func mountCap() *csi.VolumeCapability {
 // Until the gateway Service has an address, staging must fail retryably so
 // the CSI sidecar keeps retrying rather than failing the pod.
 func TestStageNFSGatewayNotReady(t *testing.T) {
-	n := &Node{NodeName: nodeKharkiv}
+	n := &Node{NodeName: nodeA}
 	if _, err := n.stageNFS(nfsStageReq(mountCap()), exportVolume("")); status.Code(err) != codes.Unavailable {
 		t.Fatalf("unready gateway must be Unavailable, got %v", err)
 	}
@@ -265,7 +265,7 @@ func TestStageNFSGatewayNotReady(t *testing.T) {
 // RWX is filesystem-only; a block capability on an export volume is a
 // misconfiguration, not something to mount.
 func TestStageNFSRejectsBlock(t *testing.T) {
-	n := &Node{NodeName: nodeKharkiv}
+	n := &Node{NodeName: nodeA}
 	block := &csi.VolumeCapability{
 		AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
 		AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER},
@@ -279,15 +279,15 @@ func TestStageNFSRejectsBlock(t *testing.T) {
 // or device lookup.
 func TestDevicePathRefusesForeignNode(t *testing.T) {
 	v := stagedVolume()
-	v.Spec.Replicas[0].Node = nodeParis
+	v.Spec.Replicas[0].Node = nodeB
 	n := newNode(t, v, fakeDRBDStatus{st: drbd.Status{DiskState: drbd.DiskUpToDate}})
 	if _, _, err := n.devicePath(t.Context(), volPvc1); status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("a node without a replica must be FailedPrecondition, got %v", err)
 	}
 }
 
-// remoteVolume is a 2-replica volume on paris+oslo with remote access
-// allowed; this node (kharkiv) holds no replica.
+// remoteVolume is a 2-replica volume on node-b+node-c with remote access
+// allowed; this node (node-a) holds no replica.
 func remoteVolume() *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
@@ -296,8 +296,8 @@ func remoteVolume() *miroirv1alpha1.MiroirVolume {
 			DRBD:              &miroirv1alpha1.DRBDSpec{Port: 7000},
 			AllowRemoteAccess: true,
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeParis, NodeID: 0, Address: addrParis},
-				{Node: nodeOslo, NodeID: 1, Address: "192.168.1.43"},
+				{Node: nodeB, NodeID: 0, Address: addrB},
+				{Node: nodeC, NodeID: 1, Address: "192.168.1.43"},
 			},
 		},
 	}
@@ -325,7 +325,7 @@ func TestDevicePathRemoteAttachAddsClientLeg(t *testing.T) {
 	if err := n.Client.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)
 	}
-	cl := got.Spec.ClientForNode(nodeKharkiv)
+	cl := got.Spec.ClientForNode(nodeA)
 	if cl == nil {
 		t.Fatalf("client leg not added: %+v", got.Spec.Clients)
 	}
@@ -355,9 +355,9 @@ func TestDevicePathRemoteRefusedWithoutOptIn(t *testing.T) {
 // diskful peer is reachable.
 func TestDevicePathClientLegServes(t *testing.T) {
 	v := remoteVolume()
-	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeKharkiv, NodeID: 2, Address: addrKharkiv}}
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeA, NodeID: 2, Address: addrA}}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DevicePath: devDrbd1000, Diskless: true},
+		nodeA: {DevicePath: devDrbd1000, Diskless: true},
 	}
 	n := newNode(t, v, fakeDRBDStatus{st: healthyRemoteStatus()})
 	dev, _, err := n.devicePath(t.Context(), volPvc1)
@@ -379,9 +379,9 @@ func TestDevicePathClientLegRefusesUnhealthy(t *testing.T) {
 	for name, st := range map[string]drbd.Status{"no quorum": noQuorum, "no UpToDate peer": stalePeers} {
 		t.Run(name, func(t *testing.T) {
 			v := remoteVolume()
-			v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeKharkiv, NodeID: 2, Address: addrKharkiv}}
+			v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeA, NodeID: 2, Address: addrA}}
 			v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-				nodeKharkiv: {DevicePath: devDrbd1000, Diskless: true},
+				nodeA: {DevicePath: devDrbd1000, Diskless: true},
 			}
 			n := newNode(t, v, fakeDRBDStatus{st: st})
 			if _, _, err := n.devicePath(t.Context(), volPvc1); status.Code(err) != codes.Unavailable {
@@ -396,9 +396,9 @@ func TestDevicePathClientLegRefusesUnhealthy(t *testing.T) {
 func TestDevicePathTieBreakerServesRemoteVolume(t *testing.T) {
 	v := remoteVolume()
 	v.Spec.Replicas = append(v.Spec.Replicas,
-		miroirv1alpha1.Replica{Node: nodeKharkiv, NodeID: 2, Address: addrKharkiv, Diskless: true})
+		miroirv1alpha1.Replica{Node: nodeA, NodeID: 2, Address: addrA, Diskless: true})
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DevicePath: devDrbd1000, Diskless: true},
+		nodeA: {DevicePath: devDrbd1000, Diskless: true},
 	}
 	n := newNode(t, v, fakeDRBDStatus{st: healthyRemoteStatus()})
 	dev, _, err := n.devicePath(t.Context(), volPvc1)
@@ -414,7 +414,7 @@ func TestDevicePathTieBreakerServesRemoteVolume(t *testing.T) {
 // agent tears it down.
 func TestNodeUnstageRemovesClientLeg(t *testing.T) {
 	v := remoteVolume()
-	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeKharkiv, NodeID: 2, Address: addrKharkiv}}
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeA, NodeID: 2, Address: addrA}}
 	n := newNode(t, v, fakeDRBDStatus{})
 	n.Mounter = mount.NewSafeFormatAndMount(mount.NewFakeMounter(nil), utilexec.New())
 
@@ -439,10 +439,10 @@ func TestNodeUnstageRemovesClientLeg(t *testing.T) {
 // tie-breaker leg — that would latch Activated and close auto-recovery.
 func TestDevicePathDisklessHoldsRecoveringSplitBrain(t *testing.T) {
 	v := remoteVolume()
-	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeKharkiv, NodeID: 2, Address: addrKharkiv}}
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeA, NodeID: 2, Address: addrA}}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DevicePath: devDrbd1000, Diskless: true},
-		nodeOslo:    {DeviceCreated: true, SplitBrain: true},
+		nodeA: {DevicePath: devDrbd1000, Diskless: true},
+		nodeC: {DeviceCreated: true, SplitBrain: true},
 	}
 	st := healthyRemoteStatus()
 	delete(st.PeerConnected, 1) // the losing leg's link is down
@@ -456,10 +456,10 @@ func TestDevicePathDisklessHoldsRecoveringSplitBrain(t *testing.T) {
 // live — mirroring the diskful hold's corroboration.
 func TestDevicePathDisklessStaleSplitSlotIgnored(t *testing.T) {
 	v := remoteVolume()
-	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeKharkiv, NodeID: 2, Address: addrKharkiv}}
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeA, NodeID: 2, Address: addrA}}
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeKharkiv: {DevicePath: devDrbd1000, Diskless: true},
-		nodeOslo:    {DeviceCreated: true, SplitBrain: true}, // stale
+		nodeA: {DevicePath: devDrbd1000, Diskless: true},
+		nodeC: {DeviceCreated: true, SplitBrain: true}, // stale
 	}
 	n := newNode(t, v, fakeDRBDStatus{st: healthyRemoteStatus()})
 	if _, _, err := n.devicePath(t.Context(), volPvc1); err != nil {

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -85,8 +85,8 @@ func TestPlaceWeightsByFreeSpace(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 100*gib, 90*gib), // 10 GiB free
-			miroirNodeObj(nodeParis, 100*gib, 10*gib),   // 90 GiB free
+			miroirNodeObj(nodeA, 100*gib, 90*gib), // 10 GiB free
+			miroirNodeObj(nodeB, 100*gib, 10*gib), // 90 GiB free
 		),
 		Nodes: testNodes,
 	}
@@ -95,8 +95,8 @@ func TestPlaceWeightsByFreeSpace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0].Node != nodeParis {
-		t.Fatalf("expected placement on paris (most free), got %+v", got)
+	if len(got) != 1 || got[0].Node != nodeB {
+		t.Fatalf("expected placement on node-b (most free), got %+v", got)
 	}
 }
 
@@ -104,10 +104,10 @@ func TestPlaceRefusesOvercommit(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 10*gib, 0),
-			miroirNodeObj(nodeParis, 10*gib, 0),
-			volOn("existing-k", nodeKharkiv, 15*gib),
-			volOn("existing-p", nodeParis, 15*gib),
+			miroirNodeObj(nodeA, 10*gib, 0),
+			miroirNodeObj(nodeB, 10*gib, 0),
+			volOn("existing-k", nodeA, 15*gib),
+			volOn("existing-p", nodeB, 15*gib),
 		),
 		Nodes: testNodes,
 	}
@@ -123,14 +123,14 @@ func TestPlaceTopologyPinnedRefusedWhenOvercommitted(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 10*gib, 0),
-			miroirNodeObj(nodeParis, 100*gib, 0), // roomy, but not the pod's node
-			volOn("existing-k", nodeKharkiv, 15*gib),
+			miroirNodeObj(nodeA, 10*gib, 0),
+			miroirNodeObj(nodeB, 100*gib, 0), // roomy, but not the pod's node
+			volOn("existing-k", nodeA, 15*gib),
 		),
 		Nodes: testNodes,
 	}
 
-	_, err := c.place(t.Context(), topologyPref(nodeKharkiv), 1, 10*gib, volNew, placementVols(t, c.Client), false)
+	_, err := c.place(t.Context(), topologyPref(nodeA), 1, 10*gib, volNew, placementVols(t, c.Client), false)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("pinned overcommitted node must be ResourceExhausted, got %v", err)
 	}
@@ -144,8 +144,8 @@ func TestPlaceFallsBackWithoutStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0].Node != nodeKharkiv {
-		t.Fatalf("expected by-name fallback to kharkiv, got %+v", got)
+	if len(got) != 1 || got[0].Node != nodeA {
+		t.Fatalf("expected by-name fallback to node-a, got %+v", got)
 	}
 }
 
@@ -153,8 +153,8 @@ func TestPlaceHonoursConfiguredRatio(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 10*gib, 0),
-			miroirNodeObj(nodeParis, 10*gib, 0),
+			miroirNodeObj(nodeA, 10*gib, 0),
+			miroirNodeObj(nodeB, 10*gib, 0),
 		),
 		Nodes:           testNodes,
 		OvercommitRatio: 1, // no overcommit allowed
@@ -218,24 +218,24 @@ func TestSpreadByZone(t *testing.T) {
 	}
 }
 
-// kharkiv and paris share zone a with the most free space; oslo is alone in
-// zone b with the least. Free-space ranking alone picks kharkiv+paris — zone
+// node-a and node-b share zone a with the most free space; node-c is alone in
+// zone b with the least. Free-space ranking alone picks node-a+node-b — zone
 // spread must instead reach into zone b so the replicas span failure domains.
 func TestPlaceSpreadsAcrossZones(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 100*gib, 10*gib), // 90 free, zone a
-			miroirNodeObj(nodeParis, 100*gib, 20*gib),   // 80 free, zone a
-			miroirNodeObj(nodeOslo, 100*gib, 90*gib),    // 10 free, zone b
-			nodeObj(nodeKharkiv, addrKharkiv),
-			nodeObj(nodeParis, "192.168.1.42"),
-			nodeObj(nodeOslo, "192.168.1.43"),
+			miroirNodeObj(nodeA, 100*gib, 10*gib), // 90 free, zone a
+			miroirNodeObj(nodeB, 100*gib, 20*gib), // 80 free, zone a
+			miroirNodeObj(nodeC, 100*gib, 90*gib), // 10 free, zone b
+			nodeObj(nodeA, addrA),
+			nodeObj(nodeB, "192.168.1.42"),
+			nodeObj(nodeC, "192.168.1.43"),
 		),
 		Nodes: nodemap.Map{
-			nodeKharkiv: {Backend: miroirv1alpha1.BackendLVMThin, Zone: "a", Device: "/dev/x"},
-			nodeParis:   {Backend: miroirv1alpha1.BackendZFS, Zone: "a", ZFSDataset: "p/m"},
-			nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin, Zone: "b", Device: "/dev/y"},
+			nodeA: {Backend: miroirv1alpha1.BackendLVMThin, Zone: "a", Device: "/dev/x"},
+			nodeB: {Backend: miroirv1alpha1.BackendZFS, Zone: "a", ZFSDataset: "p/m"},
+			nodeC: {Backend: miroirv1alpha1.BackendLVMThin, Zone: "b", Device: "/dev/y"},
 		},
 	}
 
@@ -245,8 +245,8 @@ func TestPlaceSpreadsAcrossZones(t *testing.T) {
 	}
 	nodes := []string{got[0].Node, got[1].Node}
 	slices.Sort(nodes)
-	if !slices.Equal(nodes, []string{nodeKharkiv, nodeOslo}) {
-		t.Fatalf("replicas must span zones a and b (kharkiv+oslo), got %v", nodes)
+	if !slices.Equal(nodes, []string{nodeA, nodeC}) {
+		t.Fatalf("replicas must span zones a and b (node-a+node-c), got %v", nodes)
 	}
 }
 
@@ -266,10 +266,10 @@ func TestPlaceRemoteAccessIgnoresNonStorageTopology(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 100*gib, 10*gib),
-			miroirNodeObj(nodeParis, 100*gib, 10*gib),
-			nodeObj(nodeKharkiv, addrKharkiv),
-			nodeObj(nodeParis, addrParis),
+			miroirNodeObj(nodeA, 100*gib, 10*gib),
+			miroirNodeObj(nodeB, 100*gib, 10*gib),
+			nodeObj(nodeA, addrA),
+			nodeObj(nodeB, addrB),
 		),
 		Nodes: testNodes,
 	}
@@ -294,8 +294,8 @@ func TestPlaceStrictRefusesNonStorageTopology(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 100*gib, 10*gib),
-			miroirNodeObj(nodeParis, 100*gib, 10*gib),
+			miroirNodeObj(nodeA, 100*gib, 10*gib),
+			miroirNodeObj(nodeB, 100*gib, 10*gib),
 		),
 		Nodes: testNodes,
 	}
@@ -319,26 +319,26 @@ func TestGetCapacityPerNode(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 10*gib, 0),
-			miroirNodeObj(nodeParis, 10*gib, 0),
-			volOn("existing-p", nodeParis, 5*gib),
+			miroirNodeObj(nodeA, 10*gib, 0),
+			miroirNodeObj(nodeB, 10*gib, 0),
+			volOn("existing-p", nodeB, 5*gib),
 		),
 		Nodes: testNodes,
 	}
-	// Default 2× ratio: kharkiv headroom = 20 - 0 = 20 GiB; paris = 20 - 5 = 15 GiB.
-	resp, err := c.GetCapacity(t.Context(), topologySegment(nodeKharkiv))
+	// Default 2× ratio: node-a headroom = 20 - 0 = 20 GiB; node-b = 20 - 5 = 15 GiB.
+	resp, err := c.GetCapacity(t.Context(), topologySegment(nodeA))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resp.GetAvailableCapacity() != 20*gib {
-		t.Fatalf("kharkiv capacity = %d, want %d", resp.GetAvailableCapacity(), 20*gib)
+		t.Fatalf("node-a capacity = %d, want %d", resp.GetAvailableCapacity(), 20*gib)
 	}
-	resp, err = c.GetCapacity(t.Context(), topologySegment(nodeParis))
+	resp, err = c.GetCapacity(t.Context(), topologySegment(nodeB))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resp.GetAvailableCapacity() != 15*gib {
-		t.Fatalf("paris capacity = %d, want %d", resp.GetAvailableCapacity(), 15*gib)
+		t.Fatalf("node-b capacity = %d, want %d", resp.GetAvailableCapacity(), 15*gib)
 	}
 }
 
@@ -348,12 +348,12 @@ func TestGetCapacityOvercommittedIsZero(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 10*gib, 0),
-			volOn("existing-k", nodeKharkiv, 25*gib), // 25 > 2×10
+			miroirNodeObj(nodeA, 10*gib, 0),
+			volOn("existing-k", nodeA, 25*gib), // 25 > 2×10
 		),
 		Nodes: testNodes,
 	}
-	resp, err := c.GetCapacity(t.Context(), topologySegment(nodeKharkiv))
+	resp, err := c.GetCapacity(t.Context(), topologySegment(nodeA))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,15 +367,15 @@ func TestGetCapacityOvercommittedIsZero(t *testing.T) {
 func TestGetCapacityUnknownIsZero(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
-		Client: placementClient(s, miroirNodeObj(nodeKharkiv, 10*gib, 0)),
+		Client: placementClient(s, miroirNodeObj(nodeA, 10*gib, 0)),
 		Nodes:  testNodes,
 	}
-	// paris is a storage node but has published no stats yet.
-	if resp, _ := c.GetCapacity(t.Context(), topologySegment(nodeParis)); resp.GetAvailableCapacity() != 0 {
+	// node-b is a storage node but has published no stats yet.
+	if resp, _ := c.GetCapacity(t.Context(), topologySegment(nodeB)); resp.GetAvailableCapacity() != 0 {
 		t.Fatalf("statless node must report 0, got %d", resp.GetAvailableCapacity())
 	}
-	// oslo is not in the storage map at all.
-	if resp, _ := c.GetCapacity(t.Context(), topologySegment(nodeOslo)); resp.GetAvailableCapacity() != 0 {
+	// node-c is not in the storage map at all.
+	if resp, _ := c.GetCapacity(t.Context(), topologySegment(nodeC)); resp.GetAvailableCapacity() != 0 {
 		t.Fatalf("non-storage node must report 0, got %d", resp.GetAvailableCapacity())
 	}
 }
@@ -386,8 +386,8 @@ func TestGetCapacityNoTopologyReportsBestNode(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 10*gib, 0), // 20 GiB headroom
-			miroirNodeObj(nodeParis, 100*gib, 0),  // 200 GiB headroom
+			miroirNodeObj(nodeA, 10*gib, 0),  // 20 GiB headroom
+			miroirNodeObj(nodeB, 100*gib, 0), // 200 GiB headroom
 		),
 		Nodes: testNodes,
 	}
@@ -412,14 +412,14 @@ func TestGetCapacityRemoteAccessSegments(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 10*gib, 0), // 20 GiB headroom
-			miroirNodeObj(nodeParis, 100*gib, 0),  // 200 GiB headroom
+			miroirNodeObj(nodeA, 10*gib, 0),  // 20 GiB headroom
+			miroirNodeObj(nodeB, 100*gib, 0), // 200 GiB headroom
 		),
 		Nodes: testNodes,
 	}
 	remoteParams := map[string]string{constants.ParamReplicas: "2"}
 
-	req := topologySegment(nodeOslo) // not a storage node
+	req := topologySegment(nodeC) // not a storage node
 	req.Parameters = remoteParams
 	resp, err := c.GetCapacity(t.Context(), req)
 	if err != nil {
@@ -430,13 +430,13 @@ func TestGetCapacityRemoteAccessSegments(t *testing.T) {
 			resp.GetAvailableCapacity(), 20*gib)
 	}
 
-	req = topologySegment(nodeParis)
+	req = topologySegment(nodeB)
 	req.Parameters = remoteParams
 	resp, err = c.GetCapacity(t.Context(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// paris pinned (200 GiB) + one peer leg on kharkiv (20 GiB) → 20 GiB.
+	// node-b pinned (200 GiB) + one peer leg on node-a (20 GiB) → 20 GiB.
 	if resp.GetAvailableCapacity() != 20*gib {
 		t.Fatalf("storage segment = %d, want min(own, peer) %d",
 			resp.GetAvailableCapacity(), 20*gib)
@@ -450,13 +450,13 @@ func TestGetCapacityReplicatedNeedsAllLegs(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
 		Client: placementClient(s,
-			miroirNodeObj(nodeKharkiv, 10*gib, 0),  // 20 GiB headroom
-			miroirNodeObj(nodeParis, 10*gib, 0),    // full below
-			volOn("existing-p", nodeParis, 25*gib), // 25 > 2×10 — overcommitted
+			miroirNodeObj(nodeA, 10*gib, 0),    // 20 GiB headroom
+			miroirNodeObj(nodeB, 10*gib, 0),    // full below
+			volOn("existing-p", nodeB, 25*gib), // 25 > 2×10 — overcommitted
 		),
 		Nodes: testNodes,
 	}
-	req := topologySegment(nodeKharkiv)
+	req := topologySegment(nodeA)
 	req.Parameters = map[string]string{constants.ParamReplicas: "2"}
 	resp, err := c.GetCapacity(t.Context(), req)
 	if err != nil {

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"golang.org/x/sys/unix"
 
 	"github.com/home-operations/miroir/internal/backend"
@@ -934,27 +935,28 @@ func (d *Driver) KernelVersion(ctx context.Context) (string, error) {
 	return "", errors.New("no DRBD_KERNEL_VERSION in drbdadm --version output")
 }
 
+// kernelFloor is KernelFloor pre-parsed for comparisons.
+var kernelFloor = semver.MustParse(KernelFloor)
+
 // BelowKernelFloor reports whether a module version sorts below
-// KernelFloor, comparing dotted components numerically ("9.10" is newer
-// than "9.3"). A version that does not parse reads as below: refusing an
+// KernelFloor ("9.10" is newer than "9.3"; a short "9.3" reads as
+// "9.3.0"). A version that does not parse reads as below: refusing an
 // unknown platform beats rendering options it may reject.
 func BelowKernelFloor(version string) bool {
-	floor := strings.Split(KernelFloor, ".")
-	parts := strings.Split(strings.TrimSpace(version), ".")
-	for i, f := range floor {
-		want, _ := strconv.Atoi(f)
-		if i >= len(parts) {
-			return true // shorter than the floor: "9.3" < "9.3.1"
+	trimmed := strings.TrimSpace(version)
+	v, err := semver.NewVersion(trimmed)
+	if err != nil {
+		// semver rejects a 4th dotted component (vendor module builds
+		// like "9.3.1.1") that the floor never needs; compare on the
+		// leading x.y.z before giving up.
+		if parts := strings.SplitN(trimmed, ".", 4); len(parts) == 4 {
+			v, err = semver.NewVersion(strings.Join(parts[:3], "."))
 		}
-		got, err := strconv.Atoi(parts[i])
 		if err != nil {
 			return true
 		}
-		if got != want {
-			return got < want
-		}
 	}
-	return false
+	return v.LessThan(kernelFloor)
 }
 
 // DiscardGranularity probes the backing device's discard granularity

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -33,9 +33,9 @@ const (
 	cmdAdmVersion      = "drbdadm --version"
 	cmdDumpMD          = "dump-md"
 	mockCurrentUUID    = "current-uuid 0xDEADBEEF00000001;"
-	addrKharkiv        = "192.168.1.41"
-	addrParis          = "192.168.1.42"
-	addrOslo           = "192.168.1.43"
+	addrA              = "192.168.1.41"
+	addrB              = "192.168.1.42"
+	addrC              = "192.168.1.43"
 	nodeWorker1        = "worker-1"
 )
 
@@ -48,14 +48,14 @@ func testResource(local string) Resource {
 		LocalNode: local,
 		LocalDisk: "/dev/vg-miroir/pvc-1",
 		Peers: []Peer{
-			{Node: nodeKharkiv, NodeID: 0, Address: addrKharkiv},
-			{Node: nodeParis, NodeID: 1, Address: addrParis},
+			{Node: nodeA, NodeID: 0, Address: addrA},
+			{Node: nodeB, NodeID: 1, Address: addrB},
 		},
 	}
 }
 
 func TestRenderDeterministicAndLocalDisk(t *testing.T) {
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 	a, b := Render(r), Render(r)
 	if a != b {
 		t.Fatal("render is not deterministic")
@@ -75,7 +75,7 @@ func TestRenderDeterministicAndLocalDisk(t *testing.T) {
 }
 
 func TestRenderSharedSecret(t *testing.T) {
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 	if out := Render(r); strings.Contains(out, "shared-secret") {
 		t.Fatalf("no auth must render for secretless volumes (pre-secret CRs):\n%s", out)
 	}
@@ -107,7 +107,7 @@ func TestParseEvent2(t *testing.T) {
 }
 
 func TestRenderFreezeQuorum(t *testing.T) {
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 	r.Quorum = miroirv1alpha1.QuorumFreeze
 	out := Render(r)
 	if !strings.Contains(out, "quorum majority;") || !strings.Contains(out, "on-no-quorum io-error;") {
@@ -118,9 +118,9 @@ func TestRenderFreezeQuorum(t *testing.T) {
 // A client leg renders "tiebreaker no" (it must not shift quorum math);
 // a placed tie-breaker replica keeps the default — voting is its purpose.
 func TestRenderClientLegNoTiebreaker(t *testing.T) {
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 	r.Peers = append(r.Peers,
-		Peer{Node: "tiebreak-1", NodeID: 2, Address: addrOslo, Diskless: true},
+		Peer{Node: "tiebreak-1", NodeID: 2, Address: addrC, Diskless: true},
 		Peer{Node: nodeWorker1, NodeID: 3, Address: "192.168.1.44", Diskless: true, Client: true},
 	)
 	out := Render(r)
@@ -136,9 +136,9 @@ func TestRenderClientLegNoTiebreaker(t *testing.T) {
 // A client leg rendered on its own node advertises the diskful legs'
 // discard granularity; rendered anywhere else (or unset) it must not.
 func TestRenderClientDiscardGranularity(t *testing.T) {
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 	r.Peers = append(r.Peers,
-		Peer{Node: nodeWorker1, NodeID: 2, Address: addrOslo, Diskless: true, Client: true},
+		Peer{Node: nodeWorker1, NodeID: 2, Address: addrC, Diskless: true, Client: true},
 	)
 	r.ClientDiscardGranularityBytes = 65536
 
@@ -169,7 +169,7 @@ func TestRenderClientDiscardGranularity(t *testing.T) {
 }
 
 func TestRenderNoAutoSplitBrainResolution(t *testing.T) {
-	out := Render(testResource(nodeKharkiv))
+	out := Render(testResource(nodeA))
 	for _, directive := range []string{
 		"after-sb-0pri disconnect;",
 		"after-sb-1pri disconnect;",
@@ -200,10 +200,10 @@ func fakeMknod(string, uint32, int) error { return nil }
 func TestResolveSplitBrainWinnerReconnects(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	// kharkiv is node id 0 — the seed winner and the survivor. It disconnects
+	// node-a is node id 0 — the seed winner and the survivor. It disconnects
 	// first (a bare connect aborts on a peer that already has a net-config)
 	// then reconnects without discarding data.
-	if err := d.ResolveSplitBrain(context.Background(), testResource(nodeKharkiv)); err != nil {
+	if err := d.ResolveSplitBrain(context.Background(), testResource(nodeA)); err != nil {
 		t.Fatalf("ResolveSplitBrain: %v", err)
 	}
 	fe.calledWith(t, "drbdadm disconnect pvc-1")
@@ -214,9 +214,9 @@ func TestResolveSplitBrainWinnerReconnects(t *testing.T) {
 func TestResolveSplitBrainLoserDiscards(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	// paris is node id 1 — the loser: it must disconnect then reconnect
+	// node-b is node id 1 — the loser: it must disconnect then reconnect
 	// discarding its own generation so it becomes SyncTarget.
-	if err := d.ResolveSplitBrain(context.Background(), testResource(nodeParis)); err != nil {
+	if err := d.ResolveSplitBrain(context.Background(), testResource(nodeB)); err != nil {
 		t.Fatalf("ResolveSplitBrain: %v", err)
 	}
 	fe.calledWith(t, "drbdadm disconnect pvc-1")
@@ -226,7 +226,7 @@ func TestResolveSplitBrainLoserDiscards(t *testing.T) {
 func TestResolveSplitBrainDisklessReconnects(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeParis)
+	r := testResource(nodeB)
 	r.LocalDiskless = true // a tie-breaker never discards data
 	if err := d.ResolveSplitBrain(context.Background(), r); err != nil {
 		t.Fatalf("ResolveSplitBrain: %v", err)
@@ -300,7 +300,7 @@ func (f *fakeExec) notCalledWith(t *testing.T, substr string) {
 func TestApplyFreshResource(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 
 	if err := d.Apply(t.Context(), r); err != nil {
 		t.Fatal(err)
@@ -326,7 +326,7 @@ func TestApplyFreshResource(t *testing.T) {
 func TestApplyBitmapGranularity(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 	r.BitmapGranularityBytes = 65536
 
 	if err := d.Apply(t.Context(), r); err != nil {
@@ -397,21 +397,27 @@ func TestKernelVersion(t *testing.T) {
 	}
 }
 
-// The floor compare is numeric per dotted component — "9.10" is newer
-// than "9.3" — and anything unparseable reads as below the floor.
+// The floor compare is semver-based — "9.10" is newer than "9.3", a
+// short "9.3" reads as "9.3.0" — and anything unparseable reads as
+// below the floor.
 func TestBelowKernelFloor(t *testing.T) {
 	cases := map[string]bool{
-		"9.3.1":   false, // the floor itself
-		"9.3.2":   false,
-		"9.4.0":   false,
-		"9.10.0":  false, // numeric, not lexicographic
-		"10.0.0":  false,
-		"9.3.0":   true,
-		"9.2.18":  true,
-		"8.4.11":  true,
-		"9.3":     true, // shorter than the floor
-		"":        true,
-		"unknown": true,
+		"9.3.1":      false, // the floor itself
+		"9.3.2":      false,
+		"9.4.0":      false,
+		"9.10.0":     false, // numeric, not lexicographic
+		"10.0.0":     false,
+		"9.3.1.1":    false, // 4-component vendor build: compared on x.y.z
+		"v9.3.2":     false, // leading v tolerated
+		"9.3.2-1":    false, // suffixed build of a version above the floor
+		"9.3.2+ptf1": false, // LINBIT PTF-style build metadata
+		"9.3.0":      true,
+		"9.2.18":     true,
+		"9.2.18.4":   true, // 4-component below the floor stays below
+		"8.4.11":     true,
+		"9.3":        true, // shorter than the floor
+		"":           true,
+		"unknown":    true,
 	}
 	for version, want := range cases {
 		if got := BelowKernelFloor(version); got != want {
@@ -455,7 +461,7 @@ func TestDiscardGranularity(t *testing.T) {
 func TestApplySkipDiskAttachLeavesDiskDetached(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 	r.SkipDiskAttach = true
 
 	if err := d.Apply(t.Context(), r); err != nil {
@@ -484,7 +490,7 @@ func TestApplyRecreatesOnMissingMetadata(t *testing.T) {
 	}}
 	d := &Driver{StateDir: dir, Exec: fe.run, Mknod: fakeMknod}
 
-	if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err != nil {
+	if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
@@ -504,7 +510,7 @@ func TestApplyRecreatesOnMissingMetadata(t *testing.T) {
 func TestApplyIdempotent(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 
 	if err := d.Apply(t.Context(), r); err != nil {
 		t.Fatal(err)
@@ -528,7 +534,7 @@ func TestApplyRetriesAfterCreateMDCrash(t *testing.T) {
 		"create-md": errors.New("exit status 20: open failed"),
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeParis)
+	r := testResource(nodeB)
 
 	if err := d.Apply(t.Context(), r); err == nil {
 		t.Fatal("expected create-md failure")
@@ -575,7 +581,7 @@ func TestApplyAdoptsAttachedDevice(t *testing.T) {
 		}},
 	} {
 		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-		if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err != nil {
+		if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
 			t.Fatalf("%s: %v", name, err)
 		}
 		fe.notCalledWith(t, "create-md")
@@ -602,7 +608,7 @@ func TestApplyAppliesALOnUncleanClone(t *testing.T) {
 	}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 
-	if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err != nil {
+	if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm apply-al pvc-1/0")
@@ -622,7 +628,7 @@ func TestApplySurfacesNonDRBDBusyDevice(t *testing.T) {
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 
-	if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err == nil {
+	if err := d.Apply(t.Context(), testResource(nodeA)); err == nil {
 		t.Fatal("busy backing device must surface as an error")
 	}
 	fe.notCalledWith(t, "create-md")
@@ -643,7 +649,7 @@ func TestApplyFastPathCleansStaleSentinel(t *testing.T) {
 		}
 	}
 
-	if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err != nil {
+	if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
 		t.Fatal(err)
 	}
 	fe.notCalledWith(t, "set-gi")
@@ -660,7 +666,7 @@ func TestApplyAdoptsLiveMetadataWithoutMarkers(t *testing.T) {
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 
-	if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err != nil {
+	if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
 		t.Fatal(err)
 	}
 	fe.notCalledWith(t, "create-md")
@@ -679,7 +685,7 @@ func TestApplyClaimsVirginMetadataWithoutMarkers(t *testing.T) {
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 
-	if err := d.Apply(t.Context(), testResource(nodeKharkiv)); err != nil {
+	if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
 		t.Fatal(err)
 	}
 	fe.notCalledWith(t, "create-md")
@@ -717,7 +723,7 @@ func TestDownRemovesState(t *testing.T) {
 		cmdDrbdsetupStatus: `[{"name":"pvc-1","connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	r := testResource(nodeKharkiv)
+	r := testResource(nodeA)
 
 	if err := d.Apply(t.Context(), r); err != nil {
 		t.Fatal(err)

--- a/internal/drbd/minor_test.go
+++ b/internal/drbd/minor_test.go
@@ -74,11 +74,11 @@ func TestAllocateMinorSkipsMinorsFromOwnRender(t *testing.T) {
 		Name:      "legacy",
 		Minor:     minorBase,
 		Port:      7000,
-		LocalNode: "kharkiv",
+		LocalNode: nodeA,
 		LocalDisk: "/dev/mapper/x",
 		Peers: []Peer{
-			{Node: "kharkiv", NodeID: 0, Address: addrKharkiv},
-			{Node: "paris", NodeID: 1, Address: addrParis},
+			{Node: nodeA, NodeID: 0, Address: addrA},
+			{Node: nodeB, NodeID: 1, Address: addrB},
 		},
 	})
 	if err := os.WriteFile(filepath.Join(dir, "legacy.res"), []byte(res), 0o640); err != nil {

--- a/internal/drbd/res.go
+++ b/internal/drbd/res.go
@@ -102,6 +102,17 @@ type Peer struct {
 	Client bool
 }
 
+// writeDiskOption renders a one-option disk{} block inside the current
+// volume section; 0 renders nothing (the knob stays at DRBD's default).
+func writeDiskOption(b *strings.Builder, name string, value int64) {
+	if value <= 0 {
+		return
+	}
+	b.WriteString("            disk {\n")
+	fmt.Fprintf(b, "                %s %d;\n", name, value)
+	b.WriteString("            }\n")
+}
+
 // Render produces the .res file content for the local node.
 func Render(r Resource) string {
 	peers := append([]Peer(nil), r.Peers...)
@@ -173,10 +184,8 @@ func Render(r Resource) string {
 			// A second disk statement is legal: the string form (none)
 			// and the options form fill different config fields — the
 			// same shape the diskful branch uses for rs-discard-granularity.
-			if p.Node == r.LocalNode && r.ClientDiscardGranularityBytes > 0 {
-				b.WriteString("            disk {\n")
-				fmt.Fprintf(&b, "                discard-granularity %d;\n", r.ClientDiscardGranularityBytes)
-				b.WriteString("            }\n")
+			if p.Node == r.LocalNode {
+				writeDiskOption(&b, "discard-granularity", r.ClientDiscardGranularityBytes)
 			}
 		} else {
 			disk := peerDiskPlaceholder
@@ -185,10 +194,8 @@ func Render(r Resource) string {
 			}
 			fmt.Fprintf(&b, "            disk %q;\n", disk)
 			b.WriteString("            meta-disk internal;\n")
-			if p.Node == r.LocalNode && r.DiscardGranularityBytes > 0 {
-				b.WriteString("            disk {\n")
-				fmt.Fprintf(&b, "                rs-discard-granularity %d;\n", r.DiscardGranularityBytes)
-				b.WriteString("            }\n")
+			if p.Node == r.LocalNode {
+				writeDiskOption(&b, "rs-discard-granularity", r.DiscardGranularityBytes)
 			}
 		}
 		b.WriteString("        }\n")

--- a/internal/drbd/res_test.go
+++ b/internal/drbd/res_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	nodeKharkiv = "kharkiv"
-	nodeParis   = "paris"
-	nodeOslo    = "oslo"
+	nodeA = "node-a"
+	nodeB = "node-b"
+	nodeC = "node-c"
 )
 
 func tieBreakerResource(localNode string) Resource {
@@ -38,9 +38,9 @@ func tieBreakerResource(localNode string) Resource {
 		LocalNode: localNode,
 		LocalDisk: "/dev/vg-miroir/pvc-1",
 		Peers: []Peer{
-			{Node: nodeKharkiv, NodeID: 0, Address: addrKharkiv},
-			{Node: nodeParis, NodeID: 1, Address: addrParis},
-			{Node: nodeOslo, NodeID: 2, Address: addrOslo, Diskless: true},
+			{Node: nodeA, NodeID: 0, Address: addrA},
+			{Node: nodeB, NodeID: 1, Address: addrB},
+			{Node: nodeC, NodeID: 2, Address: addrC, Diskless: true},
 		},
 	}
 }
@@ -49,7 +49,7 @@ func tieBreakerResource(localNode string) Resource {
 // (each node renders its own .res, so per-leg granularity), and only when
 // probed non-zero — the resource-level option overrides the common{} knob.
 func TestRenderDiscardGranularityLocalOnly(t *testing.T) {
-	r := tieBreakerResource(nodeKharkiv)
+	r := tieBreakerResource(nodeA)
 	r.DiscardGranularityBytes = 65536
 	out := Render(r)
 	if !strings.Contains(out, "rs-discard-granularity 65536;") {
@@ -69,15 +69,15 @@ func TestRenderDiscardGranularityLocalOnly(t *testing.T) {
 // A diskless tie-breaker peer renders "disk none" with no meta-disk; the
 // diskful peers keep the placeholder/local-disk + internal metadata.
 func TestRenderDisklessTieBreaker(t *testing.T) {
-	out := Render(tieBreakerResource(nodeKharkiv))
+	out := Render(tieBreakerResource(nodeA))
 
-	oslo := out[strings.Index(out, "on \""+nodeOslo+"\""):]
-	oslo = oslo[:strings.Index(oslo, "}\n    }")]
-	if !strings.Contains(oslo, "disk none;") {
-		t.Fatalf("tie-breaker peer must render disk none:\n%s", oslo)
+	tieBreaker := out[strings.Index(out, "on \""+nodeC+"\""):]
+	tieBreaker = tieBreaker[:strings.Index(tieBreaker, "}\n    }")]
+	if !strings.Contains(tieBreaker, "disk none;") {
+		t.Fatalf("tie-breaker peer must render disk none:\n%s", tieBreaker)
 	}
-	if strings.Contains(oslo, "meta-disk") {
-		t.Fatalf("tie-breaker peer must not render a meta-disk:\n%s", oslo)
+	if strings.Contains(tieBreaker, "meta-disk") {
+		t.Fatalf("tie-breaker peer must not render a meta-disk:\n%s", tieBreaker)
 	}
 	if !strings.Contains(out, `disk "/dev/vg-miroir/pvc-1";`) {
 		t.Fatal("local diskful peer must render the real backing path")
@@ -85,7 +85,7 @@ func TestRenderDisklessTieBreaker(t *testing.T) {
 	if !strings.Contains(out, `disk "`+peerDiskPlaceholder+`";`) {
 		t.Fatal("remote diskful peer must render the placeholder")
 	}
-	if !strings.Contains(out, "hosts \""+nodeKharkiv+"\" \""+nodeParis+"\" \""+nodeOslo+"\";") {
+	if !strings.Contains(out, "hosts \""+nodeA+"\" \""+nodeB+"\" \""+nodeC+"\";") {
 		t.Fatal("the tie-breaker must be in the connection mesh")
 	}
 }
@@ -95,7 +95,7 @@ func TestRenderDisklessTieBreaker(t *testing.T) {
 // on-no-quorum suspend-io, and keying off the suspended state would
 // entangle it with the snapshot barrier's suspend-io.
 func TestRenderFreezeQuorumOptions(t *testing.T) {
-	out := Render(tieBreakerResource(nodeKharkiv))
+	out := Render(tieBreakerResource(nodeA))
 	if !strings.Contains(out, "quorum majority;") || !strings.Contains(out, "on-no-quorum io-error;") {
 		t.Fatal("freeze must render quorum majority + on-no-quorum io-error")
 	}
@@ -109,17 +109,17 @@ func TestRenderFreezeQuorumOptions(t *testing.T) {
 // UpToDate and the first handshake would deadlock all-Inconsistent.
 func TestWinnerSkipsDiskless(t *testing.T) {
 	r := Resource{
-		LocalNode: nodeKharkiv,
+		LocalNode: nodeA,
 		Peers: []Peer{
-			{Node: nodeOslo, NodeID: 0, Diskless: true},
-			{Node: nodeKharkiv, NodeID: 1},
-			{Node: nodeParis, NodeID: 2},
+			{Node: nodeC, NodeID: 0, Diskless: true},
+			{Node: nodeA, NodeID: 1},
+			{Node: nodeB, NodeID: 2},
 		},
 	}
 	if !IsWinner(r) {
-		t.Fatal("kharkiv (lowest diskful id) must win, not the diskless tie-breaker")
+		t.Fatal("node-a (lowest diskful id) must win, not the diskless tie-breaker")
 	}
-	r.LocalNode = nodeOslo
+	r.LocalNode = nodeC
 	if IsWinner(r) {
 		t.Fatal("a diskless tie-breaker must never be the winner")
 	}
@@ -130,17 +130,17 @@ func TestRenderIPv6Address(t *testing.T) {
 		Name:      "pvc-1",
 		Minor:     1000,
 		Port:      7000,
-		LocalNode: nodeKharkiv,
+		LocalNode: nodeA,
 		LocalDisk: "/dev/mapper/x",
 		Peers: []Peer{
-			{Node: nodeKharkiv, NodeID: 0, Address: "fd00::41"},
-			{Node: nodeOslo, NodeID: 1, Address: addrOslo},
+			{Node: nodeA, NodeID: 0, Address: "fd00::41"},
+			{Node: nodeC, NodeID: 1, Address: addrC},
 		},
 	})
 	if !strings.Contains(out, "address ipv6 [fd00::41]:7000;") {
 		t.Fatalf("IPv6 peer must render family + brackets:\n%s", out)
 	}
-	if !strings.Contains(out, "address ipv4 "+addrOslo+":7000;") {
+	if !strings.Contains(out, "address ipv4 "+addrC+":7000;") {
 		t.Fatalf("IPv4 peer must stay ipv4:\n%s", out)
 	}
 }

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -36,10 +36,10 @@ import (
 )
 
 const (
-	testNS      = "miroir-system"
-	nodeKharkiv = "kharkiv"
-	nodeParis   = "paris"
-	nodeOslo    = "oslo"
+	testNS = "miroir-system"
+	nodeA  = "node-a"
+	nodeB  = "node-b"
+	nodeC  = "node-c"
 
 	testClusterIP = "10.96.1.5"
 )
@@ -92,7 +92,7 @@ func getDeployment(t *testing.T, cl client.Client, vol string) *appsv1.Deploymen
 }
 
 func TestReconcileCreatesWorkloads(t *testing.T) {
-	vol := exportVolume("pvc-abc", nodeKharkiv, nodeParis)
+	vol := exportVolume("pvc-abc", nodeA, nodeB)
 	r, cl := newReconciler(vol)
 	reconcile(t, r, "pvc-abc")
 
@@ -115,7 +115,7 @@ func TestReconcileCreatesWorkloads(t *testing.T) {
 	// Scheduled onto exactly the volume's diskful replica nodes.
 	got := affinityNodes(t, dep)
 	slices.Sort(got)
-	if want := []string{nodeKharkiv, nodeParis}; !slices.Equal(got, want) {
+	if want := []string{nodeA, nodeB}; !slices.Equal(got, want) {
 		t.Fatalf("affinity nodes = %v, want %v", got, want)
 	}
 	// Fast eviction on node loss (30s, not the 5m default) so a singleton
@@ -136,7 +136,7 @@ func TestReconcileCreatesWorkloads(t *testing.T) {
 }
 
 func TestReconcileAdoptsServiceAndPublishesAddress(t *testing.T) {
-	vol := exportVolume("pvc-xyz", nodeKharkiv, nodeParis)
+	vol := exportVolume("pvc-xyz", nodeA, nodeB)
 	// A Service already exists with an apiserver-assigned ClusterIP (as
 	// after a controller restart): the reconciler must adopt it, keep the
 	// address, and publish it.
@@ -167,7 +167,7 @@ func TestReconcileAdoptsServiceAndPublishesAddress(t *testing.T) {
 }
 
 func TestReconcileSkipsNonExportVolume(t *testing.T) {
-	vol := exportVolume("pvc-plain", nodeKharkiv)
+	vol := exportVolume("pvc-plain", nodeA)
 	vol.Spec.Export = nil // a plain RWO volume
 	r, cl := newReconciler(vol)
 
@@ -181,19 +181,19 @@ func TestReconcileSkipsNonExportVolume(t *testing.T) {
 }
 
 func TestReconcileUpdatesAffinityOnReplicaChange(t *testing.T) {
-	vol := exportVolume("pvc-move", nodeKharkiv, nodeParis)
+	vol := exportVolume("pvc-move", nodeA, nodeB)
 	r, cl := newReconciler(vol)
 	reconcile(t, r, "pvc-move")
 
-	// The replica set is edited (a replica moves to oslo); the gateway's
+	// The replica set is edited (a replica moves to node-c); the gateway's
 	// affinity must follow so it can still schedule on a data node.
 	got := &miroirv1alpha1.MiroirVolume{}
 	if err := cl.Get(t.Context(), types.NamespacedName{Name: "pvc-move"}, got); err != nil {
 		t.Fatal(err)
 	}
 	got.Spec.Replicas = []miroirv1alpha1.Replica{
-		{Node: nodeKharkiv, NodeID: 0},
-		{Node: nodeOslo, NodeID: 1},
+		{Node: nodeA, NodeID: 0},
+		{Node: nodeC, NodeID: 1},
 	}
 	if err := cl.Update(t.Context(), got); err != nil {
 		t.Fatal(err)
@@ -202,7 +202,7 @@ func TestReconcileUpdatesAffinityOnReplicaChange(t *testing.T) {
 
 	nodes := affinityNodes(t, getDeployment(t, cl, "pvc-move"))
 	slices.Sort(nodes)
-	if want := []string{nodeKharkiv, nodeOslo}; !slices.Equal(nodes, want) {
+	if want := []string{nodeA, nodeC}; !slices.Equal(nodes, want) {
 		t.Fatalf("affinity nodes after move = %v, want %v", nodes, want)
 	}
 }
@@ -231,7 +231,7 @@ func exportReadyGauge(t *testing.T, volume string) (float64, bool) {
 }
 
 func TestReconcileExportReadyMetric(t *testing.T) {
-	vol := exportVolume("pvc-metric", nodeKharkiv, nodeParis)
+	vol := exportVolume("pvc-metric", nodeA, nodeB)
 	// The Service pre-exists with an apiserver-assigned ClusterIP (the fake
 	// client assigns none), so readiness hinges on gateway availability.
 	svc := buildService(vol, testNS)

--- a/internal/membership/autodiskful_test.go
+++ b/internal/membership/autodiskful_test.go
@@ -33,23 +33,23 @@ import (
 )
 
 // clientVol is a Ready 2-replica volume with an aged, completed client leg
-// on oslo.
+// on node-c.
 func clientVol(age time.Duration) *miroirv1alpha1.MiroirVolume {
 	v := replicatedVol()
 	v.Spec.Replicas = v.Spec.Replicas[:2]
 	added := metav1.NewTime(time.Now().Add(-age))
 	v.Spec.Clients = []miroirv1alpha1.VolumeClient{
-		{Node: nodeOslo, NodeID: 2, Address: addrOslo, AddedAt: &added},
+		{Node: nodeC, NodeID: 2, Address: addrC, AddedAt: &added},
 	}
 	v.Status.Phase = miroirv1alpha1.VolumeReady
 	return v
 }
 
-// freshStats is an oslo MiroirNode with room for the volume.
+// freshStats is an node-c MiroirNode with room for the volume.
 func freshStats(free int64) *miroirv1alpha1.MiroirNode {
 	now := metav1.Now()
 	return &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeOslo},
+		ObjectMeta: metav1.ObjectMeta{Name: nodeC},
 		Status: miroirv1alpha1.MiroirNodeStatus{
 			CapacityBytes: 100 << 30, AllocatedBytes: 100<<30 - free, ObservedAt: &now,
 		},
@@ -76,7 +76,7 @@ func TestAutoDiskfulConvertsAgedClient(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		WithObjects(v, freshStats(10<<30)).Build()
 	r := &AutoDiskfulReconciler{Client: c, After: 10 * time.Minute, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}}
 
 	reconcileAD(t, r, "pvc-1")
@@ -86,10 +86,10 @@ func TestAutoDiskfulConvertsAgedClient(t *testing.T) {
 		t.Fatalf("client leg must be removed: %+v", got.Spec.Clients)
 	}
 	idx := slices.IndexFunc(got.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
-		return rep.Node == nodeOslo
+		return rep.Node == nodeC
 	})
 	if idx < 0 {
-		t.Fatalf("oslo must become a replica: %+v", got.Spec.Replicas)
+		t.Fatalf("node-c must become a replica: %+v", got.Spec.Replicas)
 	}
 	rep := got.Spec.Replicas[idx]
 	if rep.Diskless || rep.Backend != miroirv1alpha1.BackendLVMThin {
@@ -97,7 +97,7 @@ func TestAutoDiskfulConvertsAgedClient(t *testing.T) {
 	}
 	// The leg's live DRBD identity must not change: a node id is immutable
 	// on an up resource and the consumer holds the device open.
-	if rep.NodeID != 2 || rep.Address != addrOslo {
+	if rep.NodeID != 2 || rep.Address != addrC {
 		t.Fatalf("conversion must keep the client leg's node-id/address: %+v", rep)
 	}
 	if !rep.FullSync {
@@ -118,7 +118,7 @@ func TestAutoDiskfulReplacesTieBreaker(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		WithObjects(v, freshStats(10<<30)).Build()
 	r := &AutoDiskfulReconciler{Client: c, After: 10 * time.Minute, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}}
 
 	reconcileAD(t, r, "pvc-1")
@@ -136,7 +136,7 @@ func TestAutoDiskfulWaitsForThreshold(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		WithObjects(v, freshStats(10<<30)).Build()
 	r := &AutoDiskfulReconciler{Client: c, After: 10 * time.Minute, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}}
 
 	res := reconcileAD(t, r, "pvc-1")
@@ -163,16 +163,16 @@ func TestAutoDiskfulBlocks(t *testing.T) {
 		},
 		"degraded volume": {
 			mutate: func(v *miroirv1alpha1.MiroirVolume) { v.Status.Phase = miroirv1alpha1.VolumeDegraded },
-			nodes:  nodemap.Map{nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin}},
+			nodes:  nodemap.Map{nodeC: {Backend: miroirv1alpha1.BackendLVMThin}},
 			stats:  freshStats(10 << 30),
 		},
 		"no pool stats": {
 			mutate: func(*miroirv1alpha1.MiroirVolume) {},
-			nodes:  nodemap.Map{nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin}},
+			nodes:  nodemap.Map{nodeC: {Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 		"insufficient space": {
 			mutate: func(*miroirv1alpha1.MiroirVolume) {},
-			nodes:  nodemap.Map{nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin}},
+			nodes:  nodemap.Map{nodeC: {Backend: miroirv1alpha1.BackendLVMThin}},
 			stats:  freshStats(1 << 20),
 		},
 	}
@@ -198,17 +198,17 @@ func TestAutoDiskfulBlocks(t *testing.T) {
 	}
 }
 
-// tieBreakerVol is a Ready 2+1 volume whose tie-breaker (oslo) has been
+// tieBreakerVol is a Ready 2+1 volume whose tie-breaker (node-c) has been
 // Primary — a consumer staged through it — for the given duration.
 func tieBreakerVol(primaryFor time.Duration) *miroirv1alpha1.MiroirVolume {
 	v := replicatedVol()
 	v.Spec.Replicas = v.Spec.Replicas[:2]
 	v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
-		Node: nodeOslo, NodeID: 2, Address: addrOslo, Diskless: true,
+		Node: nodeC, NodeID: 2, Address: addrC, Diskless: true,
 	})
 	since := metav1.NewTime(time.Now().Add(-primaryFor))
 	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeOslo: {Diskless: true, PrimarySince: &since},
+		nodeC: {Diskless: true, PrimarySince: &since},
 	}
 	v.Status.Phase = miroirv1alpha1.VolumeReady
 	return v
@@ -223,7 +223,7 @@ func TestAutoDiskfulConvertsTieBreaker(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		WithObjects(v, freshStats(10<<30)).Build()
 	r := &AutoDiskfulReconciler{Client: c, After: 10 * time.Minute, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}}
 
 	reconcileAD(t, r, "pvc-1")
@@ -233,7 +233,7 @@ func TestAutoDiskfulConvertsTieBreaker(t *testing.T) {
 	if rep.Diskless {
 		t.Fatalf("tie-breaker must flip diskful: %+v", rep)
 	}
-	if rep.NodeID != 2 || rep.Address != addrOslo {
+	if rep.NodeID != 2 || rep.Address != addrC {
 		t.Fatalf("node-id/address must be kept for the in-place attach: %+v", rep)
 	}
 	if !rep.FullSync || rep.Backend != miroirv1alpha1.BackendLVMThin {
@@ -246,14 +246,14 @@ func TestAutoDiskfulConvertsTieBreaker(t *testing.T) {
 func TestAutoDiskfulTieBreakerWaits(t *testing.T) {
 	young := tieBreakerVol(2 * time.Minute)
 	idle := tieBreakerVol(15 * time.Minute)
-	idle.Status.PerNode[nodeOslo] = miroirv1alpha1.ReplicaStatus{Diskless: true} // no PrimarySince
+	idle.Status.PerNode[nodeC] = miroirv1alpha1.ReplicaStatus{Diskless: true} // no PrimarySince
 	for name, v := range map[string]*miroirv1alpha1.MiroirVolume{"young": young, "idle": idle} {
 		t.Run(name, func(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 				WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 				WithObjects(v, freshStats(10<<30)).Build()
 			r := &AutoDiskfulReconciler{Client: c, After: 10 * time.Minute, Nodes: nodemap.Map{
-				nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin},
+				nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 			}}
 			reconcileAD(t, r, "pvc-1")
 			if got := get(t, &Reconciler{Client: c}, "pvc-1"); !got.Spec.Replicas[2].Diskless {
@@ -269,12 +269,12 @@ func TestPrimarySinceChanged(t *testing.T) {
 	now := metav1.Now()
 	with := tieBreakerVol(time.Minute)
 	without := tieBreakerVol(time.Minute)
-	without.Status.PerNode[nodeOslo] = miroirv1alpha1.ReplicaStatus{Diskless: true}
+	without.Status.PerNode[nodeC] = miroirv1alpha1.ReplicaStatus{Diskless: true}
 	if !primarySinceChanged(without, with) || !primarySinceChanged(with, without) {
 		t.Fatal("a PrimarySince edge must fire the predicate")
 	}
 	same := with.DeepCopy()
-	same.Status.PerNode[nodeOslo] = miroirv1alpha1.ReplicaStatus{Diskless: true, PrimarySince: &now}
+	same.Status.PerNode[nodeC] = miroirv1alpha1.ReplicaStatus{Diskless: true, PrimarySince: &now}
 	if primarySinceChanged(with, same) {
 		t.Fatal("presence-stable PrimarySince must not fire the predicate")
 	}
@@ -292,7 +292,7 @@ func TestAutoDiskfulPermanentBlockSkipsRequeue(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		WithObjects(v, freshStats(10<<30)).Build()
 	r := &AutoDiskfulReconciler{Client: c, After: 10 * time.Minute, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}}
 
 	res := reconcileAD(t, r, "pvc-1")

--- a/internal/membership/reconciler_test.go
+++ b/internal/membership/reconciler_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/home-operations/miroir/internal/nodemap"
 )
 
-const nodeOslo = "oslo"
+const nodeC = "node-c"
 
 func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -58,24 +58,24 @@ func node(name, ip string) *corev1.Node {
 	}
 }
 
-// replicatedVol is a 2-replica volume on kharkiv+paris with an
-// operator-added oslo entry awaiting completion.
+// replicatedVol is a 2-replica volume on node-a+node-b with an
+// operator-added node-c entry awaiting completion.
 func replicatedVol() *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pvc-1",
 			Finalizers: []string{
-				constants.FinalizerPrefix + "kharkiv",
-				constants.FinalizerPrefix + "paris",
+				constants.FinalizerPrefix + "node-a",
+				constants.FinalizerPrefix + "node-b",
 			},
 		},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			DRBD:      &miroirv1alpha1.DRBDSpec{Port: 7000},
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: "kharkiv", Backend: miroirv1alpha1.BackendZFS, NodeID: 0, Address: "192.168.1.41"},
-				{Node: "paris", Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "192.168.1.42"},
-				{Node: nodeOslo, Backend: miroirv1alpha1.BackendZFS},
+				{Node: "node-a", Backend: miroirv1alpha1.BackendZFS, NodeID: 0, Address: "192.168.1.41"},
+				{Node: "node-b", Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "192.168.1.42"},
+				{Node: nodeC, Backend: miroirv1alpha1.BackendZFS},
 			},
 		},
 	}
@@ -102,17 +102,17 @@ func get(t *testing.T, r *Reconciler, name string) *miroirv1alpha1.MiroirVolume 
 
 func TestCompletesAddedReplica(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(replicatedVol(), node(nodeOslo, addrOslo)).
+		WithObjects(replicatedVol(), node(nodeC, addrC)).
 		Build()
 	r := &Reconciler{Client: c, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}}
 
 	reconcile(t, r, "pvc-1")
 
 	got := get(t, r, "pvc-1")
 	rep := got.Spec.Replicas[2]
-	if rep.NodeID != 2 || rep.Address != addrOslo {
+	if rep.NodeID != 2 || rep.Address != addrC {
 		t.Fatalf("entry not completed: %+v", rep)
 	}
 	if !rep.FullSync {
@@ -122,7 +122,7 @@ func TestCompletesAddedReplica(t *testing.T) {
 	if rep.Backend != miroirv1alpha1.BackendLVMThin {
 		t.Fatalf("backend not taken from the node map: %s", rep.Backend)
 	}
-	if !slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeOslo) {
+	if !slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeC) {
 		t.Fatal("teardown finalizer missing for the added node")
 	}
 }
@@ -132,10 +132,10 @@ func TestCompletesAddedReplica(t *testing.T) {
 // has not posted addresses yet still joins.
 func TestCompletesAddedReplicaWithAddressOverride(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(replicatedVol()). // no oslo Node object
+		WithObjects(replicatedVol()). // no node-c Node object
 		Build()
 	r := &Reconciler{Client: c, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendLVMThin, Address: "10.0.100.43"},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin, Address: "10.0.100.43"},
 	}}
 
 	reconcile(t, r, "pvc-1")
@@ -149,10 +149,10 @@ func TestReusesLowestFreeNodeID(t *testing.T) {
 	v := replicatedVol()
 	v.Spec.Replicas[1].NodeID = 2 // id 1 was freed by an earlier removal
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(v, node(nodeOslo, addrOslo)).
+		WithObjects(v, node(nodeC, addrC)).
 		Build()
 	r := &Reconciler{Client: c, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendZFS},
+		nodeC: {Backend: miroirv1alpha1.BackendZFS},
 	}}
 
 	reconcile(t, r, "pvc-1")
@@ -168,16 +168,16 @@ func TestCompletesDisklessReplica(t *testing.T) {
 	v := replicatedVol()
 	v.Spec.Replicas[2].Diskless = true
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(v, node(nodeOslo, addrOslo)).
+		WithObjects(v, node(nodeC, addrC)).
 		Build()
 	r := &Reconciler{Client: c, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendZFS},
+		nodeC: {Backend: miroirv1alpha1.BackendZFS},
 	}}
 
 	reconcile(t, r, "pvc-1")
 
 	rep := get(t, r, "pvc-1").Spec.Replicas[2]
-	if rep.NodeID != 2 || rep.Address != addrOslo {
+	if rep.NodeID != 2 || rep.Address != addrC {
 		t.Fatalf("diskless entry not completed: %+v", rep)
 	}
 	if rep.Backend != "" {
@@ -192,7 +192,7 @@ func TestUnknownNodeLeavesSpecUntouched(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(replicatedVol()).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{}} // oslo not a storage node
+	r := &Reconciler{Client: c, Nodes: nodemap.Map{}} // node-c not a storage node
 
 	reconcile(t, r, "pvc-1")
 
@@ -209,7 +209,7 @@ func TestUnknownNodeLeavesSpecUntouched(t *testing.T) {
 func TestRequeuesWhenNodeNotReady(t *testing.T) {
 	cases := map[string]*corev1.Node{
 		"node not registered":     nil,
-		"node without InternalIP": {ObjectMeta: metav1.ObjectMeta{Name: nodeOslo}},
+		"node without InternalIP": {ObjectMeta: metav1.ObjectMeta{Name: nodeC}},
 	}
 	for name, n := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -220,7 +220,7 @@ func TestRequeuesWhenNodeNotReady(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 				WithObjects(objs...).Build()
 			r := &Reconciler{Client: c, Nodes: nodemap.Map{
-				nodeOslo: {Backend: miroirv1alpha1.BackendZFS},
+				nodeC: {Backend: miroirv1alpha1.BackendZFS},
 			}}
 
 			if _, err := r.Reconcile(t.Context(),
@@ -238,10 +238,10 @@ func TestIgnoresUnreplicatedVolume(t *testing.T) {
 	v := replicatedVol()
 	v.Spec.DRBD = nil
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(v, node(nodeOslo, addrOslo)).
+		WithObjects(v, node(nodeC, addrC)).
 		Build()
 	r := &Reconciler{Client: c, Nodes: nodemap.Map{
-		nodeOslo: {Backend: miroirv1alpha1.BackendZFS},
+		nodeC: {Backend: miroirv1alpha1.BackendZFS},
 	}}
 
 	reconcile(t, r, "pvc-1")

--- a/internal/membership/tiebreaker_test.go
+++ b/internal/membership/tiebreaker_test.go
@@ -31,23 +31,23 @@ import (
 )
 
 const (
-	nodeKharkiv = "kharkiv"
-	nodeParis   = "paris"
-	nodeBergen  = "bergen"
-	addrBergen  = "192.168.1.44"
-	addrOslo    = "192.168.1.43"
-	volTB       = "pvc-tb"
+	nodeA      = "node-a"
+	nodeB      = "node-b"
+	nodeBergen = "bergen"
+	addrBergen = "192.168.1.44"
+	addrC      = "192.168.1.43"
+	volTB      = "pvc-tb"
 )
 
-// freezeVol is a complete 2-replica freeze volume on kharkiv+paris — the
+// freezeVol is a complete 2-replica freeze volume on node-a+node-b — the
 // shape the tie-breaker reconciler retrofits.
 func freezeVol() *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: volTB,
 			Finalizers: []string{
-				constants.FinalizerPrefix + nodeKharkiv,
-				constants.FinalizerPrefix + nodeParis,
+				constants.FinalizerPrefix + nodeA,
+				constants.FinalizerPrefix + nodeB,
 			},
 		},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
@@ -55,8 +55,8 @@ func freezeVol() *miroirv1alpha1.MiroirVolume {
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
 			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeKharkiv, Backend: miroirv1alpha1.BackendZFS, NodeID: 0, Address: "192.168.1.41"},
-				{Node: nodeParis, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "192.168.1.42"},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendZFS, NodeID: 0, Address: "192.168.1.41"},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "192.168.1.42"},
 			},
 		},
 	}
@@ -74,12 +74,12 @@ func tbReconcile(t *testing.T, r *TieBreakerReconciler) {
 // Reconciler completes it exactly like an operator-added replica.
 func TestTieBreakerRetrofitsAndMembershipCompletes(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(freezeVol(), node(nodeOslo, addrOslo)).
+		WithObjects(freezeVol(), node(nodeC, addrC)).
 		Build()
 	nodes := nodemap.Map{
-		nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},
-		nodeParis:   {Backend: miroirv1alpha1.BackendZFS},
-		nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeA: {Backend: miroirv1alpha1.BackendZFS},
+		nodeB: {Backend: miroirv1alpha1.BackendZFS},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}
 	tb := &TieBreakerReconciler{Client: c, Nodes: nodes}
 
@@ -90,20 +90,20 @@ func TestTieBreakerRetrofitsAndMembershipCompletes(t *testing.T) {
 	if len(got.Spec.Replicas) != 3 {
 		t.Fatalf("tie-breaker not added: %+v", got.Spec.Replicas)
 	}
-	if rep := got.Spec.Replicas[2]; rep.Node != nodeOslo || !rep.Diskless || rep.Address != "" {
-		t.Fatalf("want a bare diskless oslo entry, got %+v", rep)
+	if rep := got.Spec.Replicas[2]; rep.Node != nodeC || !rep.Diskless || rep.Address != "" {
+		t.Fatalf("want a bare diskless node-c entry, got %+v", rep)
 	}
 
 	reconcile(t, mr, volTB)
 	got = get(t, mr, volTB)
 	rep := got.Spec.Replicas[2]
-	if rep.NodeID != 2 || rep.Address != addrOslo || !rep.Diskless {
+	if rep.NodeID != 2 || rep.Address != addrC || !rep.Diskless {
 		t.Fatalf("membership must complete the tie-breaker: %+v", rep)
 	}
 	if rep.FullSync || rep.Backend != "" {
 		t.Fatalf("diskless entry must carry no backend or FullSync: %+v", rep)
 	}
-	if !slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeOslo) {
+	if !slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeC) {
 		t.Fatalf("tie-breaker node needs a teardown finalizer: %v", got.Finalizers)
 	}
 
@@ -120,15 +120,15 @@ func TestTieBreakerRetrofitsAndMembershipCompletes(t *testing.T) {
 // later diskful re-add would adopt (partial resync missing writes).
 func TestTieBreakerWaitsForInFlightRemoval(t *testing.T) {
 	vol := freezeVol()
-	// oslo was just removed from spec.replicas; its agent still holds the
+	// node-c was just removed from spec.replicas; its agent still holds the
 	// teardown finalizer while it waits for the remaining legs to be safe.
-	vol.Finalizers = append(vol.Finalizers, constants.FinalizerPrefix+nodeOslo)
+	vol.Finalizers = append(vol.Finalizers, constants.FinalizerPrefix+nodeC)
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(vol, node(nodeOslo, addrOslo)).Build()
+		WithObjects(vol, node(nodeC, addrC)).Build()
 	tb := &TieBreakerReconciler{Client: c, Nodes: nodemap.Map{
-		nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},
-		nodeParis:   {Backend: miroirv1alpha1.BackendZFS},
-		nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeA: {Backend: miroirv1alpha1.BackendZFS},
+		nodeB: {Backend: miroirv1alpha1.BackendZFS},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}}
 
 	res, err := tb.Reconcile(t.Context(),
@@ -147,9 +147,9 @@ func TestTieBreakerWaitsForInFlightRemoval(t *testing.T) {
 
 func TestTieBreakerSkips(t *testing.T) {
 	spare := nodemap.Map{
-		nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},
-		nodeParis:   {Backend: miroirv1alpha1.BackendZFS},
-		nodeOslo:    {Backend: miroirv1alpha1.BackendLVMThin},
+		nodeA: {Backend: miroirv1alpha1.BackendZFS},
+		nodeB: {Backend: miroirv1alpha1.BackendZFS},
+		nodeC: {Backend: miroirv1alpha1.BackendLVMThin},
 	}
 	cases := map[string]struct {
 		mutate func(*miroirv1alpha1.MiroirVolume)
@@ -164,7 +164,7 @@ func TestTieBreakerSkips(t *testing.T) {
 		"tie-breaker already present": {
 			mutate: func(v *miroirv1alpha1.MiroirVolume) {
 				v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
-					Node: nodeOslo, NodeID: 2, Address: addrOslo, Diskless: true,
+					Node: nodeC, NodeID: 2, Address: addrC, Diskless: true,
 				})
 			},
 			nodes: spare,
@@ -178,8 +178,8 @@ func TestTieBreakerSkips(t *testing.T) {
 		"no spare node": {
 			mutate: func(*miroirv1alpha1.MiroirVolume) {},
 			nodes: nodemap.Map{
-				nodeKharkiv: {Backend: miroirv1alpha1.BackendZFS},
-				nodeParis:   {Backend: miroirv1alpha1.BackendZFS},
+				nodeA: {Backend: miroirv1alpha1.BackendZFS},
+				nodeB: {Backend: miroirv1alpha1.BackendZFS},
 			},
 		},
 		"unreplicated volume": {
@@ -193,7 +193,7 @@ func TestTieBreakerSkips(t *testing.T) {
 			tc.mutate(vol)
 			want := len(vol.Spec.Replicas)
 			c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-				WithObjects(vol, node(nodeOslo, addrOslo)).Build()
+				WithObjects(vol, node(nodeC, addrC)).Build()
 			tb := &TieBreakerReconciler{Client: c, Nodes: tc.nodes}
 
 			tbReconcile(t, tb)

--- a/internal/nodemap/nodemap_test.go
+++ b/internal/nodemap/nodemap_test.go
@@ -32,10 +32,10 @@ import (
 )
 
 const (
-	nodeKharkiv = "kharkiv"
-	nodeParis   = "paris"
-	nodeOslo    = "oslo"
-	nodeBergen  = "bergen"
+	nodeA      = "node-a"
+	nodeB      = "node-b"
+	nodeC      = "node-c"
+	nodeBergen = "bergen"
 )
 
 func writeMap(t *testing.T, body string) string {
@@ -49,17 +49,17 @@ func writeMap(t *testing.T, body string) string {
 
 func TestLoadValid(t *testing.T) {
 	m, err := Load(writeMap(t, `
-kharkiv:
+node-a:
   backend: lvmthin
   device: /dev/disk/by-partlabel/r-miroir
   thinPoolSize: 400g
   zone: rack-1
   address: 10.0.100.1
-paris:
+node-b:
   backend: zfs
   zfsDataset: tank/miroir
   address: "fd00:1::2"
-oslo:
+node-c:
   backend: loopfile
   baseDir: /var/lib/miroir
 `))
@@ -69,34 +69,34 @@ oslo:
 	if len(m) != 3 {
 		t.Fatalf("want 3 nodes, got %d", len(m))
 	}
-	if m["kharkiv"].Backend != miroirv1alpha1.BackendLVMThin || m["kharkiv"].ThinPoolSize != "400g" {
-		t.Fatalf("kharkiv parsed wrong: %+v", m["kharkiv"])
+	if m["node-a"].Backend != miroirv1alpha1.BackendLVMThin || m["node-a"].ThinPoolSize != "400g" {
+		t.Fatalf("node-a parsed wrong: %+v", m["node-a"])
 	}
-	if m["kharkiv"].Zone != "rack-1" {
-		t.Fatalf("kharkiv zone not parsed: %+v", m["kharkiv"])
+	if m["node-a"].Zone != "rack-1" {
+		t.Fatalf("node-a zone not parsed: %+v", m["node-a"])
 	}
-	if m["paris"].ZFSDataset != "tank/miroir" {
-		t.Fatalf("paris dataset wrong: %+v", m["paris"])
+	if m["node-b"].ZFSDataset != "tank/miroir" {
+		t.Fatalf("node-b dataset wrong: %+v", m["node-b"])
 	}
-	if m["oslo"].BaseDir != "/var/lib/miroir" {
-		t.Fatalf("oslo baseDir wrong: %+v", m["oslo"])
+	if m["node-c"].BaseDir != "/var/lib/miroir" {
+		t.Fatalf("node-c baseDir wrong: %+v", m["node-c"])
 	}
-	if m["kharkiv"].Address != "10.0.100.1" || m["paris"].Address != "fd00:1::2" {
-		t.Fatalf("addresses parsed wrong: %q %q", m["kharkiv"].Address, m["paris"].Address)
+	if m["node-a"].Address != "10.0.100.1" || m["node-b"].Address != "fd00:1::2" {
+		t.Fatalf("addresses parsed wrong: %q %q", m["node-a"].Address, m["node-b"].Address)
 	}
 }
 
 func TestLoadErrors(t *testing.T) {
 	cases := map[string]string{
-		"unknown backend":          "kharkiv:\n  backend: btrfs\n",
-		"zfs without dataset":      "paris:\n  backend: zfs\n",
-		"loopfile without baseDir": "oslo:\n  backend: loopfile\n",
-		"unknown field":            "kharkiv:\n  backend: lvmthin\n  bogus: x\n",
-		"malformed yaml":           "kharkiv: : :\n",
-		"invalid address":          "kharkiv:\n  backend: lvmthin\n  address: not-an-ip\n",
-		"address is a CIDR":        "kharkiv:\n  backend: lvmthin\n  address: 10.0.0.0/24\n",
-		"duplicate address":        "kharkiv:\n  backend: lvmthin\n  address: 10.0.100.1\nparis:\n  backend: lvmthin\n  address: 10.0.100.1\n",
-		"duplicate address ipv6":   "kharkiv:\n  backend: lvmthin\n  address: fd00:1::2\nparis:\n  backend: lvmthin\n  address: fd00:0001:0:0::2\n",
+		"unknown backend":          "node-a:\n  backend: btrfs\n",
+		"zfs without dataset":      "node-b:\n  backend: zfs\n",
+		"loopfile without baseDir": "node-c:\n  backend: loopfile\n",
+		"unknown field":            "node-a:\n  backend: lvmthin\n  bogus: x\n",
+		"malformed yaml":           "node-a: : :\n",
+		"invalid address":          "node-a:\n  backend: lvmthin\n  address: not-an-ip\n",
+		"address is a CIDR":        "node-a:\n  backend: lvmthin\n  address: 10.0.0.0/24\n",
+		"duplicate address":        "node-a:\n  backend: lvmthin\n  address: 10.0.100.1\nnode-b:\n  backend: lvmthin\n  address: 10.0.100.1\n",
+		"duplicate address ipv6":   "node-a:\n  backend: lvmthin\n  address: fd00:1::2\nnode-b:\n  backend: lvmthin\n  address: fd00:0001:0:0::2\n",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -114,32 +114,32 @@ func TestLoadMissingFile(t *testing.T) {
 }
 
 func TestTieBreakerNode(t *testing.T) {
-	replicas := []miroirv1alpha1.Replica{{Node: nodeKharkiv}, {Node: nodeParis}}
+	replicas := []miroirv1alpha1.Replica{{Node: nodeA}, {Node: nodeB}}
 	cases := map[string]struct {
 		m    Map
 		want string
 	}{
 		"prefers a zone no replica occupies": {
 			m: Map{
-				nodeKharkiv: {Zone: "a"}, nodeParis: {Zone: "b"},
-				nodeOslo: {Zone: "a"}, nodeBergen: {Zone: "c"},
+				nodeA: {Zone: "a"}, nodeB: {Zone: "b"},
+				nodeC: {Zone: "a"}, nodeBergen: {Zone: "c"},
 			},
 			want: nodeBergen,
 		},
 		"zoneless spare is unconstrained": {
-			m:    Map{nodeKharkiv: {Zone: "a"}, nodeParis: {Zone: "b"}, nodeOslo: {}},
-			want: nodeOslo,
+			m:    Map{nodeA: {Zone: "a"}, nodeB: {Zone: "b"}, nodeC: {}},
+			want: nodeC,
 		},
 		"falls back to an occupied zone when none is free": {
-			m:    Map{nodeKharkiv: {Zone: "a"}, nodeParis: {Zone: "b"}, nodeOslo: {Zone: "a"}},
-			want: nodeOslo,
+			m:    Map{nodeA: {Zone: "a"}, nodeB: {Zone: "b"}, nodeC: {Zone: "a"}},
+			want: nodeC,
 		},
 		"name order breaks ties": {
-			m:    Map{nodeKharkiv: {}, nodeParis: {}, nodeOslo: {}, nodeBergen: {}},
+			m:    Map{nodeA: {}, nodeB: {}, nodeC: {}, nodeBergen: {}},
 			want: nodeBergen,
 		},
 		"no spare node": {
-			m:    Map{nodeKharkiv: {}, nodeParis: {}},
+			m:    Map{nodeA: {}, nodeB: {}},
 			want: "",
 		},
 	}
@@ -175,29 +175,29 @@ func TestReplicationAddress(t *testing.T) {
 		wantErr bool
 	}{
 		"override skips the node lookup": {
-			m:      Map{nodeKharkiv: {Address: "10.0.100.5"}},
+			m:      Map{nodeA: {Address: "10.0.100.5"}},
 			client: withNode(), // no Node object registered
 			want:   "10.0.100.5",
 		},
 		"falls back to InternalIP": {
-			m:      Map{nodeKharkiv: {}},
-			client: withNode(internalIP(nodeKharkiv, "192.168.1.41")),
+			m:      Map{nodeA: {}},
+			client: withNode(internalIP(nodeA, "192.168.1.41")),
 			want:   "192.168.1.41",
 		},
 		"node without InternalIP errors": {
-			m:       Map{nodeKharkiv: {}},
-			client:  withNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeKharkiv}}),
+			m:       Map{nodeA: {}},
+			client:  withNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeA}}),
 			wantErr: true,
 		},
 		"absent node errors": {
-			m:       Map{nodeKharkiv: {}},
+			m:       Map{nodeA: {}},
 			client:  withNode(),
 			wantErr: true,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, err := tc.m.ReplicationAddress(t.Context(), tc.client, nodeKharkiv)
+			got, err := tc.m.ReplicationAddress(t.Context(), tc.client, nodeA)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected an error")


### PR DESCRIPTION
Post-#197 review pass: correctness, DRY, and test hygiene. No behavior change for well-formed inputs; version-string edge cases improve.

## Semver-based kernel floor comparison

`BelowKernelFloor` now uses `github.com/Masterminds/semver/v3` (**v3.5.0**; it was already in the module graph as indirect, so this adds no new dependency) instead of the hand-rolled dotted-component compare:

- Suffixed module builds now compare correctly instead of reading as below the floor: `9.3.2-1`, `9.3.2+ptf1`, and `v9.3.2` were all rejected by the old parser (`Atoi("2-1")` errors → below floor → agent exit) and are now accepted.
- One regression the review itself caught before shipping: semver rejects a 4th dotted component, so a vendor build like `9.3.1.1` (accepted by the old parser) would have read as unparseable → below floor → `os.Exit(1)`. Fixed by retrying the parse on the leading `x.y.z`; genuine garbage still fails closed. Confirmed empirically by running both implementations side by side over an edge-case table.
- `TestBelowKernelFloor` grows from 11 to 16 cases covering every flip found (`9.3.1.1`, `9.2.18.4`, `v9.3.2`, `9.3.2-1`, `9.3.2+ptf1`).

## Generic test node names

Test fixtures' city names (`kharkiv`/`paris`/`oslo`) become `node-a`/`node-b`/`node-c` (constants `nodeA`/`nodeB`/`nodeC`, `addrA`/`addrB`/`addrC`) across 19 Go test files and 3 chart test fixtures. Checked against the one production function that orders node names lexicographically (`nodemap.TieBreakerNode`): no expected winner flips. Docs and `values.yaml` examples keep their illustrative names on purpose.

## DRY

`writeDiskOption` replaces the two identical single-option `disk{}` render blocks in `Render` (`rs-discard-granularity` diskful / `discard-granularity` client legs); output verified byte-identical, with the `> 0` guards folded into the helper.

## Review method

8-angle review (line-by-line, removed-behavior, cross-file tracer, reuse, simplification, efficiency, altitude, conventions) with empirical verification of the one correctness candidate; 5 findings confirmed and all fixed in this PR (the semver 4-component regression, a stray `le-havre` the rename missed, raw literals bypassing the new constants in `minor_test.go`, a stale algorithm comment, awkward rename-artifact locals).

Full `go test ./...`, `golangci-lint` (0 issues), `go vet`, and the chart test suite pass.
