### PR TITLE
fix(membership): auto-evict liveness gates and tie-breaker client handling

### DIFF
--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -47,7 +47,12 @@ is yours to erase.
 
 Auto-evict is deliberately timid. It stands down in any of these cases:
 
-- More than one node's heartbeat is stale. That pattern points at the
+- The node's kubelet is still Ready. Then only the miroir agent is
+  broken (a crash-loop, a stuck rollout); the node's DRBD legs keep
+  replicating in the kernel and evicting anything would sever live
+  storage.
+- More than one node's heartbeat is stale (opted-out nodes don't
+  count — theirs are expected to go dark). That pattern points at the
   network or API server, not at two simultaneous dead nodes.
 - A surviving replica still sees the "dead" node's DRBD connections up.
   The node is then alive, and only its Kubernetes connection is broken.
@@ -57,7 +62,7 @@ Auto-evict is deliberately timid. It stands down in any of these cases:
 It also needs a spare storage node with the volume's pool and room for
 the volume's full size; on a cluster with no spare node it does nothing.
 A node with known long outages can opt out with
-`nodes.<name>.autoEvict: false`. Keep the threshold well above your
+`nodes.<name>.spec.autoEvict: false`. Keep the threshold well above your
 longest planned reboot or upgrade window, since eviction discards the
 dead node's copy of the data.
 

--- a/internal/membership/autoevict.go
+++ b/internal/membership/autoevict.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,6 +112,18 @@ func (r *AutoEvictReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if remaining := r.After - time.Since(mn.Status.ObservedAt.Time); remaining > 0 {
 		return ctrl.Result{RequeueAfter: remaining}, nil
 	}
+	if ready, err := r.nodeReady(ctx, req.Name); err != nil {
+		return ctrl.Result{}, err
+	} else if ready {
+		// The kubelet still heartbeats: the node is alive and only the
+		// miroir agent's heartbeat is gone (crash-loop, rollout stuck).
+		// Its DRBD legs replicate in the kernel without the agent, and a
+		// consumer pod there is still doing IO through its client leg —
+		// evicting anything would sever live storage.
+		metricEvictStanddown.WithLabelValues("node_ready").Inc()
+		log.Info("auto-evict standing down: the node's kubelet is Ready", "node", req.Name)
+		return ctrl.Result{RequeueAfter: evictRecheckInterval}, nil
+	}
 
 	pass, stale, err := r.gather(ctx, nodes, topology)
 	if err != nil {
@@ -173,6 +186,13 @@ func (r *AutoEvictReconciler) gather(ctx context.Context, nodes *miroirv1alpha1.
 	for i := range nodes.Items {
 		n := &nodes.Items[i]
 		pass.nodes[n.Name] = n
+		if !topology.AutoEvictAllowed(n.Name) {
+			// An opted-out node is expected to go dark ("known long
+			// outages"); counting it would trip the multiple-stale valve
+			// for as long as it stays away and disable auto-evict for the
+			// nodes that actually died.
+			continue
+		}
 		if n.Status.ObservedAt != nil && time.Since(n.Status.ObservedAt.Time) >= r.After {
 			stale = append(stale, n.Name)
 		}
@@ -186,6 +206,23 @@ func (r *AutoEvictReconciler) gather(ctx context.Context, nodes *miroirv1alpha1.
 		pass.pinned[snaps.Items[i].Spec.VolumeName] = true
 	}
 	return pass, stale, nil
+}
+
+// nodeReady reports whether the node's kubelet heartbeat is current — a
+// liveness signal independent of the miroir agent. Absent Node object or
+// a NotReady/Unknown condition reads as not-alive (the eviction gates
+// below still apply).
+func (r *AutoEvictReconciler) nodeReady(ctx context.Context, name string) (bool, error) {
+	node := &corev1.Node{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name}, node); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue, nil
+		}
+	}
+	return false, nil
 }
 
 // evictOutcome classifies one volume's eviction attempt.
