### PR TITLE
fix(agent): contain kernel-wedged DRBD resources (issue #195)

### DIFF
--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -82,6 +82,24 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
+        - alert: MiroirVolumeTeardownWedged
+          expr: miroir_volume_wedged == 1
+          for: 1m
+          labels:
+            {{- include "miroir.alertRuleLabels" (dict "root" $ "severity" "critical") | nindent 12 }}
+          annotations:
+            summary: >-
+              Volume {{ "{{" }} $labels.volume {{ "}}" }} teardown is wedged
+              in the DRBD kernel module on {{ "{{" }} $labels.node {{ "}}" }}
+            description: >-
+              The kernel can no longer tear down this volume's DRBD resource
+              (device stuck Detaching after a refcount underflow,
+              LINBIT/drbd#137). The agent parked the teardown at a slow
+              retry; reboot the node to clear the kernel state.
+            {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
         - alert: MiroirVolumeDiskFailed
           expr: miroir_volume_disk_failed == 1
           for: 5m

--- a/charts/miroir/tests/prometheusrule_test.yaml
+++ b/charts/miroir/tests/prometheusrule_test.yaml
@@ -36,7 +36,7 @@ tests:
           value: miroir.volumes
       - lengthEqual:
           path: spec.groups[0].rules
-          count: 8
+          count: 9
       - equal:
           path: spec.groups[1].name
           value: miroir.pools
@@ -84,15 +84,15 @@ tests:
     asserts:
       - lengthEqual:
           path: spec.groups[0].rules
-          count: 9
+          count: 10
       - equal:
-          path: spec.groups[0].rules[8].alert
+          path: spec.groups[0].rules[9].alert
           value: MiroirVolumeVerifyStale
       - equal:
-          path: spec.groups[0].rules[8].labels.severity
+          path: spec.groups[0].rules[9].labels.severity
           value: warning
       - equal:
-          path: spec.groups[0].rules[8].expr
+          path: spec.groups[0].rules[9].expr
           value: time() - miroir_volume_verify_last_timestamp_seconds > 9 * 86400
 
   - it: should mark IO-freezing conditions critical
@@ -113,9 +113,18 @@ tests:
           value: critical
       - equal:
           path: spec.groups[0].rules[3].alert
-          value: MiroirVolumeDiskFailed
+          value: MiroirVolumeTeardownWedged
       - equal:
           path: spec.groups[0].rules[3].labels.severity
+          value: critical
+      - equal:
+          path: spec.groups[0].rules[3].expr
+          value: miroir_volume_wedged == 1
+      - equal:
+          path: spec.groups[0].rules[4].alert
+          value: MiroirVolumeDiskFailed
+      - equal:
+          path: spec.groups[0].rules[4].labels.severity
           value: warning
 
   - it: should add extra labels to the PrometheusRule

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -578,6 +578,7 @@ func main() {
 			DRBD:       drbdDriver,
 			DRBDEvents: drbdEvents,
 			Workers:    volumeWorkers,
+			Recorder:   mgr.GetEventRecorder("miroir-agent"),
 		}
 		if err := reconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to set up agent reconciler")
@@ -588,6 +589,7 @@ func main() {
 			NodeName: nodeName,
 			Pools:    pools,
 			DRBD:     drbdDriver,
+			Recorder: mgr.GetEventRecorder("miroir-agent"),
 		}
 		if err := snapReconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to set up snapshot reconciler")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -532,14 +532,16 @@ func main() {
 		if drbdReady {
 			// Reap kernel resources and rendered config orphaned by a crash
 			// between up and down — they hold backing devices open forever.
+			// Best effort: a resource wedged in the kernel (LINBIT/drbd#137)
+			// fails its down on every boot, and exiting on it would keep the
+			// agent from serving the node's healthy volumes (issue #195).
 			if err := sweepOrphans(nodeName, drbdDriver); err != nil {
-				setupLog.Error(err, "orphan sweep failed")
-				os.Exit(1)
+				setupLog.Error(err, "orphan sweep incomplete")
 			}
-			// Lift any IO barrier left by a previous agent crash.
+			// Lift any IO barrier left by a previous agent crash. Best
+			// effort for the same reason as the orphan sweep.
 			if err := resumeStaleBarriers(drbdDriver, apiStartupWait); err != nil {
-				setupLog.Error(err, "barrier resume sweep failed")
-				os.Exit(1)
+				setupLog.Error(err, "barrier resume sweep incomplete")
 			}
 		}
 		// Tracks this node's cordon state so shutdownSweep can tell a node

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -532,16 +532,21 @@ func main() {
 		if drbdReady {
 			// Reap kernel resources and rendered config orphaned by a crash
 			// between up and down — they hold backing devices open forever.
-			// Best effort: a resource wedged in the kernel (LINBIT/drbd#137)
-			// fails its down on every boot, and exiting on it would keep the
-			// agent from serving the node's healthy volumes (issue #195).
+			// The sweeps return an error only when the API list fails: exit
+			// so the restart retries it (without the list they cannot tell
+			// orphaned from owned, and nothing else re-runs them). Sweep
+			// execution itself is best-effort and logged inside — a wedged
+			// resource (LINBIT/drbd#137) must not keep the agent from
+			// serving the node's healthy volumes (issue #195).
 			if err := sweepOrphans(nodeName, drbdDriver); err != nil {
-				setupLog.Error(err, "orphan sweep incomplete")
+				setupLog.Error(err, "orphan sweep failed")
+				os.Exit(1)
 			}
-			// Lift any IO barrier left by a previous agent crash. Best
-			// effort for the same reason as the orphan sweep.
+			// Lift any IO barrier left by a previous agent crash; same
+			// fatal-only-on-API-failure contract.
 			if err := resumeStaleBarriers(drbdDriver, apiStartupWait); err != nil {
-				setupLog.Error(err, "barrier resume sweep incomplete")
+				setupLog.Error(err, "barrier resume sweep failed")
+				os.Exit(1)
 			}
 		}
 		// Tracks this node's cordon state so shutdownSweep can tell a node
@@ -712,6 +717,8 @@ func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver) {
 
 // sweepOrphans removes DRBD state with no owning volume on this node,
 // using a direct (uncached) client — the manager has not started yet.
+// Returns an error only when the volume list cannot be fetched; the sweep
+// itself is best-effort and its failures are logged here (issue #195).
 func sweepOrphans(nodeName string, driver *drbd.Driver) error {
 	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
 	if err != nil {
@@ -737,14 +744,20 @@ func sweepOrphans(nodeName string, driver *drbd.Driver) error {
 			}
 		}
 	}
-	return driver.SweepOrphans(context.Background(),
-		func(name string) bool { return owned[name] })
+	if err := driver.SweepOrphans(context.Background(),
+		func(name string) bool { return owned[name] }); err != nil {
+		setupLog.Error(err, "orphan sweep incomplete")
+	}
+	return nil
 }
 
 // resumeStaleBarriers lifts suspend-io left behind by a previous crash.
 // The kernel's view drives the sweep: a crash between suspend-io and the
 // status patch leaves a frozen device no snapshot records. Barriers whose
 // round is still within the deadline are the reconciler's to drive.
+// Returns an error only when the snapshot list cannot be fetched; resume
+// failures are per-resource, logged here — one wedged resource must not
+// strand the other frozen volumes' barriers (issue #195).
 func resumeStaleBarriers(driver *drbd.Driver, apiBudget time.Duration) error {
 	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
 	if err != nil {
@@ -768,13 +781,17 @@ func resumeStaleBarriers(driver *drbd.Driver, apiBudget time.Duration) error {
 		setupLog.Error(err, "cannot list suspended resources; skipping barrier sweep")
 		return nil
 	}
+	var errs []error
 	for _, vol := range suspended {
 		if fresh[vol] {
 			continue
 		}
 		if err := driver.ResumeIO(context.Background(), vol); err != nil {
-			return fmt.Errorf("resume stale barrier on %s: %w", vol, err)
+			errs = append(errs, fmt.Errorf("resume stale barrier on %s: %w", vol, err))
 		}
+	}
+	if err := errors.Join(errs...); err != nil {
+		setupLog.Error(err, "barrier resume sweep incomplete")
 	}
 	return nil
 }

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -14,9 +14,11 @@ diskful per-volume gauges also carry a `pool` label naming the pool
 backing that node's leg — pools are per-node, so two legs of one
 volume can report different pools — which lets you scope volume
 health to a pool (the shipped dashboard's `pool` variable does
-exactly that). `miroir_volume_diskless_primary` is the exception: a
-diskless leg holds no backing device in any pool, so it stays
-volume-only. The agent exports, per volume on that node:
+exactly that). `miroir_volume_diskless_primary` and
+`miroir_volume_wedged` are the exceptions: a diskless leg holds no
+backing device in any pool, and a wedged teardown's pool can be
+unknowable, so both stay volume-only. The agent exports, per volume
+on that node:
 
 | Metric                                        | Meaning                                                                                                                                   |
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -32,6 +34,7 @@ volume-only. The agent exports, per volume on that node:
 | `miroir_volume_diskless_primary`              | 1 while a diskless leg (client or tie-breaker) is Primary here: the consumer pays network I/O; see auto-diskful                           |
 | `miroir_volume_verify_last_timestamp_seconds` | unix time of the last completed scheduled verify; alert on staleness to catch a schedule that stopped firing                              |
 | `miroir_volume_verify_out_of_sync_bytes`      | out-of-sync bytes the last scheduled verify found (0 = clean)                                                                             |
+| `miroir_volume_wedged`                        | 1 when the kernel can no longer tear down this volume's DRBD resource (LINBIT/drbd#137); only a node reboot clears it                     |
 
 Each agent additionally exports its pool capacities
 (`miroir_pool_capacity_bytes` / `miroir_pool_allocated_bytes` /
@@ -67,7 +70,7 @@ on their PVCs (`kubectl describe pvc`).
 
 `monitoring.prometheusRule.enabled: true` ships starter alerts for
 all of the above (split-brain, quorum lost, stranded barrier, disk
-failed, degraded replication, sustained out-of-sync, an unavailable
+failed, a wedged teardown, degraded replication, sustained out-of-sync, an unavailable
 RWX export, a stale verify schedule, pool and thin-metadata usage,
 and a down agent — a node whose agent stops answering scrapes loses
 every `miroir_*` series, so none of the per-volume alerts can fire
@@ -78,5 +81,6 @@ dashboard, either a sidecar-labelled ConfigMap or a grafana-operator
 
 The per-volume alerts inherit the `pool` label and name the pool in
 their summaries, so Alertmanager routes and silences can target a
-single pool. The dashboard's `pool` variable defaults to **All**;
+single pool (the wedged-teardown alert is the exception: a pool can
+be unknowable mid-teardown, so its metric carries only `volume`). The dashboard's `pool` variable defaults to **All**;
 narrowing it filters the volume-health and pool panels together.

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -83,6 +83,12 @@ var (
 		Name: "miroir_volume_diskless_primary",
 		Help: "1 while this node's diskless leg (client or tie-breaker) is DRBD Primary: a consumer runs here and every read and write crosses the replication network. Sustained 1 means the workload pays network I/O — auto-diskful (autoDiskfulAfter) converts the leg to a local replica when the node has storage capacity.",
 	}, []string{volumeLabel})
+	// Volume-only, like miroir_volume_diskless_primary: the pool a wedged
+	// teardown reported under can be unknowable (see dropVolumeMetrics).
+	metricWedged = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "miroir_volume_wedged",
+		Help: "1 when the kernel can no longer tear down this volume's DRBD resource (device stuck Detaching after a refcount underflow, LINBIT/drbd#137); teardown is parked at a slow retry and only a node reboot clears the state.",
+	}, []string{volumeLabel})
 
 	// Pool gauges carry the pool name; the PodMonitor stamps a node label
 	// on every series, so (node, pool) identifies one pool.
@@ -113,7 +119,7 @@ func init() {
 		metricUpToDate, metricConnected, metricSplitBrain, metricSuspended,
 		metricResyncRatio, metricQuorum, metricDiskFailed, metricOutOfSyncBytes,
 		metricVerifyTimestamp, metricVerifyOutOfSyncBytes, metricPrimary, metricDisklessPrimary,
-		metricPoolCapacity, metricPoolAllocated, metricPoolMetaUsedRatio,
+		metricWedged, metricPoolCapacity, metricPoolAllocated, metricPoolMetaUsedRatio,
 		metricDRBDKernelInfo,
 	)
 }
@@ -156,6 +162,7 @@ func dropVolumeMetrics(volume string) {
 	metricVerifyTimestamp.DeletePartialMatch(byVolume)
 	metricVerifyOutOfSyncBytes.DeletePartialMatch(byVolume)
 	metricDisklessPrimary.DeleteLabelValues(volume)
+	metricWedged.DeleteLabelValues(volume)
 }
 
 // recordDisklessMetrics publishes a diskless leg's view. Deliberately not

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -134,7 +134,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	vol := &miroirv1alpha1.MiroirVolume{}
 	if err := r.Get(ctx, req.NamespacedName, vol); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return ctrl.Result{}, r.volumeGone(req.Name, err)
 	}
 
 	idx, localDiskless, present, incomplete := legState(vol, r.NodeName)
