### PR TITLE
reliability: wait for new zvol device nodes and bound placement by physical free space

### DIFF
--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -89,6 +89,7 @@ Kubernetes: `>=1.31.0`
 | drbd.verify.suspend | bool | `false` | Pause scheduled verify without dropping the schedule above. |
 | extraArgs | list | `[]` | Extra arguments for the controller container. |
 | extraEnv | list | `[]` | Extra environment variables for the controller container. |
+| freeSpaceRatio | int | `20` | Physical-space guardrail: CreateVolume is refused when the request would exceed the pool's *free* bytes × this ratio. overcommitRatio alone bounds virtual bytes, so a pool whose thin volumes have actually filled it can still admit more; running a pool out of space surfaces as I/O errors under live volumes rather than a clean refusal. 20× matches LINSTOR and BlockStor and only bites once a pool is ~90% full; lower it toward 1 to keep more physical headroom in reserve. |
 | fullnameOverride | string | `""` | Override the fully qualified name prefix of every rendered object. |
 | gateway.enabled | bool | `false` | Serve ReadWriteMany (and ReadOnlyMany) PVCs via per-volume NFS gateways. Opt-in: gateway pods run privileged in the release namespace, and any user who can create a PVC can cause one to be spawned, so enabling RWX is an explicit operator decision. While disabled the controller rejects RWX at provision time with a clear message, and the gateway ServiceAccount, RBAC, PodMonitor, and export alerts are not installed. |
 | gateway.image.digest | string | `""` |  |

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -60,6 +60,7 @@ spec:
             - --nodes-config=/etc/miroir/nodes.yaml
             - --provision-timeout={{ .Values.provisionTimeout }}
             - --overcommit-ratio={{ .Values.overcommitRatio }}
+            - --free-space-ratio={{ .Values.freeSpaceRatio }}
             - --auto-tie-breaker={{ .Values.autoTieBreaker }}
             {{- with .Values.autoDiskfulAfter }}
             - --auto-diskful-after={{ . }}

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -281,6 +281,12 @@
       "title": "extraEnv",
       "type": "array"
     },
