### PR TITLE
fix(csi): recover panics in CSI gRPC handlers

### DIFF
--- a/internal/csi/server.go
+++ b/internal/csi/server.go
@@ -22,10 +22,13 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -56,7 +59,9 @@ func Serve(ctx context.Context, socketPath string, identity csi.IdentityServer, 
 		return fmt.Errorf("listen on %s: %w", socketPath, err)
 	}
 
-	srv := grpc.NewServer(grpc.UnaryInterceptor(logInterceptor))
+	// recover is outermost so it catches a panic from any handler (and from
+	// logInterceptor); grpc-go does not recover handler panics on its own.
+	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(recoverInterceptor, logInterceptor))
 	if identity != nil {
 		csi.RegisterIdentityServer(srv, identity)
 	}
@@ -83,6 +88,25 @@ func Serve(ctx context.Context, socketPath string, identity csi.IdentityServer, 
 	}()
 	log.Info("serving CSI", "socket", socketPath)
 	return srv.Serve(lis)
+}
+
+// recoverInterceptor turns a panic in a CSI handler into a codes.Internal
+// error instead of letting it crash the process. grpc-go does not recover
+// handler panics, and this gRPC server runs outside the controller-runtime
+// manager (whose reconcilers get RecoverPanic by default), so without it a
+// panic in any RPC crashes the whole controller (provisioning), or on the
+// agent the node's CSI socket and every stage/publish there, until the pod
+// restarts. The stack is logged so the crash that would have happened stays
+// diagnosable.
+func recoverInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error(fmt.Errorf("%v", r), "recovered panic in CSI handler",
+				"method", info.FullMethod, "stack", string(debug.Stack()))
+			err = status.Errorf(codes.Internal, "internal error handling %s", info.FullMethod)
+		}
+	}()
+	return handler(ctx, req)
 }
 
 func logInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {

--- a/internal/csi/server_test.go
+++ b/internal/csi/server_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// A panicking handler must surface as codes.Internal, not unwind past the
+// interceptor and crash the process.
+func TestRecoverInterceptorRecoversPanic(t *testing.T) {
+	info := &grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodePublishVolume"}
+	resp, err := recoverInterceptor(context.Background(), nil, info,
+		func(context.Context, any) (any, error) { panic("boom") })
+	if resp != nil {
+		t.Fatalf("expected nil response after panic, got %v", resp)
+	}
+	if got := status.Code(err); got != codes.Internal {
+		t.Fatalf("expected codes.Internal, got %v (err=%v)", got, err)
+	}
+}
+
+// The healthy path is untouched: the handler's response and error pass through.
+func TestRecoverInterceptorPassesThrough(t *testing.T) {
+	info := &grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodeGetInfo"}
+	want := &struct{}{}
+	resp, err := recoverInterceptor(context.Background(), nil, info,
+		func(context.Context, any) (any, error) { return want, nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != want {
+		t.Fatalf("response not passed through: got %v, want %v", resp, want)
+	}
+}


### PR DESCRIPTION
## What

Adds a panic-recovery unary interceptor to the CSI gRPC server, chained ahead of the existing logging interceptor.

## Why

grpc-go does not recover panics in handlers, and this gRPC server runs as a plain `manager.Runnable` outside the controller-runtime manager (whose reconcilers get `RecoverPanic` by default in v0.24.1). So a panic in any CSI handler crashes the whole process:

- controller pod: provisioning drops
- agent DaemonSet: the node's CSI socket goes down, and with it every stage/publish/unpublish on that node, until the pod restarts

The handlers are careful, so this is defense-in-depth, but a storage node's data-plane socket crashing on any unforeseen input is exactly what a recovery interceptor is standard for.

## How

`recoverInterceptor` maps a panic to `codes.Internal` and logs the method plus stack, so the crash that would have happened stays diagnosable. Chained via `grpc.ChainUnaryInterceptor(recoverInterceptor, logInterceptor)` with recover outermost.

## Test plan

- `internal/csi/server_test.go` covers both a panicking handler (surfaces `codes.Internal`, no crash) and the healthy pass-through path.
- `go build ./...`, `go vet ./internal/csi`, `gofmt`, and the full `internal/csi` package suite all pass.

## Context

First fix from a performance/resiliency review. Related follow-ups filed separately: #222 (snapshot barrier exec timeouts), #223 (stale diskless metric on leg conversion).
