### PR TITLE
fix(agent): clear the diskless-primary metric when a leg becomes diskful

### DIFF
--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -125,6 +125,14 @@ func init() {
 }
 
 func recordVolumeMetrics(volume, pool string, st miroirReplicaView) {
+	// This leg is diskful, so clear any diskless-primary series a prior life
+	// of it left behind: auto-diskful and auto-evict convert a diskless
+	// tie-breaker/client leg into a diskful replica in place, without the
+	// removal path (dropVolumeMetrics) that would otherwise clear it. Left
+	// alone the stale series reads its last value until the volume is deleted.
+	// The reverse (diskful to diskless) only happens via removal, which drops
+	// every series, so no symmetric clear is needed. Cheap no-op when absent.
+	metricDisklessPrimary.DeleteLabelValues(volume)
 	metricUpToDate.WithLabelValues(volume, pool).Set(boolGauge(st.upToDate))
 	metricConnected.WithLabelValues(volume, pool).Set(boolGauge(st.connected))
 	metricSplitBrain.WithLabelValues(volume, pool).Set(boolGauge(st.splitBrain))

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -139,3 +139,32 @@ func TestRecordDRBDKernelVersion(t *testing.T) {
 		t.Fatalf("drbd_kernel_info{version=9.3.2} = %v, want 1", got)
 	}
 }
+
+// A leg converted from diskless to diskful in place (auto-diskful /
+// auto-evict, which never pass through the removal path that drops metrics)
+// must not keep exposing its diskless-primary series at a stale value;
+// recording the diskful view clears it.
+func TestDisklessMetricClearedWhenLegBecomesDiskful(t *testing.T) {
+	const volume = "pvc-diskless-to-diskful"
+	const pool = "default"
+
+	// Diskless tie-breaker / client leg: only the diskless-primary series.
+	recordDisklessMetrics(volume, true)
+	if !hasSeries(t, "miroir_volume_diskless_primary", volume) {
+		t.Fatal("diskless_primary series missing after recordDisklessMetrics")
+	}
+
+	// Converted to a diskful replica: it now publishes the diskful view, and
+	// the diskless-primary series must be gone from the scrape.
+	recordVolumeMetrics(volume, pool, miroirReplicaView{
+		upToDate: true, connected: true, quorum: true, resyncRatio: 1,
+	})
+	if hasSeries(t, "miroir_volume_diskless_primary", volume) {
+		t.Fatal("diskless_primary series still exposed after the leg became diskful")
+	}
+	if got := testutil.ToFloat64(metricUpToDate.WithLabelValues(volume, pool)); got != 1 {
+		t.Fatalf("up_to_date = %v, want 1", got)
+	}
+
+	dropVolumeMetrics(volume)
+}


### PR DESCRIPTION
## What

`recordVolumeMetrics` now drops the volume's `miroir_volume_diskless_primary` series before publishing the diskful gauges.

## Why

auto-diskful (`autoDiskfulAfter`) and auto-evict (`convertTieBreaker`) convert a diskless tie-breaker/client leg into a diskful replica **in place** - the replica entry flips `Diskless: true -> false` without going through `reconcileRemoval`, which is the only path that calls `dropVolumeMetrics`. So after such a conversion the agent starts publishing the diskful view, but the old `miroir_volume_diskless_primary{volume}` series lingers at its last value until the volume is deleted.

That series exists to signal "this leg pays network I/O for every read/write; auto-diskful should convert it." A stale `1` after the leg already gained a local disk can keep that signal (and any alert built on it) asserted.

## How

One `metricDisklessPrimary.DeleteLabelValues(volume)` at the top of `recordVolumeMetrics` (cheap no-op when absent). The reverse direction (diskful -> diskless) only happens via removal, which already clears every series, so no symmetric clear is needed.

## Test plan

- `TestDisklessMetricClearedWhenLegBecomesDiskful` records the diskless leg, then the diskful view, and asserts the diskless-primary series is gone from the scrape (via the existing wire-level `hasSeries` helper) while the diskful gauges are set.
- Full `internal/agent` package suite passes; `go vet` and `gofmt` clean.

Closes #223. Second of the follow-ups from the performance/resiliency review (first was #224).
