### PR TITLE
fix(csi): name the address-conflict exclusion in placement refusals

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -388,15 +388,29 @@ func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, c
 	}
 	// Every diskful leg needs the pool on its own node; a class naming a
 	// pool too few nodes carry must say so instead of a generic refusal.
-	// Address-conflicted nodes are excluded outright: their replication
-	// endpoint is ambiguous until the operator resolves the clash.
+	// Unplaceable nodes (address conflict) are excluded outright — but
+	// counted, so the refusal names the real cause instead of blaming the
+	// pool declarations.
 	candidates := map[string]nodemap.Pool{}
+	conflicted := 0
 	for n := range nodes {
-		if p, ok := nodes.Pool(n, pool); ok && !nodes[n].AddressConflict {
-			candidates[n] = p
+		p, ok := nodes.Pool(n, pool)
+		if !ok {
+			continue
 		}
+		if !nodes.Placeable(n) {
+			conflicted++
+			continue
+		}
+		candidates[n] = p
 	}
 	if len(candidates) < count {
+		if conflicted > 0 {
+			return nil, status.Errorf(codes.ResourceExhausted,
+				"storage pool %q exists on %d of %d storage nodes, but %d carrying it are excluded by a replication "+
+					"address conflict; a %d-replica class needs %d (kubectl get miroirnodes; see the AddressConflict condition)",
+				pool, len(candidates)+conflicted, len(nodes), conflicted, count, count)
+		}
 		return nil, status.Errorf(codes.ResourceExhausted,
 			"storage pool %q exists on %d of %d storage nodes; a %d-replica class needs %d (Helm values: nodes.<name>.spec.pools)",
 			pool, len(candidates), len(nodes), count, count)
@@ -1001,7 +1015,7 @@ func (c *Controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 	}
 	provisioned := provisionedPerPool(list.Items, "")
 	available := func(node string) int64 {
-		if _, ok := nodes.Pool(node, pool); !ok || nodes[node].AddressConflict {
+		if _, ok := nodes.Pool(node, pool); !ok || !nodes.Placeable(node) {
 			return 0 // no pool here, or the node is unplaceable (address conflict)
 		}
 		// Unknown stats fall out as zero — excluded until the agent

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -1057,16 +1057,19 @@ func (c *Controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 		return bound
 	}
 
-	// Topology-aware provisioner: one segment per call.
+	// Topology-aware provisioner: one segment per call. A node that
+	// carries the pool but is unplaceable forks like one without the pool:
+	// place() never admits it as a candidate, so with remote access the
+	// volume lands elsewhere and without it the request refuses.
 	if seg := req.GetAccessibleTopology().GetSegments(); seg != nil {
 		node := seg[constants.TopologyKey]
-		if _, hasPool := nodes.Pool(node, pool); !hasPool {
+		if _, hasPool := nodes.Pool(node, pool); !hasPool || !nodes.Placeable(node) {
 			if remoteAccess {
 				// Consumers here attach a diskless client leg; the volume
 				// lands wherever place() ranks best.
 				return &csi.GetCapacityResponse{AvailableCapacity: capacityFor("")}, nil
 			}
-			return &csi.GetCapacityResponse{}, nil // no pool here, class pinned to replica nodes
+			return &csi.GetCapacityResponse{}, nil // no placeable pool here, class pinned to replica nodes
 		}
 		return &csi.GetCapacityResponse{AvailableCapacity: capacityFor(node)}, nil
 	}

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1094,6 +1094,39 @@ func TestPickNodeNoStorageNodes(t *testing.T) {
 	}
 }
 
+// Nodes excluded by an address conflict still carry the pool; the refusal
+// must name the conflict instead of blaming pool declarations the operator
+// would find correct.
+func TestCreateVolumeRefusalNamesAddressConflict(t *testing.T) {
+	s := newScheme(t)
+	conflicted := func(pool nodemap.Pool) nodemap.Node {
+		n := storageNode(pool)
+		n.Address, n.AddressConflict = "10.0.100.9", true
+		return n
+	}
+	c := &Controller{
+		Client: fake.NewClientBuilder().WithScheme(s).
+			WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build(),
+		Nodes: nodemap.Map{
+			nodeA: conflicted(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin}),
+			nodeB: conflicted(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin}),
+		},
+	}
+
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: volCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
+	})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("expected RESOURCE_EXHAUSTED, got %v", err)
+	}
+	if msg := status.Convert(err).Message(); !strings.Contains(msg, "address conflict") ||
+		!strings.Contains(msg, "2 carrying it are excluded") {
+		t.Fatalf("the refusal must name the address-conflict exclusion, got %q", msg)
+	}
+}
+
 func TestCreateVolumeFromSnapshotEchoesContentSource(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -436,6 +436,52 @@ func TestGetCapacityPerPool(t *testing.T) {
 	}
 }
 
