### PR TITLE
feat(observability): pool label on per-volume metrics, dashboard pool filter

### DIFF
--- a/charts/miroir/dashboards/miroir.json
+++ b/charts/miroir/dashboards/miroir.json
@@ -449,7 +449,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (volume) ((1 - miroir_volume_up_to_date{volume=~\"$volume\"}) OR (1 - miroir_volume_connected{volume=~\"$volume\"}))",
+          "expr": "sum by (volume) ((1 - miroir_volume_up_to_date{volume=~\"$volume\", pool=~\"$pool\"}) OR (1 - miroir_volume_connected{volume=~\"$volume\", pool=~\"$pool\"}))",
           "refId": "A",
           "legendFormat": "{{volume}}"
         }
@@ -512,7 +512,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "min by (volume) (miroir_volume_resync_ratio{volume=~\"$volume\"})",
+          "expr": "min by (volume) (miroir_volume_resync_ratio{volume=~\"$volume\", pool=~\"$pool\"})",
           "refId": "A",
           "legendFormat": "{{volume}}"
         }
@@ -573,7 +573,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (volume) (miroir_volume_out_of_sync_bytes{volume=~\"$volume\"})",
+          "expr": "max by (volume) (miroir_volume_out_of_sync_bytes{volume=~\"$volume\", pool=~\"$pool\"})",
           "refId": "A",
           "legendFormat": "{{volume}}"
         }
@@ -634,7 +634,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "miroir_volume_quorum{volume=~\"$volume\"} == 0",
+          "expr": "miroir_volume_quorum{volume=~\"$volume\", pool=~\"$pool\"} == 0",
           "refId": "A",
           "legendFormat": "quorum lost: {{volume}} on {{node}}"
         },
@@ -643,7 +643,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "miroir_volume_disk_failed{volume=~\"$volume\"} == 1",
+          "expr": "miroir_volume_disk_failed{volume=~\"$volume\", pool=~\"$pool\"} == 1",
           "refId": "B",
           "legendFormat": "disk failed: {{volume}} on {{node}}"
         }
@@ -839,7 +839,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "time() - max by (volume) (miroir_volume_verify_last_timestamp_seconds{volume=~\"$volume\"})",
+          "expr": "time() - max by (volume) (miroir_volume_verify_last_timestamp_seconds{volume=~\"$volume\", pool=~\"$pool\"})",
           "refId": "A",
           "legendFormat": "{{volume}}"
         }
@@ -900,7 +900,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (volume) (miroir_volume_verify_out_of_sync_bytes{volume=~\"$volume\"})",
+          "expr": "max by (volume) (miroir_volume_verify_out_of_sync_bytes{volume=~\"$volume\", pool=~\"$pool\"})",
           "refId": "A",
           "legendFormat": "{{volume}}"
         }
@@ -1168,7 +1168,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "miroir_pool_capacity_bytes",
+          "expr": "miroir_pool_capacity_bytes{pool=~\"$pool\"}",
           "refId": "A",
           "legendFormat": "capacity: {{node}}/{{pool}}"
         },
@@ -1177,7 +1177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "miroir_pool_allocated_bytes",
+          "expr": "miroir_pool_allocated_bytes{pool=~\"$pool\"}",
           "refId": "B",
           "legendFormat": "allocated: {{node}}/{{pool}}"
         }
@@ -1240,7 +1240,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "miroir_pool_allocated_bytes / miroir_pool_capacity_bytes",
+          "expr": "miroir_pool_allocated_bytes{pool=~\"$pool\"} / miroir_pool_capacity_bytes{pool=~\"$pool\"}",
           "refId": "A",
           "legendFormat": "{{node}}/{{pool}}"
         }
@@ -1303,7 +1303,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "miroir_pool_meta_used_ratio",
+          "expr": "miroir_pool_meta_used_ratio{pool=~\"$pool\"}",
           "refId": "A",
           "legendFormat": "{{node}}/{{pool}}"
         }
