### PR TITLE
feat(observability): agent-down alert and DRBD kernel version info metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,11 @@ Each agent additionally exports its pool capacity
 (`miroir_pool_capacity_bytes` / `miroir_pool_allocated_bytes` /
 `miroir_pool_meta_used_ratio`), the same sample that feeds
 capacity-aware placement and the `PoolUsageHigh` condition, so pool
-exhaustion is alertable, not just an Event.
+exhaustion is alertable, not just an Event. It also exports
+`miroir_node_drbd_kernel_info` (always 1, `version` label): the DRBD
+kernel module version probed at startup, from client-only nodes too
+(which have no `MiroirNode` status). Query it for fleet version skew
+before a release raises the kernel floor.
 
 For RWX volumes the **controller** exports `miroir_export_ready`: 1
 while the volume's NFS gateway is serving (gateway pod available,
@@ -611,7 +615,10 @@ on their PVCs (`kubectl describe pvc`).
 `monitoring.prometheusRule.enabled: true` ships starter alerts for
 all of the above (split-brain, quorum lost, stranded barrier, disk
 failed, degraded replication, sustained out-of-sync, an unavailable
-RWX export, a stale verify schedule, pool and thin-metadata usage),
+RWX export, a stale verify schedule, pool and thin-metadata usage,
+and a down agent — a node whose agent stops answering scrapes loses
+every `miroir_*` series, so none of the per-volume alerts can fire
+for it; the kernel-floor refusal to start looks exactly like this),
 and `monitoring.dashboards.enabled: true` installs a Grafana
 dashboard, either a sidecar-labelled ConfigMap or a grafana-operator
 `GrafanaDashboard` CR via `monitoring.dashboards.grafanaOperator`.

--- a/charts/miroir/dashboards/miroir.json
+++ b/charts/miroir/dashboards/miroir.json
@@ -1319,6 +1319,157 @@
         "x": 0,
         "y": 57
       },
+      "id": 29,
+      "panels": [],
+      "title": "Agents",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Agent pods failing scrapes — every miroir_* series from those nodes is absent, so the per-volume panels and alerts are blind there. A crash-loop after a node change usually means the DRBD kernel module is below the agent's floor.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 58
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(up{container=\"agent\", pod=~\".*miroir.*\"} == 0) OR on() vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Agents down",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DRBD kernel module version probed at each agent's startup. Mixed versions mean a partially upgraded fleet; a node missing here has no reporting agent (down, or no DRBD module). The agent refuses to start below its kernel floor.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 20,
+        "x": 4,
+        "y": 58
+      },
+      "id": 31,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "miroir_node_drbd_kernel_info == 1",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "pod": true
+            },
+            "renameByName": {
+              "node": "Node",
+              "version": "DRBD kernel"
+            }
+          }
+        }
+      ],
+      "title": "DRBD kernel module by node",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
       "id": 17,
       "panels": [],
       "title": "Operator",
@@ -1356,7 +1507,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 67
       },
       "id": 18,
       "options": {
@@ -1417,7 +1568,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 58
+        "y": 67
       },
       "id": 19,
       "options": {

--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -275,4 +275,34 @@ spec:
             {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+
+    - name: miroir.agents
+      rules:
+        # A down agent takes every miroir_* series on its node with it, so
+        # the per-volume alerts above go silent instead of firing — and the
+        # agent exits at startup on a below-floor DRBD kernel module, so a
+        # missed node upgrade looks exactly like this. Matched on the
+        # container/namespace target labels rather than job (whose value
+        # depends on PodMonitor naming and user relabelings). A pod that
+        # never became a scrape target (agent unschedulable) has no up
+        # series and is not caught here.
+        - alert: MiroirAgentDown
+          expr: up{container="agent", namespace="{{ .Release.Namespace }}"} == 0
+          for: 10m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
+          annotations:
+            summary: >-
+              miroir agent on {{ "{{" }} $labels.node {{ "}}" }} is down —
+              its volumes are unmonitored
+            description: >-
+              The agent pod has not answered scrapes for 10 minutes: every
+              miroir_volume_* series from this node is absent (no alert on
+              them can fire) and CSI mount/unmount on the node is stalled.
+              A crash-loop right after a node change usually means the DRBD
+              kernel module is below the agent's floor or the backend is
+              misconfigured — check the agent logs.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
 {{- end }}

--- a/charts/miroir/tests/prometheusrule_test.yaml
+++ b/charts/miroir/tests/prometheusrule_test.yaml
@@ -23,13 +23,13 @@ tests:
           path: metadata.namespace
           value: miroir-system
 
-  - it: should have the volume, pool and export rule groups
+  - it: should have the volume, pool, export and agent rule groups
     set:
       monitoring.prometheusRule.enabled: true
     asserts:
       - lengthEqual:
           path: spec.groups
-          count: 3
+          count: 4
       - equal:
           path: spec.groups[0].name
           value: miroir.volumes
@@ -51,6 +51,18 @@ tests:
       - equal:
           path: spec.groups[2].rules[0].labels.severity
           value: critical
+      - equal:
+          path: spec.groups[3].name
+          value: miroir.agents
+      - equal:
+          path: spec.groups[3].rules[0].alert
+          value: MiroirAgentDown
+      - equal:
+          path: spec.groups[3].rules[0].labels.severity
+          value: critical
+      - equal:
+          path: spec.groups[3].rules[0].expr
+          value: up{container="agent", namespace="miroir-system"} == 0
 
   - it: should render the verify staleness rule only with a verify schedule
     set:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -756,6 +756,7 @@ func probeDRBD(driver *drbd.Driver) (version string, ready bool) {
 			"version", v, "floor", drbd.KernelFloor)
 		os.Exit(1)
 	}
+	agent.RecordDRBDKernelVersion(v)
 	return v, true
 }
 

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -87,6 +87,14 @@ var (
 		Name: "miroir_pool_meta_used_ratio",
 		Help: "Fraction (0-1) of dm-thin metadata used; 0 for backends without a metadata pool.",
 	})
