### PR TITLE
fix(agent): bound busy teardown retries and park impossible restores (issue #195)

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -160,6 +160,9 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// once it is safe.
 		return r.reconcileRemoval(ctx, vol)
 	}
+	// A live, placed volume is not tearing down: a busy streak left over
+	// from a cancelled removal must not pre-bias the next teardown episode.
+	r.clearBusyFails(vol.Name)
 	if vol.Spec.DRBD != nil && incomplete {
 		// A just-added entry the membership reconciler has not completed
 		// yet (no NodeID/address): nothing can be realized safely. Logged
@@ -468,21 +471,7 @@ func (r *VolumeReconciler) reconcileDeletion(ctx context.Context, vol *miroirv1a
 		return ctrl.Result{}, nil
 	}
 	if err := r.teardown(ctx, vol); err != nil {
-		if errors.Is(err, drbd.ErrWedged) {
-			r.clearBusyFails(vol.Name)
-			return r.reportWedged(ctx, vol, err)
-		}
-		// Any other outcome means a previously reported wedge is gone —
-		// e.g. the reboot happened and the device is now merely held
-		// open — so the critical alert must stop paging for it.
-		metricWedged.DeleteLabelValues(vol.Name)
-		if errors.Is(err, backend.ErrBusy) {
-			// A force-deleted pod can leave the device open past
-			// NodeUnstage; retry until the mount goes away.
-			return r.reportBusy(ctx, vol, err)
-		}
-		r.clearBusyFails(vol.Name)
-		return ctrl.Result{}, err
+		return r.handleTeardownError(ctx, vol, err)
 	}
 	// Drop metrics only once the device is gone: a retrying teardown
 	// must not blank a volume that still exists.
@@ -773,6 +762,9 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 	}
 	if reason := r.removalBlocked(ctx, vol); reason != "" {
 		log.Info("replica removal blocked", "volume", vol.Name, "reason", reason)
+		// The block interrupts the teardown episode: a busy streak from
+		// before it must not pre-bias the attempts after it unblocks.
+		r.clearBusyFails(vol.Name)
 		st := vol.Status.PerNode[r.NodeName]
 		st.Message = "replica removal blocked: " + reason
 		if err := r.patchStatus(ctx, vol, st); err != nil {
@@ -781,20 +773,7 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 	if err := r.teardown(ctx, vol); err != nil {
-		if errors.Is(err, drbd.ErrWedged) {
-			r.clearBusyFails(vol.Name)
-			return r.reportWedged(ctx, vol, err)
-		}
-		// A non-wedged outcome retires a previously reported wedge (see
-		// reconcileDeletion); the critical alert must stop paging for it.
-		metricWedged.DeleteLabelValues(vol.Name)
-		if errors.Is(err, backend.ErrBusy) {
-			// A pod still staged here holds the device open; it has to
-			// move off this node before the leg can go.
-			return r.reportBusy(ctx, vol, err)
-		}
-		r.clearBusyFails(vol.Name)
-		return ctrl.Result{}, err
+		return r.handleTeardownError(ctx, vol, err)
 	}
 	dropVolumeMetrics(vol.Name)
 	r.dropRealized(vol.Name)
@@ -932,12 +911,43 @@ func (r *VolumeReconciler) reportWedged(ctx context.Context, vol *miroirv1alpha1
 			vol.Name, r.NodeName)
 	}
 	metricWedged.WithLabelValues(vol.Name).Set(1)
+	return r.parkWithMessage(ctx, vol, cause, wedgedRequeue)
+}
+
+// parkWithMessage stamps the cause on this node's status slot and parks
+// the retry — the shared tail of every teardown/realize escalation
+// (reportWedged, reportBusy, reportRestoreOrphan), kept in one place so
+// the park contract cannot drift between them.
+func (r *VolumeReconciler) parkWithMessage(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error, requeue time.Duration) (ctrl.Result, error) {
 	st := vol.Status.PerNode[r.NodeName]
 	st.Message = cause.Error()
 	if err := r.patchStatus(ctx, vol, st); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{RequeueAfter: wedgedRequeue}, nil
+	return ctrl.Result{RequeueAfter: requeue}, nil
+}
+
+// handleTeardownError triages one failed teardown outcome, shared by the
+// deletion and removal paths so the busy-streak bookkeeping cannot drift:
+// a kernel wedge parks via reportWedged, a held-open device paces via
+// reportBusy, anything else surfaces as a hard error. Every non-busy
+// outcome resets the busy streak.
+func (r *VolumeReconciler) handleTeardownError(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, err error) (ctrl.Result, error) {
+	if errors.Is(err, drbd.ErrWedged) {
+		r.clearBusyFails(vol.Name)
+		return r.reportWedged(ctx, vol, err)
+	}
+	// Any other outcome means a previously reported wedge is gone — e.g.
+	// the reboot happened and the device is now merely held open — so the
+	// critical alert must stop paging for it.
+	metricWedged.DeleteLabelValues(vol.Name)
+	if errors.Is(err, backend.ErrBusy) {
+		// A still-staged (or force-deleted) pod holds the device open;
+		// NodeUnstage releases it once the consumer moves off this node.
+		return r.reportBusy(ctx, vol, err)
+	}
+	r.clearBusyFails(vol.Name)
+	return ctrl.Result{}, err
 }
 
 // busyFailLimit is how many consecutive ErrBusy teardown outcomes ride the
