### PR TITLE
feat(rwx)!: gateway.enabled toggle, RWX off by default

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -69,6 +69,7 @@ Kubernetes: `>=1.31.0`
 | extraArgs | list | `[]` | Extra arguments for the controller container. |
 | extraEnv | list | `[]` | Extra environment variables for the controller container. |
 | fullnameOverride | string | `""` | Override the fully qualified name prefix of every rendered object. |
+| gateway.enabled | bool | `false` | Serve ReadWriteMany (and ReadOnlyMany) PVCs via per-volume NFS gateways. Opt-in: gateway pods run privileged in the release namespace, and any user who can create a PVC can cause one to be spawned, so enabling RWX is an explicit operator decision. While disabled the controller rejects RWX at provision time with a clear message, and the gateway ServiceAccount, RBAC, PodMonitor, and export alerts are not installed. |
 | gateway.image.digest | string | `""` |  |
 | gateway.image.pullPolicy | string | `"IfNotPresent"` |  |
 | gateway.image.repository | string | `"ghcr.io/home-operations/miroir-gateway"` |  |

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -65,8 +65,10 @@ spec:
             - --auto-diskful-after={{ . }}
             {{- end }}
             - --drbd-port-base={{ .Values.drbd.portBase }}
+            {{- if .Values.gateway.enabled }}
             - --gateway-image={{ include "miroir.gatewayImage" . }}
             - --gateway-service-account={{ include "miroir.gatewayName" . }}
+            {{- end }}
             {{- if eq (include "miroir.leaderElectionEnabled" .) "true" }}
             - --leader-elect=true
             - --leader-election-id={{ include "miroir.leaderElectionID" . }}

