### PR TITLE
fix(agent): close two startup edges around a vanished or pool-less MiroirNode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -537,10 +537,18 @@ func main() {
 		// The DaemonSet's chart-side scope is every schedulable node, but
 		// only storage nodes run agent-backed backends. A node with no
 		// MiroirNode holds no volumes and runs a client-only node service so
-		// pods there can still mount RWX (NFS) volumes.
+		// pods there can still mount RWX (NFS) volumes. A MiroirNode with no
+		// pools (unwritable under the current CRD, but a pre-0.11 stored
+		// object survives revalidation) holds no storage either and gets the
+		// same treatment — setupAgentPools would read zero pools as "every
+		// pool failed" and crash-loop.
 		miroirNode, found := agentTopology(mgr, nodeName, stop)
-		if !found {
-			setupLog.Info("no MiroirNode for this node; running client-only node service", "node", nodeName)
+		if !found || len(miroirNode.Spec.Pools) == 0 {
+			msg := "no MiroirNode for this node; running client-only node service"
+			if found {
+				msg = "MiroirNode declares no pools; running client-only node service"
+			}
+			setupLog.Info(msg, "node", nodeName)
 			// Client legs get DRBD configs rendered here too, so the
 			// kernel floor binds on client-only nodes as well.
 			clientDRBD := &drbd.Driver{StateDir: drbdStateDir, Exec: backend.RealExec}

--- a/internal/agent/topologywatcher.go
+++ b/internal/agent/topologywatcher.go
@@ -21,11 +21,15 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mount "k8s.io/mount-utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 )
@@ -143,8 +147,19 @@ func (w *TopologyWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	own := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetName() == w.NodeName
 	})
+	// One synthetic boot event: a MiroirNode deleted between the agent's
+	// direct startup read and the informer's initial list produces no
+	// watch event at all (absent from the list means neither Add nor
+	// Delete), so without it the agent would serve the stale topology
+	// until some unrelated write touched the object. The extra Reconcile
+	// no-ops when nothing drifted.
+	boot := make(chan event.GenericEvent, 1)
+	boot <- event.GenericEvent{Object: &miroirv1alpha1.MiroirNode{
+		ObjectMeta: metav1.ObjectMeta{Name: w.NodeName},
+	}}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&miroirv1alpha1.MiroirNode{}, builder.WithPredicates(own)).
+		WatchesRawSource(source.Channel(boot, &handler.EnqueueRequestForObject{})).
 		Named("topologywatcher").
 		Complete(w)
 }

--- a/test/integration/crd_validation_test.go
+++ b/test/integration/crd_validation_test.go
@@ -36,6 +36,7 @@ const (
 
 	poolDefault = "default"
 	datasetTank = "tank/miroir"
+	deviceSDB   = "/dev/sdb"
 )
 
 // unreplicatedVolume is the minimal valid single-replica volume.
@@ -266,7 +267,7 @@ func minimalNode(name string, pool miroirv1alpha1.MiroirNodePool) *miroirv1alpha
 func lvmthinPool(name string) miroirv1alpha1.MiroirNodePool {
 	return miroirv1alpha1.MiroirNodePool{
 		Name: name, Backend: miroirv1alpha1.BackendLVMThin,
-		LVMThin: &miroirv1alpha1.LVMThinPool{Device: "/dev/sdb"},
+		LVMThin: &miroirv1alpha1.LVMThinPool{Device: deviceSDB},
 	}
 }
 
