### PR TITLE
fix(agent): gate snapshot rounds on peer disk states and the kernel barrier

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -652,6 +652,7 @@ func main() {
 			NodeName: nodeName,
 			Pools:    pools,
 			DRBD:     drbdDriver,
+			Reader:   mgr.GetAPIReader(),
 			Recorder: mgr.GetEventRecorder("miroir-agent"),
 		}
 		if err := snapReconciler.SetupWithManager(mgr); err != nil {

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -502,6 +502,24 @@ func diskfulPeersConnected(st drbd.Status, vol *miroirv1alpha1.MiroirVolume, sel
 	return true
 }
 
+// diskfulPeersUpToDate reports whether every completed diskful peer's disk
+// is UpToDate in this node's kernel view. A resyncing (Inconsistent) or
+// failed (Diskless) peer cannot cut a snapshot leg, so a barrier raised
+// over it is doomed to expire — and it would freeze the workload for the
+// whole SuspendDeadline each retry. Same skip rule as
+// diskfulPeersConnected.
+func diskfulPeersUpToDate(st drbd.Status, vol *miroirv1alpha1.MiroirVolume, self string) bool {
+	for _, rep := range vol.Spec.Replicas {
+		if rep.Node == self || rep.Diskless || rep.Address == "" {
+			continue
+		}
+		if st.PeerDiskState[rep.NodeID] != drbd.DiskUpToDate {
+			return false
+		}
+	}
+	return true
+}
+
 // peerBackingsGrown reports whether every peer realized the desired size.
 // The local leg is excluded: its status entry is stale (just patched).
 func peerBackingsGrown(vol *miroirv1alpha1.MiroirVolume, self string) bool {

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -78,6 +78,12 @@ type SnapshotReconciler struct {
 	// pool holding the volume's local replica.
 	Pools Pools
 	DRBD  *drbd.Driver
+	// Reader is the uncached API reader for the sibling-round check: the
+	// coordinator writes status.ioSuspended before any barrier action, so
+	// an API-server read is never stale — the informer cache can be, and
+	// a missed fresh round would lift a live barrier. Falls back to the
+	// cached client when unset (tests).
+	Reader client.Reader
 	// Recorder emits the BarrierStuck warning; optional.
 	Recorder events.EventRecorder
 
@@ -511,10 +517,13 @@ func (r *SnapshotReconciler) openRound(ctx context.Context, snap *miroirv1alpha1
 // volume is mid-round (its coordinator holds status.ioSuspended). The
 // kernel suspend-io flag is per-resource, not per-snapshot: concurrent
 // rounds would lift each other's barrier and cut non-identical legs, so
-// every barrier touch outside a round defers to a live sibling.
+// every barrier touch outside a round defers to a live sibling. Reads
+// through the uncached Reader: a round opened milliseconds ago is not in
+// the informer cache yet, and treating it as absent would lift its
+// barrier mid-cut.
 func (r *SnapshotReconciler) otherRoundActive(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot) (bool, error) {
 	list := &miroirv1alpha1.MiroirSnapshotList{}
-	if err := r.List(ctx, list); err != nil {
+	if err := r.snapReader().List(ctx, list); err != nil {
 		return false, err
 	}
 	for i := range list.Items {
@@ -524,6 +533,15 @@ func (r *SnapshotReconciler) otherRoundActive(ctx context.Context, snap *miroirv
 		}
 	}
 	return false, nil
+}
+
+// snapReader returns the uncached API reader, falling back to the cached
+// client when unset (tests).
+func (r *SnapshotReconciler) snapReader() client.Reader {
+	if r.Reader != nil {
+		return r.Reader
+	}
+	return r.Client
 }
 
 // resumeUnlessSiblingRound lifts the local barrier unless a sibling

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -304,28 +304,27 @@ func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miro
 		time.Since(snap.Status.SuspendedAt.Time) > SuspendDeadline
 	// Disconnected or resyncing legs have diverged (quorum off lets the
 	// survivor write alone) and a barrier over diverged legs cuts
-	// diverged legs. Gates raising and cutting only — a degraded volume
-	// must still resume. Only diskful peers count: a downed tie-breaker
-	// holds no leg, and gating on its link would block every snapshot in
-	// exactly the degraded mode the tie-breaker exists to survive.
-	healthy := diskfulPeersConnected(st, vol, r.NodeName) && st.DiskState == drbd.DiskUpToDate
+	// diverged legs. Peer disk states count too: a resyncing or
+	// disk-failed peer can never raise its own barrier, so a round opened
+	// over it only freezes the workload until the deadline voids it —
+	// repeating for as long as the resync runs. Gates raising and cutting
+	// only — a degraded volume must still resume. Only diskful peers
+	// count: a downed tie-breaker holds no leg, and gating on its link
+	// would block every snapshot in exactly the degraded mode the
+	// tie-breaker exists to survive.
+	healthy := diskfulPeersConnected(st, vol, r.NodeName) &&
+		diskfulPeersUpToDate(st, vol, r.NodeName) &&
+		st.DiskState == drbd.DiskUpToDate
 
 	switch {
-	case coordinator && !snap.Status.IOSuspended && healthy:
-		// A failed previous round (a replica never finished before the
-		// deadline) retries with backoff instead of churning the barrier.
-		if myState == miroirv1alpha1.SnapshotError &&
-			snap.Status.SuspendedAt != nil &&
-			time.Since(snap.Status.SuspendedAt.Time) < suspendRetryBackoff {
-			return ctrl.Result{RequeueAfter: suspendRetryBackoff}, nil
-		}
-		// One round per volume: the kernel suspend flag is shared, so a
-		// second snapshot's round would tear the first's barrier down
-		// mid-cut. Wait for the sibling round to close.
-		if active, err := r.otherRoundActive(ctx, snap); err != nil || active {
-			return ctrl.Result{RequeueAfter: 2 * time.Second}, err
-		}
-		return r.raiseBarrier(ctx, snap, vol, true)
+	case coordinator && !snap.Status.IOSuspended && healthy && !st.Suspended:
+		// The !st.Suspended guard is the kernel-truth half of the
+		// one-round-per-volume rule: a sibling round opened milliseconds
+		// ago holds suspend-io before its status write reaches this
+		// node's informer, so openRound's cache check can miss it. A held
+		// barrier with no live sibling round is stale — the case at the
+		// bottom lifts it, and the next pass opens cleanly.
+		return r.openRound(ctx, snap, vol, myState)
 
 	case !coordinator && snap.Status.IOSuspended && !expired && healthy &&
 		myState != miroirv1alpha1.SnapshotSuspended && myState != miroirv1alpha1.SnapshotDone:
@@ -486,6 +485,26 @@ func allSuspended(vol *miroirv1alpha1.MiroirVolume, snap *miroirv1alpha1.MiroirS
 		}
 	}
 	return true
+}
+
+// openRound starts a new barrier round as coordinator: a fresh raise,
+// unless the previous round's failure is still inside its retry backoff
+// or a sibling snapshot's round is mid-flight.
+func (r *SnapshotReconciler) openRound(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume, myState miroirv1alpha1.SnapshotNodeState) (ctrl.Result, error) {
+	// A failed previous round (a replica never finished before the
+	// deadline) retries with backoff instead of churning the barrier.
+	if myState == miroirv1alpha1.SnapshotError &&
+		snap.Status.SuspendedAt != nil &&
+		time.Since(snap.Status.SuspendedAt.Time) < suspendRetryBackoff {
+		return ctrl.Result{RequeueAfter: suspendRetryBackoff}, nil
+	}
+	// One round per volume: the kernel suspend flag is shared, so a
+	// second snapshot's round would tear the first's barrier down
+	// mid-cut. Wait for the sibling round to close.
+	if active, err := r.otherRoundActive(ctx, snap); err != nil || active {
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, err
+	}
+	return r.raiseBarrier(ctx, snap, vol, true)
 }
 
 // otherRoundActive reports whether a different MiroirSnapshot of the same

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -463,13 +463,15 @@ func TestSnapshotProceedsWithTieBreakerDown(t *testing.T) {
 	// Both diskful views: data link Connected, tie-breaker link down.
 	feK := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
-		"connections":[{"peer-node-id":1,"connection-state":"Connected"},
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]},
 			{"peer-node-id":2,"connection-state":"Connecting"}]}]`}
 	rK := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feK.run}}
 	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
-		"connections":[{"peer-node-id":0,"connection-state":"Connected"},
+		"connections":[{"peer-node-id":0,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]},
 			{"peer-node-id":2,"connection-state":"Connecting"}]}]`}
 	rP := &SnapshotReconciler{Client: c, NodeName: nodeB, Pools: poolsOf(newFakeBackend()),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
@@ -980,5 +982,126 @@ func TestSnapshotBarrierCallsAreBounded(t *testing.T) {
 		if d <= 0 || d > drbdBarrierTimeout+time.Second {
 			t.Fatalf("call deadline %s is not bounded by drbdBarrierTimeout (%s)", d, drbdBarrierTimeout)
 		}
+	}
+}
+
+// A resyncing peer (link up, disk Inconsistent) can never cut its leg, so
+// opening a round would only freeze the workload until the deadline voids
+// it — repeating for the whole resync. The coordinator must not raise.
+func TestSnapshotWaitsForResyncingPeer(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrA
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = addrB
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	// Primary, locally UpToDate, peer link established — but the peer is
+	// still resync-target Inconsistent.
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"Inconsistent"}]}]}]`}
+	fb := newFakeBackend()
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	reconcileSnap(t, r, snapSnap1)
+
+	fe.notCalledWith(t, "suspend-io")
+	if len(fb.snapCalls) != 0 {
+		t.Fatalf("no leg may be cut while a peer resyncs: %v", fb.snapCalls)
+	}
+}
+
+// The kernel suspend flag is the ground truth half of one-round-per-volume:
+// a healthy coordinator must not open a round while suspend-io is already
+// held — a sibling round's status write may not have reached the cache yet.
+// With a live sibling it defers; with none it lifts the stale barrier and
+// leaves the raise for the next pass.
+func TestSnapshotOpenDefersToKernelBarrier(t *testing.T) {
+	kernelSuspended := `[{"name":"` + volPvc1 + `","role":"Primary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`
+
+	build := func(t *testing.T, siblingOpen bool) (*SnapshotReconciler, *fakeDRBDExec) {
+		t.Helper()
+		s := newScheme(t)
+		v := vol(volPvc1, nodeA, nodeB)
+		v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+		v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+			nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+			nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		}
+		sibling := snapObj("snap-2", volPvc1, nodeA, nodeB)
+		sibling.Status.IOSuspended = siblingOpen
+		c := fake.NewClientBuilder().WithScheme(s).
+			WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB), sibling).
+			WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+			Build()
+		fe := &fakeDRBDExec{statusJSON: kernelSuspended}
+		return &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+			DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}, fe
+	}
+
+	// Sibling round open: neither raise nor lift — the sibling owns it.
+	r, fe := build(t, true)
+	reconcileSnap(t, r, snapSnap1)
+	fe.notCalledWith(t, "suspend-io")
+	fe.notCalledWith(t, "resume-io")
+
+	// No sibling round: the barrier is stale — lift it, raise next pass.
+	r, fe = build(t, false)
+	reconcileSnap(t, r, snapSnap1)
+	fe.notCalledWith(t, "suspend-io")
+	fe.calledWith(t, "drbdadm resume-io pvc-1")
+}
+
+// A round whose last leg lands after the deadline still ships: done==all
+// wins over expiry, so a slow-but-complete snapshot is not thrown away.
+func TestSnapshotLateCompleteRoundStillShips(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	snap := snapObj(snapSnap1, volPvc1, nodeA, nodeB)
+	expired := metav1.NewTime(time.Now().Add(-2 * SuspendDeadline))
+	snap.Status.IOSuspended = true
+	snap.Status.SuspendedAt = &expired
+	snap.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{
+		nodeA: miroirv1alpha1.SnapshotDone,
+		nodeB: miroirv1alpha1.SnapshotDone,
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snap).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	reconcileSnap(t, r, snapSnap1)
+
+	fe.calledWith(t, "drbdadm resume-io pvc-1")
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.ReadyToUse || got.Status.IOSuspended {
+		t.Fatalf("a complete round past the deadline must still ship: %+v", got.Status)
 	}
 }

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -1105,3 +1105,40 @@ func TestSnapshotLateCompleteRoundStillShips(t *testing.T) {
 		t.Fatalf("a complete round past the deadline must still ship: %+v", got.Status)
 	}
 }