+    "freeSpaceRatio": {
+      "default": 20,
+      "description": "Physical-space guardrail: CreateVolume is refused when the request would\nexceed the pool's *free* bytes × this ratio. overcommitRatio alone bounds\nvirtual bytes, so a pool whose thin volumes have actually filled it can\nstill admit more; running a pool out of space surfaces as I/O errors under\nlive volumes rather than a clean refusal. 20× matches LINSTOR and BlockStor\nand only bites once a pool is ~90% full; lower it toward 1 to keep more\nphysical headroom in reserve.",
+      "title": "freeSpaceRatio",
+      "type": "integer"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Override the fully qualified name prefix of every rendered object.",

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -53,6 +53,14 @@ provisionTimeout: 120s
 # classic CoW headroom; raise it only if you trust your usage to stay
 # sparse, lower it toward 1 to provision conservatively.
 overcommitRatio: 2
+# -- Physical-space guardrail: CreateVolume is refused when the request would
+# exceed the pool's *free* bytes × this ratio. overcommitRatio alone bounds
+# virtual bytes, so a pool whose thin volumes have actually filled it can
+# still admit more; running a pool out of space surfaces as I/O errors under
+# live volumes rather than a clean refusal. 20× matches LINSTOR and BlockStor
+# and only bites once a pool is ~90% full; lower it toward 1 to keep more
+# physical headroom in reserve.
+freeSpaceRatio: 20
 # -- Add a diskless tie-breaker replica to 2-replica freeze volumes when a
 # spare storage node exists, so majority quorum survives a single node
 # loss. Also retrofits existing freeze volumes at controller startup.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -336,6 +336,7 @@ func main() {
 		nodesConfig      string
 		provisionTimeout time.Duration
 		overcommitRatio  float64
+		freeSpaceRatio   float64
 		autoTieBreaker   bool
 		autoDiskfulAfter time.Duration
 		autoEvictAfter   time.Duration
@@ -370,6 +371,8 @@ func main() {
 		"wait for agents to realise a new volume (controller; 0 → default)")
 	flag.Float64Var(&overcommitRatio, "overcommit-ratio", 0,
 		"max provisioned-over-capacity per pool before CreateVolume is refused (controller; 0 → default 2.0)")
+	flag.Float64Var(&freeSpaceRatio, "free-space-ratio", 0,
+		"max provisioned-over-physically-free per pool before CreateVolume is refused (controller; 0 → default 20.0)")
 	flag.DurationVar(&autoDiskfulAfter, "auto-diskful-after", 0,
 		"convert a diskless client leg into a diskful replica once it has been attached this long "+
 			"(controller; 0 disables; needs a storage node with capacity — see LINSTOR auto-diskful)")
@@ -499,6 +502,7 @@ func main() {
 			Nodes:            nodes,
 			ProvisionTimeout: provisionTimeout,
 			OvercommitRatio:  overcommitRatio,
+			FreeSpaceRatio:   freeSpaceRatio,
 			AutoTieBreaker:   autoTieBreaker,
 			RWXEnabled:       gatewayImage != "",
 			DRBDPortBase:     int32(drbdPortBase),

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeExec records invocations and replays scripted responses keyed by a
@@ -195,6 +196,67 @@ func TestZFSCreateInheritsCompression(t *testing.T) {
 	}
 	fe.calledWith(t, "zfs create -s -b 4096 -V 10737418240 tank/miroir/pvc-1")
 	fe.notCalledWith(t, "compression=")
+}
+
+// zfs create returns before udev has published /dev/zvol/…; Create must
+// not hand back a path that cannot be opened yet.
+func TestZFSCreateWaitsForDeviceNode(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("zfs list -H tank/miroir/pvc-1", "", errors.New("dataset does not exist"))
+	probes := 0
+	exec := func(ctx context.Context, name string, args ...string) (string, error) {
+		if name == "blockdev" {
+			probes++
+			if probes < 3 {
+				return "", errors.New("No such file or directory")
+			}
+			return "10737418240", nil
+		}
+		return fe.run(ctx, name, args...)
+	}
+	b := newZFS(cfg, exec)
+	b.readyTimeout = time.Second
+
+	dev, err := b.Create(t.Context(), "pvc-1", 10<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dev != "/dev/zvol/tank/miroir/pvc-1" {
+		t.Fatalf("unexpected device path %q", dev)
+	}
+	if probes != 3 {
+		t.Fatalf("expected Create to poll until the device opened, got %d probes", probes)
+	}
+}
+
+func TestZFSCreateSurfacesUnreadyDevice(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("zfs list -H tank/miroir/pvc-1", "", errors.New("dataset does not exist"))
+	fe.respond("blockdev --getsize64", "", errors.New("No such file or directory"))
+	b := newZFS(cfg, fe.run)
+	b.readyTimeout = 10 * time.Millisecond
+
+	_, err := b.Create(t.Context(), "pvc-1", 10<<30)
+	if err == nil {
+		t.Fatal("expected an error when the device node never appears")
+	}
+	if !strings.Contains(err.Error(), "not usable") {
+		t.Fatalf("error should name the unready device, got %v", err)
+	}
+}
+
+func TestZFSCreateFromSnapshotWaitsForDeviceNode(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("zfs list -H tank/miroir/pvc-2", "", errors.New("dataset does not exist"))
+	fe.respond("blockdev --getsize64", "", errors.New("No such file or directory"))
+	b := newZFS(cfg, fe.run)
+	b.readyTimeout = 10 * time.Millisecond
+
+	_, err := b.CreateFromSnapshot(t.Context(), "pvc-2", "pvc-1", "snap-1")
+	if err == nil {
+		t.Fatal("expected an error when the clone's device node never appears")
+	}
+	fe.calledWith(t, "zfs clone tank/miroir/pvc-1@snap-1 tank/miroir/pvc-2")
 }
 
 func TestZFSSnapshotIdempotent(t *testing.T) {

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // zfsBackend provisions sparse zvols under a dedicated dataset (paris's
@@ -30,6 +31,8 @@ type zfsBackend struct {
 	volBlockSize int64
 	compression  string
 	exec         Exec
+	// readyTimeout bounds awaitDevice; a field so tests need not wait it out.
+	readyTimeout time.Duration
 }
 
 func newZFS(cfg Config, e Exec) *zfsBackend {
@@ -46,6 +49,7 @@ func newZFS(cfg Config, e Exec) *zfsBackend {
 		volBlockSize: blockSize,
 		compression:  compression,
 		exec:         e,
+		readyTimeout: zvolReadyTimeout,
 	}
 }
 
@@ -94,7 +98,38 @@ func (z *zfsBackend) Exists(ctx context.Context, vol string) (bool, error) {
 const (
 	defaultZFSVolBlockSize int64 = 4 << 10
 	defaultZFSCompression        = "lz4"
+	// zvolReadyTimeout bounds the wait for a fresh zvol's device node.
+	// zfs create returns once the volume exists in the pool, but
+	// /dev/zvol/… is a udev-managed symlink that lands asynchronously —
+	// the reason OpenZFS ships zvol_wait. udev normally settles in
+	// milliseconds; the budget covers a node whose queue is backed up.
+	zvolReadyTimeout  = 30 * time.Second
+	zvolReadyInterval = 100 * time.Millisecond
 )
+
+// awaitDevice returns vol's device path once the node can be opened.
+// blockdev is the probe rather than a stat: the /dev/zvol symlink appears
+// before its target is guaranteed openable, and every consumer of this
+// path (drbdadm create-md, mkfs) opens the device.
+func (z *zfsBackend) awaitDevice(ctx context.Context, vol string) (string, error) {
+	dev := z.DevicePath(vol)
+	deadline := time.Now().Add(z.readyTimeout)
+	for {
+		_, err := z.exec(ctx, "blockdev", "--getsize64", dev)
+		if err == nil {
+			return dev, nil
+		}
+		if !time.Now().Before(deadline) {
+			return "", fmt.Errorf("zvol %s: %s not usable after %s (udev may be stuck): %w",
+				vol, dev, z.readyTimeout, err)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(zvolReadyInterval):
+		}
+	}
+}
 
 // alignSize rounds sizeBytes up to blockSize. PVC sizes are not necessarily
 // block-size multiples (1G = 10^9), and the other backends already realize
@@ -123,7 +158,9 @@ func (z *zfsBackend) Create(ctx context.Context, vol string, sizeBytes int64) (s
 			return "", fmt.Errorf("zfs create %s: %w", vol, err)
 		}
 	}
-	return z.DevicePath(vol), nil
+	// Also on the already-exists path: a node that just imported the pool
+	// has the zvol without its device node yet.
+	return z.awaitDevice(ctx, vol)
 }
 
 func (z *zfsBackend) Resize(ctx context.Context, vol string, sizeBytes int64) error {
@@ -179,7 +216,7 @@ func (z *zfsBackend) CreateFromSnapshot(ctx context.Context, vol, sourceVol, sna
 			return "", err
 		}
 	}
-	return z.DevicePath(vol), nil
+	return z.awaitDevice(ctx, vol)
 }
 
 func (z *zfsBackend) Delete(ctx context.Context, vol string) error {

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -64,6 +64,10 @@ type Controller struct {
 	// refused when a node's provisioned total would exceed
 	// capacity×ratio. Zero → defaultOvercommitRatio.
 	OvercommitRatio float64
+	// FreeSpaceRatio bounds provisioning against a pool's *physical* room:
+	// CreateVolume is refused when the request would exceed
+	// free×ratio. Zero → defaultFreeSpaceRatio. See poolHeadroom.
+	FreeSpaceRatio float64
 	// AutoTieBreaker adds a diskless tie-breaker replica to new 2-replica
 	// freeze volumes when a spare storage node exists (#70).
 	AutoTieBreaker bool
@@ -91,6 +95,14 @@ const (
 	// defaultOvercommitRatio caps provisioned-over-capacity per pool;
 	// 2× is the documented default.
 	defaultOvercommitRatio = 2.0
+	// defaultFreeSpaceRatio caps provisioned-over-physically-free per
+	// pool, matching LINSTOR's and BlockStor's 20× thin default. It only
+	// binds once a pool is ~90% physically full — below that the 2×
+	// virtual bound above is always the tighter of the two. The two are
+	// complements: the virtual bound governs a pool filling with
+	// provisioned-but-empty volumes, this one a pool whose volumes have
+	// actually filled it.
+	defaultFreeSpaceRatio = 20.0
 	// defaultDRBDPortBase is the lowest DRBD replication port when
 	// DRBDPortBase is unset (zero). Ceph mgr dashboard's non-SSL default
 	// is also 7000; operators co-locating with Rook host-network Ceph can
@@ -388,19 +400,15 @@ func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, c
 		return nil, err
 	}
 	provisioned := provisionedPerPool(vols, name)
-	ratio := c.OvercommitRatio
-	if ratio <= 0 {
-		ratio = defaultOvercommitRatio
-	}
-	// overcommitted reports whether placing sizeBytes in the pool on node
-	// would push its provisioned total past capacity×ratio, using fresh
-	// stats only.
+	// overcommitted reports whether the pool on node lacks the headroom for
+	// sizeBytes, using fresh stats only — a node that has published none is
+	// admitted (GetCapacity is the one that steers the scheduler away).
 	overcommitted := func(node string) bool {
-		st := stats[node].Pool(pool)
-		if st == nil || st.CapacityBytes <= 0 {
+		room, known := c.poolHeadroom(stats[node].Pool(pool), provisioned[nodePool{node, pool}])
+		if !known {
 			return false
 		}
-		return float64(provisioned[nodePool{node, pool}]+sizeBytes) > float64(st.CapacityBytes)*ratio
+		return sizeBytes > room
 	}
 	// freeBytes is the pool headroom used to rank candidates; 0 (sorts
 	// last) when stats are unknown.
@@ -451,16 +459,21 @@ func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, c
 	})
 	pinned := len(ordered) // topology-selected nodes, honored unconditionally
 	ordered = append(ordered, rest...)
+	overcommit, freeSpace := c.ratios()
 	if len(ordered) < count {
 		return nil, status.Errorf(codes.ResourceExhausted,
-			"only %d of the %d nodes carrying pool %q can host a %d-byte volume within the %gx overcommit ratio",
-			len(ordered), len(candidates), pool, sizeBytes, ratio)
+			"only %d of the %d nodes carrying pool %q can host a %d-byte volume within its capacity guardrails "+
+				"(capacity×%g overcommit, free×%g free-space)",
+			len(ordered), len(candidates), pool, sizeBytes, overcommit, freeSpace)
 	}
 	ordered = spreadByZone(ordered, pinned, count, func(n string) string { return c.Nodes[n].Zone })
 	for _, n := range ordered {
 		if overcommitted(n) {
+			room, _ := c.poolHeadroom(stats[n].Pool(pool), provisioned[nodePool{n, pool}])
 			return nil, status.Errorf(codes.ResourceExhausted,
-				"pool %q on node %s would exceed the %gx overcommit ratio for a %d-byte volume", pool, n, ratio, sizeBytes)
+				"pool %q on node %s has room for %d of the requested %d bytes "+
+					"(capacity×%g overcommit, free×%g free-space)",
+				pool, n, room, sizeBytes, overcommit, freeSpace)
 		}
 	}
 