@@ -1618,6 +1618,33 @@
         "skipUrlSync": false
       },
       {
+        "name": "pool",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(miroir_pool_capacity_bytes, pool)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "allValue": ".*",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1
+      },
+      {
         "name": "volume",
         "type": "query",
         "datasource": {
@@ -1626,7 +1653,7 @@
         },
         "query": {
           "qryType": 1,
-          "query": "label_values(miroir_volume_up_to_date, volume)",
+          "query": "label_values(miroir_volume_up_to_date{pool=~\"$pool\"}, volume)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "current": {},

--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -32,7 +32,8 @@ spec:
             {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }} is split-brain on
+              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              (pool {{ "{{" }} $labels.pool {{ "}}" }}) is split-brain on
               {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
               DRBD detected divergent data and refused to reconnect. Resolve
@@ -49,7 +50,8 @@ spec:
             {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }} lost quorum on
+              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              (pool {{ "{{" }} $labels.pool {{ "}}" }}) lost quorum on
               {{ "{{" }} $labels.node {{ "}}" }} — writes are failing
             description: >-
               The replica partition no longer holds a quorum majority and
@@ -68,7 +70,8 @@ spec:
             {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }} IO has been
+              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              (pool {{ "{{" }} $labels.pool {{ "}}" }}) IO has been
               suspended for 10m on {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
               A snapshot write barrier (suspend-io) has been held far longer
@@ -87,7 +90,8 @@ spec:
           annotations:
             summary: >-
               Backing disk failed for volume
-              {{ "{{" }} $labels.volume {{ "}}" }} on
+              {{ "{{" }} $labels.volume {{ "}}" }}
+              (pool {{ "{{" }} $labels.pool {{ "}}" }}) on
               {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
               The backing device was detached after an I/O error and is
@@ -104,7 +108,8 @@ spec:
             {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
           annotations:
             summary: >-
-              Replica of {{ "{{" }} $labels.volume {{ "}}" }} on
+              Replica of {{ "{{" }} $labels.volume {{ "}}" }}
+              (pool {{ "{{" }} $labels.pool {{ "}}" }}) on
               {{ "{{" }} $labels.node {{ "}}" }} is not UpToDate
             description: >-
               The leg has not returned to UpToDate within 15 minutes —
@@ -121,7 +126,8 @@ spec:
             {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }} replication links
+              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              (pool {{ "{{" }} $labels.pool {{ "}}" }}) replication links
               down from {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
               Not all replication links to diskful peers are established;
@@ -137,7 +143,8 @@ spec:
             {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }} has
+              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              (pool {{ "{{" }} $labels.pool {{ "}}" }}) has
               {{ "{{" }} $value | humanize1024 {{ "}}" }}B out of sync on
               {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
@@ -176,7 +183,8 @@ spec:
             {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "warning") | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }} has not completed
+              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              (pool {{ "{{" }} $labels.pool {{ "}}" }}) has not completed
               an online verify in {{ "{{" }} $value | humanizeDuration {{ "}}" }}
             description: >-
               The scheduled drbdadm verify has not completed within the

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -10,7 +10,13 @@ health).
 PodMonitor scraping the controller **and every agent** on their
 `metrics` ports (the per-volume gauges are exported by the agent on
 each storage node; a `node` label is added to every series). The
-agent exports, per volume on that node:
+diskful per-volume gauges also carry a `pool` label naming the pool
+backing that node's leg — pools are per-node, so two legs of one
+volume can report different pools — which lets you scope volume
+health to a pool (the shipped dashboard's `pool` variable does
+exactly that). `miroir_volume_diskless_primary` is the exception: a
+diskless leg holds no backing device in any pool, so it stays
+volume-only. The agent exports, per volume on that node:
 
 | Metric                                        | Meaning                                                                                                                                   |
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -69,3 +75,8 @@ for it; the kernel-floor refusal to start looks exactly like this),
 and `monitoring.dashboards.enabled: true` installs a Grafana
 dashboard, either a sidecar-labelled ConfigMap or a grafana-operator
 `GrafanaDashboard` CR via `monitoring.dashboards.grafanaOperator`.