+
+// The sibling-round check reads through the uncached API reader: a round
+// opened milliseconds ago is not in the informer cache yet, and treating
+// it as absent would lift its live barrier. The cached client here serves
+// a stale sibling (round not visible); the reader serves the truth.
+func TestSnapshotSiblingCheckReadsThroughAPIReader(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	staleSibling := snapObj("snap-2", volPvc1, nodeA, nodeB) // cache: no round
+	freshSibling := snapObj("snap-2", volPvc1, nodeA, nodeB)
+	freshSibling.Status.IOSuspended = true // API server: round open
+	cached := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB), staleSibling).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(freshSibling).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}).
+		Build()
+
+	// Local barrier held by the fresh sibling round.
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	r := &SnapshotReconciler{Client: cached, Reader: apiServer, NodeName: nodeA,
+		Pools: poolsOf(newFakeBackend()),
+		DRBD:  &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	reconcileSnap(t, r, snapSnap1)
+
+	fe.notCalledWith(t, "resume-io")
+	fe.notCalledWith(t, "suspend-io")
+}


### PR DESCRIPTION
PR A of the sixth review cycle: the two snapshot-protocol findings, both verified end to end before fixing.

## Snapshots during a resync froze the workload in a 60s-on/30s-off loop

The round-open `healthy` gate checked peer *links* (`diskfulPeersConnected`) and the *local* disk state — never the peers' disk states. With a snapshot pending while any diskful peer resyncs (reconnect catch-up, or a FullSync joiner syncing for hours):