@@ -347,11 +384,11 @@ func (r *AutoEvictReconciler) plan(vol *miroirv1alpha1.MiroirVolume, dead string
 	// toggle-disk) restores 2 data copies at the cost of the quorum leg —
 	// strictly better than staying at 1 clean copy.
 	for i, rep := range vol.Spec.Replicas {
-		if !rep.Diskless || rep.Node == dead || !fits(rep.Node) {
+		if !rep.Diskless || rep.Node == dead {
 			continue
 		}
 		pool, ok := pass.topology.Pool(rep.Node, poolName)
-		if !ok {
+		if !ok || poolRoom(pass.nodes[rep.Node], poolName, vol.Spec.SizeBytes) != "" {
 			continue
 		}
 		return kindReplica, func(v *miroirv1alpha1.MiroirVolume) {

--- a/internal/membership/autoevict_test.go
+++ b/internal/membership/autoevict_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -359,5 +360,100 @@ func TestAutoEvictNoSpareLeavesVolume(t *testing.T) {
 	}
 	if res.RequeueAfter != evictRecheckInterval {
 		t.Fatalf("must re-check later, got %v", res.RequeueAfter)
+	}
+}
+
+// An opted-out node is expected to go dark: its stale heartbeat must not
+// trip the multiple-stale valve and freeze eviction of a node that
+// actually died.
+func TestAutoEvictValveIgnoresOptedOutNodes(t *testing.T) {
+	optOut := minAt(nodeC, 3*time.Hour, 50<<30) // dark for hours, by design
+	no := false
+	optOut.Spec.AutoEvict = &no
+	r := newAE(t, evictVol(),
+		minAt(nodeA, time.Minute, 50<<30),
+		minAt(nodeB, 2*time.Hour, 50<<30), // genuinely dead
+		optOut,
+		minAt(nodeD, time.Minute, 50<<30))
+
+	reconcileAE(t, r, nodeB)
+
+	got := get(t, &Reconciler{Client: r.Client}, volPvc1)
+	if slices.ContainsFunc(got.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
+		return rep.Node == nodeB
+	}) {
+		t.Fatalf("the opted-out node's staleness must not block the eviction: %+v", got.Spec.Replicas)
+	}
+}
+
+// A Ready kubelet is proof of life independent of the agent: a
+// crash-looping agent pod must not get the node's legs — replica or
+// client — severed while the node is alive and doing IO.
+func TestAutoEvictStandsDownWhenNodeReady(t *testing.T) {
+	kubeletAlive := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeB},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
+			{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+		}},
+	}
+	r := newAE(t, evictVol(), kubeletAlive,
+		minAt(nodeB, 2*time.Hour, 50<<30),
+		minAt(nodeD, time.Minute, 50<<30))
+
+	res := reconcileAE(t, r, nodeB)
+
+	got := get(t, &Reconciler{Client: r.Client}, volPvc1)
+	if len(got.Spec.Replicas) != 2 {
+		t.Fatalf("a Ready node must never be evicted: %+v", got.Spec)
+	}
+	if res.RequeueAfter != evictRecheckInterval {
+		t.Fatalf("must re-check later, got %v", res.RequeueAfter)
+	}
+	if v := testutil.ToFloat64(metricEvictStanddown.WithLabelValues("node_ready")); v < 1 {
+		t.Fatalf("stand-down counter must increment, got %v", v)
+	}
+}
+
+// A NotReady Node object does not stand the pass down — that is the dead
+// node the reconciler exists for.
+func TestAutoEvictProceedsWhenNodeNotReady(t *testing.T) {
+	kubeletDead := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeB},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
+			{Type: corev1.NodeReady, Status: corev1.ConditionUnknown},
+		}},
+	}
+	r := newAE(t, evictVol(), kubeletDead,
+		minAt(nodeB, 2*time.Hour, 50<<30),
+		minAt(nodeD, time.Minute, 50<<30))
+
+	reconcileAE(t, r, nodeB)
+
+	got := get(t, &Reconciler{Client: r.Client}, volPvc1)
+	if slices.ContainsFunc(got.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
+		return rep.Node == nodeB
+	}) {
+		t.Fatalf("a NotReady node must still be evicted: %+v", got.Spec.Replicas)
+	}
+}
+
+// One membership edit at a time: an entry still awaiting completion
+// blocks the swap — acting on a half-completed spec races the membership
+// reconciler's update.
+func TestAutoEvictBlocksOnIncompleteMembershipChange(t *testing.T) {
+	v := evictVol()
+	v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{Node: nodeC}) // bare, mid-completion
+	r := newAE(t, v,
+		minAt(nodeB, 2*time.Hour, 50<<30),
+		minAt(nodeC, time.Minute, 50<<30),
+		minAt(nodeD, time.Minute, 50<<30))
+
+	reconcileAE(t, r, nodeB)
+
+	got := get(t, &Reconciler{Client: r.Client}, volPvc1)
+	if !slices.ContainsFunc(got.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
+		return rep.Node == nodeB
+	}) {
+		t.Fatalf("an in-flight membership change must block eviction: %+v", got.Spec.Replicas)
 	}
 }