@@ -970,17 +980,18 @@ func (r *VolumeReconciler) reportBusy(ctx context.Context, vol *miroirv1alpha1.M
 	}
 	ctrl.LoggerFrom(ctx).Error(cause, "teardown still busy; parking the retry",
 		"volume", vol.Name, "attempts", fails)
-	if r.Recorder != nil {
+	// Latch the escalation on the crossing cycle: the parked retry can
+	// outlive the hold by hours, and re-emitting an identical Event plus a
+	// no-op status write every cycle is pure API churn.
+	if fails == busyFailLimit && r.Recorder != nil {
 		r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "TeardownBusy", "Teardown",
 			"cannot tear down %s on node %s after %d attempts: %v; something still holds the device (or its backing) open",
 			vol.Name, r.NodeName, fails, cause)
 	}
-	st := vol.Status.PerNode[r.NodeName]
-	st.Message = cause.Error()
-	if err := r.patchStatus(ctx, vol, st); err != nil {
-		return ctrl.Result{}, err
+	if vol.Status.PerNode[r.NodeName].Message == cause.Error() {
+		return ctrl.Result{RequeueAfter: busyRetryAfter}, nil
 	}
-	return ctrl.Result{RequeueAfter: busyRetryAfter}, nil
+	return r.parkWithMessage(ctx, vol, cause, busyRetryAfter)
 }
 
 // clearBusyFails resets the volume's consecutive busy-teardown count.
@@ -1015,12 +1026,7 @@ func (r *VolumeReconciler) reportRestoreOrphan(ctx context.Context, vol *miroirv
 			"cannot restore %s on node %s: source snapshot %s no longer exists; delete the volume or recreate the snapshot",
 			vol.Name, r.NodeName, vol.Spec.Source.SnapshotName)
 	}
