### PR TITLE
docs: add an upgrading guide with the 0.9/0.10 migrations

### DIFF
--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -13,10 +13,12 @@ glob = [
 ]
 run = "mise run helm-docs && git add charts/miroir/README.md charts/miroir/values.schema.json"
 
-# The generated chart README/schema are .prettierignore'd; exclude them from the
-# shared formatters too (oxfmt exits non-zero when every input is ignored).
+# The generated chart README/schema and the authored docs site are
+# .prettierignore'd; exclude them from the shared formatters too (oxfmt exits
+# non-zero when every input is ignored — staging only docs/*.md would otherwise
+# hand it an all-ignored set and fail the whole hook).
 [pre-commit.commands.format-markdown]
-exclude = ["charts/miroir/README.md"]
+exclude = ["charts/miroir/README.md", "docs/**"]
 
 [pre-commit.commands.format-json]
 exclude = ["charts/miroir/values.schema.json"]

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,8 @@ charts/miroir/crds/
 config/crd/bases/
 config/rbac/role.yaml
 config/webhook/manifests.yaml
+
+# Docs site (MkDocs); leave authored Markdown untouched by oxfmt. It re-indents
+# fenced YAML away from the 2-space form the examples are copied from, and
+# strips the indentation `!!!`-style admonitions need.
+docs/

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,142 @@
+# Upgrading
+
+Version-to-version migration steps, newest first. Only releases that need you
+to do something appear here; any version not listed upgrades by bumping the
+chart.
+
+miroir is pre-1.0, so breaking changes land in minor versions (0.9.0, 0.10.0,
+…). Read the section for every version you are crossing, oldest first —
+upgrading 0.8.x → 0.10.x means doing 0.9.0 and then 0.10.0.
+
+/// tip | Check before you upgrade
+
+`helm template` (or a Flux dry-run) against your new values catches the
+chart-side failures below without touching the cluster. Both migrations here
+are Helm values edits — neither moves data nor needs volume downtime.
+
+///
+
+## 0.9.x → 0.10.0 — named storage pools
+
+Each node's storage config moves under a named pool. Your existing single pool
+**must be adopted as the pool named `default`**: MiroirVolume replicas and
+StorageClasses written before this release carry no pool reference, and they
+all resolve to `default`.
+
+### 1. Nest each node's storage under `pools.default`
+
+`zone` and `address` stay node-level. Everything else — `backend`, `device`,
+`zfsDataset`, `zfsVolBlockSize`, `zfsCompression`, `baseDir`, `thinPoolSize` —
+moves:
+
+Before:
+
+```yaml
+nodes:
+  k8s-0:
+    zone: rack-1
+    backend: lvmthin
+    device: /dev/disk/by-partlabel/r-miroir
+```
+
+After:
+
+```yaml
+nodes:
+  k8s-0:
+    zone: rack-1
+    pools:
+      default:
+        backend: lvmthin
+        device: /dev/disk/by-partlabel/r-miroir
+```
+
+The chart fails fast on the flat shape, so a missed node is a template error
+rather than a broken cluster. Under Flux the HelmRelease reports failed and
+nothing is applied.
+
+### 2. Upgrade
+
+```bash
+flux reconcile helmrelease miroir -n miroir-system --with-source
+```
+
+Existing volumes, snapshots, VGs (`vg-miroir`), datasets, and loopfile
+directories are reused as they are — **no data migration and no volume
+downtime**. During the rollout an old agent and a new controller can briefly
+disagree on the `MiroirNode` status shape; placement treats those stats as
+unknown (the same as a cold cluster) until the DaemonSet finishes rolling.
+
+### 3. Optional: add a second pool
+
+```yaml
+nodes:
+  k8s-0:
+    pools:
+      default:
+        backend: lvmthin
+        device: /dev/disk/by-partlabel/r-miroir
+      fast:
+        backend: lvmthin
+        device: /dev/disk/by-id/nvme-Micron_7450_MTFDKBA800TFS_XXXX
+  # k8s-1, k8s-2 identical
+storageClasses:
+  - name: miroir-replicated
+    replicas: 2
+  - name: miroir-replicated-fast
+    replicas: 3
+    pool: fast
+```
+
+Each agent creates the new pool's VG and thin-pool at startup. New pools get
+`vg-miroir-<pool>`; the default pool keeps `vg-miroir`, which is why step 2
+needs no data migration.
+
+### Also breaking, but unlikely to affect you
+
+- The agent/setup `--lvm-vg` and `--lvm-thinpool` flags are gone — VG naming
+  derives from the pool name. The chart never set them; only custom
+  `agent.extraArgs` would notice.
+- `MiroirNode.spec.backend` and the flat `status.capacityBytes`,
+  `status.allocatedBytes`, `status.metaUsedPercent` fields are replaced by
+  per-pool lists. Anything scraping those CR fields directly needs the new
+  paths.
+- Pool metrics gain a `pool` label. The chart's own alerts and dashboard are
+  updated; your own recording rules or dashboards matching an exact label set
+  are not.
+- Do not remove a pool from `nodes` while volumes still reference it. Their
+  reconciles and deletions fail loudly (`storage pool "x" is not configured on
+  this node`) until the pool returns or the volumes are gone.
+
+## 0.8.x → 0.9.0 — RWX is opt-in
+
+Serving ReadWriteMany is now an explicit operator decision. Gateway pods run
+privileged in the release namespace, and anyone who can create a PVC could
+previously cause one to be spawned just by requesting RWX.
+
+/// warning | Set this before upgrading, not after
+
+**If you serve any RWX volumes, set `gateway.enabled: true` in your Helm
+values before you upgrade.**
+
+```yaml
+gateway:
+  enabled: true
+```
+
+Without it, running gateway pods keep serving until their next restart, but
+the controller stops reconciling them, the gateway RBAC is removed (so a
+restarted gateway cannot read its volume), and new RWX PVCs are rejected.
+
+///
+
+If you do not use RWX, no action is needed — the default is `false`, and the
+gateway ServiceAccount, RBAC, PodMonitor, and export alert group are simply
+not installed.
+
+Should you upgrade without the flag and only then notice, setting
+`gateway.enabled: true` and reconciling is enough: RWX rejection is
+`FailedPrecondition`, so a pending PVC provisions on the external
+provisioner's next retry. **No PVC recreation is needed.**
+
+See [ReadWriteMany (RWX)](rwx.md) for what enabling it entails.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,12 +75,13 @@ theme:
 
 markdown_extensions:
   # Admonitions use the pymdownx "blocks" syntax (/// note | Title ... ///)