--- a/internal/membership/metrics.go
+++ b/internal/membership/metrics.go
@@ -47,10 +47,10 @@ var metricEvictions = prometheus.NewCounterVec(prometheus.CounterOpts{
 // metricEvictStanddown counts passes where eviction refused to act on a
 // stale node. A rising multiple_stale rate flags an observer-side
 // problem; peer_connected flags a node cut off from the API server but
-// not from its peers.
+// not from its peers; node_ready flags a broken agent on a live node.
 var metricEvictStanddown = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Name: "miroir_autoevict_standdown_total",
-	Help: "Auto-evict passes that stood down instead of evicting, by reason (multiple_stale: more than one node's heartbeat is stale; peer_connected: a survivor still holds DRBD links to the stale node).",
+	Help: "Auto-evict passes that stood down instead of evicting, by reason (multiple_stale: more than one node's heartbeat is stale; peer_connected: a survivor still holds DRBD links to the stale node; node_ready: the node's kubelet still heartbeats, only the agent is gone).",
 }, []string{"reason"})
 
 func init() {

--- a/internal/membership/tiebreaker.go
+++ b/internal/membership/tiebreaker.go
@@ -71,15 +71,15 @@ func (r *TieBreakerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if !ok {
 			continue
 		}
-		if !slices.ContainsFunc(vol.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
-			return rep.Node == node
-		}) {
-			// A removed replica's teardown is still in flight: its agent
+		if !hasLegOn(vol, node) {
+			// A removed leg's teardown is still in flight: its agent
 			// holds the finalizer until the leg is safely gone. Picking
 			// that node now would cancel the teardown, leaking its backing
 			// device and stale DRBD metadata that a later diskful re-add
 			// would adopt. Releasing the finalizer does not bump the
 			// generation, so poll instead of waiting on a watch event.
+			// Client legs hold finalizers too — theirs are live legs, not
+			// removals in flight.
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 	}
@@ -87,7 +87,14 @@ func (r *TieBreakerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	tb := nodes.TieBreakerNode(vol.Spec.Replicas)
+	// Client-leg nodes count as used: a replica may not share a node with
+	// a client leg (CEL rule), so picking one would only bounce off the
+	// apiserver forever.
+	legs := slices.Clone(vol.Spec.Replicas)
+	for _, cl := range vol.Spec.Clients {
+		legs = append(legs, miroirv1alpha1.Replica{Node: cl.Node})
+	}
+	tb := nodes.TieBreakerNode(legs)
 	if tb == "" {
 		// No spare node; the MiroirNode watch revisits this volume when
 		// one joins the topology.

--- a/internal/membership/tiebreaker_test.go
+++ b/internal/membership/tiebreaker_test.go
@@ -205,3 +205,59 @@ func TestTieBreakerSkips(t *testing.T) {
 		})
 	}
 }
+
+// A client leg's finalizer is a live leg, not a removal in flight: the
+// retrofit must still run instead of polling forever behind it.
+func TestTieBreakerRetrofitWithClientLeg(t *testing.T) {
+	v := freezeVol()
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{
+		{Node: nodeBergen, NodeID: 2, Address: addrBergen},
+	}
+	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeBergen)
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(v, node(nodeC, addrC)).
+		Build()
+	nodes := nodemap.Map{
+		nodeA: storageNode(miroirv1alpha1.BackendZFS),
+		nodeB: storageNode(miroirv1alpha1.BackendZFS),
+		nodeC: storageNode(miroirv1alpha1.BackendZFS),
+	}
+	r := &TieBreakerReconciler{Client: c, Nodes: nodes}
+
+	tbReconcile(t, r)
+
+	got := get(t, &Reconciler{Client: c}, volTB)
+	idx := slices.IndexFunc(got.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
+		return rep.Node == nodeC
+	})
+	if idx < 0 || !got.Spec.Replicas[idx].Diskless {
+		t.Fatalf("retrofit must append the tie-breaker despite the client leg: %+v", got.Spec.Replicas)
+	}
+}
+
+// A client's node is used: a replica may not share a node with a client
+// leg (CEL rule), so the retrofit must not pick it — with no other spare
+// it skips quietly instead of bouncing off the apiserver forever.
+func TestTieBreakerSkipsClientNode(t *testing.T) {
+	v := freezeVol()
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{
+		{Node: nodeC, NodeID: 2, Address: addrC},
+	}
+	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeC)
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(v, node(nodeC, addrC)).
+		Build()
+	nodes := nodemap.Map{
+		nodeA: storageNode(miroirv1alpha1.BackendZFS),
+		nodeB: storageNode(miroirv1alpha1.BackendZFS),
+		nodeC: storageNode(miroirv1alpha1.BackendZFS), // the client's node
+	}
+	r := &TieBreakerReconciler{Client: c, Nodes: nodes}
+
+	tbReconcile(t, r)
+
+	got := get(t, &Reconciler{Client: c}, volTB)
+	if len(got.Spec.Replicas) != 2 {
+		t.Fatalf("the client's node must not receive the tie-breaker: %+v", got.Spec.Replicas)
+	}
+}