@@ -574,6 +587,40 @@ func (c *Controller) poolStats(ctx context.Context) (map[string]miroirv1alpha1.M
 		out[n.Name] = n.Status
 	}
 	return out, nil
+}
+
+// poolHeadroom reports the largest volume a pool can still admit: its
+// virtual overcommit allowance (capacity×OvercommitRatio − provisioned)
+// bounded by its physical room (free×FreeSpaceRatio). Thin legs consume
+// the pool only as they fill, so the virtual bound alone keeps admitting
+// onto a pool with no physical space left — and ENOSPC under a live
+// volume surfaces as DRBD I/O errors and a detached leg rather than a
+// clean refusal at provision time.
+//
+// known is false when the node published no fresh stats; the two callers
+// deliberately disagree on what that means, so neither gets a default
+// here (place() admits anyway, GetCapacity reports zero).
+func (c *Controller) poolHeadroom(st *miroirv1alpha1.MiroirNodePoolStatus, provisioned int64) (room int64, known bool) {
+	if st == nil || st.CapacityBytes <= 0 {
+		return 0, false
+	}
+	overcommit, freeSpace := c.ratios()
+	virtual := int64(float64(st.CapacityBytes)*overcommit) - provisioned
+	physical := int64(float64(max(0, st.CapacityBytes-st.AllocatedBytes)) * freeSpace)
+	return max(0, min(virtual, physical)), true
+}
+
+// ratios reports the effective admission ratios with defaults applied, so
+// a refusal can name the knobs an operator would turn.
+func (c *Controller) ratios() (overcommit, freeSpace float64) {
+	overcommit, freeSpace = c.OvercommitRatio, c.FreeSpaceRatio
+	if overcommit <= 0 {
+		overcommit = defaultOvercommitRatio
+	}
+	if freeSpace <= 0 {
+		freeSpace = defaultFreeSpaceRatio
+	}
+	return overcommit, freeSpace
 }
 
 // nodePool keys per-pool bookkeeping: one pool on one node. Replica pool