@@ -421,6 +421,21 @@ func (r *VolumeReconciler) dropRealized(name string) {
 	delete(r.realized, name)
 }
 
+// volumeGone handles a reconcile whose volume no longer exists in the
+// API. A CR can vanish without a final successful teardown here — an
+// operator strips the finalizers by hand (the wedge recovery, issue
+// #195) — and per-volume state left behind would page forever
+// (miroir_volume_wedged is critical) and leak.
+func (r *VolumeReconciler) volumeGone(name string, err error) error {
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+	dropVolumeMetrics(name)
+	r.dropRealized(name)
+	r.dropRecovery(name)
+	return nil
+}
+
 // dropRecovery forgets a torn-down volume's split-brain debounce stamp so a
 // later volume under the same name starts with a clean slate.
 func (r *VolumeReconciler) dropRecovery(name string) {
@@ -443,6 +458,10 @@ func (r *VolumeReconciler) reconcileDeletion(ctx context.Context, vol *miroirv1a
 		if errors.Is(err, drbd.ErrWedged) {
 			return r.reportWedged(ctx, vol, err)
 		}
+		// Any other outcome means a previously reported wedge is gone —
+		// e.g. the reboot happened and the device is now merely held
+		// open — so the critical alert must stop paging for it.
+		metricWedged.DeleteLabelValues(vol.Name)
 		if errors.Is(err, backend.ErrBusy) {
 			// A force-deleted pod can leave the device open past
 			// NodeUnstage; retry until the mount goes away.
@@ -747,6 +766,9 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 		if errors.Is(err, drbd.ErrWedged) {
 			return r.reportWedged(ctx, vol, err)
 		}
+		// A non-wedged outcome retires a previously reported wedge (see
+		// reconcileDeletion); the critical alert must stop paging for it.
+		metricWedged.DeleteLabelValues(vol.Name)
 		if errors.Is(err, backend.ErrBusy) {
 			// A pod still staged here holds the device open; it has to
 			// move off this node before the leg can go.
@@ -880,8 +902,8 @@ const wedgedRequeue = 5 * time.Minute
 // reportWedged surfaces a teardown the kernel can no longer finish
 // (drbd.ErrWedged) — Warning Event, status message, and the wedged gauge
 // the shipped alerts page on — then parks the retry at wedgedRequeue.
-// The gauge and message clear when a post-reboot retry finishes the
-// teardown (dropVolumeMetrics / slot removal).
+// The gauge clears on any non-wedged teardown outcome, on teardown
+// success (dropVolumeMetrics), and when the CR vanishes (volumeGone).
 func (r *VolumeReconciler) reportWedged(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
 	ctrl.LoggerFrom(ctx).Error(cause, "teardown wedged in kernel", "volume", vol.Name)
 	if r.Recorder != nil {

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -29,9 +29,11 @@ import (
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -67,6 +69,8 @@ type VolumeReconciler struct {
 	// KmsgPath overrides /dev/kmsg for the split-brain kernel-log capture
 	// (tests point it at a plain file).
 	KmsgPath string
+	// Recorder emits the TeardownWedged warning; optional.
+	Recorder events.EventRecorder
 
 	// realized caches the last fully realized state per volume so the
 	// steady-state poll only re-execs `drbdsetup status` instead of the
@@ -436,6 +440,9 @@ func (r *VolumeReconciler) reconcileDeletion(ctx context.Context, vol *miroirv1a
 		return ctrl.Result{}, nil
 	}
 	if err := r.teardown(ctx, vol); err != nil {
+		if errors.Is(err, drbd.ErrWedged) {
+			return r.reportWedged(ctx, vol, err)
+		}
 		if errors.Is(err, backend.ErrBusy) {
 			// A force-deleted pod can leave the device open past
 			// NodeUnstage; retry until the mount goes away.
@@ -737,6 +744,9 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 	if err := r.teardown(ctx, vol); err != nil {
+		if errors.Is(err, drbd.ErrWedged) {
+			return r.reportWedged(ctx, vol, err)
+		}
 		if errors.Is(err, backend.ErrBusy) {
 			// A pod still staged here holds the device open; it has to
 			// move off this node before the leg can go.
@@ -803,6 +813,12 @@ func (r *VolumeReconciler) teardown(ctx context.Context, vol *miroirv1alpha1.Mir
 	slot := vol.Status.PerNode[r.NodeName]
 	if vol.Spec.DRBD != nil {
 		if err := r.DRBD.Down(ctx, vol.Name); err != nil {
+			// A kernel-wedged resource must not classify as ErrBusy: the
+			// fast retry would strand another unkillable drbdsetup down
+			// every cycle, and nothing but a reboot clears the wedge.
+			if errors.Is(err, drbd.ErrWedged) {
+				return err
+			}
 			// A still-staged device answers "held open"; classify it as
 			// ErrBusy so teardown takes the 10s retry, not the workqueue's
 			// minutes-long backoff (NodeUnstage releases it shortly).
@@ -853,6 +869,33 @@ func removeNodeFinalizer(ctx context.Context, c client.Client, obj client.Object
 		return err
 	}
 	return nil
+}
+
+// wedgedRequeue spaces teardown retries of a kernel-wedged resource. The
+// 10s ErrBusy cadence would strand another unkillable drbdsetup down every
+// cycle; nothing but a node reboot clears the wedge, so the retry only
+// needs to notice that the reboot happened.
+const wedgedRequeue = 5 * time.Minute
+
+// reportWedged surfaces a teardown the kernel can no longer finish
+// (drbd.ErrWedged) — Warning Event, status message, and the wedged gauge
+// the shipped alerts page on — then parks the retry at wedgedRequeue.
+// The gauge and message clear when a post-reboot retry finishes the
+// teardown (dropVolumeMetrics / slot removal).
+func (r *VolumeReconciler) reportWedged(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
+	ctrl.LoggerFrom(ctx).Error(cause, "teardown wedged in kernel", "volume", vol.Name)
+	if r.Recorder != nil {
+		r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "TeardownWedged", "Teardown",
+			"DRBD cannot tear down %s: device stuck Detaching with connections gone (LINBIT/drbd#137); reboot node %s to clear it",
+			vol.Name, r.NodeName)
+	}
+	metricWedged.WithLabelValues(vol.Name).Set(1)
+	st := vol.Status.PerNode[r.NodeName]
+	st.Message = cause.Error()
+	if err := r.patchStatus(ctx, vol, st); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: wedgedRequeue}, nil
 }
 
 func (r *VolumeReconciler) reportError(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) error {

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1022,9 +1022,10 @@ func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 }
 
 // A kernel-wedged resource (stuck Detaching with the connections gone,
-// LINBIT/drbd#137) must leave the fast busy-retry: no further down
-// attempt, park at wedgedRequeue, TeardownWedged warning, wedged gauge,
-// actionable Message, finalizer retained.
+// LINBIT/drbd#137) must leave the fast busy-retry without ever spawning
+// another down: the first sighting defers on the busy cadence, the second
+// parks at wedgedRequeue with the TeardownWedged warning, wedged gauge,
+// actionable Message, and the finalizer retained.
 func TestReconcileTeardownWedgedParksRetry(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
@@ -1046,9 +1047,15 @@ func TestReconcileTeardownWedgedParksRetry(t *testing.T) {
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 	t.Cleanup(func() { dropVolumeMetrics(volPvc1) })
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
 
-	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+	// First sighting: the detach may still be draining — busy retry.
+	res, err := r.Reconcile(t.Context(), req)
+	if err != nil || res.RequeueAfter != 10*time.Second {
+		t.Fatalf("first sighting must defer on the busy cadence, got %v / %v", res.RequeueAfter, err)
+	}
+	// Second sighting: escalate.
+	res, err = r.Reconcile(t.Context(), req)
 	if err != nil {
 		t.Fatalf("a wedge must park the retry, not error: %v", err)
 	}
@@ -1073,6 +1080,41 @@ func TestReconcileTeardownWedgedParksRetry(t *testing.T) {
 	}
 	if msg := got.Status.PerNode[nodeA].Message; !strings.Contains(msg, "reboot") {
 		t.Fatalf("Message must say a reboot is required, got %q", msg)
+	}
+
+	// The wedge clears (reboot happened) but the device is now merely held
+	// open: the gauge — and with it the critical alert — must retire.
+	fe.statusJSON = `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],"connections":[]}]`
+	fe.errOn = map[string]error{
+		"drbdsetup down pvc-1": errors.New("pvc-1: State change failed: Device is held open by someone"),
+	}
+	res, err = r.Reconcile(t.Context(), req)
+	if err != nil || res.RequeueAfter != 10*time.Second {
+		t.Fatalf("held-open after the wedge must take the busy retry, got %v / %v", res.RequeueAfter, err)
+	}
+	if n := testutil.CollectAndCount(metricWedged); n != 0 {
+		t.Fatalf("wedged gauge must clear on a non-wedged outcome, still %d series", n)
+	}
+}
+
+// A volume whose CR vanished without a final successful teardown here —
+// finalizers stripped by hand, the documented wedge recovery — must not
+// leave its per-volume metrics behind (miroir_volume_wedged is critical
+// and would page forever).
+func TestReconcileVolumeGoneDropsMetrics(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend())}
+	metricWedged.WithLabelValues(volPvc1).Set(1)
+	t.Cleanup(func() { dropVolumeMetrics(volPvc1) })
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		t.Fatal(err)
+	}
+	if n := testutil.CollectAndCount(metricWedged); n != 0 {
+		t.Fatalf("metrics must drop when the CR is gone, still %d series", n)
 	}
 }
 

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1017,6 +1018,61 @@ func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 	got := &miroirv1alpha1.MiroirVolume{}
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal("finalizer must be retained while the device is held open")
+	}
+}
+
+// A kernel-wedged resource (stuck Detaching with the connections gone,
+// LINBIT/drbd#137) must leave the fast busy-retry: no further down
+// attempt, park at wedgedRequeue, TeardownWedged warning, wedged gauge,
+// actionable Message, finalizer retained.
+func TestReconcileTeardownWedgedParksRetry(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	now := metav1.NewTime(time.Now())
+	v.DeletionTimestamp = &now
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte("resource \"pvc-1\" {}\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"Detaching"}],"connections":[]}]`}
+	rec := events.NewFakeRecorder(4)
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(fb), Recorder: rec,
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+	t.Cleanup(func() { dropVolumeMetrics(volPvc1) })
+
+	res, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+	if err != nil {
+		t.Fatalf("a wedge must park the retry, not error: %v", err)
+	}
+	if res.RequeueAfter != wedgedRequeue {
+		t.Fatalf("want %v parked retry, got %v", wedgedRequeue, res.RequeueAfter)
+	}
+	fe.notCalledWith(t, "drbdsetup down")
+	select {
+	case e := <-rec.Events:
+		if !strings.Contains(e, "TeardownWedged") {
+			t.Fatalf("want a TeardownWedged warning, got %q", e)
+		}
+	default:
+		t.Fatal("want a TeardownWedged warning event")
+	}
+	if got := testutil.ToFloat64(metricWedged.WithLabelValues(volPvc1)); got != 1 {
+		t.Fatalf("wedged gauge = %v, want 1", got)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal("finalizer must be retained while the resource is wedged")
+	}
+	if msg := got.Status.PerNode[nodeA].Message; !strings.Contains(msg, "reboot") {
+		t.Fatalf("Message must say a reboot is required, got %q", msg)
 	}
 }
 

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -21,11 +21,14 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -75,6 +78,53 @@ type SnapshotReconciler struct {
 	// pool holding the volume's local replica.
 	Pools Pools
 	DRBD  *drbd.Driver
+	// Recorder emits the BarrierStuck warning; optional.
+	Recorder events.EventRecorder
+
+	// barrierFails counts consecutive suspend-io failures per snapshot.
+	// Past barrierFailLimit the round parks at a slow retry instead of
+	// riding the workqueue's exponential backoff forever — on a wedged
+	// kernel module (LINBIT/drbd#137) suspend-io never succeeds, and
+	// without a bound the silent retries outlive the incident.
+	barrierFailsMu sync.Mutex
+	barrierFails   map[string]int
+}
+
+// barrierFailLimit is how many consecutive suspend-io failures ride the
+// workqueue's fast exponential backoff (transients heal there) before the
+// round parks; barrierRetryAfter is the parked cadence.
+const (
+	barrierFailLimit  = 5
+	barrierRetryAfter = time.Minute
+)
+
+// suspendFailed classifies one suspend-io failure: fast backoff below
+// barrierFailLimit, then a Warning Event and the parked retry.
+func (r *SnapshotReconciler) suspendFailed(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
+	r.barrierFailsMu.Lock()
+	if r.barrierFails == nil {
+		r.barrierFails = map[string]int{}
+	}
+	r.barrierFails[snap.Name]++
+	fails := r.barrierFails[snap.Name]
+	r.barrierFailsMu.Unlock()
+	if fails < barrierFailLimit {
+		return ctrl.Result{}, cause
+	}
+	ctrl.LoggerFrom(ctx).Error(cause, "cannot raise the IO barrier; parking the retry",
+		"snapshot", snap.Name, "volume", vol.Name, "attempts", fails)
+	if r.Recorder != nil {
+		r.Recorder.Eventf(snap, nil, corev1.EventTypeWarning, "BarrierStuck", "Suspend",
+			"cannot raise the IO barrier on %s after %d attempts: %v", vol.Name, fails, cause)
+	}
+	return ctrl.Result{RequeueAfter: barrierRetryAfter}, nil
+}
+
+// suspendSucceeded resets the snapshot's consecutive-failure count.
+func (r *SnapshotReconciler) suspendSucceeded(name string) {
+	r.barrierFailsMu.Lock()
+	delete(r.barrierFails, name)
+	r.barrierFailsMu.Unlock()
 }
 
 // backendFor resolves the backend holding the volume's local leg — the
@@ -104,6 +154,9 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if !snap.DeletionTimestamp.IsZero() {
+		// The failure count dies with the snapshot, so a later snapshot
+		// under the same name starts with a clean slate.
+		r.suspendSucceeded(snap.Name)
 		// Deletion runs before the membership gate: a node that left
 		// spec.replicas after the snapshot was cut still holds its
 		// finalizer, and skipping it would wedge the snapshot in
@@ -264,8 +317,9 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 		return ctrl.Result{}, err
 	}
 	if err := r.DRBD.SuspendIO(ctx, vol.Name); err != nil {
-		return ctrl.Result{}, err
+		return r.suspendFailed(ctx, snap, vol, err)
 	}
+	r.suspendSucceeded(snap.Name)
 	var err error
 	if opensRound {
 		// The coordinator owns the round: it sets the barrier fields and
@@ -319,8 +373,9 @@ func (r *SnapshotReconciler) cutLeg(ctx context.Context, snap *miroirv1alpha1.Mi
 	// Re-assert the local barrier first (idempotent) — a crash or manual
 	// resume-io between phases must not let a leg be cut unprotected.
 	if err := r.DRBD.SuspendIO(ctx, vol.Name); err != nil {
-		return ctrl.Result{}, err
+		return r.suspendFailed(ctx, snap, vol, err)
 	}
+	r.suspendSucceeded(snap.Name)
 	// suspend-io quiesces new writes only; queued writeback must be
 	// drained or the snapshot captures stale content.
 	if err := be.Sync(ctx, vol.Name); err != nil {

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -81,16 +81,17 @@ type SnapshotReconciler struct {
 	// Recorder emits the BarrierStuck warning; optional.
 	Recorder events.EventRecorder
 
-	// barrierFails counts consecutive suspend-io failures per snapshot.
-	// Past barrierFailLimit the round parks at a slow retry instead of
-	// riding the workqueue's exponential backoff forever — on a wedged
-	// kernel module (LINBIT/drbd#137) suspend-io never succeeds, and
-	// without a bound the silent retries outlive the incident.
+	// barrierFails counts consecutive DRBD failures on the barrier path
+	// (the status read and suspend-io) per snapshot. Past barrierFailLimit
+	// the round parks at a slow retry instead of riding the workqueue's
+	// exponential backoff forever — on a wedged kernel module
+	// (LINBIT/drbd#137) neither call ever succeeds, and without a bound
+	// the silent retries outlive the incident.
 	barrierFailsMu sync.Mutex
 	barrierFails   map[string]int
 }
 
-// barrierFailLimit is how many consecutive suspend-io failures ride the
+// barrierFailLimit is how many consecutive barrier-path failures ride the
 // workqueue's fast exponential backoff (transients heal there) before the
 // round parks; barrierRetryAfter is the parked cadence.
 const (
@@ -98,9 +99,9 @@ const (
 	barrierRetryAfter = time.Minute
 )
 
-// suspendFailed classifies one suspend-io failure: fast backoff below
+// barrierFailed classifies one barrier-path failure: fast backoff below
 // barrierFailLimit, then a Warning Event and the parked retry.
-func (r *SnapshotReconciler) suspendFailed(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
+func (r *SnapshotReconciler) barrierFailed(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
 	r.barrierFailsMu.Lock()
 	if r.barrierFails == nil {
 		r.barrierFails = map[string]int{}
@@ -111,17 +112,17 @@ func (r *SnapshotReconciler) suspendFailed(ctx context.Context, snap *miroirv1al
 	if fails < barrierFailLimit {
 		return ctrl.Result{}, cause
 	}
-	ctrl.LoggerFrom(ctx).Error(cause, "cannot raise the IO barrier; parking the retry",
+	ctrl.LoggerFrom(ctx).Error(cause, "cannot drive the snapshot barrier; parking the retry",
 		"snapshot", snap.Name, "volume", vol.Name, "attempts", fails)
 	if r.Recorder != nil {
 		r.Recorder.Eventf(snap, nil, corev1.EventTypeWarning, "BarrierStuck", "Suspend",
-			"cannot raise the IO barrier on %s after %d attempts: %v", vol.Name, fails, cause)
+			"cannot drive the snapshot barrier on %s after %d attempts: %v", vol.Name, fails, cause)
 	}
 	return ctrl.Result{RequeueAfter: barrierRetryAfter}, nil
 }
 
-// suspendSucceeded resets the snapshot's consecutive-failure count.
-func (r *SnapshotReconciler) suspendSucceeded(name string) {
+// clearBarrierFails resets the snapshot's consecutive-failure count.
+func (r *SnapshotReconciler) clearBarrierFails(name string) {
 	r.barrierFailsMu.Lock()
 	delete(r.barrierFails, name)
 	r.barrierFailsMu.Unlock()
@@ -147,7 +148,10 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	vol := &miroirv1alpha1.MiroirVolume{}
 	if err := r.Get(ctx, types.NamespacedName{Name: snap.Spec.VolumeName}, vol); err != nil {
 		if apierrors.IsNotFound(err) && !snap.DeletionTimestamp.IsZero() {
-			// Source volume already gone; nothing local can remain.
+			// Source volume already gone; nothing local can remain. The
+			// failure count dies with the snapshot here too, or a later
+			// snapshot reusing the name would inherit it pre-parked.
+			r.clearBarrierFails(snap.Name)
 			return ctrl.Result{}, r.removeFinalizer(ctx, snap)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -156,7 +160,7 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if !snap.DeletionTimestamp.IsZero() {
 		// The failure count dies with the snapshot, so a later snapshot
 		// under the same name starts with a clean slate.
-		r.suspendSucceeded(snap.Name)
+		r.clearBarrierFails(snap.Name)
 		// Deletion runs before the membership gate: a node that left
 		// spec.replicas after the snapshot was cut still holds its
 		// finalizer, and skipping it would wedge the snapshot in
@@ -251,7 +255,10 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume) (ctrl.Result, error) {
 	st, err := r.DRBD.Status(ctx, vol.Name)
 	if err != nil {
-		return ctrl.Result{}, err
+		// On a wedged module this call is the one that fails (hanging
+		// until execTimeout kills it), so it must ride the same bounded
+		// retry as suspend-io or the give-up never engages.
+		return r.barrierFailed(ctx, snap, vol, err)
 	}
 	coordinator := r.isCoordinator(vol, st)
 	myState := snap.Status.PerNode[r.NodeName]
@@ -317,9 +324,9 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 		return ctrl.Result{}, err
 	}
 	if err := r.DRBD.SuspendIO(ctx, vol.Name); err != nil {
-		return r.suspendFailed(ctx, snap, vol, err)
+		return r.barrierFailed(ctx, snap, vol, err)
 	}
-	r.suspendSucceeded(snap.Name)
+	r.clearBarrierFails(snap.Name)
 	var err error
 	if opensRound {
 		// The coordinator owns the round: it sets the barrier fields and
@@ -373,9 +380,9 @@ func (r *SnapshotReconciler) cutLeg(ctx context.Context, snap *miroirv1alpha1.Mi
 	// Re-assert the local barrier first (idempotent) — a crash or manual
 	// resume-io between phases must not let a leg be cut unprotected.
 	if err := r.DRBD.SuspendIO(ctx, vol.Name); err != nil {
-		return r.suspendFailed(ctx, snap, vol, err)
+		return r.barrierFailed(ctx, snap, vol, err)
 	}
-	r.suspendSucceeded(snap.Name)
+	r.clearBarrierFails(snap.Name)
 	// suspend-io quiesces new writes only; queued writeback must be
 	// drained or the snapshot captures stale content.
 	if err := be.Sync(ctx, vol.Name); err != nil {

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -187,6 +187,71 @@ func TestSnapshotBarrierStuckParksAfterLimit(t *testing.T) {
 	}
 }
 
+// On a wedged module the status read is the call that fails (hanging
+// until execTimeout kills it); it must ride the same bounded retry as
+// suspend-io or the give-up never engages.
+func TestSnapshotStatusFailureParksAfterLimit(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{errOn: map[string]error{cmdStatus: errors.New("signal: killed")}}
+	rec := events.NewFakeRecorder(8)
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}, Recorder: rec}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}
+	for i := 1; i < barrierFailLimit; i++ {
+		if _, err := r.Reconcile(t.Context(), req); err == nil {
+			t.Fatalf("failure %d must surface for the fast backoff", i)
+		}
+	}
+	res, err := r.Reconcile(t.Context(), req)
+	if err != nil || res.RequeueAfter != barrierRetryAfter {
+		t.Fatalf("want parked retry %v, got %v / %v", barrierRetryAfter, res.RequeueAfter, err)
+	}
+	select {
+	case e := <-rec.Events:
+		if !strings.Contains(e, "BarrierStuck") {
+			t.Fatalf("want a BarrierStuck warning, got %q", e)
+		}
+	default:
+		t.Fatal("want a BarrierStuck warning event")
+	}
+}
+
+// The failure count must die with the snapshot on the volume-already-gone
+// finalizer path too, or a later snapshot reusing the name inherits it
+// pre-parked.
+func TestSnapshotVolGoneClearsBarrierFails(t *testing.T) {
+	s := newScheme(t)
+	snap := snapObj(snapSnap1, volPvc1, nodeA)
+	now := metav1.NewTime(time.Now())
+	snap.DeletionTimestamp = &now
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(snap).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}).Build()
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD:         &drbd.Driver{StateDir: t.TempDir(), Exec: (&fakeDRBDExec{}).run},
+		barrierFails: map[string]int{snapSnap1: 3}}
+
+	reconcileSnap(t, r, snapSnap1)
+
+	r.barrierFailsMu.Lock()
+	_, leaked := r.barrierFails[snapSnap1]
+	r.barrierFailsMu.Unlock()
+	if leaked {
+		t.Fatal("the failure count must die with the snapshot on the vol-gone path")
+	}
+}
+
 func TestSnapshotReplicatedBarrier(t *testing.T) {
 	s := newScheme(t)
 	v := vol(volPvc1, nodeA, nodeB)

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -132,6 +133,57 @@ func TestSnapshotCoordinatorFailsOverFromDeadReplica0(t *testing.T) {
 	}
 	if got.Status.IOSuspended {
 		t.Fatalf("survivor coordinator must void the dead round: %+v", got.Status)
+	}
+}
+
+// A suspend-io that fails persistently (e.g. a wedged kernel module,
+// LINBIT/drbd#137) must not ride the workqueue's exponential backoff
+// forever: after barrierFailLimit consecutive failures the round parks at
+// barrierRetryAfter with a BarrierStuck warning.
+func TestSnapshotBarrierStuckParksAfterLimit(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{
+		statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+			"connections":[{"connection-state":"Connected"}]}]`,
+		errOn: map[string]error{"suspend-io": errors.New(
+			"exit status 20: Command 'drbdsetup suspend-io 1001' did not terminate within 5 seconds")},
+	}
+	rec := events.NewFakeRecorder(8)
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}, Recorder: rec}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}
+	for i := 1; i < barrierFailLimit; i++ {
+		if _, err := r.Reconcile(t.Context(), req); err == nil {
+			t.Fatalf("failure %d must surface for the fast backoff", i)
+		}
+	}
+	res, err := r.Reconcile(t.Context(), req)
+	if err != nil {
+		t.Fatalf("failure %d must park the retry, not error: %v", barrierFailLimit, err)
+	}
+	if res.RequeueAfter != barrierRetryAfter {
+		t.Fatalf("want %v parked retry, got %v", barrierRetryAfter, res.RequeueAfter)
+	}
+	select {
+	case e := <-rec.Events:
+		if !strings.Contains(e, "BarrierStuck") {
+			t.Fatalf("want a BarrierStuck warning, got %q", e)
+		}
+	default:
+		t.Fatal("want a BarrierStuck warning event")
 	}
 }
 

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -679,6 +679,20 @@ func (d *Driver) WipeMetadata(ctx context.Context, name, disk string, minor int3
 // a D-state child ignores the SIGKILL and keeps its holds.
 const downTimeout = 30 * time.Second
 
+// disconnectTimeout bounds each best-effort disconnect in downResource,
+// which otherwise rides RealExec's 2-minute bound — per peer, per teardown
+// attempt — when the kernel resource is wedged. A healthy disconnect
+// completes in milliseconds.
+const disconnectTimeout = 10 * time.Second
+
+// ErrWedged marks a resource the kernel can no longer tear down: the
+// device is stuck Detaching with every connection already gone, so
+// drbdsetup down blocks in uninterruptible sleep and the next attempt hits
+// the same wall (refcount underflow, LINBIT/drbd#137). Callers must leave
+// the fast retry loop — every extra down attempt can strand another
+// unkillable process — and surface that only a node reboot clears it.
+var ErrWedged = errors.New("resource wedged in kernel (LINBIT/drbd#137): node reboot required")
+
 // downResource disconnects each peer connection, then downs the resource.
 // Disconnecting first avoids a kernel deadlock: drbdsetup down on a
 // resource with an active resync connection can enter uninterruptible
@@ -690,7 +704,9 @@ const downTimeout = 30 * time.Second
 // removed.
 func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32) error {
 	for _, id := range peerIDs {
-		_, _ = d.Exec(ctx, "drbdsetup", "disconnect", name, strconv.Itoa(int(id)))
+		dcCtx, cancel := context.WithTimeout(ctx, disconnectTimeout)
+		_, _ = d.Exec(dcCtx, "drbdsetup", "disconnect", name, strconv.Itoa(int(id)))
+		cancel()
 	}
 	downCtx, cancel := context.WithTimeout(ctx, downTimeout)
 	defer cancel()
@@ -700,33 +716,48 @@ func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32)
 	return nil
 }
 
-// livePeerIDs reports the resource's DRBD peer node ids per the kernel's
-// live view — the ids downResource must disconnect. Empty when the
-// resource is down or the status is unreadable (nothing to disconnect).
-func (d *Driver) livePeerIDs(ctx context.Context, name string) []int32 {
+// liveTeardownView reports the resource's DRBD peer node ids per the
+// kernel's live view — the ids downResource must disconnect — and whether
+// the resource carries the wedge signature: device Detaching with no
+// connections left. A healthy detach completes in milliseconds once the
+// peers are gone, and nothing but teardown detaches, so that state at
+// teardown entry means a previous down was killed mid-flight and never
+// completed (ErrWedged). Empty/false when the resource is down or the
+// status is unreadable (nothing to disconnect).
+func (d *Driver) liveTeardownView(ctx context.Context, name string) (peerIDs []int32, wedged bool) {
 	out, err := d.Exec(ctx, "drbdsetup", "status", "--json", name)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	var parsed []jsonStatus
 	if json.Unmarshal([]byte(out), &parsed) != nil {
-		return nil
+		return nil, false
 	}
-	var ids []int32
 	for _, res := range parsed {
-		if res.Name == name {
-			ids = append(ids, res.peerIDs()...)
+		if res.Name != name {
+			continue
+		}
+		peerIDs = append(peerIDs, res.peerIDs()...)
+		if len(res.Connections) == 0 && len(res.Devices) > 0 &&
+			res.Devices[0].DiskState == diskDetaching {
+			wedged = true
 		}
 	}
-	return ids
+	return peerIDs, wedged
 }
 
 // Down stops the resource and removes its rendered state. Idempotent.
+// Returns ErrWedged (wrapped) without spawning another down when the
+// kernel shows the resource stuck mid-teardown.
 func (d *Driver) Down(ctx context.Context, name string) error {
 	if _, err := os.Stat(d.path(name + ".res")); os.IsNotExist(err) {
 		return nil // never configured here
 	}
-	if err := d.downResource(ctx, name, d.livePeerIDs(ctx, name)); err != nil {
+	peerIDs, wedged := d.liveTeardownView(ctx, name)
+	if wedged {
+		return fmt.Errorf("down %s: %w", name, ErrWedged)
+	}
+	if err := d.downResource(ctx, name, peerIDs); err != nil {
 		return err
 	}
 	for _, suffix := range stateSuffixes {
@@ -753,6 +784,11 @@ const DiskInconsistent = "Inconsistent"
 // tie-breaker-ness (that is spec-driven, see Replica.Diskless); it is
 // only meaningful for observing a detach on a leg the spec says is diskful.
 const DiskDiskless = "Diskless"
+
+// diskDetaching is the transient disk state while the kernel drains a
+// detach. Seen at teardown entry (with the connections already gone) it
+// means a previous down was killed mid-flight — see ErrWedged.
+const diskDetaching = "Detaching"
 
 // rolePrimary is the DRBD role of a node that holds the device open.
 const rolePrimary = "Primary"

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -47,6 +48,14 @@ type Driver struct {
 	// Mknod creates device nodes; injectable because the real call needs
 	// CAP_MKNOD. Nil means unix.Mknod.
 	Mknod func(path string, mode uint32, dev int) error
+
+	// wedgeSeen stamps resources whose teardown wore the wedge signature
+	// once (see ErrWedged). Down escalates only on the second consecutive
+	// sighting: a killed down whose detach is still draining wears the
+	// same signature briefly, and a premature ErrWedged pages "reboot
+	// required" for a state that resolves itself.
+	wedgeMu   sync.Mutex
+	wedgeSeen map[string]bool
 }
 
 // isMissingMetadata matches drbdadm's complaint when a backing device
@@ -293,26 +302,37 @@ var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted"
 // SweepOrphans tears down kernel resources and rendered config files with
 // no owning volume on this node — leftovers of an agent crash between up
 // and down, which would otherwise hold backing devices open forever. Best
-// effort: errors are joined so one stuck resource cannot strand the rest.
+// effort per resource: errors are joined so one stuck resource cannot
+// strand the rest. An unreadable kernel view aborts the whole sweep,
+// files included — without it a live resource is indistinguishable from a
+// stale file, and stripping its config is the state this sweep's own
+// stuck-guard exists to prevent.
 func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool) error {
+	out, err := d.Exec(ctx, "drbdsetup", "status", "--json")
+	if err != nil {
+		return fmt.Errorf("status: %w", err)
+	}
+	var parsed []jsonStatus
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		return fmt.Errorf("parse status: %w", err)
+	}
 	var errs []error
 	stuck := map[string]bool{}
-	out, err := d.Exec(ctx, "drbdsetup", "status", "--json")
-	if err == nil {
-		var parsed []jsonStatus
-		if jsonErr := json.Unmarshal([]byte(out), &parsed); jsonErr == nil {
-			for _, res := range parsed {
-				if owned(res.Name) {
-					continue
-				}
-				// A resource wedged in the kernel (stuck Detaching,
-				// LINBIT/drbd#137) fails its down on every attempt; keep
-				// sweeping the other orphans (issue #195).
-				if err := d.downResource(ctx, res.Name, res.peerIDs()); err != nil {
-					errs = append(errs, fmt.Errorf("down orphan %s: %w", res.Name, err))
-					stuck[res.Name] = true
-				}
-			}
+	for _, res := range parsed {
+		if owned(res.Name) {
+			continue
+		}
+		// A wedged orphan's down can only hang 30s and strand another
+		// unkillable process (issue #195); the signature is already in
+		// hand from this sweep's own parse, so skip without spawning one.
+		if res.wedgeSignature() {
+			errs = append(errs, fmt.Errorf("orphan %s: %w", res.Name, ErrWedged))
+			stuck[res.Name] = true
+			continue
+		}
+		if err := d.downResource(ctx, res.Name, res.peerIDs()); err != nil {
+			errs = append(errs, fmt.Errorf("down orphan %s: %w", res.Name, err))
+			stuck[res.Name] = true
 		}
 	}
 	entries, err := os.ReadDir(d.StateDir)
@@ -357,6 +377,13 @@ func (d *Driver) DownSecondaries(ctx context.Context) error {
 	var errs []error
 	for _, res := range parsed {
 		if res.Role == rolePrimary {
+			continue
+		}
+		// Never spawn a down against the wedge signature (issue #195):
+		// it can only hang until the shutdown deadline and strand an
+		// unkillable process into the reboot.
+		if res.wedgeSignature() {
+			errs = append(errs, fmt.Errorf("%s: %w", res.Name, ErrWedged))
 			continue
 		}
 		if err := d.downResource(ctx, res.Name, res.peerIDs()); err != nil {
@@ -686,18 +713,23 @@ const downTimeout = 30 * time.Second
 const disconnectTimeout = 10 * time.Second
 
 // ErrWedged marks a resource the kernel can no longer tear down: the
-// device is stuck Detaching with every connection already gone, so
-// drbdsetup down blocks in uninterruptible sleep and the next attempt hits
-// the same wall (refcount underflow, LINBIT/drbd#137). Callers must leave
-// the fast retry loop — every extra down attempt can strand another
-// unkillable process — and surface that only a node reboot clears it.
+// device is stuck Detaching with nothing left to disconnect, so drbdsetup
+// down blocks in uninterruptible sleep and the next attempt hits the same
+// wall (refcount underflow, LINBIT/drbd#137). Callers must leave the fast
+// retry loop — every extra down attempt can strand another unkillable
+// process — and surface that only a node reboot clears it. Down escalates
+// to this only on the second consecutive sighting of the signature, so a
+// detach still draining gets one retry cycle to finish first.
 var ErrWedged = errors.New("resource wedged in kernel (LINBIT/drbd#137): node reboot required")
 
 // downResource disconnects each peer connection, then downs the resource.
 // Disconnecting first avoids a kernel deadlock: drbdsetup down on a
 // resource with an active resync connection can enter uninterruptible
 // sleep negotiating teardown with the peer. Disconnects are best-effort
-// (a StandAlone or unconfigured connection errors harmlessly); drbdsetup
+// (a StandAlone or unconfigured connection errors harmlessly) — except
+// when one is killed at its deadline: then the connection may be half-torn
+// and running down would race exactly that teardown, so the down is
+// deferred to the caller's retry (which disconnects again). drbdsetup
 // needs no config, takes peers by node id, and down exits 0 for unknown
 // names, keeping teardown idempotent. drbdsetup, not drbdadm: drbdadm
 // refuses conflicting .res files, and teardown is how a conflict gets
@@ -706,7 +738,14 @@ func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32)
 	for _, id := range peerIDs {
 		dcCtx, cancel := context.WithTimeout(ctx, disconnectTimeout)
 		_, _ = d.Exec(dcCtx, "drbdsetup", "disconnect", name, strconv.Itoa(int(id)))
+		expired := dcCtx.Err() != nil
 		cancel()
+		if expired {
+			// ErrBusy: the caller's short retry re-disconnects; the state
+			// clears on its own once the kernel finishes the teardown.
+			return fmt.Errorf("disconnect %s peer %d killed after %s; deferring down: %w",
+				name, id, disconnectTimeout, backend.ErrBusy)
+		}
 	}
 	downCtx, cancel := context.WithTimeout(ctx, downTimeout)
 	defer cancel()
@@ -718,12 +757,9 @@ func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32)
 
 // liveTeardownView reports the resource's DRBD peer node ids per the
 // kernel's live view — the ids downResource must disconnect — and whether
-// the resource carries the wedge signature: device Detaching with no
-// connections left. A healthy detach completes in milliseconds once the
-// peers are gone, and nothing but teardown detaches, so that state at
-// teardown entry means a previous down was killed mid-flight and never
-// completed (ErrWedged). Empty/false when the resource is down or the
-// status is unreadable (nothing to disconnect).
+// the resource wears the wedge signature (see jsonStatus.wedgeSignature).
+// Empty/false when the resource is down or the status is unreadable
+// (nothing to disconnect).
 func (d *Driver) liveTeardownView(ctx context.Context, name string) (peerIDs []int32, wedged bool) {
 	out, err := d.Exec(ctx, "drbdsetup", "status", "--json", name)
 	if err != nil {
@@ -738,25 +774,51 @@ func (d *Driver) liveTeardownView(ctx context.Context, name string) (peerIDs []i
 			continue
 		}
 		peerIDs = append(peerIDs, res.peerIDs()...)
-		if len(res.Connections) == 0 && len(res.Devices) > 0 &&
-			res.Devices[0].DiskState == diskDetaching {
+		if res.wedgeSignature() {
 			wedged = true
 		}
 	}
 	return peerIDs, wedged
 }
 
+// markWedgeSighting records one sighting of the wedge signature and
+// reports whether an earlier consecutive sighting was already on record.
+func (d *Driver) markWedgeSighting(name string) (again bool) {
+	d.wedgeMu.Lock()
+	defer d.wedgeMu.Unlock()
+	if d.wedgeSeen == nil {
+		d.wedgeSeen = map[string]bool{}
+	}
+	again = d.wedgeSeen[name]
+	d.wedgeSeen[name] = true
+	return again
+}
+
+func (d *Driver) clearWedgeSighting(name string) {
+	d.wedgeMu.Lock()
+	delete(d.wedgeSeen, name)
+	d.wedgeMu.Unlock()
+}
+
 // Down stops the resource and removes its rendered state. Idempotent.
-// Returns ErrWedged (wrapped) without spawning another down when the
-// kernel shows the resource stuck mid-teardown.
+// A resource wearing the wedge signature never gets another down spawned:
+// the first sighting defers (the detach may still be draining), a second
+// consecutive one returns ErrWedged (wrapped).
 func (d *Driver) Down(ctx context.Context, name string) error {
 	if _, err := os.Stat(d.path(name + ".res")); os.IsNotExist(err) {
 		return nil // never configured here
 	}
 	peerIDs, wedged := d.liveTeardownView(ctx, name)
 	if wedged {
-		return fmt.Errorf("down %s: %w", name, ErrWedged)
+		if d.markWedgeSighting(name) {
+			return fmt.Errorf("down %s: %w", name, ErrWedged)
+		}
+		// ErrBusy: one short retry cycle for a drain to finish before the
+		// signature escalates.
+		return fmt.Errorf("down %s: detach in flight after a killed down; deferring: %w",
+			name, backend.ErrBusy)
 	}
+	d.clearWedgeSighting(name)
 	if err := d.downResource(ctx, name, peerIDs); err != nil {
 		return err
 	}
@@ -789,6 +851,11 @@ const DiskDiskless = "Diskless"
 // detach. Seen at teardown entry (with the connections already gone) it
 // means a previous down was killed mid-flight — see ErrWedged.
 const diskDetaching = "Detaching"
+
+// connStandAlone is the connection state of a peer DRBD gave up
+// reconnecting to. drbdsetup disconnect refuses it (-9), so a StandAlone
+// entry can linger in status through every teardown attempt.
+const connStandAlone = "StandAlone"
 
 // rolePrimary is the DRBD role of a node that holds the device open.
 const rolePrimary = "Primary"
@@ -874,6 +941,25 @@ type jsonStatus struct {
 			OutOfSyncKiB     int64   `json:"out-of-sync"`
 		} `json:"peer_devices"`
 	} `json:"connections"`
+}
+
+// wedgeSignature reports the kernel view of a teardown that cannot make
+// progress: device stuck Detaching while every remaining connection is
+// one disconnect cannot act on (StandAlone) or already gone. A healthy
+// detach completes in milliseconds once the peers are out of the way, and
+// nothing but teardown detaches, so this state means a previous down was
+// killed mid-flight and never completed — a drain still finishing, or the
+// refcount underflow of LINBIT/drbd#137 (see ErrWedged).
+func (s jsonStatus) wedgeSignature() bool {
+	if len(s.Devices) == 0 || s.Devices[0].DiskState != diskDetaching {
+		return false
+	}
+	for _, c := range s.Connections {
+		if c.ConnectionState != connStandAlone {
+			return false
+		}
+	}
+	return true
 }
 
 // peerIDs lists the entry's connection peer node ids — the handles

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -292,8 +292,11 @@ var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted"
 
 // SweepOrphans tears down kernel resources and rendered config files with
 // no owning volume on this node — leftovers of an agent crash between up
-// and down, which would otherwise hold backing devices open forever.
+// and down, which would otherwise hold backing devices open forever. Best
+// effort: errors are joined so one stuck resource cannot strand the rest.
 func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool) error {
+	var errs []error
+	stuck := map[string]bool{}
 	out, err := d.Exec(ctx, "drbdsetup", "status", "--json")
 	if err == nil {
 		var parsed []jsonStatus
@@ -302,31 +305,37 @@ func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool)
 				if owned(res.Name) {
 					continue
 				}
+				// A resource wedged in the kernel (stuck Detaching,
+				// LINBIT/drbd#137) fails its down on every attempt; keep
+				// sweeping the other orphans (issue #195).
 				if err := d.downResource(ctx, res.Name, res.peerIDs()); err != nil {
-					return fmt.Errorf("down orphan %s: %w", res.Name, err)
+					errs = append(errs, fmt.Errorf("down orphan %s: %w", res.Name, err))
+					stuck[res.Name] = true
 				}
 			}
 		}
 	}
 	entries, err := os.ReadDir(d.StateDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+		if !os.IsNotExist(err) {
+			errs = append(errs, err)
 		}
-		return err
+		return errors.Join(errs...)
 	}
 	for _, e := range entries {
 		name, found := strings.CutSuffix(e.Name(), ".res")
-		if !found || owned(name) {
+		// A resource whose down failed is still configured in the kernel;
+		// its rendered config stays visible to recovery tooling.
+		if !found || owned(name) || stuck[name] {
 			continue
 		}
 		for _, suffix := range stateSuffixes {
 			if err := os.Remove(d.path(name + suffix)); err != nil && !os.IsNotExist(err) {
-				return err
+				errs = append(errs, err)
 			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // DownSecondaries brings down every resource this node holds Secondary,

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -903,8 +903,10 @@ func TestSweepOrphansContinuesOnError(t *testing.T) {
 }
 
 // A resource stuck Detaching with the connections gone is wedged in the
-// kernel (LINBIT/drbd#137): Down must return ErrWedged without spawning
-// another down — each attempt can strand another unkillable process.
+// kernel (LINBIT/drbd#137): Down must never spawn another down — each
+// attempt can strand another unkillable process. The first sighting
+// defers (a killed down's detach may still be draining); the second
+// consecutive sighting escalates to ErrWedged.
 func TestDownWedgedSkipsDown(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{
 		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
@@ -916,14 +918,67 @@ func TestDownWedgedSkipsDown(t *testing.T) {
 	}
 
 	err := d.Down(t.Context(), volPvc1)
-	if !errors.Is(err, ErrWedged) {
-		t.Fatalf("want ErrWedged, got %v", err)
+	if err == nil || errors.Is(err, ErrWedged) {
+		t.Fatalf("first sighting must defer without escalating, got %v", err)
+	}
+	if err := d.Down(t.Context(), volPvc1); !errors.Is(err, ErrWedged) {
+		t.Fatalf("second consecutive sighting must return ErrWedged, got %v", err)
 	}
 	fe.notCalledWith(t, "drbdsetup down")
 	// The rendered config stays: the resource is still configured in the
 	// kernel, and a post-reboot retry finishes the teardown.
 	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
 		t.Fatalf("wedged resource's config must remain: %v", err)
+	}
+}
+
+// A lingering StandAlone connection — which disconnect refuses (-9) and
+// cannot remove — must not defeat the wedge signature.
+func TestDownWedgedWithStandAlonePeer(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"Detaching"}],
+			"connections":[{"peer-node-id":1,"connection-state":"StandAlone"}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = d.Down(t.Context(), volPvc1)
+	if err := d.Down(t.Context(), volPvc1); !errors.Is(err, ErrWedged) {
+		t.Fatalf("StandAlone peer must not defeat the signature, got %v", err)
+	}
+	fe.notCalledWith(t, "drbdsetup down")
+}
+
+// A completed teardown between two sightings resets the escalation: the
+// signature vanishing means the drain finished, so a later teardown of a
+// same-named resource must start from a clean slate.
+func TestDownWedgeSightingResetsWhenSignatureClears(t *testing.T) {
+	wedged := `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"Detaching"}],"connections":[]}]`
+	healthy := `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"` + DiskUpToDate + `"}],"connections":[]}]`
+	fe := &fakeExec{responses: map[string]string{cmdDrbdsetupStatus: wedged}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = d.Down(t.Context(), volPvc1) // first sighting recorded
+	fe.responses[cmdDrbdsetupStatus] = healthy
+	if err := d.Down(t.Context(), volPvc1); err != nil {
+		t.Fatalf("signature gone: down must proceed, got %v", err)
+	}
+	fe.calledWith(t, "drbdsetup down pvc-1")
+	// Re-render and wedge again: escalation must need two fresh sightings.
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	fe.responses[cmdDrbdsetupStatus] = wedged
+	if err := d.Down(t.Context(), volPvc1); errors.Is(err, ErrWedged) {
+		t.Fatal("a cleared sighting must not carry over to a fresh wedge")
 	}
 }
 
@@ -945,6 +1000,70 @@ func TestDownDetachingWithPeersStillDowns(t *testing.T) {
 	}
 	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
 	fe.calledWith(t, "drbdsetup down pvc-1")
+}
+
+// A wedged orphan must be skipped from the sweep's own status parse —
+// spawning a down against it can only hang 30s and strand another
+// unkillable process per agent boot.
+func TestSweepOrphansSkipsWedgedWithoutDown(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[
+			{"name":"pvc-1","role":"Secondary","devices":[{"disk-state":"Detaching"}],"connections":[]},
+			{"name":"pvc-2","role":"Secondary","connections":[]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	err := d.SweepOrphans(t.Context(), func(string) bool { return false })
+	if !errors.Is(err, ErrWedged) {
+		t.Fatalf("want the wedged orphan surfaced as ErrWedged, got %v", err)
+	}
+	fe.notCalledWith(t, "drbdsetup down pvc-1")
+	fe.calledWith(t, "drbdsetup down pvc-2")
+	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
+		t.Fatalf("wedged orphan's config must remain: %v", err)
+	}
+}
+
+// An unreadable kernel view must abort the sweep before any file is
+// removed: a live resource is then indistinguishable from a stale file,
+// and stripping its config is the state the stuck-guard exists to prevent.
+func TestSweepOrphansKeepsFilesWhenStatusUnreadable(t *testing.T) {
+	fe := &fakeExec{errOn: map[string]error{
+		cmdDrbdsetupStatus: errors.New("signal: killed"),
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.SweepOrphans(t.Context(), func(string) bool { return false }); err == nil {
+		t.Fatal("an unreadable status must surface an error")
+	}
+	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
+		t.Fatalf("no file may be removed without the kernel view: %v", err)
+	}
+}
+
+// DownSecondaries must not spawn a down against a wedged resource either:
+// at shutdown it can only hang until the deadline and strand an
+// unkillable process into the reboot.
+func TestDownSecondariesSkipsWedged(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[
+			{"name":"pvc-1","role":"Secondary","devices":[{"disk-state":"Detaching"}],"connections":[]},
+			{"name":"pvc-2","role":"Secondary","connections":[]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	err := d.DownSecondaries(t.Context())
+	if !errors.Is(err, ErrWedged) {
+		t.Fatalf("want the wedged resource surfaced as ErrWedged, got %v", err)
+	}
+	fe.notCalledWith(t, "drbdsetup down pvc-1")
+	fe.calledWith(t, "drbdsetup down pvc-2")
 }
 
 func TestSweepOrphansSkipsOwned(t *testing.T) {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -902,6 +902,51 @@ func TestSweepOrphansContinuesOnError(t *testing.T) {
 	}
 }
 
+// A resource stuck Detaching with the connections gone is wedged in the
+// kernel (LINBIT/drbd#137): Down must return ErrWedged without spawning
+// another down — each attempt can strand another unkillable process.
+func TestDownWedgedSkipsDown(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"Detaching"}],"connections":[]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	err := d.Down(t.Context(), volPvc1)
+	if !errors.Is(err, ErrWedged) {
+		t.Fatalf("want ErrWedged, got %v", err)
+	}
+	fe.notCalledWith(t, "drbdsetup down")
+	// The rendered config stays: the resource is still configured in the
+	// kernel, and a post-reboot retry finishes the teardown.
+	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
+		t.Fatalf("wedged resource's config must remain: %v", err)
+	}
+}
+
+// Detaching with a peer connection still up is a normal teardown
+// transient, not the wedge signature — down must proceed.
+func TestDownDetachingWithPeersStillDowns(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"Detaching"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.Down(t.Context(), volPvc1); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
+	fe.calledWith(t, "drbdsetup down pvc-1")
+}
+
 func TestSweepOrphansSkipsOwned(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{
 		cmdDrbdsetupStatus: `[

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -870,6 +870,60 @@ func TestDownSecondariesContinuesOnError(t *testing.T) {
 	fe.calledWith(t, "drbdsetup down pvc-3")
 }
 
+func TestSweepOrphansContinuesOnError(t *testing.T) {
+	fe := &fakeExec{
+		responses: map[string]string{
+			cmdDrbdsetupStatus: `[
+				{"name":"pvc-1","role":"Secondary","connections":[{"peer-node-id":1,"connection-state":"Connected"}]},
+				{"name":"pvc-2","role":"Secondary","connections":[]}]`,
+		},
+		errOn: map[string]error{"down pvc-1": errors.New("signal: killed")},
+	}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	for _, name := range []string{volPvc1, "pvc-2"} {
+		if err := os.WriteFile(d.path(name+".res"), nil, 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := d.SweepOrphans(t.Context(), func(string) bool { return false })
+	if err == nil || !strings.Contains(err.Error(), volPvc1) {
+		t.Fatalf("want a joined error naming pvc-1, got %v", err)
+	}
+	// One wedged orphan must not strand the rest of the sweep.
+	fe.calledWith(t, "drbdsetup down pvc-2")
+	// The wedged resource is still configured in the kernel: its rendered
+	// config must survive, while the downed orphan's is removed.
+	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
+		t.Fatalf("wedged resource's config must remain: %v", err)
+	}
+	if _, err := os.Stat(d.path("pvc-2.res")); !os.IsNotExist(err) {
+		t.Fatalf("downed orphan's config must be removed, got %v", err)
+	}
+}
+
+func TestSweepOrphansSkipsOwned(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[
+			{"name":"pvc-1","role":"Secondary","connections":[]},
+			{"name":"pvc-2","role":"Secondary","connections":[]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	owned := func(name string) bool { return name == volPvc1 }
+	if err := d.SweepOrphans(t.Context(), owned); err != nil {
+		t.Fatal(err)
+	}
+	fe.notCalledWith(t, "drbdsetup down pvc-1")
+	fe.calledWith(t, "drbdsetup down pvc-2")
+	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
+		t.Fatalf("owned resource's config must remain: %v", err)
+	}
+}
+
 func TestIsResizeDuringResync(t *testing.T) {
 	if !IsResizeDuringResync(errors.New("exit status 10: Resize not allowed during resync.")) {
 		t.Fatal("must match DRBD's resync refusal")


### PR DESCRIPTION
Implements the full containment plan from #195 (see [the findings comment](https://github.com/home-operations/miroir/issues/195#issuecomment-4983735864)): a resource wedged in the kernel (stuck `Detaching` with an underflowed refcount, LINBIT/drbd#137) fails `drbdsetup down` on every attempt, and the agent turned that single stuck resource into a node-wide outage. The kernel bug itself is upstream's to fix; this PR keeps the agent alive, stops it from making the wedge worse, and makes the state visible.

## Changes

**Commit 1 - startup survives a wedged resource**

- **Startup sweeps are no longer fatal** (`cmd/main.go`): both `sweepOrphans` and `resumeStaleBarriers` logged the error and called `os.Exit(1)`, so a wedged orphan put the agent in CrashLoopBackOff and the node's healthy volumes went unmanaged until a reboot (observed in both #195 incidents). They now log and continue, matching the shutdown-path call of the same barrier sweep.
- **`SweepOrphans` is per-resource best-effort** (`internal/drbd/drbd.go`): errors are collected with `errors.Join` and the sweep continues, the same pattern `DownSecondaries` uses. The rendered config of a resource whose down failed is kept, since that resource is still configured in the kernel.

**Commit 2 - wedge detection, deliberate escalation, bounded retries**

- **`Down` detects the wedge signature** (device `Detaching`, `connections: []` - readable from the same status call that fetched the peer ids) and returns a sentinel `drbd.ErrWedged` without spawning another `down`: each SIGKILLed attempt can strand another unkillable D-state process, which is what eventually pinned LVM and took the node down. `Detaching` with peers still connected stays on the normal path.
- **Teardown escalates instead of hammering**: `ErrWedged` no longer classifies as `ErrBusy` (10s retry); both teardown callers park the retry at 5 minutes, emit a `TeardownWedged` warning Event, set the node's status `Message` ("node reboot required"), and raise a new `miroir_volume_wedged` gauge. The gauge is volume-only (a pool can be unknowable mid-teardown) and clears when a post-reboot retry finishes the teardown. A critical `MiroirVolumeTeardownWedged` starter alert ships with it.
- **`disconnect` is bounded** (10s): the best-effort disconnects in `downResource` rode `RealExec`'s 2-minute bound, per peer, per teardown attempt.
- **Snapshot barrier gives up deliberately**: `raiseBarrier`/`cutLeg` returned `SuspendIO` errors raw, so a wedged module meant silent, unbounded exponential backoff. Transients still take the fast backoff; after 5 consecutive failures the round parks at a 1-minute retry with a `BarrierStuck` warning Event.

## Testing

- `mise run test`, `lint`, `test-integration`, `helm-lint`, `helm-test` (109/109), `docs` all pass locally.
- New unit tests: wedged orphan doesn't strand the sweep and keeps its config; owned resources untouched; `Down` returns `ErrWedged` without another down attempt (and proceeds normally when peers are still connected); a wedged teardown parks at 5m with Event + gauge + Message and keeps the finalizer; snapshot barrier parks after the failure limit with the Event; helm test covers the new alert.

Fixes the miroir side of #195. What remains on that issue is upstream: getting the LINBIT/drbd#139 one-liner onto drbd-dev and into a release.
