### PR TITLE
perf(controller): trim redundant topology folds and watch fan-out

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,7 +111,6 @@ func setupMembership(mgr ctrl.Manager, nodes nodemap.Source, autoTieBreaker bool
 	if autoEvictAfter > 0 {
 		ae := &membership.AutoEvictReconciler{
 			Client:   mgr.GetClient(),
-			Nodes:    nodes,
 			After:    autoEvictAfter,
 			Recorder: mgr.GetEventRecorder("miroir-controller"),
 		}

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -191,12 +191,20 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	}
 	placed := srcReplicas
 	if snapID == "" {
-		p, err := c.place(ctx, req.GetAccessibilityRequirements(), replicas, sizeBytes, req.GetName(), vols, remoteAccess, params.pool)
+		// One topology snapshot serves both placement and the tie-breaker
+		// pick; separate resolves could observe different topologies
+		// mid-RPC.
+		nodes, err := c.nodes(ctx)
 		if err != nil {
 			c.allocMu.Unlock()
 			return nil, err
 		}
-		placed, err = c.withTieBreaker(ctx, p, replicas, quorum)
+		p, err := c.place(ctx, nodes, req.GetAccessibilityRequirements(), replicas, sizeBytes, req.GetName(), vols, remoteAccess, params.pool)
+		if err != nil {
+			c.allocMu.Unlock()
+			return nil, err
+		}
+		placed, err = c.withTieBreaker(ctx, nodes, p, replicas, quorum)
 		if err != nil {
 			c.allocMu.Unlock()
 			return nil, err
@@ -381,11 +389,7 @@ func (c *Controller) allocVolumes(ctx context.Context, needed bool) ([]miroirv1a
 // so a cold cluster still provisions. For replicated volumes it resolves
 // each node's InternalIP and assigns DRBD node ids by slice position —
 // replicas[0] is the GI-seed winner (internal/drbd).
-func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, count int, sizeBytes int64, name string, vols []miroirv1alpha1.MiroirVolume, remoteAccess bool, pool string) ([]miroirv1alpha1.Replica, error) {
-	nodes, err := c.nodes(ctx)
-	if err != nil {
-		return nil, err
-	}
+func (c *Controller) place(ctx context.Context, nodes nodemap.Map, reqs *csi.TopologyRequirement, count int, sizeBytes int64, name string, vols []miroirv1alpha1.MiroirVolume, remoteAccess bool, pool string) ([]miroirv1alpha1.Replica, error) {
 	// Every diskful leg needs the pool on its own node; a class naming a
 	// pool too few nodes carry must say so instead of a generic refusal.
 	// Unplaceable nodes (address conflict) are excluded outright — but
@@ -516,15 +520,12 @@ func (c *Controller) place(ctx context.Context, reqs *csi.TopologyRequirement, c
 
 // withTieBreaker appends a diskless tie-breaker to a freshly placed
 // 2-replica freeze volume, so majority quorum survives a single node loss
-// (#70). Unchanged when disabled, not applicable, or no spare node exists —
+// (#70). It picks from the same topology snapshot the caller placed with.
+// Unchanged when disabled, not applicable, or no spare node exists —
 // the tie-breaker reconciler retrofits skipped volumes once one joins.
-func (c *Controller) withTieBreaker(ctx context.Context, placed []miroirv1alpha1.Replica, replicas int, quorum miroirv1alpha1.QuorumPolicy) ([]miroirv1alpha1.Replica, error) {
+func (c *Controller) withTieBreaker(ctx context.Context, nodes nodemap.Map, placed []miroirv1alpha1.Replica, replicas int, quorum miroirv1alpha1.QuorumPolicy) ([]miroirv1alpha1.Replica, error) {
 	if !c.AutoTieBreaker || replicas != 2 || quorum != miroirv1alpha1.QuorumFreeze {
 		return placed, nil
-	}
-	nodes, err := c.nodes(ctx)
-	if err != nil {
-		return nil, err
 	}
 	tb := nodes.TieBreakerNode(placed)
 	if tb == "" {

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -66,6 +66,17 @@ func placementClient(s *runtime.Scheme, objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
 }
 
+// placeNodes resolves the controller's topology the way CreateVolume does
+// before handing it to place().
+func placeNodes(t *testing.T, c *Controller) nodemap.Map {
+	t.Helper()
+	m, err := c.Nodes.Map(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
 // placementVols lists the seeded volumes the way CreateVolume does, to
 // feed place()'s overcommit accounting.
 func placementVols(t *testing.T, c client.Client) []miroirv1alpha1.MiroirVolume {
@@ -93,7 +104,7 @@ func TestPlaceWeightsByFreeSpace(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	got, err := c.place(t.Context(), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +126,7 @@ func TestPlaceRefusesOvercommit(t *testing.T) {
 	}
 
 	// Default 2× ratio: 15 + 10 = 25 GiB provisioned > 20 GiB cap on both.
-	_, err := c.place(t.Context(), nil, 1, 10*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 10*gib, volNew, placementVols(t, c.Client), false, poolDefault)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("overcommit must be ResourceExhausted, got %v", err)
 	}
@@ -132,7 +143,7 @@ func TestPlaceTopologyPinnedRefusedWhenOvercommitted(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	_, err := c.place(t.Context(), topologyPref(nodeA), 1, 10*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, 10*gib, volNew, placementVols(t, c.Client), false, poolDefault)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("pinned overcommitted node must be ResourceExhausted, got %v", err)
 	}
@@ -142,7 +153,7 @@ func TestPlaceFallsBackWithoutStats(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: placementClient(s), Nodes: testNodes}
 
-	got, err := c.place(t.Context(), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +174,7 @@ func TestPlaceHonoursConfiguredRatio(t *testing.T) {
 	}
 
 	// 11 GiB on a 10 GiB pool breaches a 1× ratio on every node.
-	_, err := c.place(t.Context(), nil, 1, 11*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 11*gib, volNew, placementVols(t, c.Client), false, poolDefault)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("1x ratio must refuse an over-capacity volume, got %v", err)
 	}
@@ -184,7 +195,7 @@ func TestPlaceRefusesPhysicallyFullPool(t *testing.T) {
 	}
 
 	// Default 20× free-space ratio: 1 GiB free admits at most 20 GiB.
-	_, err := c.place(t.Context(), nil, 1, 25*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 25*gib, volNew, placementVols(t, c.Client), false, poolDefault)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("a physically full pool must be ResourceExhausted, got %v", err)
 	}
@@ -203,7 +214,7 @@ func TestPlaceHonoursConfiguredFreeSpaceRatio(t *testing.T) {
 
 	// The default 20× would admit this out of the same 10 GiB of free space,
 	// as would the untouched 2× virtual bound.
-	_, err := c.place(t.Context(), nil, 1, 50*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 50*gib, volNew, placementVols(t, c.Client), false, poolDefault)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("1x free-space ratio must refuse a volume past the physical headroom, got %v", err)
 	}
@@ -281,7 +292,7 @@ func TestPlaceSpreadsAcrossZones(t *testing.T) {
 		},
 	}
 
-	got, err := c.place(t.Context(), nil, 2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,7 +349,7 @@ func TestPlaceFiltersAndRanksByPool(t *testing.T) {
 
 	// node-c has the roomiest default pool but no fast pool at all; node-b's
 	// fast pool has more headroom than node-a's.
-	got, err := c.place(t.Context(), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +367,7 @@ func TestPlaceRefusesPoolOnTooFewNodes(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: placementClient(s), Nodes: multiPoolNodes()}
 
-	_, err := c.place(t.Context(), nil, 3, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 3, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("want ResourceExhausted, got %v", err)
 	}
@@ -388,10 +399,10 @@ func TestPlaceOvercommitIsPoolScoped(t *testing.T) {
 	// Each pool holds 15 GiB provisioned of its 2×10 GiB budget: another
 	// 10 GiB breaches either pool alone (25 > 20), so per-pool accounting
 	// refuses — but 5 GiB still fits (20 > 15+5 is false; 20 >= 20 passes).
-	if _, err := c.place(t.Context(), nil, 1, 10*gib, volNew, placementVols(t, c.Client), false, poolFast); status.Code(err) != codes.ResourceExhausted {
+	if _, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 10*gib, volNew, placementVols(t, c.Client), false, poolFast); status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("fast pool at 15/20 GiB must refuse 10 GiB more, got %v", err)
 	}
-	got, err := c.place(t.Context(), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -506,7 +517,7 @@ func TestPlaceRemoteAccessIgnoresNonStorageTopology(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	got, err := c.place(t.Context(), topologyReq("edge-node"), 2, 5*gib, volNew, placementVols(t, c.Client), true, poolDefault)
+	got, err := c.place(t.Context(), placeNodes(t, c), topologyReq("edge-node"), 2, 5*gib, volNew, placementVols(t, c.Client), true, poolDefault)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -532,7 +543,7 @@ func TestPlaceStrictRefusesNonStorageTopology(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	if _, err := c.place(t.Context(), topologyReq("edge-node"), 2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault); status.Code(err) != codes.ResourceExhausted {
+	if _, err := c.place(t.Context(), placeNodes(t, c), topologyReq("edge-node"), 2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault); status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("non-storage topology without remote access must refuse, got %v", err)
 	}
 }
@@ -628,10 +639,10 @@ func TestGetCapacityAgreesWithPlacement(t *testing.T) {
 	room := resp.GetAvailableCapacity()
 
 	vols := placementVols(t, c.Client)
-	if _, err := c.place(t.Context(), topologyPref(nodeA), 1, room, volNew, vols, false, poolDefault); err != nil {
+	if _, err := c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, room, volNew, vols, false, poolDefault); err != nil {
 		t.Fatalf("place must admit exactly the reported capacity (%d): %v", room, err)
 	}
-	_, err = c.place(t.Context(), topologyPref(nodeA), 1, room+1, volNew, vols, false, poolDefault)
+	_, err = c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, room+1, volNew, vols, false, poolDefault)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("place must refuse one byte over the reported capacity, got %v", err)
 	}

--- a/internal/membership/autoevict.go
+++ b/internal/membership/autoevict.go
@@ -56,10 +56,6 @@ import (
 // alive; kicking it would discard a healthy replica).
 type AutoEvictReconciler struct {
 	client.Client
-	// Nodes yields the storage topology, folded from the MiroirNode CRs
-	// per reconcile — placement candidates and the per-node opt-out come
-	// from it.
-	Nodes nodemap.Source
 	// After is the heartbeat staleness that declares a node dead; the
 	// setup path guards > 0.
 	After time.Duration
@@ -91,18 +87,22 @@ type evictPass struct {
 func (r *AutoEvictReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	topology, err := r.Nodes.Map(ctx)
-	if err != nil {
+	// One MiroirNode list serves the whole pass — the topology fold, the
+	// opt-out gate, the heartbeat read, and the staleness census — so no
+	// two reads can observe different topologies.
+	nodes := &miroirv1alpha1.MiroirNodeList{}
+	if err := r.List(ctx, nodes); err != nil {
 		return ctrl.Result{}, err
 	}
+	topology := nodemap.FromNodes(nodes.Items)
 	if !topology.AutoEvictAllowed(req.Name) {
-		// Not a storage node, or opted out via the topology.
+		// Deleted between event and reconcile, or opted out via the spec.
 		return ctrl.Result{}, nil
 	}
-	mn := &miroirv1alpha1.MiroirNode{}
-	if err := r.Get(ctx, req.NamespacedName, mn); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
+	idx := slices.IndexFunc(nodes.Items, func(n miroirv1alpha1.MiroirNode) bool {
+		return n.Name == req.Name
+	})
+	mn := &nodes.Items[idx]
 	if mn.Status.ObservedAt == nil {
 		// Never heartbeated: there is no "was alive, went dark" signal to
 		// act on (a node added to the map but not yet provisioned).
@@ -112,7 +112,7 @@ func (r *AutoEvictReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{RequeueAfter: remaining}, nil
 	}
 
-	pass, stale, err := r.gather(ctx, topology)
+	pass, stale, err := r.gather(ctx, nodes, topology)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -160,14 +160,10 @@ func (r *AutoEvictReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
-// gather lists the cluster state one eviction pass needs — MiroirNodes
-// (the safety-valve census and the capacity views) and snapshots (the
-// pin set) — exactly once.
-func (r *AutoEvictReconciler) gather(ctx context.Context, topology nodemap.Map) (*evictPass, []string, error) {
-	nodes := &miroirv1alpha1.MiroirNodeList{}
-	if err := r.List(ctx, nodes); err != nil {
-		return nil, nil, err
-	}
+// gather builds the cluster state one eviction pass needs from the
+// caller's MiroirNode list (the safety-valve census and the capacity
+// views) plus one snapshot list (the pin set).
+func (r *AutoEvictReconciler) gather(ctx context.Context, nodes *miroirv1alpha1.MiroirNodeList, topology nodemap.Map) (*evictPass, []string, error) {
 	pass := &evictPass{
 		pinned:   map[string]bool{},
 		nodes:    make(map[string]*miroirv1alpha1.MiroirNode, len(nodes.Items)),
@@ -177,9 +173,6 @@ func (r *AutoEvictReconciler) gather(ctx context.Context, topology nodemap.Map) 
 	for i := range nodes.Items {
 		n := &nodes.Items[i]
 		pass.nodes[n.Name] = n
-		if _, ok := topology[n.Name]; !ok {
-			continue
-		}
 		if n.Status.ObservedAt != nil && time.Since(n.Status.ObservedAt.Time) >= r.After {
 			stale = append(stale, n.Name)
 		}

--- a/internal/membership/autoevict_test.go
+++ b/internal/membership/autoevict_test.go
@@ -32,7 +32,6 @@ import (
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 	"github.com/home-operations/miroir/internal/constants"
 	"github.com/home-operations/miroir/internal/drbd"
-	"github.com/home-operations/miroir/internal/nodemap"
 )
 
 const (
@@ -40,23 +39,19 @@ const (
 	volPvc1 = "pvc-1"
 )
 
-// evictMap is the 3-storage-node topology plus a spare (node-d), all on
-// the default pool.
-func evictMap() nodemap.Map {
-	return nodemap.Map{
-		nodeA: storageNode(miroirv1alpha1.BackendZFS),
-		nodeB: storageNode(miroirv1alpha1.BackendZFS),
-		nodeC: storageNode(miroirv1alpha1.BackendZFS),
-		nodeD: storageNode(miroirv1alpha1.BackendZFS),
-	}
-}
-
-// minAt is a MiroirNode whose heartbeat is age old, with the given free
-// space in the default pool.
+// minAt is a MiroirNode carrying a zfs default pool whose heartbeat is
+// age old, with the given free space in the pool. The reconciler folds
+// its topology from these CRs — the nodes seeded per test ARE the
+// topology.
 func minAt(name string, age time.Duration, free int64) *miroirv1alpha1.MiroirNode {
 	at := metav1.NewTime(time.Now().Add(-age))
 	return &miroirv1alpha1.MiroirNode{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: miroirv1alpha1.MiroirNodeSpec{
+			Pools: []miroirv1alpha1.MiroirNodePool{{
+				Name: poolDefault, Backend: miroirv1alpha1.BackendZFS,
+			}},
+		},
 		Status: miroirv1alpha1.MiroirNodeStatus{
 			Pools: []miroirv1alpha1.MiroirNodePoolStatus{{
 				Name: poolDefault, CapacityBytes: 100 << 30, AllocatedBytes: 100<<30 - free,
@@ -88,12 +83,12 @@ func reconcileAE(t *testing.T, r *AutoEvictReconciler, name string) ctrl.Result 
 	return res
 }
 
-func newAE(t *testing.T, nodes nodemap.Map, objs ...client.Object) *AutoEvictReconciler {
+func newAE(t *testing.T, objs ...client.Object) *AutoEvictReconciler {
 	t.Helper()
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		WithObjects(objs...).Build()
-	return &AutoEvictReconciler{Client: c, Nodes: nodes, After: time.Hour}
+	return &AutoEvictReconciler{Client: c, After: time.Hour}
 }
 
 // A node stale past the threshold gets its diskful leg swapped in one
@@ -101,7 +96,7 @@ func newAE(t *testing.T, nodes nodemap.Map, objs ...client.Object) *AutoEvictRec
 // reconciler to complete. The dead node's teardown finalizer stays — it
 // is the record that the leg was never cleaned up there.
 func TestAutoEvictSwapsDeadDiskful(t *testing.T) {
-	r := newAE(t, evictMap(), evictVol(),
+	r := newAE(t, evictVol(),
 		minAt(nodeA, time.Minute, 50<<30),
 		minAt(nodeB, 2*time.Hour, 50<<30),
 		minAt(nodeD, time.Minute, 50<<30))
@@ -137,7 +132,7 @@ func TestAutoEvictSwapsDeadDiskful(t *testing.T) {
 
 // A heartbeat younger than the threshold only schedules a re-check.
 func TestAutoEvictWaitsForThreshold(t *testing.T) {
-	r := newAE(t, evictMap(), evictVol(),
+	r := newAE(t, evictVol(),
 		minAt(nodeB, 30*time.Minute, 10<<30))
 
 	res := reconcileAE(t, r, nodeB)
@@ -154,7 +149,7 @@ func TestAutoEvictWaitsForThreshold(t *testing.T) {
 // More than one stale heartbeat reads as an observer-side problem, not
 // two simultaneous dead nodes: the safety valve stands the whole pass down.
 func TestAutoEvictValveMultipleStale(t *testing.T) {
-	r := newAE(t, evictMap(), evictVol(),
+	r := newAE(t, evictVol(),
 		minAt(nodeA, 2*time.Hour, 50<<30),
 		minAt(nodeB, 2*time.Hour, 50<<30),
 		minAt(nodeD, time.Minute, 50<<30))
@@ -170,15 +165,13 @@ func TestAutoEvictValveMultipleStale(t *testing.T) {
 	}
 }
 
-// A node-map opt-out exempts the node no matter how stale it is.
+// A spec opt-out exempts the node no matter how stale it is.
 func TestAutoEvictOptOut(t *testing.T) {
-	nodes := evictMap()
-	optOut := nodes[nodeB]
+	optOut := minAt(nodeB, 2*time.Hour, 50<<30)
 	no := false
-	optOut.AutoEvict = &no
-	nodes[nodeB] = optOut
-	r := newAE(t, nodes, evictVol(),
-		minAt(nodeB, 2*time.Hour, 50<<30),
+	optOut.Spec.AutoEvict = &no
+	r := newAE(t, evictVol(),
+		optOut,
 		minAt(nodeD, time.Minute, 50<<30))
 
 	reconcileAE(t, r, nodeB)
@@ -194,7 +187,7 @@ func TestAutoEvictOptOut(t *testing.T) {
 func TestAutoEvictBlocksOnDirtySurvivor(t *testing.T) {
 	v := evictVol()
 	v.Status.PerNode[nodeA] = miroirv1alpha1.ReplicaStatus{DiskState: drbd.DiskInconsistent}
-	r := newAE(t, evictMap(), v,
+	r := newAE(t, v,
 		minAt(nodeB, 2*time.Hour, 50<<30),
 		minAt(nodeD, time.Minute, 50<<30))
 
@@ -214,7 +207,7 @@ func TestAutoEvictStandsDownWhenPeerConnected(t *testing.T) {
 	v.Status.PerNode[nodeA] = miroirv1alpha1.ReplicaStatus{
 		DiskState: drbd.DiskUpToDate, Connected: true,
 	}
-	r := newAE(t, evictMap(), v,
+	r := newAE(t, v,
 		minAt(nodeB, 2*time.Hour, 50<<30),
 		minAt(nodeD, time.Minute, 50<<30))
 
@@ -236,7 +229,7 @@ func TestAutoEvictBlocksOnSnapshot(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "snap-1"},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volPvc1},
 	}
-	r := newAE(t, evictMap(), evictVol(), snap,
+	r := newAE(t, evictVol(), snap,
 		minAt(nodeB, 2*time.Hour, 50<<30),
 		minAt(nodeD, time.Minute, 50<<30))
 
@@ -261,7 +254,7 @@ func TestAutoEvictSwapsDeadTieBreaker(t *testing.T) {
 	v.Status.PerNode[nodeB] = miroirv1alpha1.ReplicaStatus{
 		DiskState: drbd.DiskUpToDate, Connected: true,
 	}
-	r := newAE(t, evictMap(), v,
+	r := newAE(t, v,
 		minAt(nodeA, time.Minute, 50<<30),
 		minAt(nodeB, time.Minute, 50<<30),
 		minAt(nodeC, 2*time.Hour, 50<<30),
@@ -300,7 +293,7 @@ func TestAutoEvictDropsDeadClient(t *testing.T) {
 	v.Status.PerNode[nodeB] = miroirv1alpha1.ReplicaStatus{
 		DiskState: drbd.DiskUpToDate, Connected: true,
 	}
-	r := newAE(t, evictMap(), v,
+	r := newAE(t, v,
 		minAt(nodeC, 2*time.Hour, 50<<30))
 
 	reconcileAE(t, r, nodeC)
@@ -317,13 +310,12 @@ func TestAutoEvictDropsDeadClient(t *testing.T) {
 // With no spare node, a live diskless tie-breaker is flipped diskful in
 // place (toggle-disk) so the volume returns to two data copies.
 func TestAutoEvictFlipsTieBreakerWithoutSpare(t *testing.T) {
-	nodes := evictMap()
-	delete(nodes, nodeD)
+	// No node-d in the topology: the fold only sees the seeded CRs.
 	v := evictVol()
 	v.Spec.Replicas = append(v.Spec.Replicas,
 		miroirv1alpha1.Replica{Node: nodeC, NodeID: 2, Address: addrC, Diskless: true})
 	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeC)
-	r := newAE(t, nodes, v,
+	r := newAE(t, v,
 		minAt(nodeA, time.Minute, 50<<30),
 		minAt(nodeB, 2*time.Hour, 50<<30),
 		minAt(nodeC, time.Minute, 50<<30))
@@ -355,10 +347,8 @@ func TestAutoEvictFlipsTieBreakerWithoutSpare(t *testing.T) {
 // With neither a spare node nor a tie-breaker, the volume is left alone
 // and the pass re-checks later.
 func TestAutoEvictNoSpareLeavesVolume(t *testing.T) {
-	nodes := evictMap()
-	delete(nodes, nodeC)
-	delete(nodes, nodeD)
-	r := newAE(t, nodes, evictVol(),
+	// Only the dead node is in the topology: no spare, no tie-breaker.
+	r := newAE(t, evictVol(),
 		minAt(nodeB, 2*time.Hour, 50<<30))
 
 	res := reconcileAE(t, r, nodeB)

--- a/internal/membership/reconciler.go
+++ b/internal/membership/reconciler.go
@@ -256,11 +256,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // enqueueAllVolumes maps a MiroirNode event to every MiroirVolume: which
 // volumes a topology change unblocks cannot be known without reconciling
-// them, and both objects are cluster-scoped with small counts.
+// them, and both objects are cluster-scoped with small counts. Deep-copy
+// is off — three reconcilers each list here per node event and only the
+// names are read; the items must not be mutated or escape this func.
 func enqueueAllVolumes(c client.Client) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []ctrl.Request {
 		list := &miroirv1alpha1.MiroirVolumeList{}
-		if err := c.List(ctx, list); err != nil {
+		if err := c.List(ctx, list, client.UnsafeDisableDeepCopy); err != nil {
 			return nil
 		}
 		reqs := make([]ctrl.Request, 0, len(list.Items))

--- a/internal/topology/conflict.go
+++ b/internal/topology/conflict.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -64,19 +65,29 @@ type ConflictReconciler struct {
 	Recorder events.EventRecorder
 }
 
-// Reconcile recomputes one node's conflict state against the full
-// topology and updates its condition on change.
-func (r *ConflictReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	node := &miroirv1alpha1.MiroirNode{}
-	if err := r.Get(ctx, req.NamespacedName, node); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
+// Reconcile recomputes every node's conflict state against the full
+// topology in one pass and updates the conditions that changed. The
+// request is a fixed sentinel (SetupWithManager), so the request name is
+// ignored.
+func (r *ConflictReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	list := &miroirv1alpha1.MiroirNodeList{}
 	if err := r.List(ctx, list); err != nil {
 		return ctrl.Result{}, err
 	}
 	topo := nodemap.FromNodes(list.Items)
+	for i := range list.Items {
+		// A mid-pass failure retries the whole pass: SetStatusCondition
+		// skips already-updated nodes, so the retry is cheap and emits no
+		// duplicate events.
+		if err := r.reconcileNode(ctx, &list.Items[i], topo); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
 
+// reconcileNode updates one node's AddressConflict condition on change.
+func (r *ConflictReconciler) reconcileNode(ctx context.Context, node *miroirv1alpha1.MiroirNode, topo nodemap.Map) error {
 	cond := metav1.Condition{
 		Type:    ConditionAddressConflict,
 		Status:  metav1.ConditionFalse,
@@ -105,37 +116,30 @@ func (r *ConflictReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	prev := meta.FindStatusCondition(node.Status.Conditions, ConditionAddressConflict)
 	wasConflicted := prev != nil && prev.Status == metav1.ConditionTrue
 	if !meta.SetStatusCondition(&node.Status.Conditions, cond) {
-		return ctrl.Result{}, nil
+		return nil
 	}
 	if err := r.Status().Update(ctx, node); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 	if cond.Status == metav1.ConditionTrue && !wasConflicted && r.Recorder != nil {
 		r.Recorder.Eventf(node, nil, corev1.EventTypeWarning, ConditionAddressConflict, "Reconcile",
 			cond.Message)
 	}
-	return ctrl.Result{}, nil
+	return nil
 }
 
-// SetupWithManager registers the reconciler. Every topology edit fans out
-// to every MiroirNode: removing one node's address is what clears its
-// former peer's conflict, so the peer must be revisited too. Generation
-// filter keeps the per-minute status heartbeats out.
+// SetupWithManager registers the reconciler. Every topology edit enqueues
+// one fixed request and the pass revisits all nodes — removing one node's
+// address is what clears its former peer's conflict, so peers must be
+// recomputed anyway, and a per-node fan-out would make one chart apply
+// O(N²) reconcile work. Generation filter keeps the per-minute status
+// heartbeats out.
 func (r *ConflictReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&miroirv1alpha1.MiroirNode{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&miroirv1alpha1.MiroirNode{}, handler.EnqueueRequestsFromMapFunc(
-			func(ctx context.Context, _ client.Object) []ctrl.Request {
-				list := &miroirv1alpha1.MiroirNodeList{}
-				if err := r.List(ctx, list); err != nil {
-					return nil
-				}
-				reqs := make([]ctrl.Request, 0, len(list.Items))
-				for i := range list.Items {
-					reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])})
-				}
-				return reqs
-			}), builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Named("topologyconflict").
+		Watches(&miroirv1alpha1.MiroirNode{}, handler.EnqueueRequestsFromMapFunc(
+			func(context.Context, client.Object) []ctrl.Request {
+				return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: "topology"}}}
+			}), builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/topology/conflict_test.go
+++ b/internal/topology/conflict_test.go
@@ -76,6 +76,32 @@ func reconcile(t *testing.T, c client.Client, name string) *miroirv1alpha1.Miroi
 	return n
 }
 
+// One pass covers the whole topology: a single reconcile (any request
+// name) must stamp the condition on every node, conflicted or not.
+func TestConflictSinglePassCoversAllNodes(t *testing.T) {
+	c := newClient(t, addrNode(nodeA, "10.0.100.1"), addrNode(nodeB, "10.0.100.1"),
+		addrNode(nodeC, "10.0.100.3"))
+	r := &ConflictReconciler{Client: c}
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "topology"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for name, conflicted := range map[string]bool{nodeA: true, nodeB: true, nodeC: false} {
+		n := &miroirv1alpha1.MiroirNode{}
+		if err := c.Get(t.Context(), types.NamespacedName{Name: name}, n); err != nil {
+			t.Fatal(err)
+		}
+		cond := meta.FindStatusCondition(n.Status.Conditions, ConditionAddressConflict)
+		if cond == nil {
+			t.Fatalf("one pass must stamp the condition on %s", name)
+		}
+		if got := cond.Status == metav1.ConditionTrue; got != conflicted {
+			t.Fatalf("%s: conflicted=%v, want %v (%+v)", name, got, conflicted, cond)
+		}
+	}
+}
+
 func TestConflictConditionRaisedAndNamesPeer(t *testing.T) {
 	c := newClient(t, addrNode(nodeA, "10.0.100.1"), addrNode(nodeB, "10.0.100.1"),
 		addrNode(nodeC, "10.0.100.3"))


### PR DESCRIPTION
Closes #241 — all four items, same theme: the watch-driven topology re-lists and re-folds more than it needs to. No behavior change intended anywhere; the wins are fewer cached-list deep-copies, fewer folds, and one consistent topology snapshot per pass instead of several that could disagree.

## CreateVolume: one topology snapshot per RPC

`place()` and `withTieBreaker()` each resolved `c.nodes(ctx)` under `allocMu` — two full cached-list deep-copies plus two `FromNodes` folds per replicated CreateVolume, and the two calls could observe different topologies in one RPC (worst case was only a suboptimal/skipped tie-breaker pick, which the retrofit reconciler repairs — but now it can't happen). CreateVolume resolves once and passes the `nodemap.Map` down, the same shape `replicationAddress` already used. `GetCapacity` and `restoreReplicas` are separate RPCs and keep their own resolves.

## Auto-evict: one MiroirNode list per pass

`Reconcile` called `r.Nodes.Map(ctx)` (list + fold) and then `gather()` listed the same objects again — two snapshots that could disagree between the opt-out gate and the staleness census. The pass now takes one `MiroirNodeList` up front and everything derives from it: the topology fold, the opt-out gate, the heartbeat read (the separate `Get` is gone too), the safety-valve census, and the capacity views. The `Nodes` source field is removed; the tests now seed topology through the MiroirNode CRs they were already creating for the census, which also means they exercise the real `FromNodes` fold.

The census's "in topology" guard is dropped as vestigial: the topology *is* the fold of the same list, so every listed node is in it by construction.

## ConflictReconciler: singleton pass instead of O(N²) fan-out

The enqueue-all `Watches` (necessary — removing one node's address is what clears its former peer's conflict) enqueued every node per event, and the redundant `For()` added workqueue-deduped duplicates on top; each of those reconciles did its own O(N) list+fold, so one chart apply touching N nodes cost O(N²) reconciles × O(N) folds. The reconciler now enqueues a single fixed request key per topology event and recomputes every node's `AddressConflict` condition in one pass: one list, one fold, N condition updates (skipped when unchanged). Bursts collapse in the workqueue to one or two passes total. A mid-pass error retries the whole pass; `SetStatusCondition` skips already-updated nodes so retries are cheap and emit no duplicate events.

New test pins the single-pass contract (one reconcile stamps all nodes); the existing per-node tests pass unchanged since the request name was already immaterial to them.

## enqueueAllVolumes: stop deep-copying volumes to read names

Membership, tie-breaker, and auto-diskful each map a MiroirNode generation event to a full `MiroirVolumeList` deep-copy whose only consumed field is `.Name`. The list now passes `client.UnsafeDisableDeepCopy` (items never escape the map func, nothing mutates them). A `PartialObjectMetadataList` was considered and rejected: with a cache-backed client it would spin up a second, metadata-only informer for the GVK — duplicate watch + memory — where deep-copy-off reuses the informer the reconcilers already hold. Mitigated in practice by the generation predicates (this only fires on topology spec edits), so the cheap fix is the right-sized one.

## Verification

- `go test ./...` green on linux (docker `golang:1.26.3`), membership/topology/nodemap natively; `GOOS=linux go vet ./...` clean; `golangci-lint` v2.12.2 clean.
- Auto-evict test fixtures moved from an injected static map to CR-seeded topology — every prior scenario (swap, valve, opt-out, dirty survivor, peer-connected stand-down, snapshot pin, tie-breaker swap/flip, client drop, no-spare) re-verified against the fold path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved volume placement consistency by using a single, up-to-date topology view during allocation.
  - Improved automatic node eviction decisions by ensuring they use current node information.
  - Address-conflict status updates now cover all nodes in a topology refresh, with clearer conflict notifications.
  - Preserved placement behavior across capacity, topology, pool, and diskless volume scenarios.
- **Performance**
  - Reduced redundant resource lookups during reconciliation and volume placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->