@@ -892,8 +939,8 @@ func (c *Controller) ControllerGetVolume(ctx context.Context, req *csi.Controlle
 // kube-scheduler (via the external-provisioner's CSIStorageCapacity objects)
 // steers a WaitForFirstConsumer pod onto a node whose pool can hold the volume,
 // instead of landing there and having CreateVolume refuse it. The number is the
-// same overcommit headroom place() guards on — capacity×ratio − provisioned —
-// so the scheduler filters a node exactly when placement would reject it.
+// same headroom place() guards on — both go through poolHeadroom — so the
+// scheduler filters a node exactly when placement would reject it.
 //
 // The provisioner calls this once per (StorageClass, topology segment) with
 // the class's parameters, and the agent registers the driver on every node —
@@ -928,19 +975,14 @@ func (c *Controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 		return nil, status.Errorf(codes.Internal, "list MiroirVolumes: %v", err)
 	}
 	provisioned := provisionedPerPool(list.Items, "")
-	ratio := c.OvercommitRatio
-	if ratio <= 0 {
-		ratio = defaultOvercommitRatio
-	}
 	available := func(node string) int64 {
 		if _, ok := c.Nodes.Pool(node, pool); !ok {
 			return 0 // the class's pool is not on this node
 		}
-		st := stats[node].Pool(pool)
-		if st == nil || st.CapacityBytes <= 0 {
-			return 0 // no fresh stats yet; excluded until the agent publishes
-		}
-		return max(0, int64(float64(st.CapacityBytes)*ratio)-provisioned[nodePool{node, pool}])
+		// Unknown stats fall out as zero — excluded until the agent
+		// publishes, where place() would still admit.
+		room, _ := c.poolHeadroom(stats[node].Pool(pool), provisioned[nodePool{node, pool}])
+		return room
 	}
 
 	// capacityFor is the largest volume the class can still place: each of

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -169,6 +169,46 @@ func TestPlaceHonoursConfiguredRatio(t *testing.T) {
 	}
 }
 