-  # rather than the indented `!!! note` form ON PURPOSE: the repo's pre-commit
-  # hook runs `oxfmt` over markdown, and oxfmt (a CommonMark formatter) strips
-  # the 4-space body indentation that `!!! note` requires, silently breaking
-  # every admonition. The blocks form keeps its body at column 0, so oxfmt
-  # leaves it intact. (Convention: keep a blank line before the closing /// so
-  # oxfmt doesn't fold it into a preceding list item.)
+  # rather than the indented `!!! note` form. docs/ is now excluded from oxfmt
+  # (.prettierignore + .lefthook.toml), but the blocks form stays: it is the
+  # only one registered below (the `admonition` extension is not enabled), and
+  # it is proof against a stray oxfmt run — oxfmt strips the 4-space body
+  # indentation `!!! note` needs and silently breaks every admonition, while
+  # the blocks form keeps its body at column 0. (Convention: keep a blank line
+  # before the closing /// so it is not folded into a preceding list item.)
   - pymdownx.blocks.admonition:
       # The blocks extension only activates for the type names registered here
       # (its built-in default list does NOT include `info`). Each name doubles

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - Disk failures, rebuilds, and verification: resilience.md
   - User guide:
       - ReadWriteMany (RWX): rwx.md
+      - Upgrading miroir: upgrading.md
       - Node maintenance and upgrades: maintenance.md
       - Monitoring: monitoring.md
       - Helm chart values: configuration.md


### PR DESCRIPTION
Adds `docs/upgrading.md` and backfills the 0.9.0 and 0.10.0 migrations.

## Why

miroir has nowhere to document a migration. Every breaking release so far shipped as a bare one-line changelog subject with no steps (#192, #198, #207, #210), and `docs/maintenance.md` is *node* maintenance (drain, reboot, kernel upgrades), not version upgrades. #234 lands as 0.11.0 and needs a page to write its section into, so this creates the page and backfills the recent history rather than starting it empty.

## What's here

Newest-first page, one section per release that needs operator action; anything not listed upgrades by bumping the chart. Both sections are lifted from the original PR bodies rather than reconstructed from the diffs:

- **0.10.0 (#210) — named storage pools.** Nest each node's storage under `pools.default`; `zone`/`address` stay node-level. It says plainly that this moves no data, because the obvious fear is that named pools mean rebuilding volumes: `volumeGroupFor` keeps `vg-miroir` for the default pool, so existing VGs, datasets, and loopfile dirs are reused as-is. Also notes the chart's fail-fast on the flat shape (a missed node is a template error, not a broken cluster), the removed `--lvm-vg`/`--lvm-thinpool` flags, the per-pool status fields, and the new `pool` metric label.
- **0.9.0 (#207) — RWX is opt-in.** Set `gateway.enabled: true` *before* upgrading if you serve RWX. Without it, running gateways keep serving while the controller stops reconciling them and their RBAC is removed. Also records the recovery path, since it's mild: rejection is `FailedPrecondition`, so a pending PVC provisions on the external provisioner's next retry with no PVC recreation.

Scoped to the two most recent breaking releases. The seven older ones (0.2.0-0.8.0) are not backfilled — say the word if they're worth it.

## Formatter exclusion

Separate commit. `docs/` is now `.prettierignore`d and excluded from lefthook's `format-markdown`, matching what kopiur does.

oxfmt rewrites authored Markdown in two ways this page can't take: it re-indents fenced YAML away from the 2-space form the examples are copied out of, and it strips the body indentation `!!!`-style admonitions need. Both halves of the exclusion are load-bearing and do different jobs — `.prettierignore` stops oxfmt rewriting the files, and the lefthook `exclude` stops lefthook handing it a docs-only set, which oxfmt exits non-zero on (`Expected at least one target file`), failing the whole hook. Verified on the commit here: with `docs/upgrading.md` staged, the hook reports `format-markdown (skip) no files for inspection` instead of failing. CI doesn't format Markdown, so nothing else disagrees.

## Verification

- `mise run docs` (strict) builds clean; the page renders with `class="admonition tip"` / `class="admonition warning"` and is linked from the nav.
- All four YAML examples validated with `yq`.
- Each commit builds on its own — the nav entry is in the docs commit, not the exclusion commit.

## Two things worth a look

- **`mkdocs.yml` comment rewrite** (in the exclusion commit): the admonition note justified the blocks syntax by the pre-commit hook running oxfmt over `docs/`, which this PR makes untrue. It now argues from what the extension actually registers and from surviving a stray oxfmt run. The syntax choice is unchanged.
- **The rest of `docs/` is still 4-space YAML** while this page is 2-space. Now that oxfmt no longer owns `docs/`, normalizing the others is possible but is not in this PR.