@@ -317,7 +318,7 @@ var _ = Describe("MiroirNode CEL validation", func() {
 	It("rejects another backend's options — they are unrepresentable, not ignored", func() {
 		node := minimalNode("min-cross-block", miroirv1alpha1.MiroirNodePool{
 			Name: poolDefault, Backend: miroirv1alpha1.BackendLVMThin,
-			LVMThin: &miroirv1alpha1.LVMThinPool{Device: "/dev/sdb"},
+			LVMThin: &miroirv1alpha1.LVMThinPool{Device: deviceSDB},
 			ZFS:     &miroirv1alpha1.ZFSPool{Dataset: datasetTank},
 		})
 		err := k8sClient.Create(ctx, node)

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -15,8 +15,9 @@ limitations under the License.
 */
 
 // Package integration runs against a real (envtest) apiserver. It exists
-// for behavior only the apiserver enforces — CRD structural schemas and
-// CEL validation rules — which no fake client or unit test exercises.
+// for behavior only the apiserver exhibits — CRD structural schemas, CEL
+// validation rules, and watch delivery semantics — which no fake client or
+// unit test exercises.
 package integration
 
 import (
@@ -27,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -35,6 +37,8 @@ import (
 
 var (
 	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	scheme    *runtime.Scheme
 	k8sClient client.Client
 	ctx       context.Context
 	cancel    context.CancelFunc
@@ -51,10 +55,11 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 
-	scheme := runtime.NewScheme()
+	scheme = runtime.NewScheme()
 	Expect(miroirv1alpha1.AddToScheme(scheme)).To(Succeed())
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/test/integration/topologywatcher_test.go
+++ b/test/integration/topologywatcher_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/agent"
+)
+
+// The startup race only a real apiserver reproduces: a MiroirNode deleted
+// between the agent's direct startup read and the informer's initial list
+// yields no watch event at all — the object is simply absent from the
+// list, so neither an Add nor a Delete is ever delivered. The watcher's
+// synthetic boot event is what guarantees one comparison anyway; without
+// it this spec hangs and the agent would serve the stale topology
+// indefinitely.
+var _ = Describe("TopologyWatcher boot event", func() {
+	It("restarts a storage agent whose MiroirNode vanished before the cache synced", func() {
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:  scheme,
+			Metrics: metricsserver.Options{BindAddress: "0"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		stopped := make(chan struct{})
+		var once sync.Once
+		w := &agent.TopologyWatcher{
+			Client:   mgr.GetClient(),
+			NodeName: "boot-race-node", // no MiroirNode of this name exists
+			BootedPools: []miroirv1alpha1.MiroirNodePool{{
+				Name: poolDefault, Backend: miroirv1alpha1.BackendLVMThin,
+				LVMThin: &miroirv1alpha1.LVMThinPool{Device: deviceSDB},
+			}},
+			Stop: func() { once.Do(func() { close(stopped) }) },
+		}
+		Expect(w.SetupWithManager(mgr)).To(Succeed())
+
+		mgrCtx, mgrCancel := context.WithCancel(ctx)
+		DeferCleanup(mgrCancel)
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.Start(mgrCtx)).To(Succeed())
+		}()
+
+		// Generous deadline: covers manager startup and cache sync, not
+		// just the event delivery itself.
+		Eventually(stopped, "30s").Should(BeClosed(),
+			"the boot event must drive one comparison even though the apiserver delivers no event for the vanished object")
+	})
+})


### PR DESCRIPTION
Closes #242.

## Deletion between the startup read and cache sync

The agent reads its MiroirNode via the direct APIReader before the manager starts. If the object is deleted before the informer's initial list completes, the informer delivers no event for that name at all — absent from the initial list means neither an Add nor a Delete — so the TopologyWatcher never ran and the agent served the stale storage topology indefinitely (poolstats just logged NotFound every tick, contradicting its own comment that "the topology watcher restarts the agent moments later").

The watcher now seeds one synthetic boot event through a `source.Channel`, guaranteeing a first spec comparison after cache sync. In the normal case the initial-list Add already triggered a comparison and the boot event no-ops; in the race it detects the drift and restarts into client-only mode. That also makes the poolstats comment true in every window.

An envtest spec reproduces the race (delete-before-sync is just "the object never existed" from the informer's perspective): verified that it hangs and fails without the fix, and passes with it — three consecutive clean suite runs.

## Zero pools read as "every pool failed"

`setupAgentPools` exits when `failed == len(pools)`, which is `0 == 0` for an empty pool set: a MiroirNode with empty `spec.pools` (unwritable under the current CRD's `MinItems=1`, but a pre-0.11 stored object survives revalidation) crash-looped the agent with a misleading "every pool failed setup". It now takes the same client-only path as a node with no MiroirNode, with a message naming the reason — and since the topology watcher snapshots the empty pool set, pools appearing later restart it into a storage agent as usual.

## Testing

- New envtest spec `TopologyWatcher boot event` (fails without the fix).
- Full unit suite, integration suite (22 specs, 3 consecutive runs), `go vet`, `golangci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent mode now correctly runs as client-only when a node has no storage pools, avoiding startup failures.
  * Topology monitoring now performs its initial reconciliation even when the watched node is absent.

* **Tests**
  * Added integration coverage for startup reconciliation behavior.
  * Improved integration test setup and validation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->