### PR DESCRIPTION
PR B of the sixth review cycle: the three membership findings, all verified end to end.

## A Ready kubelet stands the whole eviction pass down

Auto-evict's premise is "MiroirNode heartbeat stale ⇒ node dead", but the heartbeat comes from the miroir agent — a crash-looping agent pod (bad rollout, resource pressure) goes stale while the node is perfectly alive. For diskful replicas the DRBD peer-connected gate caught that; **client legs had no proof-of-life at all**: `ReplicaStatus.Connected` covers diskful peers only, so survivors carry no signal about a client node's link, and the pass would drop a live consumer's leg — replicas re-render, connections drop, and the pod's diskless device loses every peer mid-IO.

Rather than surfacing per-peer connectivity into the CRD (an API addition), the pass now checks the strongest cheap liveness signal there is: the node's `corev1.Node` Ready condition. Kubelet Ready ⇒ the node is alive and only the agent is broken ⇒ stand down entirely (new `node_ready` stand-down reason, metric + docs updated). NotReady/Unknown/absent proceeds — and for the genuinely-dead-node case Kubernetes itself has already evicted the consumer pods long before `autoEvictAfter` fires, so dropping the dead consumer's client leg stays safe. This also adds belt-and-braces for replicas: if the kubelet is Ready, evicting *any* leg was wrong. Happy to swap this for the per-peer-status design if you'd rather have DRBD-level proof for clients too.

## The multiple-stale valve counted opted-out nodes

`autoEvict: false` is documented for "nodes with known long outages" — exactly the nodes expected to go heartbeat-stale. The valve censused them anyway, so one opted-out node dark for a weekend plus one real node death read as `multiple_stale` and disabled auto-evict cluster-wide until the opt-out node returned. The census now skips nodes failing `AutoEvictAllowed`; an observer-side problem still trips the valve off the remaining nodes.

## Tie-breaker retrofit vs client legs

The in-flight-removal check looked for each finalizer's node in `Spec.Replicas` only. A client leg's finalizer (live leg, added at stage time) therefore read as "removal in flight" → the retrofit requeued at 30s **forever** and never added a tie-breaker even with a valid spare. It now uses `hasLegOn` (replicas + clients). Second defect in the same function: `TieBreakerNode` wasn't given client nodes as used, so it could pick the client's node and bounce off the CEL client-replica exclusivity rule in an error loop — clients are now appended as used legs, the same way `autoevict.plan` already did.

## Also

- The tie-breaker-flip loop resolved the pool twice; the second lookup's `!ok` branch was unreachable. Single resolve now.
- `docs/resilience.md`: stands-down list updated for the two new behaviors, and the `nodes.<name>.autoEvict` example gains its missing `.spec` (the documented path silently did nothing).

## Tests

`TestAutoEvictStandsDownWhenNodeReady` (+ metric), `TestAutoEvictProceedsWhenNodeNotReady`, `TestAutoEvictValveIgnoresOptedOutNodes`, `TestAutoEvictBlocksOnIncompleteMembershipChange` (the previously untested race gate), `TestTieBreakerRetrofitWithClientLeg`, `TestTieBreakerSkipsClientNode`. Full linux suite green, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Auto-eviction now stands down when a node’s kubelet remains ready, preventing disruption to live storage when only the storage agent is unavailable.
  - Opted-out nodes no longer interfere with stale-node safety checks.
  - Eviction remains blocked during incomplete membership changes.
  - Tie-breaker selection now avoids nodes already serving client connections.

- **Documentation**
  - Clarified auto-eviction safeguards and updated the configuration setting for opting out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->