1. The coordinator is UpToDate and connected → `healthy` → it raises the suspend-io barrier, freezing the Primary's writes.
2. The SyncTarget peer is `Inconsistent`, so its own `healthy` gate refuses — it can never raise, `allSuspended` never becomes true, nobody cuts.
3. The round dies at `SuspendDeadline` (60s), voids, backs off 30s, and re-raises. Net: the workload is frozen ~2/3 of the time for the entire resync.

The comment above the gate showed the *intent* to cover resync ("disconnected or resyncing legs have diverged") — but the resync half only ever fired on the resyncing leg's own agent, not on the coordinator that pays for the doomed round. A disk-failed (latched Diskless) peer triggered the same loop.

Fix: `diskfulPeersUpToDate` — every completed diskful peer's disk must read `UpToDate` in the local kernel view (`st.PeerDiskState`, already parsed) before raising or cutting. Same skip rule as `diskfulPeersConnected` (incomplete entries and diskless legs excluded, so a downed tie-breaker still doesn't block snapshots). Deliberately **not** `st.Resyncing`: online verify sets that too and would wrongly block snapshots for the whole verify pass, while peers stay `UpToDate` during verify.

## Sibling rounds could double-open through informer lag

`otherRoundActive` reads the informer cache, so a sibling snapshot's round opened milliseconds earlier (its `status.ioSuspended` write not yet delivered to the watch) was invisible, and two rounds over one volume would lift each other's barrier mid-cut — writes land between one round's cuts and that snapshot's legs are no longer byte-identical, silently breaking the restore contract.

