### PR TITLE
feat(observability): diskful Primary gauge, gateway health endpoint + liveness, chart description refresh

### DIFF
--- a/charts/miroir/Chart.yaml
+++ b/charts/miroir/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: miroir
-description: Low-resource replicated block storage CSI driver for small Talos clusters
+description: Replicated block storage for small Kubernetes clusters — CSI on LVM thin, ZFS, or loopfile backends with synchronous DRBD9 replication
 type: application
 # Placeholder — CI overrides both at publish time (helm package
 # --version/--app-version from the release tag).

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -2,19 +2,20 @@
 
 ![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
-Low-resource replicated block storage CSI driver for small Talos clusters
+Replicated block storage for small Kubernetes clusters — CSI on LVM thin, ZFS, or loopfile backends with synchronous DRBD9 replication
 
 **Homepage:** <https://github.com/home-operations/miroir>
 
 ## Usage
 
-Low-resource replicated block storage CSI driver for small Talos Linux
-clusters. Control plane in Go; data path delegated to in-kernel primitives
-(dm-thin / ZFS today, DRBD9 replication planned).
+Replicated block storage for small Kubernetes clusters. Control plane in
+Go; data path delegated to in-kernel primitives (dm-thin, ZFS, or loop
+devices, with synchronous DRBD9 replication). Full documentation at
+<https://miroir.home-operations.com/>.
 
 ```sh
 helm install miroir oci://ghcr.io/home-operations/charts/miroir \
-  --namespace miroir --create-namespace
+  --namespace miroir-system --create-namespace -f values.yaml
 ```
 
 ## Maintainers

--- a/charts/miroir/README.md.gotmpl
+++ b/charts/miroir/README.md.gotmpl
@@ -8,13 +8,14 @@
 
 ## Usage
 
-Low-resource replicated block storage CSI driver for small Talos Linux
-clusters. Control plane in Go; data path delegated to in-kernel primitives
-(dm-thin / ZFS today, DRBD9 replication planned).
+Replicated block storage for small Kubernetes clusters. Control plane in
+Go; data path delegated to in-kernel primitives (dm-thin, ZFS, or loop
+devices, with synchronous DRBD9 replication). Full documentation at
+<https://miroir.home-operations.com/>.
 
 ```sh
 helm install miroir oci://ghcr.io/home-operations/charts/miroir \
-  --namespace miroir --create-namespace
+  --namespace miroir-system --create-namespace -f values.yaml
 ```
 
 

--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -39,25 +39,14 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "miroir.agentName" . }}
-      # hostNetwork so the pod IP is the node IP and the container
-      # hostname matches the node — DRBD peers dial the host IP and
-      # match `on <hostname>` blocks; agent ports must be host-unique.
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      # drbdadm/drbdsetup need the host PID namespace for /proc access
-      # to the kernel module's worker threads.
       hostPID: true
-      # system-node-critical so kubelet graceful shutdown stops the agent
-      # after workloads — their DRBD legs are then Secondary and safe to
-      # release (see agentShutdownSweep). Needs Talos
-      # shutdownGracePeriodCriticalPods >= the grace period below (see README).
       {{- include "miroir.imagePullSecrets" . | nindent 6 }}
       priorityClassName: system-node-critical
-      # Longer grace lets the cordon-gated DRBD teardown finish before SIGKILL;
-      # routine restarts stay schedulable and skip it.
       terminationGracePeriodSeconds: 60
       tolerations:
-        - operator: Exists # CSI node service must run on every schedulable node
+        - operator: Exists
       containers:
         - name: agent
           image: {{ include "miroir.agentImage" . }}
@@ -88,10 +77,6 @@ spec:
           securityContext:
             privileged: true
           ports:
-            # Serves /metrics plus the /healthz and /readyz probes (single
-            # operational port; see cmd/main.go). Stays in the agent's 98xx
-            # host-port range: hostNetwork means this binds on the node, and
-            # :8081 is the org-standard pod port other workloads use.
             - name: metrics
               containerPort: 9810
           livenessProbe:
@@ -112,14 +97,8 @@ spec:
             - name: kubelet
               mountPath: {{ .Values.agent.kubeletDir }}
               mountPropagation: Bidirectional
-            # Plain bind of host /dev (no mountPropagation): the
-            # container must share the host's devtmpfs inode table so
-            # kernel-created nodes (zvol/LV activation) appear in-pod.
             - name: dev
               mountPath: /dev
-            # libzfs/libblkid read partition metadata from the host
-            # udev runtime DB; without it zvol operations can see an
-            # empty DB and misread device state.
             - name: run-udev
               mountPath: /run/udev
               readOnly: true
@@ -128,22 +107,13 @@ spec:
             - name: modules
               mountPath: /lib/modules
               readOnly: true
-            # Rendered .res files + create-md/seed markers live on the
-            # host so DRBD state survives pod restarts; the container
-            # path is drbdadm's default include dir. /etc is read-only
-            # on Talos, hence the /var/lib host backing.
             - name: drbd-cfg
               mountPath: /etc/drbd.d
-            # The hostPath bind shadows the image-baked global config;
-            # re-introduce it via subPath or drbdadm warns on every
-            # invocation.
             - name: drbd-global-conf
               mountPath: /etc/drbd.d/global_common.conf
               subPath: global_common.conf
               readOnly: true
 {{- range $i, $dir := $loopDirs }}
-            # loopfile backing files live on the host filesystem; identity
-            # mount so the path matches nodes.yaml baseDir.
             - name: loopfile-base-{{ $i }}
               mountPath: {{ $dir }}
 {{- end }}

--- a/charts/miroir/templates/configmap.tpl
+++ b/charts/miroir/templates/configmap.tpl
@@ -15,9 +15,6 @@ data:
   nodes.yaml: |
     {{- .Values.nodes | toYaml | nindent 4 }}
 ---
