### PR TITLE
perf(agent): scope the MiroirNode informer to the node's own object

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -174,13 +175,26 @@ func fetchMiroirNode(r client.Reader, name string, budget time.Duration) (*miroi
 // objects). In controller mode the export reconciler manages gateway
 // Deployments and Services only in its own namespace, so scope those
 // informers there: Owns() otherwise lists them cluster-wide, which the
-// namespaced Role neither grants nor should. Other types stay cluster-scoped.
-func cacheOptions(mode, namespace string) cache.Options {
+// namespaced Role neither grants nor should. In agent mode the MiroirNode
+// informer is pinned to the node's own object — no agent consumer reads
+// another node's (the topology watcher and poolstats are self-only), and
+// an unscoped watch would deliver every node's per-minute status heartbeat
+// to every agent: N cached objects and N events/min per agent, N² across
+// the cluster, for reconciles a name predicate then discards. Other types
+// stay cluster-scoped.
+func cacheOptions(mode, namespace, nodeName string) cache.Options {
 	opts := cache.Options{DefaultTransform: cache.TransformStripManagedFields()}
 	if mode == modeController && namespace != "" {
 		opts.ByObject = map[client.Object]cache.ByObject{
 			&appsv1.Deployment{}: {Namespaces: map[string]cache.Config{namespace: {}}},
 			&corev1.Service{}:    {Namespaces: map[string]cache.Config{namespace: {}}},
+		}
+	}
+	if mode == "agent" && nodeName != "" {
+		opts.ByObject = map[client.Object]cache.ByObject{
+			&miroirv1alpha1.MiroirNode{}: {
+				Field: fields.OneTermEqualSelector("metadata.name", nodeName),
+			},
 		}
 	}
 	return opts
@@ -433,7 +447,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: metricsAddr},
-		Cache:   cacheOptions(mode, podNamespace),
+		Cache:   cacheOptions(mode, podNamespace, nodeName),
 		// The dedicated health-probe server is disabled; the probes are
 		// co-hosted on the (plain HTTP) metrics listener so each workload
 		// exposes a single operational port — the agent runs hostNetwork,

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -21,9 +21,12 @@ import (
 	"errors"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -92,5 +95,48 @@ func TestListWithRetryReturnsTerminalErrorImmediately(t *testing.T) {
 		}).Build()
 	if err := listWithRetry(c, &miroirv1alpha1.MiroirVolumeList{}, apiStartupWait); !apierrors.IsUnauthorized(err) {
 		t.Fatalf("want the terminal Unauthorized returned, got %v", err)
+	}
+}
+
+// byObjectFor resolves a type's entry in Options.ByObject: the map is
+// keyed by object pointers, so lookups must match by type, not identity.
+func byObjectFor[T client.Object](opts cache.Options) (cache.ByObject, bool) {
+	for obj, cfg := range opts.ByObject {
+		if _, ok := obj.(T); ok {
+			return cfg, true
+		}
+	}
+	return cache.ByObject{}, false
+}
+
+func TestCacheOptionsAgentPinsOwnMiroirNode(t *testing.T) {
+	opts := cacheOptions("agent", "", "node-a")
+	byNode, ok := byObjectFor[*miroirv1alpha1.MiroirNode](opts)
+	if !ok {
+		t.Fatal("agent mode must scope the MiroirNode informer")
+	}
+	if byNode.Field == nil || byNode.Field.String() != "metadata.name=node-a" {
+		t.Fatalf("MiroirNode informer must be pinned to the node's own object, got %v", byNode.Field)
+	}
+}
+
+// nodeName is validated after the manager (and its cache config) is
+// built; an empty name must not produce a match-nothing selector.
+func TestCacheOptionsAgentWithoutNodeNameStaysUnscoped(t *testing.T) {
+	if opts := cacheOptions("agent", "", ""); opts.ByObject != nil {
+		t.Fatalf("no scoping without a node name, got %v", opts.ByObject)
+	}
+}
+
+func TestCacheOptionsControllerStaysClusterScopedForMiroirNodes(t *testing.T) {
+	opts := cacheOptions(modeController, "miroir-system", "")
+	if _, ok := byObjectFor[*appsv1.Deployment](opts); !ok {
+		t.Fatal("controller mode must namespace the gateway Deployment informer")
+	}
+	if _, ok := byObjectFor[*corev1.Service](opts); !ok {
+		t.Fatal("controller mode must namespace the gateway Service informer")
+	}
+	if _, ok := byObjectFor[*miroirv1alpha1.MiroirNode](opts); ok {
+		t.Fatal("the controller reads every MiroirNode; its informer must stay cluster-scoped")
 	}
 }


### PR DESCRIPTION
Closes #240.

In agent mode, `cacheOptions()` left the MiroirNode informer cluster-scoped, so every agent cached all N MiroirNode objects and decoded every node's per-minute status heartbeat — N events/min per agent, N² across the cluster — only for the TopologyWatcher's name predicate to discard everything but its own. No agent-mode consumer reads another node's MiroirNode (the watcher and poolstats are both self-only, verified — no MiroirNode Lists exist under `internal/agent/`), so the informer is now pinned with a `metadata.name` field selector, exactly as sketched in the issue. Per-agent watch cost stays O(1) as topologies grow.

Two details beyond the sketch:

- An agent started without a node name stays **unscoped** rather than getting a match-nothing selector: `--node-name` validation exits the process before the cache ever starts, so the guard only avoids a misleading config in the window before that.
- `cacheOptions` gains unit tests (agent pins its own object; empty node name stays unscoped; controller mode keeps its namespaced gateway informers and a cluster-scoped MiroirNode informer, which placement's per-RPC fold requires).

Verified: unit tests for `./cmd/` on linux (docker), envtest suite incl. #244's topology-watcher cases, lint clean (the two staticcheck findings in `internal/csi/node_test.go` pre-exist on main).