+
+	// Info-style: constant 1, the payload is the version label. Exported
+	// from client-only nodes too — unlike MiroirNode status, which only
+	// the pool stats publisher (storage nodes) updates.
+	metricDRBDKernelInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "miroir_node_drbd_kernel_info",
+		Help: "Always 1, labelled with the DRBD kernel module version probed at agent startup; absent on nodes without the module. Query it for fleet version skew before a kernel floor raise.",
+	}, []string{"version"})
 )
 
 func init() {
@@ -95,6 +103,7 @@ func init() {
 		metricResyncRatio, metricQuorum, metricDiskFailed, metricOutOfSyncBytes,
 		metricVerifyTimestamp, metricVerifyOutOfSyncBytes, metricDisklessPrimary,
 		metricPoolCapacity, metricPoolAllocated, metricPoolMetaUsedRatio,
+		metricDRBDKernelInfo,
 	)
 }
 
@@ -136,6 +145,14 @@ func dropVolumeMetrics(volume string) {
 // quorum would fire the data-leg alerts for a leg that holds no data.
 func recordDisklessMetrics(volume string, primary bool) {
 	metricDisklessPrimary.WithLabelValues(volume).Set(boolGauge(primary))
+}
+
+// RecordDRBDKernelVersion publishes the module version probed at agent
+// startup. Set once per process: a module change means a node reboot and
+// thus a fresh agent, so startup is current enough (same contract as
+// PoolStatsPublisher.DRBDVersion).
+func RecordDRBDKernelVersion(version string) {
+	metricDRBDKernelInfo.WithLabelValues(version).Set(1)
 }
 
 // recordVerifyMetrics publishes the outcome of a completed verify pass. The

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -105,3 +105,13 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 		}
 	}
 }
+
+// The kernel info gauge must expose the probed version as a label with a
+// constant 1 — the shape "up{version=...}"-style queries and the fleet
+// skew table depend on.
+func TestRecordDRBDKernelVersion(t *testing.T) {
+	RecordDRBDKernelVersion("9.3.2")
+	if got := testutil.ToFloat64(metricDRBDKernelInfo.WithLabelValues("9.3.2")); got != 1 {
+		t.Fatalf("drbd_kernel_info{version=9.3.2} = %v, want 1", got)
+	}
+}


### PR DESCRIPTION
## Why

Since #198 the agent exits at startup when the DRBD kernel module is below the floor. A node that misses the Talos upgrade gets a crash-looping agent, and a down agent takes every `miroir_*` series on its node with it — the series go *absent*, not to 0, so none of the existing per-volume alerts fire. The node silently vanishes from monitoring.

## What

- **`MiroirAgentDown` alert** (new `miroir.agents` group, critical, `for: 10m`): `up{container="agent", namespace="<release ns>"} == 0`. Matched on target labels rather than `job`, whose value depends on PodMonitor naming and user relabelings. Known limit (noted in the template): a pod that never became a scrape target has no `up` series and is not caught.
- **`miroir_node_drbd_kernel_info{version}`** (always 1): the module version probed at agent startup, set from `probeDRBD` so client-only nodes export it too (they probe the module but publish no `MiroirNode` status). Makes fleet version skew queryable *before* the next kernel floor raise ships.
- **Dashboard**: new *Agents* row with an "Agents down" stat and a "DRBD kernel module by node" table.
- README monitoring section updated; helm-unittest coverage for the new rule group.

## Verification

- `mise run test` (full unit suite), `go vet`, `golangci-lint`: clean
- `mise run helm-lint` / `mise run helm-test`: 98/98 pass
- Rendered the PrometheusRule via `helm template` and inspected the new group
- Dashboard JSON validated with `jq` (unique panel ids, parseable)