+
+The per-volume alerts inherit the `pool` label and name the pool in
+their summaries, so Alertmanager routes and silences can target a
+single pool. The dashboard's `pool` variable defaults to **All**;
+narrowing it filters the volume-health and pool panels together.

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -31,50 +31,54 @@ const (
 )
 
 var (
+	// Diskful volume gauges carry the pool backing this node's leg (pools
+	// are per-node, so peers' legs of the same volume may report different
+	// pool values). Diskless legs have no backing pool, so
+	// miroir_volume_diskless_primary stays volume-only.
 	metricUpToDate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_up_to_date",
 		Help: "1 when this node's replica is UpToDate (unreplicated volumes are always 1 once created).",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricConnected = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_connected",
 		Help: "1 when all replication links from this node to diskful peers are established (a diskless tie-breaker's link is excluded).",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricSplitBrain = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_split_brain",
 		Help: "1 when DRBD refused to reconnect after divergence; manual resolution required.",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricSuspended = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_suspended",
 		Help: "1 while a user suspend-io (the snapshot write barrier) freezes this node's IO; sustained means a stranded barrier (snapshot rounds last seconds).",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricResyncRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_resync_ratio",
 		Help: "Fraction in sync (0-1) of the least-synced diskful peer while resyncing; 1 when fully in sync (unreplicated volumes report 1).",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricQuorum = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_quorum",
 		Help: "1 when this node's replica sees DRBD quorum; 0 while a freeze-policy volume has lost quorum and refuses writes with I/O errors (on-no-quorum io-error; always 1 under last-man-standing, and for unreplicated volumes).",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricDiskFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_disk_failed",
 		Help: "1 when this leg's backing disk was detached after an I/O error and is latched failed — replace the disk, then remove and re-add the replica.",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricOutOfSyncBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_out_of_sync_bytes",
 		Help: "Largest per-peer out-of-sync amount in bytes: the exposure if the healthiest peer is lost. Grows while a peer is down with no resync running; also counts online-verify findings.",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricVerifyTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_verify_last_timestamp_seconds",
 		Help: "Unix time of the last completed scheduled online verify for this volume; absent until the first verify runs. Alert on staleness to catch a verify schedule that stopped firing.",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricVerifyOutOfSyncBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_verify_out_of_sync_bytes",
 		Help: "Out-of-sync bytes the last scheduled verify found (0 = clean). Findings also surface in miroir_volume_out_of_sync_bytes until a disconnect/connect resync clears them.",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricPrimary = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_primary",
 		Help: "1 while this node's diskful leg is DRBD Primary: the consumer pod or the RWX gateway runs here and this leg serves the I/O. Diskless legs report miroir_volume_diskless_primary instead; unreplicated volumes have no DRBD role and always report 0.",
-	}, []string{volumeLabel})
+	}, []string{volumeLabel, poolLabel})
 	metricDisklessPrimary = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_diskless_primary",
 		Help: "1 while this node's diskless leg (client or tie-breaker) is DRBD Primary: a consumer runs here and every read and write crosses the replication network. Sustained 1 means the workload pays network I/O — auto-diskful (autoDiskfulAfter) converts the leg to a local replica when the node has storage capacity.",
@@ -114,16 +118,16 @@ func init() {
 	)
 }
 