+// A pinned node that carries the pool but is excluded by an address
+// conflict forks like a node without the pool: a remote-access class gets
+// the cluster-wide answer (place() lands the volume elsewhere and the pod
+// attaches through a diskless client leg), a strict class gets zero —
+// matching place()'s refusal.
+func TestGetCapacityConflictedSegment(t *testing.T) {
+	s := newScheme(t)
+	conflicted := storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin})
+	conflicted.Address, conflicted.AddressConflict = "10.0.100.9", true
+	c := &Controller{
+		Client: placementClient(s,
+			miroirNodeObj(nodeA, 10*gib, 0),
+			miroirNodeObj(nodeB, 10*gib, 0),
+			miroirNodeObj(nodeC, 10*gib, 0),
+		),
+		Nodes: nodemap.Map{
+			nodeA: conflicted,
+			nodeB: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin}),
+			nodeC: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin}),
+		},
+	}
+
+	req := topologySegment(nodeA)
+	req.Parameters = map[string]string{constants.ParamReplicas: "2"} // remote access defaults on
+	resp, err := c.GetCapacity(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.GetAvailableCapacity() != 20*gib {
+		t.Fatalf("a remote-access class must report the cluster answer, got %d", resp.GetAvailableCapacity())
+	}
+
+	req = topologySegment(nodeA)
+	req.Parameters = map[string]string{
+		constants.ParamReplicas:          "2",
+		constants.ParamAllowRemoteAccess: "false",
+	}
+	resp, err = c.GetCapacity(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.GetAvailableCapacity() != 0 {
+		t.Fatalf("a strict class pinned to a conflicted node must report 0, got %d", resp.GetAvailableCapacity())
+	}
+}
+
 // topologyReq mirrors a strict-topology provisioner request: the
 // scheduler-selected node as both requisite and preferred.
 func topologyReq(node string) *csi.TopologyRequirement {

--- a/internal/nodemap/nodemap.go
+++ b/internal/nodemap/nodemap.go
@@ -206,6 +206,17 @@ func (m Map) Pool(node, pool string) (Pool, bool) {
 	return p, ok
 }
 
+// Placeable reports whether a node may receive new legs: it is in the
+// topology and its replication endpoint is unambiguous (no address
+// conflict). Every candidate enumeration — place, GetCapacity, PickSpare —
+// flows through this one predicate so exclusion reasons cannot drift
+// between them; ReplicationAddress refuses conflicted nodes separately
+// because client legs on nodes outside the topology still resolve there.
+func (m Map) Placeable(node string) bool {
+	n, ok := m[node]
+	return ok && !n.AddressConflict
+}
+
 // AutoEvictAllowed reports whether auto-evict may re-place the node's
 // legs: the node is in the map and has not opted out.
 func (m Map) AutoEvictAllowed(node string) bool {
@@ -249,7 +260,7 @@ func (m Map) TieBreakerNode(replicas []miroirv1alpha1.Replica) string {
 func (m Map) PickSpare(usedNodes, usedZones map[string]bool, keep func(node string) bool) string {
 	spare := make([]string, 0, len(m))
 	for n := range m {
-		if !usedNodes[n] && !m[n].AddressConflict && (keep == nil || keep(n)) {
+		if !usedNodes[n] && m.Placeable(n) && (keep == nil || keep(n)) {
 			spare = append(spare, n)
 		}
 	}

--- a/internal/nodemap/nodemap_test.go
+++ b/internal/nodemap/nodemap_test.go
@@ -123,6 +123,15 @@ func TestFromNodesMarksAddressConflicts(t *testing.T) {
 	if _, err := m.ReplicationAddress(t.Context(), nil, nodeA); !errors.Is(err, ErrAddressConflict) {
 		t.Fatalf("ReplicationAddress must refuse a conflicted node with ErrAddressConflict, got %v", err)
 	}
+	if m.Placeable(nodeA) || m.Placeable(nodeB) {
+		t.Fatal("conflicted nodes must not be placeable")
+	}
+	if !m.Placeable(nodeC) {
+		t.Fatal("a unique-address node must be placeable")
+	}
+	if m.Placeable("absent") {
+		t.Fatal("a node outside the topology must not be placeable")
+	}
 }
 
 // A non-IP address string is reachable only through a stale CRD (no isIP


### PR DESCRIPTION
Closes #239.

## The misleading error

`place()` drops address-conflicted nodes from the candidate set but counted them in the refusal's denominator. On a cluster where every node carries the pool but two share a replication address, CreateVolume failed with:

> storage pool "default" exists on 0 of 2 storage nodes; a 2-replica class needs 2 (Helm values: nodes.<name>.spec.pools)

pointing the operator at pool declarations that are correct and never mentioning the conflict that excluded the nodes. The refusal now counts the exclusions and names the cause:

> storage pool "default" exists on 2 of 2 storage nodes, but 2 carrying it are excluded by a replication address conflict; a 2-replica class needs 2 (kubectl get miroirnodes; see the AddressConflict condition)

The no-conflict wording is unchanged.

## One eligibility predicate

The exclusion rule was enforced independently at `place()`, `GetCapacity()`, and `PickSpare` — three hand-written `AddressConflict` checks that the next exclusion reason would have to find. They now all flow through `nodemap.Map.Placeable` (in the topology + unambiguous replication endpoint). `ReplicationAddress` keeps its own `ErrAddressConflict` refusal by design: client legs on nodes outside the topology still resolve through it, so membership is not part of its rule.

## Testing

- `TestCreateVolumeRefusalNamesAddressConflict`: two conflicted nodes carrying the pool → the RESOURCE_EXHAUSTED message names the conflict.
- `TestFromNodesMarksAddressConflicts` extended with `Placeable` assertions (conflicted, unique, absent).
- Full unit suite, `go vet`, `golangci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Placement now consistently excludes unplaceable nodes caused by replication address conflicts (and centralizes this decision across spare selection and capacity checks).
  * Capacity calculations were adjusted so conflicted segment-pinned requests behave correctly, including different outcomes when remote access is enabled vs. disabled.
  * Resource exhaustion messages now more clearly indicate when exclusions are due to address conflicts.

* **Tests**
  * Added coverage for failure when all candidate nodes have address conflicts and for correct capacity behavior for conflicted segment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->