Fix: the coordinator's round-open case now also requires `!st.Suspended` — the kernel suspend flag is ground truth and is already fetched. A held barrier means either a live sibling round (the cache check or the fall-through defers) or a stale barrier, which falls through to the existing `resumeUnlessSiblingRound` lift-then-reopen path. Previously a healthy coordinator would raise straight over a stale barrier; now it lifts first and opens on the next pass. On the coordinator the single snapshot worker serializes the resume/open interleavings, so the kernel gate closes the double-open where it matters (writes only originate on the Primary).

The round-open branch moved to `openRound` verbatim (gocyclo 30 ceiling).

## Tests

- `TestSnapshotWaitsForResyncingPeer`: link up + peer `Inconsistent` → no `suspend-io`, no cuts (the named gap — the prior health test only covered a *disconnected* peer).
- `TestSnapshotOpenDefersToKernelBarrier`: kernel-held barrier + live sibling → neither raise nor lift; no sibling → lift, no raise this pass.
- `TestSnapshotLateCompleteRoundStillShips`: pins the `collectLegs` boundary that done==all wins over expiry, so a slow-but-complete round ships instead of voiding.
- The tie-breaker-down fixture's Connected link gains the `peer_devices` block real `drbdsetup status --json` output always carries (it previously exercised the gate vacuously).

Full linux suite green (docker golang:1.26.3), lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened snapshot coordinator readiness by requiring diskful peers to be disk up-to-date (based on the kernel’s view) in addition to connectivity and local disk state.
  * Refined coordinator behavior to open rounds via a dedicated flow, deferring when a kernel suspend barrier is already held and clearing stale barriers when no sibling round is active.
  * Improved sibling-round detection to avoid stale informer-cache results.
  * Ensured late-completing rounds past their deadline can still transition to Ready-to-Use.

* **Tests**
  * Added/extended regression coverage for resyncing peers, barrier deferral/clearing, late completion, and sibling-round API-reader detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->