-func recordVolumeMetrics(volume string, st miroirReplicaView) {
-	metricUpToDate.WithLabelValues(volume).Set(boolGauge(st.upToDate))
-	metricConnected.WithLabelValues(volume).Set(boolGauge(st.connected))
-	metricSplitBrain.WithLabelValues(volume).Set(boolGauge(st.splitBrain))
-	metricSuspended.WithLabelValues(volume).Set(boolGauge(st.suspended))
-	metricResyncRatio.WithLabelValues(volume).Set(st.resyncRatio)
-	metricQuorum.WithLabelValues(volume).Set(boolGauge(st.quorum))
-	metricDiskFailed.WithLabelValues(volume).Set(boolGauge(st.diskFailed))
-	metricOutOfSyncBytes.WithLabelValues(volume).Set(st.outOfSyncBytes)
-	metricPrimary.WithLabelValues(volume).Set(boolGauge(st.primary))
+func recordVolumeMetrics(volume, pool string, st miroirReplicaView) {
+	metricUpToDate.WithLabelValues(volume, pool).Set(boolGauge(st.upToDate))
+	metricConnected.WithLabelValues(volume, pool).Set(boolGauge(st.connected))
+	metricSplitBrain.WithLabelValues(volume, pool).Set(boolGauge(st.splitBrain))
+	metricSuspended.WithLabelValues(volume, pool).Set(boolGauge(st.suspended))
+	metricResyncRatio.WithLabelValues(volume, pool).Set(st.resyncRatio)
+	metricQuorum.WithLabelValues(volume, pool).Set(boolGauge(st.quorum))
+	metricDiskFailed.WithLabelValues(volume, pool).Set(boolGauge(st.diskFailed))
+	metricOutOfSyncBytes.WithLabelValues(volume, pool).Set(st.outOfSyncBytes)
+	metricPrimary.WithLabelValues(volume, pool).Set(boolGauge(st.primary))
 }
 
 // recordPoolMetrics publishes one pool's sample. The pool set is fixed per
@@ -135,18 +139,22 @@ func recordPoolMetrics(pool string, capacityBytes, allocatedBytes int64, metaUse
 	metricPoolMetaUsedRatio.WithLabelValues(pool).Set(metaUsedRatio)
 }
 
+// dropVolumeMetrics deletes by volume alone (partial match): the pool a
+// torn-down leg reported under can be unknowable here, for the same reason
+// deletions sweep every pool — see Pools.SweepDelete.
 func dropVolumeMetrics(volume string) {
-	metricUpToDate.DeleteLabelValues(volume)
-	metricConnected.DeleteLabelValues(volume)
-	metricSplitBrain.DeleteLabelValues(volume)
-	metricSuspended.DeleteLabelValues(volume)
-	metricResyncRatio.DeleteLabelValues(volume)
-	metricQuorum.DeleteLabelValues(volume)
-	metricDiskFailed.DeleteLabelValues(volume)
-	metricOutOfSyncBytes.DeleteLabelValues(volume)
-	metricPrimary.DeleteLabelValues(volume)
-	metricVerifyTimestamp.DeleteLabelValues(volume)
-	metricVerifyOutOfSyncBytes.DeleteLabelValues(volume)
+	byVolume := prometheus.Labels{volumeLabel: volume}
+	metricUpToDate.DeletePartialMatch(byVolume)
+	metricConnected.DeletePartialMatch(byVolume)
+	metricSplitBrain.DeletePartialMatch(byVolume)
+	metricSuspended.DeletePartialMatch(byVolume)
+	metricResyncRatio.DeletePartialMatch(byVolume)
+	metricQuorum.DeletePartialMatch(byVolume)
+	metricDiskFailed.DeletePartialMatch(byVolume)
+	metricOutOfSyncBytes.DeletePartialMatch(byVolume)
+	metricPrimary.DeletePartialMatch(byVolume)
+	metricVerifyTimestamp.DeletePartialMatch(byVolume)
+	metricVerifyOutOfSyncBytes.DeletePartialMatch(byVolume)
 	metricDisklessPrimary.DeleteLabelValues(volume)
 }
 
@@ -168,9 +176,9 @@ func RecordDRBDKernelVersion(version string) {
 // recordVerifyMetrics publishes the outcome of a completed verify pass. The
 // coordinator sets these directly (they are event-driven, not part of the
 // per-poll recordVolumeMetrics view).
-func recordVerifyMetrics(volume string, at time.Time, outOfSyncBytes int64) {
-	metricVerifyTimestamp.WithLabelValues(volume).Set(float64(at.Unix()))
-	metricVerifyOutOfSyncBytes.WithLabelValues(volume).Set(float64(outOfSyncBytes))
+func recordVerifyMetrics(volume, pool string, at time.Time, outOfSyncBytes int64) {
+	metricVerifyTimestamp.WithLabelValues(volume, pool).Set(float64(at.Unix()))
+	metricVerifyOutOfSyncBytes.WithLabelValues(volume, pool).Set(float64(outOfSyncBytes))
 }
 
 type miroirReplicaView struct {

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -53,7 +54,8 @@ func hasSeries(t *testing.T, family, volume string) bool {
 // serving stale health series.
 func TestVolumeMetricsLifecycle(t *testing.T) {
 	const volume = "pvc-metrics-lifecycle"
-	recordVolumeMetrics(volume, miroirReplicaView{
+	const pool = "fast"
+	recordVolumeMetrics(volume, pool, miroirReplicaView{
 		upToDate:       true,
 		connected:      false,
 		splitBrain:     true,
@@ -65,34 +67,48 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 		outOfSyncBytes: 2048 * 1024,
 	})
 
-	if got := testutil.ToFloat64(metricUpToDate.WithLabelValues(volume)); got != 1 {
+	recordVerifyMetrics(volume, pool, time.Unix(1700000000, 0), 512)
+	recordDisklessMetrics(volume, true)
+
+	if got := testutil.ToFloat64(metricUpToDate.WithLabelValues(volume, pool)); got != 1 {
 		t.Fatalf("up_to_date = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricConnected.WithLabelValues(volume)); got != 0 {
+	if got := testutil.ToFloat64(metricConnected.WithLabelValues(volume, pool)); got != 0 {
 		t.Fatalf("connected = %v, want 0", got)
 	}
-	if got := testutil.ToFloat64(metricSplitBrain.WithLabelValues(volume)); got != 1 {
+	if got := testutil.ToFloat64(metricSplitBrain.WithLabelValues(volume, pool)); got != 1 {
 		t.Fatalf("split_brain = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricSuspended.WithLabelValues(volume)); got != 0 {
+	if got := testutil.ToFloat64(metricSuspended.WithLabelValues(volume, pool)); got != 0 {
 		t.Fatalf("suspended = %v, want 0", got)
 	}
-	if got := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volume)); got != 0.425 {
+	if got := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volume, pool)); got != 0.425 {
 		t.Fatalf("resync_ratio = %v, want 0.425", got)
 	}
-	if got := testutil.ToFloat64(metricQuorum.WithLabelValues(volume)); got != 1 {
+	if got := testutil.ToFloat64(metricQuorum.WithLabelValues(volume, pool)); got != 1 {
 		t.Fatalf("quorum = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volume)); got != 1 {
+	if got := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volume, pool)); got != 1 {
 		t.Fatalf("disk_failed = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricOutOfSyncBytes.WithLabelValues(volume)); got != 2048*1024 {
+	if got := testutil.ToFloat64(metricOutOfSyncBytes.WithLabelValues(volume, pool)); got != 2048*1024 {
 		t.Fatalf("out_of_sync_bytes = %v, want %v", got, 2048*1024)
 	}
-	if got := testutil.ToFloat64(metricPrimary.WithLabelValues(volume)); got != 1 {
+	if got := testutil.ToFloat64(metricPrimary.WithLabelValues(volume, pool)); got != 1 {
 		t.Fatalf("primary = %v, want 1", got)
 	}
+	if got := testutil.ToFloat64(metricVerifyTimestamp.WithLabelValues(volume, pool)); got != 1700000000 {
+		t.Fatalf("verify_last_timestamp_seconds = %v, want 1700000000", got)
+	}
+	if got := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volume, pool)); got != 512 {
+		t.Fatalf("verify_out_of_sync_bytes = %v, want 512", got)
+	}
+	if got := testutil.ToFloat64(metricDisklessPrimary.WithLabelValues(volume)); got != 1 {
+		t.Fatalf("diskless_primary = %v, want 1", got)
+	}
 
+	// Drop knows only the volume, not the pool the series were recorded
+	// under — the partial-match delete must still clear every family.
 	dropVolumeMetrics(volume)
 	for _, family := range []string{
 		"miroir_volume_up_to_date",
@@ -104,6 +120,9 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 		"miroir_volume_disk_failed",
 		"miroir_volume_out_of_sync_bytes",
 		"miroir_volume_primary",
+		"miroir_volume_verify_last_timestamp_seconds",
+		"miroir_volume_verify_out_of_sync_bytes",
+		"miroir_volume_diskless_primary",
 	} {
 		if hasSeries(t, family, volume) {
 			t.Fatalf("%s{volume=%q} still exposed after drop", family, volume)

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -204,7 +204,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// resyncRatio 1 and quorum true, not the zero values: an
 			// unreplicated volume is fully in sync with itself and has no
 			// quorum to lose — zeros would perma-fire the alerts.
-			recordVolumeMetrics(vol.Name, miroirReplicaView{
+			recordVolumeMetrics(vol.Name, poolName, miroirReplicaView{
 				upToDate: true, connected: true, quorum: true, resyncRatio: 1,
 			})
 			if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
@@ -277,7 +277,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	splitActive := r.handleSplitBrain(ctx, vol, resource, st, connected)
 	diskFailed := diskFailedLatch(vol, r.NodeName, st, localDiskless)
 	if !localDiskless {
-		recordVolumeMetrics(vol.Name, miroirReplicaView{
+		recordVolumeMetrics(vol.Name, poolName, miroirReplicaView{
 			upToDate:   st.DiskState == drbd.DiskUpToDate,
 			connected:  connected,
 			splitBrain: st.SplitBrain,
@@ -342,7 +342,7 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 		return false, ctrl.Result{}
 	}
 	if !entry.replicated {
-		recordVolumeMetrics(vol.Name, miroirReplicaView{
+		recordVolumeMetrics(vol.Name, volumePoolOn(vol, r.NodeName), miroirReplicaView{
 			upToDate: true, connected: true, quorum: true, resyncRatio: 1,
 		})
 		return true, ctrl.Result{}
@@ -366,7 +366,7 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 		return false, ctrl.Result{}
 	}
 	if !localDiskless {
-		recordVolumeMetrics(vol.Name, miroirReplicaView{
+		recordVolumeMetrics(vol.Name, volumePoolOn(vol, r.NodeName), miroirReplicaView{
 			upToDate:       st.DiskState == drbd.DiskUpToDate,
 			connected:      diskfulPeersConnected(st, vol, r.NodeName),
 			splitBrain:     st.SplitBrain,

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -224,7 +224,7 @@ func TestReconcileRealizesReplica(t *testing.T) {
 	}
 	// No peers means fully in sync: the zero value would perma-fire any
 	// <1 resync alert for every unreplicated volume.
-	if ratio := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volPvc1)); ratio != 1 {
+	if ratio := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); ratio != 1 {
 		t.Fatalf("unreplicated resync_ratio = %v, want 1", ratio)
 	}
 }
@@ -1105,7 +1105,7 @@ func TestReconcileLatchedDiskSkipsReAttach(t *testing.T) {
 		t.Fatalf("latch must stay set while the leg is Diskless: %+v", st)
 	}
 	// The latch is the actionable hardware-failure alert signal.
-	if v := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volPvc1)); v != 1 {
+	if v := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 1 {
 		t.Fatalf("miroir_volume_disk_failed = %v, want 1", v)
 	}
 }
@@ -1164,11 +1164,11 @@ func TestReconcileQuorumLostExportsGauge(t *testing.T) {
 
 	reconcile(t, r, volPvc1)
 
-	if v := testutil.ToFloat64(metricQuorum.WithLabelValues(volPvc1)); v != 0 {
+	if v := testutil.ToFloat64(metricQuorum.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 0 {
 		t.Fatalf("miroir_volume_quorum = %v, want 0 on quorum loss", v)
 	}
 	// Local disk is fine — up_to_date must stay 1 (quorum is the signal).
-	if v := testutil.ToFloat64(metricUpToDate.WithLabelValues(volPvc1)); v != 1 {
+	if v := testutil.ToFloat64(metricUpToDate.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 1 {
 		t.Fatalf("miroir_volume_up_to_date = %v, want 1", v)
 	}
 }

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -181,7 +181,7 @@ func (v *VerifyScheduler) verifyVolume(ctx context.Context, vol *miroirv1alpha1.
 // per-node slot apply.
 func (v *VerifyScheduler) recordResult(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, oosBytes int64) error {
 	now := metav1.Now()
-	recordVerifyMetrics(vol.Name, now.Time, oosBytes)
+	recordVerifyMetrics(vol.Name, volumePoolOn(vol, v.NodeName), now.Time, oosBytes)
 	if oosBytes > 0 && v.Recorder != nil {
 		v.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "VerifyOutOfSync", "Verify",
 			"online verify found %d out-of-sync bytes; a disconnect/connect cycle is needed to resync", oosBytes)

--- a/internal/agent/verify_test.go
+++ b/internal/agent/verify_test.go
@@ -186,7 +186,7 @@ func TestVerifyHappyPathRecordsCleanResult(t *testing.T) {
 	if st.LastVerifyOutOfSyncBytes == nil || *st.LastVerifyOutOfSyncBytes != 0 {
 		t.Fatalf("clean verify must record 0 out-of-sync bytes, got %v", st.LastVerifyOutOfSyncBytes)
 	}
-	if v := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volPvc1)); v != 0 {
+	if v := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 0 {
 		t.Fatalf("verify oos gauge = %v, want 0", v)
 	}
 	select {
@@ -211,7 +211,7 @@ func TestVerifyOutOfSyncRecordsAndEvents(t *testing.T) {
 	if st.LastVerifyOutOfSyncBytes == nil || *st.LastVerifyOutOfSyncBytes != 256*1024 {
 		t.Fatalf("verify must record 256 KiB out of sync, got %v", st.LastVerifyOutOfSyncBytes)
 	}
-	if v := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volPvc1)); v != 256*1024 {
+	if v := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 256*1024 {
 		t.Fatalf("verify oos gauge = %v, want %d", v, 256*1024)
 	}
 	select {


### PR DESCRIPTION
## What

Follow-up to #210: named pools exist in specs, statuses, and the pool gauges, but volume health could not be scoped to a pool.

- **Agent metrics**: the diskful `miroir_volume_*` gauges (including the two verify gauges) now carry a `pool` label naming the pool backing that node's leg. Pools are per-node, so two legs of one volume may report different pools — the label describes the leg, matching the existing per-node export model. Cardinality is unchanged (a leg has exactly one pool).
  - `miroir_volume_diskless_primary` stays volume-only: a diskless leg holds no backing device in any pool.
  - `dropVolumeMetrics` deletes by partial match on the volume: the pool can be unknowable at teardown (crash before the first status patch), the same reason deletes sweep every pool.
- **Dashboard**: new `pool` variable, multi-select, defaulting to **All** (`allValue: .*`). It scopes the volume-health panels and the pool panels together, and the `volume` variable is chained on it so picking a pool narrows the volume list.
- **PrometheusRule**: the per-volume alert summaries name the pool (`(pool {{ $labels.pool }})`). Expressions are unchanged — the label flows into alert labels automatically, so Alertmanager routing/silencing by pool works out of the box. `MiroirVolumeRemoteConsumer` is untouched (diskless metric, no pool).
- **Docs**: `monitoring.md` documents the label, the exception, and the dashboard/alert behavior.

## Breaking

Existing recording rules or dashboards doing exact label matching on `miroir_volume_*` series are unaffected (comparisons and `by (volume)` aggregations keep working); only queries that assume the exact label set (e.g. `group by ()` fingerprint tricks) would notice the new label.

## Verification

- `mise run test` — unit suite passes (agent coverage 84.7%); the metrics lifecycle test now records under a named pool and asserts the partial-match drop clears every family, verify and diskless included.
- `mise run helm-test` (109 tests) and `mise run helm-lint` pass; rendered the PrometheusRule and inspected the summaries.
- `mise run docs` strict build passes.
- Dashboard JSON validated with `jq`; all panel expressions reviewed post-edit.