-	st := vol.Status.PerNode[r.NodeName]
-	st.Message = cause.Error()
-	if err := r.patchStatus(ctx, vol, st); err != nil {
-		return ctrl.Result{}, err
-	}
-	return ctrl.Result{RequeueAfter: restoreOrphanRequeue}, nil
+	return r.parkWithMessage(ctx, vol, cause, restoreOrphanRequeue)
 }
 
 func (r *VolumeReconciler) reportError(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) error {

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -84,6 +84,13 @@ type VolumeReconciler struct {
 	// several times per second. See recoverSplitBrain.
 	recoveryMu   sync.Mutex
 	lastRecovery map[string]time.Time
+
+	// busyFails counts consecutive ErrBusy teardown outcomes per volume.
+	// Past busyFailLimit the loop escalates — Warning Event, status
+	// Message, parked cadence — instead of silently retrying every 10s
+	// forever with the cause swallowed (issue #195). See reportBusy.
+	busyMu    sync.Mutex
+	busyFails map[string]int
 }
 
 // realizedState is the fingerprint of a completed full pass: repeating
@@ -108,6 +115,11 @@ const drbdPollInterval = 30 * time.Second
 
 // errSplitBrain gives the split-brain transition log a real error value.
 var errSplitBrain = errors.New("DRBD split-brain detected")
+
+// errRestoreSourceGone marks a restore whose source snapshot was deleted
+// before this leg cloned it: the backing can never be created here, so the
+// retry parks instead of riding the workqueue backoff forever (issue #195).
+var errRestoreSourceGone = errors.New("restore source snapshot no longer exists")
 
 // legState classifies this node's part in the volume: the replica index
 // (-1 when not a replica), whether the local leg is diskless — a
@@ -183,7 +195,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// volume restores from a snapshot.
 		dev, err = r.realizeBacking(ctx, pool.Backend, vol, vol.Spec.Replicas[idx].FullSync)
 		if err != nil {
-			return ctrl.Result{}, r.reportError(ctx, vol, err)
+			return r.reportRealizeError(ctx, vol, err)
 		}
 		// Record the device before growing it: computePhase treats errors
 		// with DeviceCreated=false as hard provisioning failures, and a
@@ -433,6 +445,7 @@ func (r *VolumeReconciler) volumeGone(name string, err error) error {
 	dropVolumeMetrics(name)
 	r.dropRealized(name)
 	r.dropRecovery(name)
+	r.clearBusyFails(name)
 	return nil
 }
 
@@ -456,6 +469,7 @@ func (r *VolumeReconciler) reconcileDeletion(ctx context.Context, vol *miroirv1a
 	}
 	if err := r.teardown(ctx, vol); err != nil {
 		if errors.Is(err, drbd.ErrWedged) {
+			r.clearBusyFails(vol.Name)
 			return r.reportWedged(ctx, vol, err)
 		}
 		// Any other outcome means a previously reported wedge is gone —
@@ -465,9 +479,9 @@ func (r *VolumeReconciler) reconcileDeletion(ctx context.Context, vol *miroirv1a
 		if errors.Is(err, backend.ErrBusy) {
 			// A force-deleted pod can leave the device open past
 			// NodeUnstage; retry until the mount goes away.
-			ctrl.LoggerFrom(ctx).Info("device busy during teardown, retrying", "volume", vol.Name)
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			return r.reportBusy(ctx, vol, err)
 		}
+		r.clearBusyFails(vol.Name)
 		return ctrl.Result{}, err
 	}
 	// Drop metrics only once the device is gone: a retrying teardown
@@ -475,6 +489,7 @@ func (r *VolumeReconciler) reconcileDeletion(ctx context.Context, vol *miroirv1a
 	dropVolumeMetrics(vol.Name)
 	r.dropRealized(vol.Name)
 	r.dropRecovery(vol.Name)
+	r.clearBusyFails(vol.Name)
 	return ctrl.Result{}, r.removeFinalizer(ctx, vol)
 }
 
@@ -534,6 +549,9 @@ func (r *VolumeReconciler) realizeBacking(ctx context.Context, be backend.Backen
 	}
 	snap := &miroirv1alpha1.MiroirSnapshot{}
 	if err := r.Get(ctx, types.NamespacedName{Name: vol.Spec.Source.SnapshotName}, snap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("snapshot %q: %w", vol.Spec.Source.SnapshotName, errRestoreSourceGone)
+		}
 		return "", err
 	}
 	return be.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name)