+// The gap the free-space bound closes: nothing is provisioned here, so the
+// 2× virtual allowance (200 GiB) would happily admit onto a pool with 1 GiB
+// of physical room left. Filling a thin pool surfaces as I/O errors under
+// live volumes, so the refusal belongs at provision time.
+func TestPlaceRefusesPhysicallyFullPool(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{
+		Client: placementClient(s,
+			miroirNodeObj(nodeA, 100*gib, 99*gib),
+			miroirNodeObj(nodeB, 100*gib, 99*gib),
+		),
+		Nodes: testNodes,
+	}
+
+	// Default 20× free-space ratio: 1 GiB free admits at most 20 GiB.
+	_, err := c.place(t.Context(), nil, 1, 25*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("a physically full pool must be ResourceExhausted, got %v", err)
+	}
+}
+
+func TestPlaceHonoursConfiguredFreeSpaceRatio(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{
+		Client: placementClient(s,
+			miroirNodeObj(nodeA, 100*gib, 90*gib),
+			miroirNodeObj(nodeB, 100*gib, 90*gib),
+		),
+		Nodes:          testNodes,
+		FreeSpaceRatio: 1, // no overcommit against the 10 GiB still free
+	}
+
+	// The default 20× would admit this out of the same 10 GiB of free space,
+	// as would the untouched 2× virtual bound.
+	_, err := c.place(t.Context(), nil, 1, 50*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("1x free-space ratio must refuse a volume past the physical headroom, got %v", err)
+	}
+}
+
 func TestSpreadByZone(t *testing.T) {
 	zoneOf := func(m map[string]string) func(string) string {
 		return func(n string) string { return m[n] }
@@ -505,6 +545,49 @@ func TestGetCapacityOvercommittedIsZero(t *testing.T) {
 	}
 	if resp.GetAvailableCapacity() != 0 {
 		t.Fatalf("overcommitted node must report 0, got %d", resp.GetAvailableCapacity())
+	}
+}
+
+// GetCapacity must bound by physical room too, or the scheduler would keep
+// steering pods onto a node whose pool CreateVolume then refuses.
+func TestGetCapacityBoundedByFreeSpace(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{
+		Client: placementClient(s, miroirNodeObj(nodeA, 100*gib, 99*gib)),
+		Nodes:  testNodes,
+	}
+	resp, err := c.GetCapacity(t.Context(), topologySegment(nodeA))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1 GiB free × 20 = 20 GiB, well under the 200 GiB virtual allowance.
+	if resp.GetAvailableCapacity() != 20*gib {
+		t.Fatalf("capacity = %d, want the physical bound %d", resp.GetAvailableCapacity(), 20*gib)
+	}
+}
+
+// Acceptance criterion (#228): placement and GetCapacity must enforce the
+// same headroom, so the scheduler filters a node exactly when place() would
+// reject it. The reported figure is the largest volume place() still admits.
+func TestGetCapacityAgreesWithPlacement(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{
+		Client: placementClient(s, miroirNodeObj(nodeA, 100*gib, 95*gib)),
+		Nodes:  testNodes,
+	}
+	resp, err := c.GetCapacity(t.Context(), topologySegment(nodeA))
+	if err != nil {
+		t.Fatal(err)
+	}
+	room := resp.GetAvailableCapacity()
+
+	vols := placementVols(t, c.Client)
+	if _, err := c.place(t.Context(), topologyPref(nodeA), 1, room, volNew, vols, false, poolDefault); err != nil {
+		t.Fatalf("place must admit exactly the reported capacity (%d): %v", room, err)
+	}
+	_, err = c.place(t.Context(), topologyPref(nodeA), 1, room+1, volNew, vols, false, poolDefault)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("place must refuse one byte over the reported capacity, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Implements findings 1 and 2 of #228.

## 1. Wait for a newly created zvol to become usable

`zfs create` returns once the volume exists in the pool, but `/dev/zvol/…` is a udev-managed symlink that lands asynchronously — the reason OpenZFS ships `zvol_wait`. `Create` and `CreateFromSnapshot` returned the path immediately, so the agent could record `DeviceCreated` and hand `drbdadm create-md` or `mkfs` a device that is not there yet. Both paths recovered on the reconcile retry, so this was noise and delay rather than corruption, but the failure was confusing and the status field briefly lied.

Both paths now poll `blockdev --getsize64` until the device opens, bounded at 30s, wrapping the underlying error into the timeout message. `blockdev` rather than a `stat`: the symlink can appear before its target is openable, and every consumer of the path opens the device. The wait also covers `Create`'s already-exists branch, where a node that just imported the pool has the zvol without its device node.

Deviation from the issue: no `udevadm settle`. It defaults to a 120s timeout, which would blow through the 30s budget and break the bounded guarantee the acceptance criteria ask for. The poll is the real gate and would only save ~100ms on a path that already takes seconds.

## 2. Physical-free-space admission limit

Placement bounded provisioned *virtual* bytes at `capacity × overcommitRatio` and used actual allocation only to rank candidates, so a pool whose thin volumes had physically filled it still admitted new ones. `GetCapacity` reported the same virtual-only headroom. Running a pool out of space surfaces as I/O errors under live volumes rather than a clean refusal at provision time.

Both are now additionally bounded by the pool's physical room, following LINSTOR and BlockStor:

```
min(capacity × overcommitRatio − provisioned,  free × freeSpaceRatio)
```

`place()` and `GetCapacity` go through one `poolHeadroom` helper so they cannot drift, with a test asserting `GetCapacity`'s answer is exactly the largest volume `place()` admits and one byte more is refused. The helper returns a `known` flag rather than defaulting, because the two callers deliberately disagree about missing stats (`place()` admits, `GetCapacity` reports zero). The refusal messages now report actual headroom instead of naming only the overcommit ratio, which was misleading once either bound could be the binding one.

`freeSpaceRatio` defaults to **20×**, matching both upstreams. It only binds once a pool is ~90% physically full — below that the 2× virtual bound is always the tighter of the two — so **existing clusters keep provisioning exactly as before**. The 2× total overcommit default is unchanged.

## Not included

- **Finding 3 (quorum semantics)** — the deliverable is e2e coverage of partition/healing/failover, which needs a real cluster. One correction for the issue though: the hazard I expected, that `suspend-io` would let `resumeStaleBarriers` resume a quorum-suspended device and defeat the protection, **is not present** — `UserSuspended` keys on DRBD's `suspended-user` field specifically, so the snapshot barrier and a quorum suspend are already distinguishable. That makes the switch more feasible than the issue implies, but it still needs the tests first.
- **Finding 4 (4K vs 16K benchmark)** — needs hardware, and belongs to #227.

## Testing

`go test ./...` (incl. envtest integration), `go vet`, `golangci-lint` (0 issues), `helm lint`, and 114 chart unit tests all pass.

New coverage: zvol poll-until-ready, timeout with an actionable error, the clone path, refusal on a physically full pool, the configured ratio being honored, `GetCapacity` bounded by free space, and place/GetCapacity agreement.

Verification note: the probe's failure mode was confirmed against the real `blockdev` (absent zvol path exits 1, which is what the loop polls on). The success path against real ZFS is covered only at the logic level by unit tests and wants a cluster.
