### PR TITLE
fix(agent): bound the snapshot reconciler's DRBD calls (issue #222)

### DIFF
--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -99,6 +99,15 @@ const (
 	barrierRetryAfter = time.Minute
 )
 
+// drbdBarrierTimeout bounds each DRBD control call the snapshot round makes.
+// This reconciler is single-worker (its round protocol assumes head-of-line
+// ordering), so a call left on RealExec's 2-minute default would, against a
+// wedged resource (LINBIT/drbd#137), stall every other volume's snapshot on
+// the node for that long. The teardown path bounds its own DRBD calls the
+// same way (drbd.downTimeout); these are metadata ops that finish in
+// milliseconds on healthy hardware.
+const drbdBarrierTimeout = 30 * time.Second
+
 // barrierFailed classifies one barrier-path failure: fast backoff below
 // barrierFailLimit, then a Warning Event and the parked retry.
 func (r *SnapshotReconciler) barrierFailed(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
@@ -139,6 +148,28 @@ func (r *SnapshotReconciler) backendFor(vol *miroirv1alpha1.MiroirVolume) (backe
 	return pb.Backend, nil
 }
 
+// drbdStatus, suspendIO, and resumeIO wrap the driver's DRBD control calls
+// with drbdBarrierTimeout so one wedged call cannot pin the single reconcile
+// worker. RealExec applies the tighter of its own bound and the parent
+// deadline, so the effective bound is drbdBarrierTimeout.
+func (r *SnapshotReconciler) drbdStatus(ctx context.Context, name string) (drbd.Status, error) {
+	ctx, cancel := context.WithTimeout(ctx, drbdBarrierTimeout)
+	defer cancel()
+	return r.DRBD.Status(ctx, name)
+}
+
+func (r *SnapshotReconciler) suspendIO(ctx context.Context, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, drbdBarrierTimeout)
+	defer cancel()
+	return r.DRBD.SuspendIO(ctx, name)
+}
+
+func (r *SnapshotReconciler) resumeIO(ctx context.Context, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, drbdBarrierTimeout)
+	defer cancel()
+	return r.DRBD.ResumeIO(ctx, name)
+}
+
 // Reconcile drives one snapshot's state machine from this node's view.
 func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	snap := &miroirv1alpha1.MiroirSnapshot{}