@@ -764,6 +782,7 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 	}
 	if err := r.teardown(ctx, vol); err != nil {
 		if errors.Is(err, drbd.ErrWedged) {
+			r.clearBusyFails(vol.Name)
 			return r.reportWedged(ctx, vol, err)
 		}
 		// A non-wedged outcome retires a previously reported wedge (see
@@ -772,14 +791,15 @@ func (r *VolumeReconciler) reconcileRemoval(ctx context.Context, vol *miroirv1al
 		if errors.Is(err, backend.ErrBusy) {
 			// A pod still staged here holds the device open; it has to
 			// move off this node before the leg can go.
-			log.Info("device busy during replica removal, retrying", "volume", vol.Name)
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			return r.reportBusy(ctx, vol, err)
 		}
+		r.clearBusyFails(vol.Name)
 		return ctrl.Result{}, err
 	}
 	dropVolumeMetrics(vol.Name)
 	r.dropRealized(vol.Name)
 	r.dropRecovery(vol.Name)
+	r.clearBusyFails(vol.Name)
 	// Drop this node's status slot — merge-patch null deletes the key.
 	// Best-effort ordering: a crash here leaves a stale slot, which
 	// nothing reads (phase and growth iterate spec.replicas only).
@@ -918,6 +938,89 @@ func (r *VolumeReconciler) reportWedged(ctx context.Context, vol *miroirv1alpha1
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: wedgedRequeue}, nil
+}
+
+// busyFailLimit is how many consecutive ErrBusy teardown outcomes ride the
+// fast 10s retry — NodeUnstage normally releases the device within a few
+// cycles — before the loop escalates; busyRetryAfter is the parked cadence.
+// The finalizer is never released on busy: the hold may be a live mount,
+// and force-releasing would leak the backing device or destroy it under a
+// consumer (issue #195).
+const (
+	busyFailLimit  = 30 // ~5 minutes at the 10s cadence
+	busyRetryAfter = time.Minute
+)
+
+// reportBusy paces one ErrBusy teardown outcome: the fast 10s retry below
+// busyFailLimit, then a Warning Event, a status Message naming the cause,
+// and the parked cadence. The cause is always logged — an ErrBusy from the
+// backend sweep looks identical to a held-open device without it.
+func (r *VolumeReconciler) reportBusy(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
+	r.busyMu.Lock()
+	if r.busyFails == nil {
+		r.busyFails = map[string]int{}
+	}
+	r.busyFails[vol.Name]++
+	fails := r.busyFails[vol.Name]
+	r.busyMu.Unlock()
+	if fails < busyFailLimit {
+		ctrl.LoggerFrom(ctx).Info("device busy during teardown, retrying",
+			"volume", vol.Name, "attempts", fails, "error", cause)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+	ctrl.LoggerFrom(ctx).Error(cause, "teardown still busy; parking the retry",
+		"volume", vol.Name, "attempts", fails)
+	if r.Recorder != nil {
+		r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "TeardownBusy", "Teardown",
+			"cannot tear down %s on node %s after %d attempts: %v; something still holds the device (or its backing) open",
+			vol.Name, r.NodeName, fails, cause)
+	}
+	st := vol.Status.PerNode[r.NodeName]
+	st.Message = cause.Error()
+	if err := r.patchStatus(ctx, vol, st); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: busyRetryAfter}, nil
+}
+
+// clearBusyFails resets the volume's consecutive busy-teardown count.
+func (r *VolumeReconciler) clearBusyFails(name string) {
+	r.busyMu.Lock()
+	delete(r.busyFails, name)
+	r.busyMu.Unlock()
+}
+
+// reportRealizeError routes a realizeBacking failure: an impossible
+// restore parks (reportRestoreOrphan), anything else takes the normal
+// status-and-backoff path.
+func (r *VolumeReconciler) reportRealizeError(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
+	if errors.Is(cause, errRestoreSourceGone) {
+		return r.reportRestoreOrphan(ctx, vol, cause)
+	}
+	return ctrl.Result{}, r.reportError(ctx, vol, cause)
+}
+
+// restoreOrphanRequeue spaces retries of a restore whose source snapshot
+// is gone. Only deleting the volume (or recreating the snapshot under the
+// same name) unsticks it, so the retry only needs to notice that happened.
+const restoreOrphanRequeue = 5 * time.Minute
+
+// reportRestoreOrphan surfaces a restore that can never complete on this
+// node (errRestoreSourceGone) — Warning Event and a status Message naming
+// the operator's options — then parks the retry at restoreOrphanRequeue.
+func (r *VolumeReconciler) reportRestoreOrphan(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
+	ctrl.LoggerFrom(ctx).Error(cause, "restore source snapshot is gone; parking the volume", "volume", vol.Name)
+	if r.Recorder != nil {
+		r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "RestoreSourceMissing", "Realize",
+			"cannot restore %s on node %s: source snapshot %s no longer exists; delete the volume or recreate the snapshot",
+			vol.Name, r.NodeName, vol.Spec.Source.SnapshotName)
+	}
+	st := vol.Status.PerNode[r.NodeName]
+	st.Message = cause.Error()
+	if err := r.patchStatus(ctx, vol, st); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: restoreOrphanRequeue}, nil
 }
 
 func (r *VolumeReconciler) reportError(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) error {

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -62,6 +62,8 @@ const (
 	diskStateDiskless     = "Diskless"
 	nodeC                 = "node-c"
 	addrC                 = "192.168.1.43"
+	// cmdDownPvc1 keys fakeDRBDExec.errOn for `drbdsetup down pvc-1`.
+	cmdDownPvc1 = "drbdsetup down pvc-1"
 )
 
 // fakeBackend records calls and simulates a thin pool in memory.
@@ -371,9 +373,12 @@ func TestReconcileSourceSnapshotGoneRecoversBacking(t *testing.T) {
 	}
 }
 
