### PR TITLE
feat(api): CEL guards for volume shrink and snapshot retarget, envtest suite

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,6 +61,11 @@ jobs:
       - name: Running Unit Tests
         run: mise run test
 
+      # envtest apiserver: the only place CRD structural schemas and CEL
+      # validation rules are actually enforced.
+      - name: Running Integration Tests
+        run: mise run test-integration
+
   helm-unittest:
     name: Helm Unit Tests
     runs-on: ubuntu-24.04

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirsnapshotspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirsnapshotspec.go
@@ -25,6 +25,9 @@ package v1alpha1
 // CSI CreateSnapshot.
 type MiroirSnapshotSpecApplyConfiguration struct {
 	// VolumeName references the MiroirVolume this snapshot captures.
+	// Immutable: the backend CoW snapshots were cut on the source volume's
+	// replicas, so retargeting the reference would point restores and
+	// per-node teardown at a volume that never held them.
 	VolumeName *string `json:"volumeName,omitempty"`
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirvolumespec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirvolumespec.go
@@ -34,6 +34,9 @@ import (
 // under a live filesystem), and a replicated one keeps 2–3 replicas.
 type MiroirVolumeSpecApplyConfiguration struct {
 	// SizeBytes is the provisioned (virtual, thin) size of the volume.
+	// The transition rule pins it monotonic: nothing downstream supports
+	// shrinking — agents only grow the backing device and the filesystem,
+	// and a shrunk spec would desync DRBD metadata from the device.
 	SizeBytes *int64 `json:"sizeBytes,omitempty"`
 	// Replicas lists the placement of the volume: one entry for local
 	// volumes, two or more for DRBD-replicated ones. MaxItems matches the

--- a/api/v1alpha1/miroirsnapshot_types.go
+++ b/api/v1alpha1/miroirsnapshot_types.go
@@ -20,6 +20,10 @@ const (
 // CSI CreateSnapshot.
 type MiroirSnapshotSpec struct {
 	// VolumeName references the MiroirVolume this snapshot captures.
+	// Immutable: the backend CoW snapshots were cut on the source volume's
+	// replicas, so retargeting the reference would point restores and
+	// per-node teardown at a volume that never held them.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeName is immutable: the snapshot's backend data lives on the volume it was cut from"
 	VolumeName string `json:"volumeName"`
 }
 

--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -182,6 +182,11 @@ func (s MiroirVolumeSpec) FirstDiskfulReplica() *Replica {
 // +kubebuilder:validation:XValidation:rule="!has(self.clients) || !has(self.export)",message="an NFS-exported (RWX) volume is consumed over NFS and cannot have DRBD client legs"
 // +kubebuilder:validation:XValidation:rule="has(self.export) == has(oldSelf.export)",message="a volume cannot gain or lose its NFS export (RWX) in place"
 // +kubebuilder:validation:XValidation:rule="!(has(self.export) && has(self.drbd)) || self.quorumPolicy == 'freeze'",message="replicated RWX volumes must use freeze quorum (a rescheduled gateway under last-man-standing risks dual-primary split-brain)"
+// +kubebuilder:validation:XValidation:rule="self.replicas.all(r, self.replicas.exists_one(o, o.node == r.node))",message="replica nodes must be unique: a node holds at most one leg of a volume"
+// +kubebuilder:validation:XValidation:rule="!has(self.clients) || self.clients.all(c, self.clients.exists_one(o, o.node == c.node))",message="client-leg nodes must be unique"
+// +kubebuilder:validation:XValidation:rule="!has(self.drbd) || !has(oldSelf.drbd) || self.drbd.port == oldSelf.drbd.port",message="drbd.port is immutable: it was allocated cluster-wide at creation and the allocator assumes existing volumes keep their ports"
+// +kubebuilder:validation:XValidation:rule="has(self.source) == has(oldSelf.source) && (!has(self.source) || !has(oldSelf.source) || self.source.snapshotName == oldSelf.source.snapshotName)",message="source is immutable: it records the snapshot this volume was cloned from"
+// +kubebuilder:validation:XValidation:rule="!has(self.export) || !has(oldSelf.export) || self.export.fsType == oldSelf.export.fsType",message="export.fsType is immutable: the gateway formatted the volume with it at first start"
 type MiroirVolumeSpec struct {
 	// SizeBytes is the provisioned (virtual, thin) size of the volume.
 	// The transition rule pins it monotonic: nothing downstream supports

--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -184,7 +184,11 @@ func (s MiroirVolumeSpec) FirstDiskfulReplica() *Replica {
 // +kubebuilder:validation:XValidation:rule="!(has(self.export) && has(self.drbd)) || self.quorumPolicy == 'freeze'",message="replicated RWX volumes must use freeze quorum (a rescheduled gateway under last-man-standing risks dual-primary split-brain)"
 type MiroirVolumeSpec struct {
 	// SizeBytes is the provisioned (virtual, thin) size of the volume.
+	// The transition rule pins it monotonic: nothing downstream supports
+	// shrinking — agents only grow the backing device and the filesystem,
+	// and a shrunk spec would desync DRBD metadata from the device.
 	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:XValidation:rule="self >= oldSelf",message="a volume cannot shrink in place: agents only grow the backing device and filesystem; restore a snapshot into a new, smaller volume instead"
 	SizeBytes int64 `json:"sizeBytes"`
 	// Replicas lists the placement of the volume: one entry for local
 	// volumes, two or more for DRBD-replicated ones. MaxItems matches the

--- a/charts/miroir/crds/miroir.home-operations.com_miroirsnapshots.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirsnapshots.yaml
@@ -56,9 +56,16 @@ spec:
               CSI CreateSnapshot.
             properties:
               volumeName:
-                description: VolumeName references the MiroirVolume this snapshot
-                  captures.
+                description: |-
+                  VolumeName references the MiroirVolume this snapshot captures.
+                  Immutable: the backend CoW snapshots were cut on the source volume's
+                  replicas, so retargeting the reference would point restores and
+                  per-node teardown at a volume that never held them.
                 type: string
+                x-kubernetes-validations:
+                - message: 'volumeName is immutable: the snapshot''s backend data
+                    lives on the volume it was cut from'
+                  rule: self == oldSelf
             required:
             - volumeName
             type: object

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -236,11 +236,19 @@ spec:
                 minItems: 1
                 type: array
               sizeBytes:
-                description: SizeBytes is the provisioned (virtual, thin) size of
-                  the volume.
+                description: |-
+                  SizeBytes is the provisioned (virtual, thin) size of the volume.
+                  The transition rule pins it monotonic: nothing downstream supports
+                  shrinking — agents only grow the backing device and the filesystem,
+                  and a shrunk spec would desync DRBD metadata from the device.
                 format: int64
                 minimum: 1
                 type: integer
+                x-kubernetes-validations:
+                - message: 'a volume cannot shrink in place: agents only grow the
+                    backing device and filesystem; restore a snapshot into a new,
+                    smaller volume instead'
+                  rule: self >= oldSelf
               source:
                 description: Source, if set, provisions content from a snapshot (CoW
                   clone).

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -298,6 +298,23 @@ spec:
                 gateway under last-man-standing risks dual-primary split-brain)
               rule: '!(has(self.export) && has(self.drbd)) || self.quorumPolicy ==
                 ''freeze'''
+            - message: 'replica nodes must be unique: a node holds at most one leg
+                of a volume'
+              rule: self.replicas.all(r, self.replicas.exists_one(o, o.node == r.node))
+            - message: client-leg nodes must be unique
+              rule: '!has(self.clients) || self.clients.all(c, self.clients.exists_one(o,
+                o.node == c.node))'
+            - message: 'drbd.port is immutable: it was allocated cluster-wide at creation
+                and the allocator assumes existing volumes keep their ports'
+              rule: '!has(self.drbd) || !has(oldSelf.drbd) || self.drbd.port == oldSelf.drbd.port'
+            - message: 'source is immutable: it records the snapshot this volume was
+                cloned from'
+              rule: has(self.source) == has(oldSelf.source) && (!has(self.source)
+                || !has(oldSelf.source) || self.source.snapshotName == oldSelf.source.snapshotName)
+            - message: 'export.fsType is immutable: the gateway formatted the volume
+                with it at first start'
+              rule: '!has(self.export) || !has(oldSelf.export) || self.export.fsType
+                == oldSelf.export.fsType'
           status:
             description: MiroirVolumeStatus is the observed state aggregated from
               node agents.

--- a/config/crd/bases/miroir.home-operations.com_miroirsnapshots.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirsnapshots.yaml
@@ -56,9 +56,16 @@ spec:
               CSI CreateSnapshot.
             properties:
               volumeName:
-                description: VolumeName references the MiroirVolume this snapshot
-                  captures.
+                description: |-
+                  VolumeName references the MiroirVolume this snapshot captures.
+                  Immutable: the backend CoW snapshots were cut on the source volume's
+                  replicas, so retargeting the reference would point restores and
+                  per-node teardown at a volume that never held them.
                 type: string
+                x-kubernetes-validations:
+                - message: 'volumeName is immutable: the snapshot''s backend data
+                    lives on the volume it was cut from'
+                  rule: self == oldSelf
             required:
             - volumeName
             type: object

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -236,11 +236,19 @@ spec:
                 minItems: 1
                 type: array
               sizeBytes:
-                description: SizeBytes is the provisioned (virtual, thin) size of
-                  the volume.
+                description: |-
+                  SizeBytes is the provisioned (virtual, thin) size of the volume.
+                  The transition rule pins it monotonic: nothing downstream supports
+                  shrinking — agents only grow the backing device and the filesystem,
+                  and a shrunk spec would desync DRBD metadata from the device.
                 format: int64
                 minimum: 1
                 type: integer
+                x-kubernetes-validations:
+                - message: 'a volume cannot shrink in place: agents only grow the
+                    backing device and filesystem; restore a snapshot into a new,
+                    smaller volume instead'
+                  rule: self >= oldSelf
               source:
                 description: Source, if set, provisions content from a snapshot (CoW
                   clone).

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -298,6 +298,23 @@ spec:
                 gateway under last-man-standing risks dual-primary split-brain)
               rule: '!(has(self.export) && has(self.drbd)) || self.quorumPolicy ==
                 ''freeze'''
+            - message: 'replica nodes must be unique: a node holds at most one leg
+                of a volume'
+              rule: self.replicas.all(r, self.replicas.exists_one(o, o.node == r.node))
+            - message: client-leg nodes must be unique
+              rule: '!has(self.clients) || self.clients.all(c, self.clients.exists_one(o,
+                o.node == c.node))'
+            - message: 'drbd.port is immutable: it was allocated cluster-wide at creation
+                and the allocator assumes existing volumes keep their ports'
+              rule: '!has(self.drbd) || !has(oldSelf.drbd) || self.drbd.port == oldSelf.drbd.port'
+            - message: 'source is immutable: it records the snapshot this volume was
+                cloned from'
+              rule: has(self.source) == has(oldSelf.source) && (!has(self.source)
+                || !has(oldSelf.source) || self.source.snapshotName == oldSelf.source.snapshotName)
+            - message: 'export.fsType is immutable: the gateway formatted the volume
+                with it at first start'
+              rule: '!has(self.export) || !has(oldSelf.export) || self.export.fsType
+                == oldSelf.export.fsType'
           status:
             description: MiroirVolumeStatus is the observed state aggregated from
               node agents.

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,8 @@ Tooling is pinned with [mise](https://mise.jdx.dev); the everyday
 tasks:
 
 ```bash
-mise run test          # unit tests (regenerates manifests first)
+mise run test              # unit tests (regenerates manifests first)
+mise run test-integration  # envtest apiserver: CRD schema + CEL rules
 mise run lint          # golangci-lint
 mise run build         # bin/miroir
 mise run manifests     # CRD + RBAC generation

--- a/test/integration/crd_validation_test.go
+++ b/test/integration/crd_validation_test.go
@@ -26,13 +26,15 @@ import (
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 )
 
+const nodeA = "node-a"
+
 // unreplicatedVolume is the minimal valid single-replica volume.
 func unreplicatedVolume(name string) *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
-			Replicas:  []miroirv1alpha1.Replica{{Node: "node-a", Backend: miroirv1alpha1.BackendLVMThin}},
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 	}
 }
@@ -46,7 +48,7 @@ func replicatedVolume(name string) *miroirv1alpha1.MiroirVolume {
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: "node-a", Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0},
 				{Node: "node-b", Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1},
 				{Node: "node-c", Backend: miroirv1alpha1.BackendLVMThin, NodeID: 2},
 			},
@@ -70,6 +72,66 @@ var _ = Describe("MiroirVolume CEL validation", func() {
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(vol), vol)).To(Succeed())
 		vol.Spec.SizeBytes = 2 << 30
 		Expect(k8sClient.Update(ctx, vol)).To(Succeed(), "growth must stay allowed")
+	})
+
+	It("rejects duplicate replica nodes", func() {
+		vol := replicatedVolume("pvc-dup-replica")
+		vol.Spec.Replicas[2].Node = nodeA
+		err := k8sClient.Create(ctx, vol)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "duplicate replica nodes must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("must be unique"))
+	})
+
+	It("rejects duplicate client-leg nodes", func() {
+		vol := replicatedVolume("pvc-dup-client")
+		vol.Spec.Replicas = vol.Spec.Replicas[:2]
+		vol.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: "node-d"}, {Node: "node-d"}}
+		err := k8sClient.Create(ctx, vol)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "duplicate client nodes must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("must be unique"))
+	})
+
+	It("rejects changing the allocated DRBD port", func() {
+		vol := replicatedVolume("pvc-port-pin")
+		Expect(k8sClient.Create(ctx, vol)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, vol)).To(Succeed()) })
+
+		vol.Spec.DRBD.Port = 7001
+		err := k8sClient.Update(ctx, vol)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "port change must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("port is immutable"))
+	})
+
+	It("rejects retargeting or adding a clone source", func() {
+		vol := unreplicatedVolume("pvc-source-pin")
+		vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-a"}
+		Expect(k8sClient.Create(ctx, vol)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, vol)).To(Succeed()) })
+
+		vol.Spec.Source.SnapshotName = "snap-b"
+		err := k8sClient.Update(ctx, vol)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "source retarget must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("source is immutable"))
+
+		unsourced := unreplicatedVolume("pvc-source-add")
+		Expect(k8sClient.Create(ctx, unsourced)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, unsourced)).To(Succeed()) })
+
+		unsourced.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-a"}
+		err = k8sClient.Update(ctx, unsourced)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "adding a source after creation must be rejected, got: %v", err)
+	})
+
+	It("rejects changing the export filesystem after formatting", func() {
+		vol := replicatedVolume("pvc-fstype-pin")
+		vol.Spec.Export = &miroirv1alpha1.ExportSpec{FSType: "ext4"}
+		Expect(k8sClient.Create(ctx, vol)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, vol)).To(Succeed()) })
+
+		vol.Spec.Export.FSType = "xfs"
+		err := k8sClient.Update(ctx, vol)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "fsType change must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("fsType is immutable"))
 	})
 
 	// Canary for the pre-existing transition rule the agents rely on: a

--- a/test/integration/crd_validation_test.go
+++ b/test/integration/crd_validation_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+// unreplicatedVolume is the minimal valid single-replica volume.
+func unreplicatedVolume(name string) *miroirv1alpha1.MiroirVolume {
+	return &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 1 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: "node-a", Backend: miroirv1alpha1.BackendLVMThin}},
+		},
+	}
+}
+
+// replicatedVolume has three diskful replicas so a single leg can flip
+// state without also tripping the min-diskful-count rule — transition
+// rules must be tested in isolation.
+func replicatedVolume(name string) *miroirv1alpha1.MiroirVolume {
+	return &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 1 << 30,
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: "node-a", Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0},
+				{Node: "node-b", Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1},
+				{Node: "node-c", Backend: miroirv1alpha1.BackendLVMThin, NodeID: 2},
+			},
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+		},
+	}
+}
+
+var _ = Describe("MiroirVolume CEL validation", func() {
+	It("rejects shrinking sizeBytes and allows growth", func() {
+		vol := unreplicatedVolume("pvc-shrink-guard")
+		Expect(k8sClient.Create(ctx, vol)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, vol)).To(Succeed()) })
+
+		vol.Spec.SizeBytes = 1 << 29
+		err := k8sClient.Update(ctx, vol)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "shrink must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("cannot shrink"))
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(vol), vol)).To(Succeed())
+		vol.Spec.SizeBytes = 2 << 30
+		Expect(k8sClient.Update(ctx, vol)).To(Succeed(), "growth must stay allowed")
+	})
+
+	// Canary for the pre-existing transition rule the agents rely on: a
+	// leg's on-disk DRBD metadata cannot be discarded in place.
+	It("rejects flipping a diskful replica to diskless in place", func() {
+		vol := replicatedVolume("pvc-diskless-flip")
+		Expect(k8sClient.Create(ctx, vol)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, vol)).To(Succeed()) })
+
+		vol.Spec.Replicas[2].Diskless = true
+		vol.Spec.Replicas[2].Backend = ""
+		err := k8sClient.Update(ctx, vol)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "diskful→diskless must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("cannot become diskless"))
+	})
+})
+
+var _ = Describe("MiroirSnapshot CEL validation", func() {
+	It("rejects retargeting volumeName", func() {
+		snap := &miroirv1alpha1.MiroirSnapshot{
+			ObjectMeta: metav1.ObjectMeta{Name: "snap-retarget"},
+			Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: "pvc-a"},
+		}
+		Expect(k8sClient.Create(ctx, snap)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, snap)).To(Succeed()) })
+
+		snap.Spec.VolumeName = "pvc-b"
+		err := k8sClient.Update(ctx, snap)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "retarget must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("immutable"))
+	})
+})

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package integration runs against a real (envtest) apiserver. It exists
+// for behavior only the apiserver enforces — CRD structural schemas and
+// CEL validation rules — which no fake client or unit test exercises.
+package integration
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+var (
+	testEnv   *envtest.Environment
+	k8sClient client.Client
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "integration suite (envtest apiserver: CRD schema + CEL)")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.Background())
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+	scheme := runtime.NewScheme()
+	Expect(miroirv1alpha1.AddToScheme(scheme)).To(Succeed())
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	Expect(testEnv.Stop()).To(Succeed())
+})


### PR DESCRIPTION
Follow-up from the admission-webhook discussion: miroir's answer to tuppr-style webhooks is CEL on the CRDs (zero availability coupling, enforced even when miroir is down). The audit found the gaps below plus one testing hole. Three commits.

## CEL guards

**Transition rules (updates):**
- **`spec.sizeBytes` is monotonic** (`self >= oldSelf`). It only had `Minimum=1`, so a direct edit could shrink a volume — nothing downstream supports that (agents only grow), and a shrunk spec desyncs DRBD metadata from the device. The message points at snapshot-restore-into-a-new-volume as the supported path.
- **`MiroirSnapshot.spec.volumeName` is immutable.** The backend CoW snapshots live on the source volume's replicas; a retargeted reference would point restores and teardown at a volume that never held them.
- **`drbd.port` is immutable**: allocated cluster-wide at creation; the allocator's port scan assumes existing volumes keep their ports.
- **`source` is immutable** (including add-after-create): the clone's provenance record, read back by controller idempotency.
- **`export.fsType` is immutable**: the gateway formatted the device with it at first start.

**Create-time rule:**
- **replica and client-leg nodes must be unique** — a node holds at most one leg of a volume; nothing previously prevented an operator edit from doubling one up.

**Deliberately not pinned** (audited and rejected): replica `nodeID` — membership assigns it *after* creation when completing operator-added replicas/client legs, and `omitempty` makes id 0 indistinguishable from unset, so a guard would be leaky and risk breaking legitimate flows; `drbd.sharedSecret` — a rotation converges as agents re-render, not clearly unsupported; `MiroirNode.spec.backend` — changes are how node rebuilds onto a different backend are expressed.

## Integration suite (envtest)

`mise run test-integration` referenced a suite that never existed, and the CRDs' CEL rules — transition rules especially — had no automated coverage anywhere: they're apiserver-enforced, so no fake-client unit test can exercise them. New `test/integration` package runs the real CRDs against an envtest apiserver: 8 specs covering every new rule (rejection *and* the allowed direction where relevant, e.g. growth) plus the pre-existing diskful→diskless transition rule as a canary. CI runs it after the unit tests.

## Verification

- `mise run test-integration`: 8/8 specs against a live apiserver
- Full unit suite, golangci-lint, 106 helm tests, zizmor, strict docs build: all clean
- CRDs regenerated into both `config/crd/bases` and `charts/miroir/crds`