@@ -174,7 +205,7 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// (Status fails → nothing is suspended). Never lift a barrier a
 		// sibling snapshot's live round now owns.
 		if vol.Spec.DRBD != nil {
-			if st, err := r.DRBD.Status(ctx, vol.Name); err == nil && st.Suspended {
+			if st, err := r.drbdStatus(ctx, vol.Name); err == nil && st.Suspended {
 				if err := r.resumeUnlessSiblingRound(ctx, snap, vol); err != nil {
 					return ctrl.Result{}, err
 				}
@@ -209,7 +240,7 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// unless a sibling snapshot's round owns the kernel barrier now.
 		// Best-effort: if DRBD cannot report, nothing holds a barrier.
 		if vol.Spec.DRBD != nil {
-			if st, err := r.DRBD.Status(ctx, vol.Name); err == nil && st.Suspended {
+			if st, err := r.drbdStatus(ctx, vol.Name); err == nil && st.Suspended {
 				return ctrl.Result{}, r.resumeUnlessSiblingRound(ctx, snap, vol)
 			}
 		}
@@ -260,7 +291,7 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume) (ctrl.Result, error) {
-	st, err := r.DRBD.Status(ctx, vol.Name)
+	st, err := r.drbdStatus(ctx, vol.Name)
 	if err != nil {
 		// On a wedged module this call is the one that fails (hanging
 		// until execTimeout kills it), so it must ride the same bounded
@@ -310,7 +341,7 @@ func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miro
 	case snap.Status.IOSuspended && expired && st.Suspended:
 		// Dead round, coordinator gone before voiding it: self-expire
 		// the local barrier; the void patch stays the coordinator's.
-		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.DRBD.ResumeIO(ctx, vol.Name)
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.resumeIO(ctx, vol.Name)
 
 	case !snap.Status.IOSuspended && st.Suspended:
 		// The round ended (voided) while the local barrier was still up —
@@ -330,7 +361,7 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 	if _, err := r.backendFor(vol); err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.DRBD.SuspendIO(ctx, vol.Name); err != nil {
+	if err := r.suspendIO(ctx, vol.Name); err != nil {
 		return r.barrierFailed(ctx, snap, vol, err)
 	}
 	r.clearBarrierFails(snap.Name)
@@ -366,7 +397,7 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 	if err != nil {
 		// The barrier is only real once recorded; a failed patch must
 		// not leave IO frozen until the retry.
-		_ = r.DRBD.ResumeIO(ctx, vol.Name)
+		_ = r.resumeIO(ctx, vol.Name)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: time.Second}, nil
@@ -386,7 +417,7 @@ func (r *SnapshotReconciler) cutLeg(ctx context.Context, snap *miroirv1alpha1.Mi
 	}
 	// Re-assert the local barrier first (idempotent) — a crash or manual
 	// resume-io between phases must not let a leg be cut unprotected.
-	if err := r.DRBD.SuspendIO(ctx, vol.Name); err != nil {
+	if err := r.suspendIO(ctx, vol.Name); err != nil {
 		return r.barrierFailed(ctx, snap, vol, err)
 	}
 	r.clearBarrierFails(snap.Name)
@@ -421,7 +452,7 @@ func (r *SnapshotReconciler) collectLegs(ctx context.Context, snap *miroirv1alph
 	}
 	// Resume before reporting anything else: a frozen volume is an
 	// outage, a late snapshot is just not ready.
-	if err := r.DRBD.ResumeIO(ctx, vol.Name); err != nil {
+	if err := r.resumeIO(ctx, vol.Name); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, r.patchSnap(ctx, snap, func(s *miroirv1alpha1.MiroirSnapshot) {
@@ -483,7 +514,7 @@ func (r *SnapshotReconciler) resumeUnlessSiblingRound(ctx context.Context, snap 
 	if err != nil || active {
 		return err
 	}
-	return r.DRBD.ResumeIO(ctx, vol.Name)
+	return r.resumeIO(ctx, vol.Name)
 }
 
 // isCoordinator: the Primary owns the barrier (suspend-io only blocks

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -950,3 +950,35 @@ func TestSnapshotPeerWaitsForBarrier(t *testing.T) {
 		t.Fatal("peer must wait for the IO barrier")
 	}
 }
+
+// The single-worker reconciler must bound each DRBD control call on the
+// barrier path tighter than RealExec's 2-minute default, so one wedged call
+// cannot stall every other volume's snapshot on the node. The injected exec
+// records the deadline each wrapped call carries.
+func TestSnapshotBarrierCallsAreBounded(t *testing.T) {
+	var deadlines []time.Duration
+	capture := func(ctx context.Context, _ string, _ ...string) (string, error) {
+		dl, ok := ctx.Deadline()
+		if !ok {
+			t.Error("snapshot DRBD call reached exec with no deadline")
+			return "[]", nil
+		}
+		deadlines = append(deadlines, time.Until(dl))
+		return "[]", nil
+	}
+	r := &SnapshotReconciler{DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: capture}}
+
+	ctx := context.Background()
+	_, _ = r.drbdStatus(ctx, volPvc1)
+	_ = r.suspendIO(ctx, volPvc1)
+	_ = r.resumeIO(ctx, volPvc1)
+
+	if len(deadlines) != 3 {
+		t.Fatalf("expected 3 bounded DRBD calls, got %d", len(deadlines))
+	}
+	for _, d := range deadlines {
+		if d <= 0 || d > drbdBarrierTimeout+time.Second {
+			t.Fatalf("call deadline %s is not bounded by drbdBarrierTimeout (%s)", d, drbdBarrierTimeout)
+		}
+	}
+}


### PR DESCRIPTION
## What

Wraps the snapshot reconciler's DRBD control calls (`Status`, `SuspendIO`, `ResumeIO`) with a 30s `drbdBarrierTimeout`, via three small helper methods that every barrier-path call now routes through.

## Why

The snapshot reconciler is intentionally **single-worker** (its round protocol assumes head-of-line ordering). But its DRBD calls went through `d.adm` / `d.Exec` and inherited `RealExec`'s 2-minute `execTimeout`. The teardown path already tightened its own DRBD calls to 30s/10s (`drbd.downTimeout` / `disconnectTimeout`) precisely so a wedged resource cannot pin one of the volume workers; the snapshot path had no equivalent bound.

So on a resource hitting the drbd#137 wedge class (#195), one call blocking for ~2 minutes stalls **every other volume's snapshot on that node** for that long, and `barrierFailLimit` bounds the number of failures but not the per-call duration.

## How

`drbdStatus` / `suspendIO` / `resumeIO` each derive a `context.WithTimeout(ctx, drbdBarrierTimeout)` and call the driver. `RealExec` already applies `context.WithTimeout(ctx, execTimeout)` internally, which takes the tighter of the two deadlines, so the effective bound becomes 30s. All nine barrier-path call sites in `snapshot.go` now go through the wrappers. No behavior change on healthy hardware (these are metadata ops that finish in milliseconds).

Scope is the snapshot reconciler only; the 4-worker volume reconciler and the startup barrier sweep are out of scope for this issue.

## Test plan

- `TestSnapshotBarrierCallsAreBounded` injects a deadline-capturing exec and asserts each of the three wrapped calls carries a deadline no looser than `drbdBarrierTimeout` (without the wrappers the calls would reach the exec with no deadline).
- Full `internal/agent` suite passes (including the existing barrier/round tests); `go vet` and `gofmt` clean.

Closes #222. Third of the follow-ups from the performance/resiliency review (#224, #225 are the others).
