### PR TITLE
chart: roll workloads on node-map edits and move zfs pool validation into the schema

### DIFF
--- a/charts/miroir/templates/agent.tpl
+++ b/charts/miroir/templates/agent.tpl
@@ -35,10 +35,16 @@ spec:
         {{- with .Values.agent.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.agent.podAnnotations }}
       annotations:
+        {{- /* nodemap.Load reads nodes.yaml once at startup, so a topology
+        edit would otherwise sit unread until something unrelated restarted
+        the pod — kubelet syncs the mounted ConfigMap in place. Only the
+        nodes map is hashed: global_common.conf is read by drbdadm on every
+        invocation, so it needs no restart. */}}
+        checksum/nodes: {{ .Values.nodes | toYaml | sha256sum }}
+        {{- with .Values.agent.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "miroir.agentName" . }}
       hostNetwork: true

--- a/charts/miroir/templates/configmap.tpl
+++ b/charts/miroir/templates/configmap.tpl
@@ -8,18 +8,6 @@
 {{- if not $node.pools }}
 {{- fail (printf "nodes.%s declares no pools; declare at least pools.default (see values.yaml)" $name) }}
 {{- end }}
-{{- range $poolName, $pool := $node.pools }}
-{{- if eq (toString $pool.backend) "zfs" }}
-{{- $blockSize := upper (toString (default "4K" (dig "zfsVolBlockSize" "" $pool))) }}
-{{- if not (has $blockSize (list "4K" "8K" "16K" "32K" "64K" "128K")) }}
-{{- fail (printf "nodes.%s.pools.%s.zfsVolBlockSize must be one of 4K, 8K, 16K, 32K, 64K, or 128K" $name $poolName) }}
-{{- end }}
-{{- $compression := lower (toString (default "lz4" (dig "zfsCompression" "" $pool))) }}
-{{- if and (ne $compression "inherit") (not (regexMatch "^(on|off|lz4|lzjb|zle|gzip(-[1-9])?|zstd(-([1-9]|1[0-9]))?|zstd-fast(-(10|[1-9]|[2-9]0|100|500|1000))?)$" $compression)) }}
-{{- fail (printf "nodes.%s.pools.%s.zfsCompression is not a supported OpenZFS compression value" $name $poolName) }}
-{{- end }}
-{{- end }}
-{{- end }}
 {{- end }}
 {{- if hasKey .Values.drbd "verifyAlg" }}
 {{- fail "drbd.verifyAlg was renamed to drbd.verify.algorithm" }}

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -26,10 +26,14 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- /* The controller loads the node map once at startup and places
+        replicas from it; without this a topology edit sits unread until the
+        pod happens to restart. */}}
+        checksum/nodes: {{ .Values.nodes | toYaml | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "miroir.controllerName" . }}
       {{- include "miroir.imagePullSecrets" . | nindent 6 }}

--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -328,6 +328,20 @@ tests:
           path: spec.template.metadata.annotations["reloader.stakater.com/auto"]
           value: "true"
 
+  - it: stamps a node-map checksum so a topology edit rolls the agent
+    set:
+      nodes:
+        node-a:
+          pools:
+            default:
+              backend: lvmthin
+              device: /dev/disk/by-partlabel/r-miroir
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/nodes"]
+          pattern: "^[0-9a-f]{64}$"
+
   - it: omits --verify-schedule by default
     set:
       nodes:

--- a/charts/miroir/tests/configmap_test.yaml
+++ b/charts/miroir/tests/configmap_test.yaml
@@ -42,7 +42,7 @@ tests:
               zfsVolBlockSize: 12K
     asserts:
       - failedTemplate:
-          errorMessagePattern: "zfsVolBlockSize must be one of"
+          errorMessagePattern: "zfsVolBlockSize.*value must be one of"
 
   - it: rejects an invalid ZFS compression value
     set:
@@ -55,7 +55,7 @@ tests:
               zfsCompression: snappy
     asserts:
       - failedTemplate:
-          errorMessagePattern: "zfsCompression is not a supported OpenZFS compression value"
+          errorMessagePattern: "zfsCompression.*does not match pattern"
 
   - it: takes the ZFS defaults when the settings are present but empty
     set:

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -422,6 +422,13 @@ tests:
           path: spec.template.metadata.annotations["reloader.stakater.com/auto"]
           value: "true"
 
+  - it: stamps a node-map checksum so a topology edit rolls the controller
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/nodes"]
+          pattern: "^[0-9a-f]{64}$"
+
   - it: leaves the provisioner without capacity flags by default
     documentIndex: 0
     asserts:

--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -639,6 +639,42 @@
       "type": "string"
     },
     "nodes": {
+      "additionalProperties": {
+        "properties": {
+          "pools": {
+            "additionalProperties": {
+              "properties": {
+                "zfsCompression": {
+                  "pattern": "^(inherit|on|off|lz4|lzjb|zle|gzip(-[1-9])?|zstd(-([1-9]|1[0-9]))?|zstd-fast(-(10|[1-9]|[2-9]0|100|500|1000))?)?$",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "zfsVolBlockSize": {
+                  "enum": [
+                    "4K",
+                    "8K",
+                    "16K",
+                    "32K",
+                    "64K",
+                    "128K",
+                    "",
+                    null
+                  ],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
       "description": "=============================================================================\nStorage topology\n=============================================================================\nPer-node storage topology — the single source of truth for which nodes\nhold volumes and how. Rendered into the miroir-nodes ConfigMap, read by\nthe controller (placement) and each agent (backend selection).\nEach node declares named storage `pools` (StorageClasses select one via\ntheir `pool` knob; classes that name none use the pool called \"default\").\nA pool name identifies the same tier across nodes — a 2-replica volume in\npool `fast` needs a `fast` pool on 2 nodes. Per pool: `backend` (lvmthin /\nzfs / loopfile) plus its location (`device`, `zfsDataset`, or `baseDir`)\nand optional `thinPoolSize`.\nZFS pools optionally set `zfsVolBlockSize` (4K, 8K, 16K, 32K, 64K,\nor 128K; default 4K) and `zfsCompression` (default lz4; `inherit` uses\nthe parent dataset). Both apply only to newly created zvols. Existing\nvolumes are unchanged, and snapshot clones retain their source properties.\nOptional per-node `zone` (rack, host group, AZ): when set, the controller\nspreads a volume's replicas across distinct zones; empty is unconstrained.\nOptional per-node `address` (IPv4 or IPv6) pins DRBD replication to a\ndedicated storage NIC/VLAN; empty uses the node's InternalIP. It applies\nto volumes created afterwards — existing volumes keep the address\npersisted at creation.\nOptional per-node `autoEvict: false` exempts the node from auto-evict\n(see `autoEvictAfter`): its legs are never re-placed while it is down —\nfor a node with known long outages.\nnodes:\n  kharkiv:\n    # zone: rack-1         # spread replicas across failure domains\n    # address: 10.0.100.11 # replicate over a dedicated storage NIC\n    # autoEvict: false     # never re-place this node's legs (autoEvictAfter)\n    pools:\n      default:\n        backend: lvmthin\n        device: /dev/disk/by-partlabel/r-miroir\n        # thinPoolSize: 400g   # bound the pool when sharing the VG\n      fast:                    # a second tier on another disk\n        backend: lvmthin\n        device: /dev/disk/by-id/nvme-Micron_7450_XXXX\n  paris:\n    # zone: rack-2\n    pools:\n      default:\n        backend: zfs\n        zfsDataset: data-pool/miroir\n        # zfsVolBlockSize: 4K  # powers of two from 4K through 128K\n        # zfsCompression: lz4  # use inherit for the parent dataset policy\n  le-havre:\n    pools:\n      default:\n        # loopfile: sparse files on the node's existing filesystem — no\n        # dedicated disk or pool. baseDir must be reflink-capable (XFS\n        # reflink=1, e.g. Talos /var, or btrfs) for CoW snapshots; the\n        # agent refuses to start otherwise. The dir is hostPath-mounted\n        # into the agent at the same path.\n        backend: loopfile\n        baseDir: /var/lib/miroir",
       "required": [],
       "title": "nodes",

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -286,6 +286,23 @@ gateway:
 #         # into the agent at the same path.
 #         backend: loopfile
 #         baseDir: /var/lib/miroir
+# @schema
+# type: object
+# additionalProperties:
+#   type: object
+#   properties:
+#     pools:
+#       type: object
+#       additionalProperties:
+#         type: object
+#         properties:
+#           zfsVolBlockSize:
+#             type: [string, "null"]
+#             enum: ["4K", "8K", "16K", "32K", "64K", "128K", "", null]
+#           zfsCompression:
+#             type: [string, "null"]
+#             pattern: ^(inherit|on|off|lz4|lzjb|zle|gzip(-[1-9])?|zstd(-([1-9]|1[0-9]))?|zstd-fast(-(10|[1-9]|[2-9]0|100|500|1000))?)?$
+# @schema
 nodes: {}
 
 # =============================================================================

--- a/internal/nodemap/nodemap.go
+++ b/internal/nodemap/nodemap.go
@@ -167,6 +167,11 @@ const (
 	DefaultZFSCompression  = "lz4"
 )
 
+// Both rules are mirrored by the `nodes` @schema block in
+// charts/miroir/values.yaml, which is what a Helm install trips first —
+// keep the two in step. Helm cannot see this package, so the chart cannot
+// derive them; these stay the real enforcement (non-Helm installs, and the
+// case-folding the schema's enum/pattern cannot express).
 var (
 	zfsVolBlockSizes = map[string]int64{
 		"4K": 4 << 10, "8K": 8 << 10, "16K": 16 << 10,


### PR DESCRIPTION
Implements items 1 and 2 of #230. Item 3 (the `MiroirNode.Spec` inversion) is deliberately untouched — per the issue, it deserves its own decision rather than riding along with a validation tidy-up.

## 1. Editing `nodes` does not roll anything

`nodemap.Load` runs once at startup in both modes, and neither pod template carried a checksum, so `helm upgrade` with an edited `nodes` map rewrote the ConfigMap and restarted nothing — the edit landed whenever something unrelated next restarted the pod.

Both pod templates now carry `checksum/nodes`.

Only `.Values.nodes` is hashed, not the rendered `configmap.tpl`. That file also carries `global_common.conf`, which drbdadm re-reads on every invocation and so needs no restart; hashing the whole file would roll both workloads on a drbd-only edit. Verified: the checksum changes when `nodes` changes and is stable across a `drbd.alExtents` change. The setup Job needs nothing — it is a Helm hook with `before-hook-creation` and already re-runs each upgrade.

## 2. Node map validation written twice

The compression regex and the `4K..128K` list were hand-copied between `nodemap.go` and `configmap.tpl`. Both move into the generated `values.schema.json` via a `# @schema` block on `nodes`; Helm enforces them natively at install/upgrade, and the template loses its whole per-pool loop (-12 lines).

Go stays the real enforcement, so the rules are still stated twice — that is the structural point the issue makes, and it does not go away until item 3 settles. The mitigation is a pointer comment next to the Go definitions.

**What stayed in the template, on purpose.** The structural `fail`s. JSON Schema can say *"additional properties not allowed"* but not *"move backend/device/… under `pools`"*, and the pre-0.10 migration hint earns its line. Node-level `additionalProperties` is therefore left open so that `fail` still fires — closing it would shadow the good message with a generic one.

### Behavior notes

- **Empty stays valid.** The schema accepts `null` and `""`, so an explicitly empty setting still defaults. This is the case d3a6f61 just fixed, and its principle — *the chart must not reject a topology the node would accept* — is why.
- **Case-sensitive now.** The template folded case (`upper`/`lower`); JSON Schema cannot without a per-letter char class for every token, which would read worse than the duplication being removed. So `zfsVolBlockSize: 4k` or `zfsCompression: LZ4` — valid today — are refused at `helm upgrade`, with the allowed set named. Canonical spellings are what values.yaml documents and what zfs(8) wants, and Go still folds case for non-Helm installs. This is the one thing here a user could trip on.
- **No longer gated on `backend == zfs`**, so a bad zfs setting on an lvmthin pool is caught rather than silently ignored.

Errors are also better than the `fail`s they replace, e.g.:

```
at '/nodes/node-a/pools/default/zfsVolBlockSize': value must be one of '4K', '8K', '16K', '32K', '64K', '128K', '', <nil>
```

## Testing

`go test ./...` (incl. envtest), `go vet`, `golangci-lint` (0 issues), `helm lint`, and 116 chart tests (114 + 2 new) all pass.

Verified by hand against `helm template`: `null`/`""`/absent accepted; `16K`, `inherit`, `zstd-3`, `gzip-9`, `zstd-fast-1000` accepted; `12K`, `snappy`, `zstd-99`, `4k` rejected; the legacy flat shape still gets its migration message.

One thing worth knowing, unrelated to this change: `failedTemplate.errorMessagePattern` in the chart tests is **not** actually enforced — substituting an impossible pattern still passes, on `main` as well as here. Those tests are load-bearing for *"an invalid value is rejected"* but not for the message. I updated the two patterns to match the new schema errors so the file is not misleading, but did not try to fix the assertion itself.