-// TestReconcileSourceSnapshotGoneAndDeviceMissingFails: no snapshot and no
-// device — the restore can't complete, so fail loud rather than seed empty.
-func TestReconcileSourceSnapshotGoneAndDeviceMissingFails(t *testing.T) {
+// TestReconcileSourceSnapshotGoneAndDeviceMissingParks: no snapshot and no
+// device — the restore can never complete, so fail loud (Failed phase,
+// RestoreSourceMissing warning, Message) and park the retry rather than
+// hot-loop the NotFound through the workqueue backoff (issue #195). Never
+// seed an empty device.
+func TestReconcileSourceSnapshotGoneAndDeviceMissingParks(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend() // no existing device
 	v := vol(volPvc1, nodeA)
@@ -382,16 +387,38 @@ func TestReconcileSourceSnapshotGoneAndDeviceMissingFails(t *testing.T) {
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
+	rec := events.NewFakeRecorder(4)
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb), Recorder: rec}
 
-	_, err := r.Reconcile(t.Context(),
+	res, err := r.Reconcile(t.Context(),
 		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
-	if err == nil {
-		t.Fatal("expected error: restore source is gone and device was never created")
+	if err != nil {
+		t.Fatalf("an impossible restore must park, not error: %v", err)
+	}
+	if res.RequeueAfter != restoreOrphanRequeue {
+		t.Fatalf("want %v parked retry, got %v", restoreOrphanRequeue, res.RequeueAfter)
 	}
 	if len(fb.createVol) != 0 || len(fb.fromSnapVol) != 0 {
 		t.Fatalf("must not create or clone an empty device: create=%v fromSnap=%v",
 			fb.createVol, fb.fromSnapVol)
+	}
+	select {
+	case e := <-rec.Events:
+		if !strings.Contains(e, "RestoreSourceMissing") {
+			t.Fatalf("want a RestoreSourceMissing warning, got %q", e)
+		}
+	default:
+		t.Fatal("want a RestoreSourceMissing warning event")
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.Phase != miroirv1alpha1.VolumeFailed {
+		t.Fatalf("phase = %s, want Failed", got.Status.Phase)
+	}
+	if msg := got.Status.PerNode[nodeA].Message; !strings.Contains(msg, "no longer exists") {
+		t.Fatalf("Message must name the missing snapshot, got %q", msg)
 	}
 }
 
@@ -1000,7 +1027,7 @@ func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
 	fe := &fakeDRBDExec{errOn: map[string]error{
-		"drbdsetup down pvc-1": errors.New("pvc-1: State change failed: Device is held open by someone"),
+		cmdDownPvc1: errors.New("pvc-1: State change failed: Device is held open by someone"),
 	}}
 	r := &VolumeReconciler{
 		Client: c, NodeName: nodeA, Pools: poolsOf(fb),
@@ -1018,6 +1045,83 @@ func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 	got := &miroirv1alpha1.MiroirVolume{}
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal("finalizer must be retained while the device is held open")
+	}
+}
+
+// The 10s busy retry is not unbounded: past busyFailLimit consecutive
+// ErrBusy outcomes teardown escalates — TeardownBusy warning, a status
+// Message naming the actual cause, parked cadence — while the finalizer
+// stays put, and a later successful teardown resets the streak (issue
+// #195: a busy loop ran silently for 2+ hours with the cause swallowed).
+func TestReconcileTeardownBusyEscalates(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	now := metav1.NewTime(time.Now())
+	v.DeletionTimestamp = &now
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte("resource \"pvc-1\" {}\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{errOn: map[string]error{
+		cmdDownPvc1: errors.New("pvc-1: State change failed: Device is held open by someone"),
+	}}
+	rec := events.NewFakeRecorder(4)
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(fb), Recorder: rec,
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+
+	for i := 1; i < busyFailLimit; i++ {
+		res, err := r.Reconcile(t.Context(), req)
+		if err != nil || res.RequeueAfter != 10*time.Second {
+			t.Fatalf("attempt %d must ride the 10s busy retry, got %v / %v", i, res.RequeueAfter, err)
+		}
+	}
+	res, err := r.Reconcile(t.Context(), req)
+	if err != nil {
+		t.Fatalf("the escalation must park, not error: %v", err)
+	}
+	if res.RequeueAfter != busyRetryAfter {
+		t.Fatalf("want %v parked retry, got %v", busyRetryAfter, res.RequeueAfter)
+	}
+	select {
+	case e := <-rec.Events:
+		if !strings.Contains(e, "TeardownBusy") {
+			t.Fatalf("want a TeardownBusy warning, got %q", e)
+		}
+	default:
+		t.Fatal("want a TeardownBusy warning event")
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal("finalizer must be retained while the device is held open")
+	}
+	if msg := got.Status.PerNode[nodeA].Message; !strings.Contains(msg, "held open") {
+		t.Fatalf("Message must carry the swallowed cause, got %q", msg)
+	}
+
+	// The hold clears: teardown completes, this node's finalizer releases,
+	// and the failure streak resets.
+	fe.errOn = nil
+	if _, err := r.Reconcile(t.Context(), req); err != nil {
+		t.Fatalf("teardown after the hold cleared: %v", err)
+	}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeA) {
+		t.Fatalf("this node's finalizer must release once teardown succeeds: %v", got.Finalizers)
+	}
+	r.busyMu.Lock()
+	streak := len(r.busyFails)
+	r.busyMu.Unlock()
+	if streak != 0 {
+		t.Fatalf("busy streak must clear on success, still %d entries", streak)
 	}
 }
 
@@ -1087,7 +1191,7 @@ func TestReconcileTeardownWedgedParksRetry(t *testing.T) {
 	fe.statusJSON = `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],"connections":[]}]`
 	fe.errOn = map[string]error{
-		"drbdsetup down pvc-1": errors.New("pvc-1: State change failed: Device is held open by someone"),
+		cmdDownPvc1: errors.New("pvc-1: State change failed: Device is held open by someone"),
 	}
 	res, err = r.Reconcile(t.Context(), req)
 	if err != nil || res.RequeueAfter != 10*time.Second {
@@ -1745,7 +1849,7 @@ func TestReconcileRemovedReplicaTearsDown(t *testing.T) {
 	if _, ok := fb.created[volPvc1]; ok {
 		t.Fatal("backing device not deleted")
 	}
-	fe.calledWith(t, "drbdsetup down pvc-1")
+	fe.calledWith(t, cmdDownPvc1)
 	got := &miroirv1alpha1.MiroirVolume{}
 	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
 		t.Fatal(err)

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1105,6 +1105,18 @@ func TestReconcileTeardownBusyEscalates(t *testing.T) {
 		t.Fatalf("Message must carry the swallowed cause, got %q", msg)
 	}
 
+	// The escalation latches: further parked cycles must not re-emit the
+	// Warning Event (the park can outlive the hold by hours).
+	res, err = r.Reconcile(t.Context(), req)
+	if err != nil || res.RequeueAfter != busyRetryAfter {
+		t.Fatalf("post-escalation cycle must stay parked, got %v / %v", res.RequeueAfter, err)
+	}
+	select {
+	case e := <-rec.Events:
+		t.Fatalf("parked cycles must not re-emit events, got %q", e)
+	default:
+	}
+
 	// The hold clears: teardown completes, this node's finalizer releases,
 	// and the failure streak resets.
 	fe.errOn = nil
@@ -1122,6 +1134,43 @@ func TestReconcileTeardownBusyEscalates(t *testing.T) {
 	r.busyMu.Unlock()
 	if streak != 0 {
 		t.Fatalf("busy streak must clear on success, still %d entries", streak)
+	}
+}
+
+// A busy streak is "consecutive attempts of one teardown episode": both a
+// volume back on the normal reconcile path (removal cancelled, replica
+// re-added) and a blocked removal must reset it, or the stale count
+// pre-biases a later teardown toward premature escalation.
+func TestReconcileBusyStreakResetsOutsideTeardown(t *testing.T) {
+	s := newScheme(t)
+
+	// Live volume on the normal path.
+	fb := newFakeBackend()
+	v := vol(volPvc1, nodeA)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		busyFails: map[string]int{volPvc1: busyFailLimit - 1}}
+	reconcile(t, r, volPvc1)
+	if n := r.busyFails[volPvc1]; n != 0 {
+		t.Fatalf("normal reconcile must reset the busy streak, still %d", n)
+	}
+
+	// Pending-removal replica whose teardown is blocked.
+	fb = newFakeBackend()
+	v = vol(volPvc1, nodeB) // leg moved to node-b; node-a keeps its finalizer
+	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeA)
+	c = fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	r = &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		busyFails: map[string]int{volPvc1: busyFailLimit - 1}}
+	res, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+	if err != nil || res.RequeueAfter != 30*time.Second {
+		t.Fatalf("want the 30s removal-blocked requeue, got %v / %v", res.RequeueAfter, err)
+	}
+	if n := r.busyFails[volPvc1]; n != 0 {
+		t.Fatalf("a blocked removal must reset the busy streak, still %d", n)
 	}
 }
 

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -229,6 +229,13 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if vol.Spec.DRBD == nil {
+		// The volume reconciler has not created the backing device yet —
+		// the two reconcilers race at startup, and Sync on the missing
+		// device would error-loop until it exists (issue #195). Mirrors
+		// the replicated path's DiskState gate above.
+		if !vol.Status.PerNode[r.NodeName].DeviceCreated {
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 		// Single replica: no barrier needed, but queued writes must land.
 		be, err := r.backendFor(vol)
 		if err != nil {

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -74,8 +74,12 @@ func reconcileSnap(t *testing.T, r *SnapshotReconciler, name string) ctrl.Result
 func TestSnapshotUnreplicatedReadyImmediately(t *testing.T) {
 	s := newScheme(t)
 	fb := newFakeBackend()
+	v := vol(volPvc1, nodeA)
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true},
+	}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(vol(volPvc1, nodeA), snapObj(snapSnap1, volPvc1, nodeA)).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
 		Build()
 	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
@@ -88,6 +92,35 @@ func TestSnapshotUnreplicatedReadyImmediately(t *testing.T) {
 	}
 	if !got.Status.ReadyToUse {
 		t.Fatalf("unreplicated snapshot must be ready after one pass: %+v", got.Status)
+	}
+}
+
+// A snapshot scheduled before the volume reconciler created the backing
+// device (the two reconcilers race at startup, issue #195) must wait
+// quietly instead of error-looping Sync on the missing device.
+func TestSnapshotUnreplicatedWaitsForBackingDevice(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(vol(volPvc1, nodeA), snapObj(snapSnap1, volPvc1, nodeA)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
+
+	res := reconcileSnap(t, r, snapSnap1)
+
+	if res.RequeueAfter != 5*time.Second {
+		t.Fatalf("want a 5s wait for the backing device, got %v", res.RequeueAfter)
+	}
+	if len(fb.snapCalls) != 0 {
+		t.Fatalf("must not touch the backend before the device exists: %v", fb.snapCalls)
+	}
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.ReadyToUse {
+		t.Fatal("snapshot must not report ready before the device exists")
 	}
 }
 


### PR DESCRIPTION
Follow-ups from the post-#214 deployment report on #195 (see [the review comment](https://github.com/home-operations/miroir/issues/195#issuecomment-4986241275) for the full triage, including which reported claims did not hold up against the code).

## Changes

### Bounded `ErrBusy` teardown with the cause surfaced

The `ErrBusy` teardown retry looped at a flat 10s forever, and the log line swallowed the underlying error - a stuck volume ran silently for 2+ hours in the field with no way to tell whether DRBD or a backend sweep was refusing. Both the deletion and removal paths now go through a shared `reportBusy`:

- The cause is logged on every attempt (`"error", cause`), so the very first retry is diagnosable.
- Past 30 consecutive busy outcomes (~5 minutes at the 10s cadence) the loop escalates: `TeardownBusy` Warning Event, `status.Message` carrying the cause, and a 1m parked cadence.
- The streak resets on success, on a wedge (which has its own #214 reporting), on any hard error, and when the CR vanishes - mirroring the `barrierFails` pattern.
- The finalizer is **never** auto-released on busy: the hold may be a live mount, and force-releasing would leak the backing device or destroy it under a consumer.

### Impossible restores park instead of hot-looping

A volume restoring from a snapshot that was deleted before this leg cloned it can never realize, but the NotFound rode the workqueue's exponential backoff forever. `realizeBacking` now marks that case with an `errRestoreSourceGone` sentinel; the reconcile emits a `RestoreSourceMissing` Warning Event, sets the status Message (the volume reads `Failed` via the existing hard-provisioning-failure rule), and parks at 5m - enough to notice the volume being deleted or the snapshot recreated. Note teardown itself was never blocked by a missing source snapshot: deleting such a volume already works.

### Single-replica snapshot waits for the backing device

The snapshot and volume reconcilers race at startup: the single-replica cut path called `be.Sync` before the volume reconciler had created the backing device, producing a `blockdev --flushbufs ... No such file or directory` error loop until the device appeared. The path now waits on the volume's `DeviceCreated` status with a quiet 5s requeue, mirroring the replicated path's existing `DiskState == ""` gate.

## Testing

- `TestReconcileTeardownBusyEscalates` walks the full escalation: 29 attempts on the 10s cadence, then the Event + Message + 1m park, finalizer retained throughout, and the streak clearing once the hold releases.
- `TestReconcileSourceSnapshotGoneAndDeviceMissingParks` (replaces the fail-loud variant) asserts the park, the Event, the `Failed` phase, and that no empty device is seeded.
- `TestSnapshotUnreplicatedWaitsForBackingDevice` asserts the 5s wait with zero backend calls before the device exists.
- `go test ./...`, `golangci-lint run`, and the envtest integration suite (12/12) all pass.

Refs #195.