--- a/charts/miroir/templates/podmonitor-gateway.tpl
+++ b/charts/miroir/templates/podmonitor-gateway.tpl
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.podMonitor.enabled }}
+{{- if and .Values.monitoring.podMonitor.enabled .Values.gateway.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -225,6 +225,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
+    {{- if .Values.gateway.enabled }}
     - name: miroir.exports
       rules:
         - alert: MiroirExportUnavailable
@@ -244,6 +245,7 @@ spec:
             {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+    {{- end }}
 
     - name: miroir.agents
       rules:

--- a/charts/miroir/templates/rbac.tpl
+++ b/charts/miroir/templates/rbac.tpl
@@ -138,6 +138,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "miroir.agentName" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.gateway.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -206,3 +207,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "miroir.gatewayName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -38,14 +38,6 @@ tests:
       - lengthEqual:
           path: spec.template.spec.containers
           count: 4
-      # RWX: the controller is told which gateway image and ServiceAccount
-      # to spawn per-volume NFS gateways with.
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --gateway-image=ghcr.io/home-operations/miroir-gateway:0.0.1
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --gateway-service-account=miroir-gateway
       - contains:
           any: true
           path: spec.template.spec.containers
@@ -472,3 +464,26 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --auto-diskful-after=10m
+  - it: withholds the gateway args by default (RWX is opt-in)
+    documentIndex: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --gateway-image=ghcr.io/home-operations/miroir-gateway:0.0.1
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --gateway-service-account=miroir-gateway
+
+  # RWX: the controller is told which gateway image and ServiceAccount
+  # to spawn per-volume NFS gateways with.
+  - it: passes the gateway args when the gateway is enabled
+    documentIndex: 0
+    set:
+      gateway.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --gateway-image=ghcr.io/home-operations/miroir-gateway:0.0.1
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --gateway-service-account=miroir-gateway

--- a/charts/miroir/tests/podmonitor_gateway_test.yaml
+++ b/charts/miroir/tests/podmonitor_gateway_test.yaml
@@ -10,9 +10,17 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should not create the gateway PodMonitor when only podMonitor is enabled (RWX is opt-in)
+    set:
+      monitoring.podMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should select gateway pods by their app name on the metrics port
     set:
       monitoring.podMonitor.enabled: true
+      gateway.enabled: true
     asserts:
       - isKind:
           of: PodMonitor
@@ -29,6 +37,7 @@ tests:
   - it: should relabel node and volume onto every series
     set:
       monitoring.podMonitor.enabled: true
+      gateway.enabled: true
     asserts:
       - equal:
           path: spec.podMetricsEndpoints[0].relabelings[0].targetLabel

--- a/charts/miroir/tests/prometheusrule_test.yaml
+++ b/charts/miroir/tests/prometheusrule_test.yaml
@@ -23,9 +23,10 @@ tests:
           path: metadata.namespace
           value: miroir-system
 
-  - it: should have the volume, pool, export and agent rule groups
+  - it: should have the volume, pool, export and agent rule groups with the gateway enabled
     set:
       monitoring.prometheusRule.enabled: true
+      gateway.enabled: true
     asserts:
       - lengthEqual:
           path: spec.groups
@@ -63,6 +64,17 @@ tests:
       - equal:
           path: spec.groups[3].rules[0].expr
           value: up{container="agent", namespace="miroir-system"} == 0
+
+  - it: should omit the export rule group by default (RWX is opt-in)
+    set:
+      monitoring.prometheusRule.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.groups
+          count: 3
+      - equal:
+          path: spec.groups[2].name
+          value: miroir.agents
 
   - it: should render the verify staleness rule only with a verify schedule
     set:

--- a/charts/miroir/tests/rbac_test.yaml
+++ b/charts/miroir/tests/rbac_test.yaml
@@ -5,7 +5,18 @@ release:
   name: miroir
   namespace: miroir-system
 tests:
-  - it: emits controller + agent + gateway RBAC (SAs, cluster roles, and the namespaced gateway Role)
+  - it: emits controller + agent RBAC by default (gateway RBAC is opt-in)
+    asserts:
+      - hasDocuments:
+          count: 6
+      - documentIndex: 5
+        equal:
+          path: kind
+          value: ClusterRoleBinding
+
+  - it: emits controller + agent + gateway RBAC when the gateway is enabled
+    set:
+      gateway.enabled: true
     asserts:
       - hasDocuments:
           count: 11

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -284,6 +284,12 @@
     "gateway": {
       "description": "=============================================================================\nGateway (per-RWX-volume NFS share manager)\n=============================================================================\nThe controller spawns one gateway Deployment per RWX (ReadWriteMany)\nvolume: it mounts the volume's device on a replica node and exports it\nover NFSv4 (userspace NFS-Ganesha), which consumers on any node mount.\nThe image is the agent userland plus NFS-Ganesha.",
       "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Serve ReadWriteMany (and ReadOnlyMany) PVCs via per-volume NFS\ngateways. Opt-in: gateway pods run privileged in the release namespace,\nand any user who can create a PVC can cause one to be spawned, so\nenabling RWX is an explicit operator decision. While disabled the\ncontroller rejects RWX at provision time with a clear message, and the\ngateway ServiceAccount, RBAC, PodMonitor, and export alerts are not\ninstalled.",
+          "title": "enabled",
+          "type": "boolean"
+        },
         "image": {
           "properties": {
             "digest": {

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -195,6 +195,14 @@ agent:
 # over NFSv4 (userspace NFS-Ganesha), which consumers on any node mount.
 # The image is the agent userland plus NFS-Ganesha.
 gateway:
+  # -- Serve ReadWriteMany (and ReadOnlyMany) PVCs via per-volume NFS
+  # gateways. Opt-in: gateway pods run privileged in the release namespace,
+  # and any user who can create a PVC can cause one to be spawned, so
+  # enabling RWX is an explicit operator decision. While disabled the
+  # controller rejects RWX at provision time with a clear message, and the
+  # gateway ServiceAccount, RBAC, PodMonitor, and export alerts are not
+  # installed.
+  enabled: false
   image:
     repository: ghcr.io/home-operations/miroir-gateway
     # Overrides the image tag; defaults to the chart appVersion.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -436,6 +436,7 @@ func main() {
 			ProvisionTimeout: provisionTimeout,
 			OvercommitRatio:  overcommitRatio,
 			AutoTieBreaker:   autoTieBreaker,
+			RWXEnabled:       gatewayImage != "",
 			DRBDPortBase:     int32(drbdPortBase),
 		}
 		if err := setupMembership(mgr, nodes, autoTieBreaker, autoDiskfulAfter); err != nil {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,9 @@ exist and where their behavior is explained.
   `verify.algorithm` / `verify.schedule`
   ([verification](resilience.md)), `autoTieBreaker`,
   `autoDiskfulAfter` ([auto-diskful](remote-consumers.md#auto-diskful)).
+- **`gateway`** — the per-RWX-volume NFS gateway: `enabled` (RWX is
+  opt-in, off by default) and the gateway image
+  ([ReadWriteMany](rwx.md)).
 - **`monitoring`** — PodMonitor, PrometheusRule, dashboards
   ([Monitoring](monitoring.md)).
 - **`agent` / `controller` / `sidecars`** — workload knobs: images,

--- a/docs/rwx.md
+++ b/docs/rwx.md
@@ -4,6 +4,14 @@ A PVC with `accessModes: [ReadWriteMany]` (or `ReadOnlyMany`) on a
 replicated class is served as a **shared filesystem over NFS**: many
 pods on many nodes read and write it at once, like CephFS.
 
+RWX is **opt-in**: set `gateway.enabled: true` in Helm values first.
+It is off by default because gateway pods run privileged in the
+release namespace and any user who can create a PVC can cause one to
+be spawned — enabling the capability is an explicit operator
+decision. While disabled, an RWX PVC is rejected at provision time
+with a clear message on the PVC's events; enabling the gateway lets
+a pending RWX PVC provision on the next retry.
+
 ```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -67,6 +67,12 @@ type Controller struct {
 	// AutoTieBreaker adds a diskless tie-breaker replica to new 2-replica
 	// freeze volumes when a spare storage node exists (#70).
 	AutoTieBreaker bool
+	// RWXEnabled mirrors whether the export reconciler is running (a
+	// gateway image is configured). When false, RWX CreateVolume requests
+	// are rejected at provision time — otherwise the volume would be
+	// created with a spec.export no reconciler ever serves and its
+	// consumers would hang on a gateway that never comes.
+	RWXEnabled bool
 	// DRBDPortBase is the lowest TCP port the allocator hands to replicated
 	// volumes (one per resource, ascending). Zero → defaultDRBDPortBase.
 	// Configurable so operators can move the range off host-network tenants
@@ -145,7 +151,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	}
 	replicas, quorum, remoteAccess := params.replicas, params.quorum, params.remoteAccess
 	shared := isShared(req.GetVolumeCapabilities())
-	if err := validateSharedRequest(shared, replicas, quorum); err != nil {
+	if err := validateSharedRequest(c.RWXEnabled, shared, replicas, quorum); err != nil {
 		return nil, err
 	}
 
@@ -1125,9 +1131,16 @@ func parseQuorum(params map[string]string) (miroirv1alpha1.QuorumPolicy, error) 
 }
 
 // validateSharedRequest rejects RWX shapes the NFS gateway cannot serve.
-func validateSharedRequest(shared bool, replicas int, quorum miroirv1alpha1.QuorumPolicy) error {
+// FailedPrecondition (not InvalidArgument) for the disabled case: the
+// request is well-formed and provisioning self-heals on the provisioner's
+// retry once an operator enables the gateway.
+func validateSharedRequest(rwxEnabled, shared bool, replicas int, quorum miroirv1alpha1.QuorumPolicy) error {
 	if !shared {
 		return nil
+	}
+	if !rwxEnabled {
+		return status.Error(codes.FailedPrecondition,
+			"RWX (ReadWriteMany) volumes are disabled: no NFS gateway is configured (set gateway.enabled=true in Helm values)")
 	}
 	if replicas < 2 {
 		return status.Error(codes.InvalidArgument,

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -216,6 +216,7 @@ func TestCreateVolumeRWXSetsExport(t *testing.T) {
 		Client:           readyOnGet(s, nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)),
 		Nodes:            testNodes,
 		ProvisionTimeout: 2 * time.Second,
+		RWXEnabled:       true,
 		DRBDPortBase:     7000,
 	}
 
@@ -249,7 +250,7 @@ func TestCreateVolumeRWXSetsExport(t *testing.T) {
 
 func TestCreateVolumeRejectsRWXSingleReplica(t *testing.T) {
 	s := newScheme(t)
-	c := &Controller{Client: readyOnGet(s), Nodes: testNodes}
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, RWXEnabled: true}
 
 	// RWX needs a second replica node for the gateway to fail over to.
 	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
@@ -283,7 +284,7 @@ func TestCreateVolumeRejectsRWXBlock(t *testing.T) {
 
 func TestCreateVolumeRejectsRWXLastManStanding(t *testing.T) {
 	s := newScheme(t)
-	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, DRBDPortBase: 7000}
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, RWXEnabled: true, DRBDPortBase: 7000}
 
 	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
 		Name:               volPvc1,
@@ -293,6 +294,25 @@ func TestCreateVolumeRejectsRWXLastManStanding(t *testing.T) {
 	})
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("RWX with last-man-standing quorum must be rejected, got %v", err)
+	}
+}
+
+// With no gateway configured an RWX volume would carry a spec.export no
+// reconciler ever serves; the request must fail at provision time instead.
+// FailedPrecondition, not InvalidArgument: provisioning self-heals on retry
+// once the gateway is enabled.
+func TestCreateVolumeRejectsRWXWhenDisabled(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, DRBDPortBase: 7000}
+
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: rwxCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("RWX with the gateway disabled must be rejected with FailedPrecondition, got %v", err)
 	}
 }
 

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -5,7 +5,8 @@
 #   ./test/smoke/smoke.sh
 #
 # Requires: kubectl pointed at the cluster, the miroir-replicated
-# StorageClass and miroir-snap VolumeSnapshotClass installed.
+# StorageClass and miroir-snap VolumeSnapshotClass installed, and
+# gateway.enabled=true in Helm values (the RWX failover scenario needs it).
 set -euo pipefail
 
 NS=miroir-smoke


### PR DESCRIPTION
## Why

Gateway pods run privileged (hostPath `/dev`) in the release namespace, and any user who can create a PVC — a low-privilege, namespaced ability routinely granted to app teams — can cause one to be spawned just by requesting `ReadWriteMany`. Serving RWX is now an explicit operator decision rather than an always-on capability. It also turns the PSA failure mode (gateway pod rejected by pod security admission → RWX volume created but never served, clients hanging) into a crisp provision-time rejection.

## What

- **`gateway.enabled` chart value, default `false` — RWX is opt-in.** When disabled (the default):
  - the controller gets no `--gateway-image`/`--gateway-service-account` args (the binary's existing disable path);
  - the gateway ServiceAccount, ClusterRole/Binding, and the controller's gateway-workload Role/RoleBinding are not installed (no standing unused privilege);
  - the gateway PodMonitor and the `miroir.exports` alert group are not rendered.
- **CreateVolume rejects RWX when no gateway is configured.** The binary half-supported disabling (`setupExport` skips with an empty image) but the CSI controller still stamped `spec.export` on RWX requests, creating a volume no reconciler would ever serve. Rejection is `FailedPrecondition`, deliberately not `InvalidArgument`: the message points at `gateway.enabled=true`, and a pending PVC provisions on the provisioner's retry once the gateway is enabled — no PVC recreation needed.
- Docs: the RWX page now leads with the opt-in requirement; values reference updated; smoke-suite prereq comment notes the flag; chart README/schema regenerated.

## BREAKING CHANGE

Existing installs serving RWX volumes must set `gateway.enabled: true` in Helm values **before** upgrading. Without it, running gateway pods keep serving until their next restart, but the controller stops reconciling them, the gateway RBAC is removed (a restarted gateway cannot read its volume), and new RWX PVCs are rejected.

## Verification

- Go: RWX-with-gateway-disabled → `FailedPrecondition` test; full suite + golangci-lint clean.
- Chart (106 tests passing): default render has zero gateway artifacts (args, RBAC, PodMonitor, exports alert group all absent); each reappears under `gateway.enabled=true`.
- e2e/conformance unaffected (they never exercise RWX — kind has no DRBD/ganesha); strict docs build passes.