-# drbd-utils global config: the drbd.d hostPath bind shadows the image-baked
-# copy. Cluster-wide resync tuning goes in common{} (inherited by every
-# resource); per-resource settings live in the rendered .res files.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -10,9 +10,9 @@ spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
   {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
-    type: RollingUpdate # leader election arbitrates the rollout overlap
+    type: RollingUpdate
   {{- else }}
-    type: Recreate # one writer for allocations; no leader election
+    type: Recreate
   {{- end }}
   selector:
     matchLabels:
@@ -65,8 +65,6 @@ spec:
             - --auto-diskful-after={{ . }}
             {{- end }}
             - --drbd-port-base={{ .Values.drbd.portBase }}
-            # RWX gateway: the controller spawns per-volume NFS-Ganesha
-            # Deployments in its own namespace from this image.
             - --gateway-image={{ include "miroir.gatewayImage" . }}
             - --gateway-service-account={{ include "miroir.gatewayName" . }}
             {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
@@ -79,7 +77,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
-            # The controller creates gateway workloads in its own namespace.
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -91,8 +88,6 @@ spec:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
           ports:
-            # Serves /metrics plus the /healthz and /readyz probes (single
-            # operational port; see cmd/main.go).
             - name: metrics
               containerPort: 8081
           livenessProbe:
@@ -116,14 +111,10 @@ spec:
             - --default-fstype=ext4
             {{- if .Values.storageCapacity.enabled }}
             - --enable-capacity
-            # Own the CSIStorageCapacity objects from the controller Deployment
-            # (pod → ReplicaSet → Deployment) so they are garbage-collected with it.
             - --capacity-ownerref-level=2
             {{- end }}
           {{- if .Values.storageCapacity.enabled }}
           env:
-            # The provisioner reads these to create CSIStorageCapacity objects in
-            # this namespace and resolve the owning Deployment.
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -194,8 +185,6 @@ metadata:
     {{- include "miroir.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
 spec:
-  # Drains take controllers one at a time, so the warm standby picks up the
-  # Lease instead of provisioning stalling on a full pod reschedule.
   maxUnavailable: 1
   selector:
     matchLabels:

--- a/charts/miroir/templates/podmonitor-gateway.tpl
+++ b/charts/miroir/templates/podmonitor-gateway.tpl
@@ -1,0 +1,44 @@
+{{- if .Values.monitoring.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "miroir.fullname" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "miroir.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.monitoring.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  # Per-RWX-volume NFS gateway pods are created dynamically by the
+  # controller and carry their own labels (see shareLabels in
+  # internal/export/workloads.go), not the chart's selector labels, so the
+  # main PodMonitor cannot match them. Harmless with no RWX volumes: the
+  # selector simply matches nothing.
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: miroir-gateway
+  podMetricsEndpoints:
+    - port: metrics
+      interval: {{ .Values.monitoring.podMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.monitoring.podMonitor.scrapeTimeout | default "10s" }}
+      path: {{ .Values.monitoring.podMonitor.path | default "/metrics" }}
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+        # Stamp the served volume so gateway series join the volume-labelled
+        # miroir_volume_* / miroir_export_ready series.
+        - sourceLabels: [__meta_kubernetes_pod_label_miroir_home_operations_com_volume]
+          targetLabel: volume
+        {{- with .Values.monitoring.podMonitor.relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.monitoring.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/miroir/templates/podmonitor-gateway.tpl
+++ b/charts/miroir/templates/podmonitor-gateway.tpl
@@ -14,11 +14,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  # Per-RWX-volume NFS gateway pods are created dynamically by the
-  # controller and carry their own labels (see shareLabels in
-  # internal/export/workloads.go), not the chart's selector labels, so the
-  # main PodMonitor cannot match them. Harmless with no RWX volumes: the
-  # selector simply matches nothing.
   selector:
     matchLabels:
       app.kubernetes.io/name: miroir-gateway
@@ -30,8 +25,6 @@ spec:
       relabelings:
         - sourceLabels: [__meta_kubernetes_pod_node_name]
           targetLabel: node
-        # Stamp the served volume so gateway series join the volume-labelled
-        # miroir_volume_* / miroir_export_ready series.
         - sourceLabels: [__meta_kubernetes_pod_label_miroir_home_operations_com_volume]
           targetLabel: volume
         {{- with .Values.monitoring.podMonitor.relabelings }}

--- a/charts/miroir/templates/podmonitor.tpl
+++ b/charts/miroir/templates/podmonitor.tpl
@@ -14,9 +14,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  # Both the controller pod and every agent pod expose a port named
-  # "metrics" — the per-volume miroir_volume_* gauges live on the agents,
-  # so scraping the controller alone would miss all of them.
   selector:
     matchLabels:
       {{- include "miroir.selectorLabels" . | nindent 6 }}
@@ -30,8 +27,6 @@ spec:
       scrapeTimeout: {{ .Values.monitoring.podMonitor.scrapeTimeout | default "10s" }}
       path: {{ .Values.monitoring.podMonitor.path | default "/metrics" }}
       relabelings:
-        # Agents run hostNetwork, so instance is a bare node IP; a node
-        # label keeps per-node storage series readable.
         - sourceLabels: [__meta_kubernetes_pod_node_name]
           targetLabel: node
         {{- with .Values.monitoring.podMonitor.relabelings }}

--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -25,8 +25,6 @@ spec:
   groups:
     - name: miroir.volumes
       rules:
-        # DRBD refused to reconnect after divergence; data is forked and
-        # only an operator can pick the losing side.
         - alert: MiroirVolumeSplitBrain
           expr: miroir_volume_split_brain == 1
           for: 1m
@@ -44,9 +42,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        # A freeze volume without quorum refuses writes (on-no-quorum
-        # io-error): pods using it are seeing I/O errors right now, even
-        # though the local disk is healthy.
         - alert: MiroirVolumeQuorumLost
           expr: miroir_volume_quorum == 0
           for: 2m
@@ -66,8 +61,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        # Snapshot write barriers last seconds; a sustained suspend means a
-        # stranded barrier freezing the workload.
         - alert: MiroirVolumeSuspendedBarrier
           expr: miroir_volume_suspended == 1
           for: 10m
@@ -86,8 +79,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        # on-io-error detach latched a failing backing disk; serving
-        # continues via the peer but redundancy is reduced until re-added.
         - alert: MiroirVolumeDiskFailed
           expr: miroir_volume_disk_failed == 1
           for: 5m
@@ -106,7 +97,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        # A leg that stays out of UpToDate is running on reduced redundancy.
         - alert: MiroirVolumeNotUpToDate
           expr: miroir_volume_up_to_date == 0
           for: 15m
@@ -124,7 +114,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        # Replication links to diskful peers are down.
         - alert: MiroirVolumeDisconnected
           expr: miroir_volume_connected == 0
           for: 10m
@@ -141,8 +130,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        # Out-of-sync data that a resync does not drain within an hour is
-        # stuck exposure — or online-verify found silent corruption.
         - alert: MiroirVolumeOutOfSync
           expr: miroir_volume_out_of_sync_bytes > 0
           for: 1h
@@ -162,11 +149,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        # A consumer has been running on a diskless leg (client or
-        # tie-breaker) for a while: every read and write crosses the
-        # replication network. Auto-diskful converts the leg when enabled
-        # and the node has capacity, so a sustained firing means it is
-        # disabled, blocked, or the node holds no storage.
         - alert: MiroirVolumeRemoteConsumer
           expr: miroir_volume_diskless_primary == 1
           for: 30m
@@ -186,12 +168,6 @@ spec:
             {{- end }}
         {{- if .Values.drbd.verify.schedule }}
 
-        # Only rendered when a verify schedule is configured. A schedule
-        # that silently stops firing (agent down over the cron slot, verify
-        # suspended and forgotten) erodes the only cross-leg integrity
-        # check; the last-completed timestamp going stale is the signal.
-        # Volumes that never completed a verify have no series and are not
-        # caught here.
         - alert: MiroirVolumeVerifyStale
           expr: >-
             time() - miroir_volume_verify_last_timestamp_seconds
@@ -215,8 +191,6 @@ spec:
 
     - name: miroir.pools
       rules:
-        # Matches the agent's PoolUsageHigh condition: thin pools and ZFS
-        # degrade badly past ~85% full.
         - alert: MiroirPoolUsageHigh
           expr: miroir_pool_allocated_bytes / miroir_pool_capacity_bytes > 0.80
           for: 15m
@@ -234,8 +208,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        # dm-thin metadata exhaustion corrupts the pool even with data
-        # space free.
         - alert: MiroirPoolMetaUsageHigh
           expr: miroir_pool_meta_used_ratio > 0.80
           for: 15m
@@ -255,11 +227,6 @@ spec:
 
     - name: miroir.exports
       rules:
-        # The gateway is a per-volume singleton: while it is down every NFS
-        # client of the RWX volume hangs, even though the miroir_volume_*
-        # gauges stay green (the DRBD replicas are healthy). 5m rides out a
-        # normal failover — 30s node eviction, reschedule, and DRBD
-        # releasing the dead pod's Primary claim.
         - alert: MiroirExportUnavailable
           expr: miroir_export_ready == 0
           for: 5m
@@ -280,14 +247,6 @@ spec:
 
     - name: miroir.agents
       rules:
-        # A down agent takes every miroir_* series on its node with it, so
-        # the per-volume alerts above go silent instead of firing — and the
-        # agent exits at startup on a below-floor DRBD kernel module, so a
-        # missed node upgrade looks exactly like this. Matched on the
-        # container/namespace target labels rather than job (whose value
-        # depends on PodMonitor naming and user relabelings). A pod that
-        # never became a scrape target (agent unschedulable) has no up
-        # series and is not caught here.
         - alert: MiroirAgentDown
           expr: up{container="agent", namespace="{{ .Release.Namespace }}"} == 0
           for: 10m

--- a/charts/miroir/templates/rbac.tpl
+++ b/charts/miroir/templates/rbac.tpl
@@ -21,20 +21,15 @@ metadata:
   labels:
     {{- include "miroir.labels" . | nindent 4 }}
 rules:
-  # miroir desired state
   - apiGroups: ["miroir.home-operations.com"]
     resources: ["miroirvolumes", "miroirsnapshots"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["miroir.home-operations.com"]
     resources: ["miroirvolumes/status", "miroirsnapshots/status"]
-    # patch: the controller records the Formatted flag on a restored
-    # (clone-from-snapshot) volume so the agent skips mkfs.
     verbs: ["get", "update", "patch"]
-  # capacity-aware placement reads the pool stats agents publish
   - apiGroups: ["miroir.home-operations.com"]
     resources: ["miroirnodes"]
     verbs: ["get", "list", "watch"]
-  # external-provisioner sidecar (topology needs nodes + csinodes)
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
@@ -53,7 +48,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  # external-snapshotter sidecar
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses", "volumesnapshots"]
     verbs: ["get", "list", "watch"]
@@ -69,7 +63,6 @@ rules:
   - apiGroups: ["groupsnapshot.storage.k8s.io"]
     resources: ["volumegroupsnapshotcontents/status"]
     verbs: ["update", "patch"]
-  # external-resizer sidecar
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
     verbs: ["update", "patch"]
@@ -77,12 +70,6 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   {{- if .Values.storageCapacity.enabled }}
-  # external-provisioner capacity feature: publishes CSIStorageCapacity and
-  # walks pod → ReplicaSet → Deployment for the owner reference. No
-  # `deployments get`: the walk stops at the ReplicaSet and reads the
-  # Deployment's identity from its ownerReferences (pkg/owner/owner.go's
-  # levels==1 special case, "we avoid one lookup and thus the need for RBAC
-  # GET permission for the parent"; verified in the v6.3.0 source).
   - apiGroups: ["storage.k8s.io"]
     resources: ["csistoragecapacities"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -91,9 +78,6 @@ rules:
     verbs: ["get"]
   {{- end }}
   {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
-  # leader election (replicaCount > 1 or leaderElection.enabled): the
-  # controller manager and each CSI sidecar hold their own
-  # coordination.k8s.io Lease
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -123,23 +107,19 @@ metadata:
 rules:
   - apiGroups: ["miroir.home-operations.com"]
     resources: ["miroirvolumes", "miroirsnapshots"]
-    verbs: ["get", "list", "watch", "update"] # update releases finalizers
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["miroir.home-operations.com"]
     resources: ["miroirvolumes/status", "miroirsnapshots/status"]
     verbs: ["get", "patch"]
-  # each agent owns its own MiroirNode, publishing pool capacity
   - apiGroups: ["miroir.home-operations.com"]
     resources: ["miroirnodes"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["miroir.home-operations.com"]
     resources: ["miroirnodes/status"]
     verbs: ["get", "update", "patch"]
-  # PoolUsageHigh events at the 80% capacity warn line
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-  # reads its own Node's cordon state to distinguish a node shutdown
-  # (release DRBD backings so the pool can export) from a routine pod restart
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
@@ -159,8 +139,6 @@ subjects:
     name: {{ include "miroir.agentName" . }}
     namespace: {{ .Release.Namespace }}
 ---
-# The controller manages per-RWX-volume gateway workloads in its own
-# namespace only — a namespaced Role, not cluster-wide.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -192,8 +170,6 @@ subjects:
     name: {{ include "miroir.controllerName" . }}
     namespace: {{ .Release.Namespace }}
 ---
-# Gateway pods read their volume and latch its Formatted/Activated status
-# while staging. MiroirVolumes are cluster-scoped, so this is a ClusterRole.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/miroir/templates/setup-job.tpl
+++ b/charts/miroir/templates/setup-job.tpl
@@ -25,8 +25,6 @@ spec:
         - operator: Exists
       containers:
         - name: setup
-          # The setup Job bootstraps the node pool with the same storage
-          # userland the agent uses.
           image: {{ include "miroir.agentImage" $ }}
           imagePullPolicy: {{ include "miroir.agentImagePullPolicy" $ }}
           args:

--- a/charts/miroir/templates/storageclass.tpl
+++ b/charts/miroir/templates/storageclass.tpl
@@ -17,17 +17,11 @@ reclaimPolicy: {{ $sc.reclaimPolicy | default "Delete" }}
 parameters:
   miroir.home-operations.com/replicas: {{ $replicas | quote }}
   {{- if gt (int $replicas) 1 }}
-  # freeze: never diverges, halts on any disconnect; last-man-standing:
-  # survivor keeps writing on node loss, split-brain alerts on reconnect.
   miroir.home-operations.com/quorum: {{ $sc.quorum | default "freeze" }}
   {{- if hasKey $sc "allowRemoteVolumeAccess" }}
-  # Absent defaults to allowed (controller-side); rendered only when the
-  # entry pins it either way.
   miroir.home-operations.com/allowRemoteVolumeAccess: {{ $sc.allowRemoteVolumeAccess | quote }}
   {{- end }}
   {{- if $sc.bitmapGranularity }}
-  # DRBD bitmap block size in bytes, fixed when a replica's metadata is
-  # created; absent means DRBD's default (4096).
   miroir.home-operations.com/bitmapGranularity: {{ $sc.bitmapGranularity | quote }}
   {{- end }}
   {{- end }}

--- a/charts/miroir/tests/podmonitor_gateway_test.yaml
+++ b/charts/miroir/tests/podmonitor_gateway_test.yaml
@@ -1,0 +1,41 @@
+suite: podmonitor gateway
+templates:
+  - podmonitor-gateway.tpl
+release:
+  name: miroir
+  namespace: miroir-system
+tests:
+  - it: should not create the gateway PodMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should select gateway pods by their app name on the metrics port
+    set:
+      monitoring.podMonitor.enabled: true
+    asserts:
+      - isKind:
+          of: PodMonitor
+      - equal:
+          path: metadata.name
+          value: miroir-gateway
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: miroir-gateway
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: metrics
+
+  - it: should relabel node and volume onto every series
+    set:
+      monitoring.podMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[0].targetLabel
+          value: node
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[1].sourceLabels
+          value: [__meta_kubernetes_pod_label_miroir_home_operations_com_volume]
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[1].targetLabel
+          value: volume

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -237,7 +237,7 @@ func runSetup(nodeName, nodesConfig, vg, thinPool string) {
 // is signalled. It builds a direct client (no manager/cache) and drives
 // the host's DRBD/mount tooling like the agent, exiting non-zero if the
 // export ever fails so the pod restarts.
-func runGateway(nodeName, volumeName, exportDir, ganeshaConf, drbdStateDir string) {
+func runGateway(nodeName, volumeName, exportDir, ganeshaConf, drbdStateDir, httpAddr string) {
 	if nodeName == "" {
 		setupLog.Error(nil, "--node-name (or NODE_NAME) is required in gateway mode")
 		os.Exit(1)
@@ -257,6 +257,7 @@ func runGateway(nodeName, volumeName, exportDir, ganeshaConf, drbdStateDir strin
 		NodeName:    nodeName,
 		ExportDir:   exportDir,
 		GaneshaConf: ganeshaConf,
+		HTTPAddr:    httpAddr,
 	}, setupLog.WithName("gateway")); err != nil {
 		setupLog.Error(err, "gateway exited")
 		os.Exit(1)
@@ -359,7 +360,9 @@ func main() {
 		return
 	}
 	if mode == "gateway" {
-		runGateway(nodeName, volumeName, exportDir, ganeshaConf, drbdStateDir)
+		// The gateway skips the manager but serves the same operational
+		// endpoint itself (/healthz liveness + /metrics) on metricsAddr.
+		runGateway(nodeName, volumeName, exportDir, ganeshaConf, drbdStateDir, metricsAddr)
 		return
 	}
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -22,6 +22,7 @@ agent exports, per volume on that node:
 | `miroir_volume_quorum`                        | 0 while a `freeze` volume has lost quorum and refuses writes, the "workloads are failing I/O" signal (always 1 under `last-man-standing`) |
 | `miroir_volume_disk_failed`                   | 1 when this leg's disk was detached after an I/O error and latched failed; replace the disk, then remove and re-add the replica           |
 | `miroir_volume_out_of_sync_bytes`             | worst per-peer out-of-sync bytes: the exposure if the healthiest peer is lost; also counts online-verify findings                         |
+| `miroir_volume_primary`                       | 1 while this node's diskful leg is Primary: the consumer pod or the RWX gateway runs here and this leg serves the I/O                     |
 | `miroir_volume_diskless_primary`              | 1 while a diskless leg (client or tie-breaker) is Primary here: the consumer pays network I/O; see auto-diskful                           |
 | `miroir_volume_verify_last_timestamp_seconds` | unix time of the last completed scheduled verify; alert on staleness to catch a schedule that stopped firing                              |
 | `miroir_volume_verify_out_of_sync_bytes`      | out-of-sync bytes the last scheduled verify found (0 = clean)                                                                             |
@@ -41,6 +42,14 @@ while the volume's NFS gateway is serving (gateway pod available,
 export address published). This is the signal the per-volume gauges
 cannot give you: DRBD replicas stay healthy while a dead gateway
 leaves every NFS client hanging.
+
+Each **gateway** pod additionally serves its own metrics endpoint
+(scraped by a second PodMonitor, with `node` and `volume` labels):
+`miroir_gateway_nfs_healthy` is the result of the last liveness
+probe's NFS NULL call against the pod's local ganesha. The same
+probe backs the pod's `/healthz`, so a ganesha that still accepts
+TCP connections but has stopped answering NFS fails liveness and is
+restarted — previously that failure mode was invisible.
 
 Prometheus is not the only surface. Volume health also flows through
 the CSI `VolumeCondition`: enable `sidecars.healthMonitor.enabled`

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -68,6 +68,10 @@ var (
 		Name: "miroir_volume_verify_out_of_sync_bytes",
 		Help: "Out-of-sync bytes the last scheduled verify found (0 = clean). Findings also surface in miroir_volume_out_of_sync_bytes until a disconnect/connect resync clears them.",
 	}, []string{volumeLabel})
+	metricPrimary = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "miroir_volume_primary",
+		Help: "1 while this node's diskful leg is DRBD Primary: the consumer pod or the RWX gateway runs here and this leg serves the I/O. Diskless legs report miroir_volume_diskless_primary instead; unreplicated volumes have no DRBD role and always report 0.",
+	}, []string{volumeLabel})
 	metricDisklessPrimary = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_diskless_primary",
 		Help: "1 while this node's diskless leg (client or tie-breaker) is DRBD Primary: a consumer runs here and every read and write crosses the replication network. Sustained 1 means the workload pays network I/O — auto-diskful (autoDiskfulAfter) converts the leg to a local replica when the node has storage capacity.",
@@ -101,7 +105,7 @@ func init() {
 	metrics.Registry.MustRegister(
 		metricUpToDate, metricConnected, metricSplitBrain, metricSuspended,
 		metricResyncRatio, metricQuorum, metricDiskFailed, metricOutOfSyncBytes,
-		metricVerifyTimestamp, metricVerifyOutOfSyncBytes, metricDisklessPrimary,
+		metricVerifyTimestamp, metricVerifyOutOfSyncBytes, metricPrimary, metricDisklessPrimary,
 		metricPoolCapacity, metricPoolAllocated, metricPoolMetaUsedRatio,
 		metricDRBDKernelInfo,
 	)
@@ -116,6 +120,7 @@ func recordVolumeMetrics(volume string, st miroirReplicaView) {
 	metricQuorum.WithLabelValues(volume).Set(boolGauge(st.quorum))
 	metricDiskFailed.WithLabelValues(volume).Set(boolGauge(st.diskFailed))
 	metricOutOfSyncBytes.WithLabelValues(volume).Set(st.outOfSyncBytes)
+	metricPrimary.WithLabelValues(volume).Set(boolGauge(st.primary))
 }
 
 // recordPoolMetrics publishes the node pool sample; one pool per node, so
@@ -135,6 +140,7 @@ func dropVolumeMetrics(volume string) {
 	metricQuorum.DeleteLabelValues(volume)
 	metricDiskFailed.DeleteLabelValues(volume)
 	metricOutOfSyncBytes.DeleteLabelValues(volume)
+	metricPrimary.DeleteLabelValues(volume)
 	metricVerifyTimestamp.DeleteLabelValues(volume)
 	metricVerifyOutOfSyncBytes.DeleteLabelValues(volume)
 	metricDisklessPrimary.DeleteLabelValues(volume)
@@ -170,6 +176,7 @@ type miroirReplicaView struct {
 	suspended      bool
 	quorum         bool
 	diskFailed     bool
+	primary        bool
 	resyncRatio    float64
 	outOfSyncBytes float64
 }

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -60,6 +60,7 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 		suspended:      false,
 		quorum:         true,
 		diskFailed:     true,
+		primary:        true,
 		resyncRatio:    0.425,
 		outOfSyncBytes: 2048 * 1024,
 	})
@@ -88,6 +89,9 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 	if got := testutil.ToFloat64(metricOutOfSyncBytes.WithLabelValues(volume)); got != 2048*1024 {
 		t.Fatalf("out_of_sync_bytes = %v, want %v", got, 2048*1024)
 	}
+	if got := testutil.ToFloat64(metricPrimary.WithLabelValues(volume)); got != 1 {
+		t.Fatalf("primary = %v, want 1", got)
+	}
 
 	dropVolumeMetrics(volume)
 	for _, family := range []string{
@@ -99,6 +103,7 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 		"miroir_volume_quorum",
 		"miroir_volume_disk_failed",
 		"miroir_volume_out_of_sync_bytes",
+		"miroir_volume_primary",
 	} {
 		if hasSeries(t, family, volume) {
 			t.Fatalf("%s{volume=%q} still exposed after drop", family, volume)

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -276,6 +276,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			suspended:  st.Suspended,
 			quorum:     st.Quorum,
 			diskFailed: diskFailed,
+			primary:    st.Primary,
 			// drbdsetup reports percent-in-sync and KiB; the exported
 			// gauges are a 0-1 ratio and bytes per Prometheus base units.
 			resyncRatio:    st.ResyncPercent / 100,
@@ -358,6 +359,7 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 			suspended:      st.Suspended,
 			quorum:         st.Quorum,
 			diskFailed:     diskFailedLatch(vol, r.NodeName, st, localDiskless),
+			primary:        st.Primary,
 			resyncRatio:    st.ResyncPercent / 100,
 			outOfSyncBytes: float64(st.OutOfSyncKiB) * 1024,
 		})

--- a/internal/export/workloads.go
+++ b/internal/export/workloads.go
@@ -37,6 +37,9 @@ const (
 	gatewayAppName = "miroir-gateway"
 	// nfsPort is the NFSv4 port the gateway serves and the Service fronts.
 	nfsPort = 2049
+	// httpPort is the gateway's operational endpoint (/healthz liveness,
+	// /metrics for the gateway PodMonitor) — the org-standard pod port.
+	httpPort = 8081
 )
 
 // shareName is the Deployment/Service name for a volume's gateway.
@@ -103,7 +106,10 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 							ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 						}},
 						SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
-						Ports:           []corev1.ContainerPort{{Name: "nfs", ContainerPort: nfsPort, Protocol: corev1.ProtocolTCP}},
+						Ports: []corev1.ContainerPort{
+							{Name: "nfs", ContainerPort: nfsPort, Protocol: corev1.ProtocolTCP},
+							{Name: "metrics", ContainerPort: httpPort, Protocol: corev1.ProtocolTCP},
+						},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name: "dev", MountPath: "/dev",
 						}},
@@ -122,6 +128,19 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 							},
 							InitialDelaySeconds: 5,
 							PeriodSeconds:       10,
+						},
+						// /healthz answers an NFS NULL RPC against ganesha, so a
+						// wedged-but-listening server (green on the TCP readiness
+						// probe above) gets restarted. It passes unconditionally
+						// while the gateway is still staging — a failover wait must
+						// not be liveness-killed — so no InitialDelay is needed.
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromInt32(httpPort)},
+							},
+							PeriodSeconds:    20,
+							TimeoutSeconds:   10,
+							FailureThreshold: 3,
 						},
 					}},
 					Volumes: []corev1.Volume{{

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -59,6 +59,9 @@ type Config struct {
 	// GaneshaConf is where the rendered config is written. Default
 	// /etc/ganesha/ganesha.conf.
 	GaneshaConf string
+	// HTTPAddr is the operational endpoint (/healthz liveness probe,
+	// /metrics). Default :8081, the org-standard pod port.
+	HTTPAddr string
 	// StageRetry is how often to retry staging while DRBD promotion is
 	// refused (the failover wait). Default 5s.
 	StageRetry time.Duration
@@ -73,6 +76,9 @@ func (c *Config) withDefaults() {
 	}
 	if c.GaneshaConf == "" {
 		c.GaneshaConf = "/etc/ganesha/ganesha.conf"
+	}
+	if c.HTTPAddr == "" {
+		c.HTTPAddr = ":8081"
 	}
 	if c.StageRetry == 0 {
 		c.StageRetry = 5 * time.Second
@@ -93,6 +99,15 @@ const (
 // (non-nil error → pod restart). It blocks.
 func Run(ctx context.Context, cl client.Client, drbdStatus stage.DRBDStatus, cfg Config, log logr.Logger) error {
 	cfg.withDefaults()
+	// Health endpoint up before staging: /healthz passes unconditionally
+	// until ganesha starts, so the kubelet's liveness probe never kills the
+	// pod during the (possibly minutes-long) failover staging wait.
+	h := &health{
+		volume:  cfg.VolumeID,
+		nfsAddr: fmt.Sprintf("127.0.0.1:%d", ganeshaPort),
+		timeout: 5 * time.Second,
+	}
+	healthErr := h.serve(ctx, cfg.HTTPAddr, log)
 	deps := stage.Deps{
 		Client:   cl,
 		NodeName: cfg.NodeName,
@@ -133,7 +148,7 @@ func Run(ctx context.Context, cl client.Client, drbdStatus stage.DRBDStatus, cfg
 	if err := writeGaneshaConf(cfg, mountPath); err != nil {
 		return err
 	}
-	return supervise(ctx, deps.Mounter, cfg, dev, mountPath, log)
+	return supervise(ctx, deps.Mounter, cfg, dev, mountPath, h, healthErr, log)
 }
 
 // writeGaneshaConf renders and writes the export config and ensures the
@@ -165,13 +180,16 @@ func writeGaneshaConf(cfg Config, mountPath string) error {
 // on the diskful legs; the gateway is where the fs is mounted, so it does
 // the fs grow). It returns nil on a clean ctx-cancelled stop and an error
 // if ganesha exits on its own — a dead server must restart the pod.
-func supervise(ctx context.Context, mounter *mount.SafeFormatAndMount, cfg Config, dev, mountPath string, log logr.Logger) error {
+func supervise(ctx context.Context, mounter *mount.SafeFormatAndMount, cfg Config, dev, mountPath string, h *health, healthErr <-chan error, log logr.Logger) error {
 	cmd := exec.Command(ganeshaBin, "-F", "-f", cfg.GaneshaConf, "-N", "NIV_EVENT")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start ganesha: %w", err)
 	}
+	// From here /healthz answers with a real NFS NULL probe — a ganesha
+	// that accepts TCP but stops answering RPC now fails liveness.
+	h.serving.Store(true)
 	log.Info("ganesha serving", "export", "/"+cfg.VolumeID, "port", ganeshaPort)
 
 	done := make(chan error, 1)
@@ -197,6 +215,13 @@ func supervise(ctx context.Context, mounter *mount.SafeFormatAndMount, cfg Confi
 			return nil
 		case err := <-done:
 			return fmt.Errorf("ganesha exited: %w", err)
+		case err := <-healthErr:
+			// The liveness endpoint could not bind or died: the kubelet
+			// would kill the pod as probe-dead anyway, so exit deliberately
+			// with the real reason in the log.
+			_ = cmd.Process.Kill()
+			<-done
+			return err
 		case <-ticker.C:
 			need, err := resizer.NeedResize(dev, mountPath)
 			if err != nil {

--- a/internal/gateway/health.go
+++ b/internal/gateway/health.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// The gateway runs without the controller-runtime manager (see cmd/main.go),
+// so it carries its own registry instead of the global one the controller
+// and agent share.
+var (
+	gatewayRegistry  = prometheus.NewRegistry()
+	metricNFSHealthy = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "miroir_gateway_nfs_healthy",
+		Help: "1 when the last liveness probe's NFS NULL call succeeded against the local ganesha; 0 when ganesha accepted the TCP connection but did not answer RPC (wedged). Sampled at the kubelet's probe cadence.",
+	}, []string{"volume"})
+)
+
+func init() {
+	gatewayRegistry.MustRegister(metricNFSHealthy)
+}
+
+// health serves the gateway's operational endpoint: /healthz for the pod's
+// liveness probe and /metrics for the gateway PodMonitor.
+type health struct {
+	volume  string
+	nfsAddr string
+	timeout time.Duration
+	// serving flips once ganesha has started. Before that /healthz always
+	// passes: staging legitimately blocks for minutes on failover (waiting
+	// for DRBD to release the dead gateway's Primary claim), and a liveness
+	// kill during that wait would restart the pod and reset the wait.
+	serving atomic.Bool
+}
+
+func (h *health) healthz(w http.ResponseWriter, _ *http.Request) {
+	if !h.serving.Load() {
+		_, _ = io.WriteString(w, "staging")
+		return
+	}
+	if err := nfsNull(h.nfsAddr, h.timeout); err != nil {
+		metricNFSHealthy.WithLabelValues(h.volume).Set(0)
+		http.Error(w, "nfs probe: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	metricNFSHealthy.WithLabelValues(h.volume).Set(1)
+	_, _ = io.WriteString(w, "ok")
+}
+
+// serve runs the HTTP endpoint until ctx is cancelled. Failure to bind is
+// fatal via the returned channel: a gateway whose liveness endpoint never
+// answers would be killed by the kubelet anyway, so fail loudly at startup.
+func (h *health) serve(ctx context.Context, addr string, log logr.Logger) <-chan error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", h.healthz)
+	mux.Handle("/metrics", promhttp.HandlerFor(gatewayRegistry, promhttp.HandlerOpts{}))
+	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	errc := make(chan error, 1)
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+	go func() {
+		log.Info("health endpoint serving", "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errc <- fmt.Errorf("health endpoint: %w", err)
+		}
+	}()
+	return errc
+}
+
+// nfsNull performs an ONC RPC NULL call (program 100003, NFSv4, procedure
+// 0) over TCP — the protocol-level "are you alive" ping every RPC server
+// must answer. This is what distinguishes a healthy ganesha from a wedged
+// one: a wedged server still accepts TCP connections (so the readiness
+// TCPSocket probe stays green) but never answers RPC.
+func nfsNull(addr string, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return err
+	}
+	defer conn.Close() //nolint:errcheck // read-side probe; nothing to flush
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return err
+	}
+
+	// RFC 5531 call body (40 bytes) behind a record mark: xid, CALL(0),
+	// RPC v2, NFS program, v4, NULL proc, AUTH_NONE cred + verf.
+	xid := uint32(time.Now().UnixNano()) //nolint:gosec // wrap-around is fine for an xid
+	var call [44]byte
+	binary.BigEndian.PutUint32(call[0:], 0x80000000|40) // last fragment, 40-byte body
+	binary.BigEndian.PutUint32(call[4:], xid)
+	binary.BigEndian.PutUint32(call[12:], 2)      // RPC version
+	binary.BigEndian.PutUint32(call[16:], 100003) // NFS program number
+	binary.BigEndian.PutUint32(call[20:], 4)      // NFSv4
+	// msg_type CALL, proc NULL, and the two AUTH_NONE blocks are all zeros.
+	if _, err := conn.Write(call[:]); err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+
+	var mark [4]byte
+	if _, err := io.ReadFull(conn, mark[:]); err != nil {
+		return fmt.Errorf("read record mark: %w", err)
+	}
+	rm := binary.BigEndian.Uint32(mark[:])
+	if rm&0x80000000 == 0 {
+		return fmt.Errorf("fragmented reply")
+	}
+	n := rm & 0x7fffffff
+	if n < 16 || n > 1024 {
+		return fmt.Errorf("implausible reply length %d", n)
+	}
+	body := make([]byte, n)
+	if _, err := io.ReadFull(conn, body); err != nil {
+		return fmt.Errorf("read reply: %w", err)
+	}
+	if got := binary.BigEndian.Uint32(body[0:]); got != xid {
+		return fmt.Errorf("xid mismatch: sent %d, got %d", xid, got)
+	}
+	if mt := binary.BigEndian.Uint32(body[4:]); mt != 1 {
+		return fmt.Errorf("not a reply (msg_type %d)", mt)
+	}
+	if rs := binary.BigEndian.Uint32(body[8:]); rs != 0 {
+		return fmt.Errorf("rpc denied (reply_stat %d)", rs)
+	}
+	// Skip the opaque verifier (flavor + length + padded body), then check
+	// accept_stat.
+	vlen := int(binary.BigEndian.Uint32(body[16:]))
+	if vlen > 400 {
+		return fmt.Errorf("implausible verifier length %d", vlen)
+	}
+	off := 20 + ((vlen + 3) &^ 3)
+	if len(body) < off+4 {
+		return fmt.Errorf("short reply (%d bytes)", len(body))
+	}
+	if as := binary.BigEndian.Uint32(body[off:]); as != 0 {
+		return fmt.Errorf("call not accepted (accept_stat %d)", as)
+	}
+	return nil
+}

--- a/internal/gateway/health_test.go
+++ b/internal/gateway/health_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// fakeNFS listens on a loopback port and answers each connection according
+// to mode: "reply" sends a well-formed accepted NULL reply, "wedge" reads
+// the call and never answers (the wedged-but-listening ganesha), "garbage"
+// answers with a non-RPC byte stream.
+func fakeNFS(t *testing.T, mode string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close() //nolint:errcheck // test server
+				var mark [4]byte
+				if _, err := io.ReadFull(c, mark[:]); err != nil {
+					return
+				}
+				n := binary.BigEndian.Uint32(mark[:]) & 0x7fffffff
+				call := make([]byte, n)
+				if _, err := io.ReadFull(c, call); err != nil {
+					return
+				}
+				switch mode {
+				case "wedge":
+					time.Sleep(10 * time.Second)
+				case "garbage":
+					_, _ = c.Write([]byte("definitely not sunrpc"))
+				default:
+					// Accepted NULL reply: xid, REPLY, MSG_ACCEPTED,
+					// AUTH_NONE verf, SUCCESS.
+					var reply [28]byte
+					binary.BigEndian.PutUint32(reply[0:], 0x80000000|24)
+					copy(reply[4:8], call[0:4]) // echo xid
+					binary.BigEndian.PutUint32(reply[8:], 1)
+					_, _ = c.Write(reply[:])
+				}
+			}(conn)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func TestNFSNull(t *testing.T) {
+	if err := nfsNull(fakeNFS(t, "reply"), time.Second); err != nil {
+		t.Fatalf("healthy server: %v", err)
+	}
+	if err := nfsNull(fakeNFS(t, "wedge"), 200*time.Millisecond); err == nil {
+		t.Fatal("wedged server (accepts TCP, never answers RPC) reported healthy")
+	}
+	if err := nfsNull(fakeNFS(t, "garbage"), time.Second); err == nil {
+		t.Fatal("non-RPC responder reported healthy")
+	}
+	if err := nfsNull("127.0.0.1:1", 200*time.Millisecond); err == nil {
+		t.Fatal("closed port reported healthy")
+	}
+}
+
+// The liveness contract: pass unconditionally while staging (a failover
+// wait must not be probe-killed), then answer with the real NFS probe once
+// serving.
+func TestHealthzPhases(t *testing.T) {
+	h := &health{volume: "pvc-health", nfsAddr: fakeNFS(t, "wedge"), timeout: 200 * time.Millisecond}
+
+	rec := httptest.NewRecorder()
+	h.healthz(rec, nil)
+	if rec.Code != 200 {
+		t.Fatalf("staging healthz = %d, want 200", rec.Code)
+	}
+
+	h.serving.Store(true)
+	rec = httptest.NewRecorder()
+	h.healthz(rec, nil)
+	if rec.Code != 503 {
+		t.Fatalf("wedged serving healthz = %d, want 503", rec.Code)
+	}
+
+	h.nfsAddr = fakeNFS(t, "reply")
+	rec = httptest.NewRecorder()
+	h.healthz(rec, nil)
+	if rec.Code != 200 {
+		t.Fatalf("healthy serving healthz = %d, want 200", rec.Code)
+	}
+}


### PR DESCRIPTION
Closes out the remaining items from the July observability review, in three commits.

## miroir_volume_primary (diskful legs)

Where a volume's I/O is actually served — the consumer pod's node, or the node the RWX gateway is promoted on — was only visible in CR status (`primarySince`). Now exported per volume from the agent alongside the other leg gauges. Diskless legs keep `miroir_volume_diskless_primary`; unreplicated volumes report a constant 0 (no DRBD role).

## Gateway liveness + metrics

The gateway pod had no liveness probe and no metrics endpoint (`--mode=gateway` never builds the controller-runtime manager), so a wedged ganesha that still accepted TCP passed the TCPSocket readiness probe forever while every NFS client hung.

- The gateway now serves `/healthz` and `/metrics` itself on :8081. `/healthz` answers an **ONC RPC NULL call** (NFS program, v4) against the local ganesha — a protocol-level ping a wedged-but-listening server cannot fake — and passes unconditionally during staging so the failover wait (DRBD releasing the dead peer's Primary claim) is never liveness-killed.
- Probe result exported as `miroir_gateway_nfs_healthy{volume}`.
- The gateway Deployment gains the metrics port and an HTTPGet liveness probe; `CreateOrUpdate` rolls existing gateways on controller upgrade (Recreate strategy — expect the usual brief NFS stall per RWX volume, once).
- A second PodMonitor scrapes gateway pods (they carry their own labels, so the main one can't match them), stamping `node` and `volume` onto every series.

## Chart description refresh

`Chart.yaml` and the chart README template still said "DRBD9 replication planned"; updated, plus a pointer to the docs site. helm-docs output regenerated.

Docs: `monitoring.md` gains the new gauge row and a gateway-metrics paragraph.

## Verification

- Unit tests: the NULL-RPC probe is tested against fake NFS responders (healthy / wedged / garbage / closed port), and the `/healthz` phase contract (200 while staging, 503 wedged, 200 healthy) is asserted directly; agent metrics lifecycle test extended for the new gauge.
- `mise run test` (full suite), `golangci-lint`: clean; `mise run helm-lint` + `helm-test` (101/101); `mise run docs` strict build passes.
- End-to-end gateway run needs a cluster with DRBD (kind e2e unavailable locally); the probe protocol and handler are covered by the unit tests above.