### PR TITLE
fix(backend): loopfile crash-safety and lvmthin pool activation

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -470,6 +470,22 @@ func TestLVMThinSetupIdempotent(t *testing.T) {
 	}
 	fe.notCalledWith(t, "pvcreate")
 	fe.notCalledWith(t, "lvcreate")
+	// The existing pool is activated: Talos does not activate LVs at
+	// boot, and an inactive pool reports empty kernel-status fields that
+	// fail every Stats tick until the first volume lands on the node.
+	fe.calledWith(t, "lvchange --activate y vg-miroir/thinpool")
+}
+
+// A crash-retried Snapshot must skip the lvcreate when the snapshot LV
+// already exists (zfs and loopfile pin the same contract).
+func TestLVMThinSnapshotIdempotent(t *testing.T) {
+	fe := &fakeExec{} // lvs succeeds → snapshot LV exists
+	b := newLVMThin(cfg, fe.run)
+
+	if err := b.Snapshot(t.Context(), "pvc-1", "snapshot-1"); err != nil {
+		t.Fatal(err)
+	}
+	fe.notCalledWith(t, "lvcreate")
 }
 
 func TestLVMThinSetupNoDeviceFails(t *testing.T) {

--- a/internal/backend/loopfile.go
+++ b/internal/backend/loopfile.go
@@ -149,12 +149,15 @@ func (lf *loopfile) attach(ctx context.Context, vol, file string) (string, error
 			return "", fmt.Errorf("losetup --find %s: %w", file, aerr)
 		}
 		dev = strings.TrimSpace(out)
-		// Direct I/O drops the host page cache under the loop device: the
-		// filesystem above it already caches, so buffered mode double-caches
-		// (wasted memory, extra copy). Best-effort — a backing filesystem
-		// without O_DIRECT (e.g. some ZFS builds) must not fail the attach.
-		_, _ = lf.exec(ctx, "losetup", "--direct-io=on", dev)
 	}
+	// Direct I/O drops the host page cache under the loop device: the
+	// filesystem above it already caches, so buffered mode double-caches
+	// (wasted memory, extra copy). Best-effort — a backing filesystem
+	// without O_DIRECT (e.g. some ZFS builds) must not fail the attach —
+	// and applied on the reuse path too, so a crash between attach and
+	// this call cannot leave the volume buffered for the attachment's
+	// lifetime.
+	_, _ = lf.exec(ctx, "losetup", "--direct-io=on", dev)
 	link := lf.DevicePath(vol)
 	if _, err := lf.exec(ctx, "ln", "-sfn", dev, link); err != nil {
 		return "", fmt.Errorf("symlink %s -> %s: %w", link, dev, err)
@@ -174,8 +177,15 @@ func (lf *loopfile) Create(ctx context.Context, vol string, sizeBytes int64) (st
 	}
 	if !ok {
 		// Sparse (thin) backing file, like the zfs -s zvol / lvm-thin LV.
-		if _, err := lf.exec(ctx, "truncate", "-s", strconv.FormatInt(sizeBytes, 10), file); err != nil {
+		// Created through a temp path + atomic rename: truncate is
+		// open(O_CREAT)+ftruncate, and a crash between the two would leave
+		// a 0-byte image the retry's exists() accepts as complete.
+		tmp := file + ".tmp"
+		if _, err := lf.exec(ctx, "truncate", "-s", strconv.FormatInt(sizeBytes, 10), tmp); err != nil {
 			return "", fmt.Errorf("create backing file %s: %w", file, err)
+		}
+		if _, err := lf.exec(ctx, "mv", tmp, file); err != nil {
+			return "", fmt.Errorf("move backing file into place %s: %w", file, err)
 		}
 	}
 	return lf.attach(ctx, vol, file)
@@ -271,17 +281,54 @@ func (lf *loopfile) CreateFromSnapshot(ctx context.Context, vol, _ /* sourceVol 
 	return lf.attach(ctx, vol, file)
 }
 
+// held reports why the loop device cannot be detached ("" when it can):
+// a stacked device on top (a DRBD attach) or a mounted filesystem.
+// losetup -d on a held device does not fail on modern kernels — it sets
+// lazy AUTOCLEAR and returns success — so detaching without this check
+// would let Delete destroy an in-use volume's backing file.
+func (lf *loopfile) held(ctx context.Context, dev string) (string, error) {
+	out, err := lf.exec(ctx, "lsblk", "-rno", "NAME,MOUNTPOINT", dev)
+	if err != nil {
+		return "", fmt.Errorf("lsblk %s: %w", dev, err)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) > 1 {
+		return "stacked device " + strings.Fields(lines[1])[0] + " holds it", nil
+	}
+	if f := strings.Fields(lines[0]); len(f) > 1 {
+		return "mounted at " + f[1], nil
+	}
+	return "", nil
+}
+
 func (lf *loopfile) Delete(ctx context.Context, vol string) error {
 	file := lf.imgPath(vol)
 	ok, err := lf.exists(ctx, file)
-	if err != nil || !ok {
+	if err != nil {
 		return err
+	}
+	if !ok {
+		// A crash between Create's truncate and its rename can leave only
+		// the .tmp; it would otherwise outlive the volume.
+		if _, err := lf.exec(ctx, "rm", "-f", file+".tmp"); err != nil {
+			return fmt.Errorf("remove leftover %s.tmp: %w", file, err)
+		}
+		return nil
 	}
 	dev, err := lf.loopDev(ctx, file)
 	if err != nil {
 		return err
 	}
 	if dev != "" {
+		reason, err := lf.held(ctx, dev)
+		if err != nil {
+			return err
+		}
+		if reason != "" {
+			// A positive determination — wrap ErrBusy directly instead of
+			// going through Busy()'s error-text classifier.
+			return fmt.Errorf("%w: detach %s: %s", ErrBusy, dev, reason)
+		}
 		if _, err := lf.exec(ctx, "losetup", "-d", dev); err != nil {
 			return Busy(fmt.Errorf("detach %s: %w", dev, err))
 		}
@@ -289,18 +336,20 @@ func (lf *loopfile) Delete(ctx context.Context, vol string) error {
 	if _, err := lf.exec(ctx, "rm", "-f", lf.DevicePath(vol)); err != nil {
 		return fmt.Errorf("remove symlink %s: %w", lf.DevicePath(vol), err)
 	}
-	if _, err := lf.exec(ctx, "rm", "-f", file); err != nil {
+	// The .tmp sibling is a crash leftover of reflinkAtomic/Create; as a
+	// full CoW reference it would silently pin the image's extents.
+	if _, err := lf.exec(ctx, "rm", "-f", file, file+".tmp"); err != nil {
 		return fmt.Errorf("remove backing file %s: %w", file, err)
 	}
 	return nil
 }
 
 func (lf *loopfile) DeleteSnapshot(ctx context.Context, _ /* vol */, snap string) error {
-	ok, err := lf.exists(ctx, lf.snapPath(snap))
-	if err != nil || !ok {
-		return err
-	}
-	if _, err := lf.exec(ctx, "rm", "-f", lf.snapPath(snap)); err != nil {
+	// No exists() gate: rm -f is the idempotency, and it must also reap a
+	// crash-leftover .tmp (reflinkAtomic aborted before its rename) when
+	// the snapshot itself never made it into place — as a full CoW
+	// reference the leftover silently pins the source image's extents.
+	if _, err := lf.exec(ctx, "rm", "-f", lf.snapPath(snap), lf.snapPath(snap)+".tmp"); err != nil {
 		return fmt.Errorf("remove snapshot %s: %w", snap, err)
 	}
 	return nil

--- a/internal/backend/loopfile_test.go
+++ b/internal/backend/loopfile_test.go
@@ -40,7 +40,10 @@ func TestLoopfileCreateAttachesNewFile(t *testing.T) {
 	if dev != "/var/lib/miroir/dev/pvc-1" {
 		t.Fatalf("unexpected device path %q", dev)
 	}
-	fe.calledWith(t, "truncate -s 10737418240 /var/lib/miroir/volumes/pvc-1.img")
+	// Temp path + rename: a crash between truncate's open and ftruncate
+	// must never leave a 0-byte image the retry's exists() accepts.
+	fe.calledWith(t, "truncate -s 10737418240 /var/lib/miroir/volumes/pvc-1.img.tmp")
+	fe.calledWith(t, "mv /var/lib/miroir/volumes/pvc-1.img.tmp /var/lib/miroir/volumes/pvc-1.img")
 	fe.calledWith(t, "losetup --find --show /var/lib/miroir/volumes/pvc-1.img")
 	fe.calledWith(t, "losetup --direct-io=on /dev/loop0")
 	fe.calledWith(t, "ln -sfn /dev/loop0 /var/lib/miroir/dev/pvc-1")
@@ -146,16 +149,36 @@ func TestLoopfileDeleteDetachesAndRemoves(t *testing.T) {
 	fe.calledWith(t, "rm -f /var/lib/miroir/volumes/pvc-1.img")
 }
 
-func TestLoopfileDeleteBusyWhenAttached(t *testing.T) {
+// A held loop device must be detected BEFORE losetup -d: on modern
+// kernels detaching a held device does not fail — it sets lazy AUTOCLEAR
+// and returns success — so an error-based guard never fires and Delete
+// would destroy an in-use volume's backing file.
+func TestLoopfileDeleteBusyWhenStacked(t *testing.T) {
 	fe := &fakeExec{} // stat succeeds → file exists
 	fe.respond("losetup -j", "/dev/loop3\n", nil)
-	fe.respond("losetup -d /dev/loop3", "",
-		errors.New("losetup: /dev/loop3: detach failed: Device or resource busy"))
+	// A DRBD attach shows as a stacked child of the loop device.
+	fe.respond("lsblk -rno NAME,MOUNTPOINT /dev/loop3", "loop3\ndrbd1000\n", nil)
 	b := newLoopfile(lcfg, fe.run)
 
 	if err := b.Delete(t.Context(), "pvc-1"); !errors.Is(err, ErrBusy) {
-		t.Fatalf("want ErrBusy while the loop device is attached, got %v", err)
+		t.Fatalf("want ErrBusy while a stacked device holds the loop, got %v", err)
 	}
+	fe.notCalledWith(t, "losetup -d")
+	fe.notCalledWith(t, "rm -f")
+}
+
+func TestLoopfileDeleteBusyWhenMounted(t *testing.T) {
+	fe := &fakeExec{} // stat succeeds → file exists
+	fe.respond("losetup -j", "/dev/loop3\n", nil)
+	fe.respond("lsblk -rno NAME,MOUNTPOINT /dev/loop3",
+		"loop3 /var/lib/kubelet/plugins/miroir/staging/pvc-1\n", nil)
+	b := newLoopfile(lcfg, fe.run)
+
+	if err := b.Delete(t.Context(), "pvc-1"); !errors.Is(err, ErrBusy) {
+		t.Fatalf("want ErrBusy while the loop device is mounted, got %v", err)
+	}
+	fe.notCalledWith(t, "losetup -d")
+	fe.notCalledWith(t, "rm -f")
 }
 
 func TestLoopfileDeleteAbsentIsNoop(t *testing.T) {
@@ -168,7 +191,8 @@ func TestLoopfileDeleteAbsentIsNoop(t *testing.T) {
 		t.Fatal(err)
 	}
 	fe.notCalledWith(t, "losetup -d")
-	fe.notCalledWith(t, "rm -f /var/lib/miroir/volumes/pvc-1.img")
+	// Only the crash-leftover .tmp is reaped; the backing file is gone.
+	fe.calledWith(t, "rm -f /var/lib/miroir/volumes/pvc-1.img.tmp")
 }
 
 func TestLoopfileSetupProbesReflink(t *testing.T) {

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -52,6 +52,14 @@ func (l *lvmThin) Setup(ctx context.Context) error {
 			return fmt.Errorf("check thin pool %s/%s: %w", l.vg, l.pool, perr)
 		}
 		if ok {
+			// Talos does not activate LVs at boot: after a reboot of a node
+			// holding no miroir volumes (nothing else runs lvchange), an
+			// inactive pool reports empty kernel-status fields and every
+			// Stats tick fails until the first volume lands here.
+			// Idempotent on an active pool.
+			if _, err := l.lvm(ctx, "lvchange", "--activate", "y", l.ref(l.pool)); err != nil {
+				return fmt.Errorf("activate thin pool %s/%s: %w", l.vg, l.pool, err)
+			}
 			return nil
 		}
 	} else if !strings.Contains(err.Error(), "not found") {
@@ -60,7 +68,7 @@ func (l *lvmThin) Setup(ctx context.Context) error {
 		// failing pvcreate against an in-use device.
 		return fmt.Errorf("vgs %s: %w", l.vg, err)
 	} else if l.device == "" {
-		return fmt.Errorf("VG %s absent and no --lvm-device configured to create it", l.vg)
+		return fmt.Errorf("VG %s absent and the pool declares no lvmthin.device to create it from", l.vg)
 	} else {
 		if _, err := l.lvm(ctx, "pvcreate", l.device); err != nil &&
 			!strings.Contains(err.Error(), "already") {


### PR DESCRIPTION
PR C of the sixth review cycle: the backend findings, all verified.

## loopfile Delete destroyed in-use volumes

The `ErrBusy` guard wrapped a `losetup -d` failure that modern kernels never produce: `LOOP_CLR_FD` on a held device sets lazy `AUTOCLEAR` and returns 0. So a replicas:1 loopfile volume still mounted (force-deleted pod, dead kubelet, missed NodeUnstage) deleted clean through — symlink and backing file removed while the pod kept writing into an unlinked file whose contents evaporate at unmount. lvmthin (`lvremove` → "in use") and zfs (`destroy` → "busy") already returned ErrBusy in the identical scenario, which is the documented `Backend.Delete` contract. The old `TestLoopfileDeleteBusyWhenAttached` scripted a `detach failed: Device or resource busy` error real losetup does not emit, so it verified fiction.

`Delete` now asks `lsblk -rno NAME,MOUNTPOINT` before detaching: a stacked child (a DRBD attach) or a mountpoint is a positive busy determination — wrapped as `ErrBusy` directly rather than through `Busy()`'s error-text classifier, which none of the honest reasons would match. Normal teardown is unaffected (DRBD is downed before the backend Delete, and a properly unstaged fs has no mountpoint). New tests script both real signals and assert neither `losetup -d` nor any `rm` runs.

## reflinkAtomic's `.tmp` leaked forever on unretried ops

A crash between `cp --reflink` and `mv` leaves `<name>.img.tmp`. A retry overwrites it, but an op that is never retried (snapshot CR deleted mid-cut, restore volume deleted) orphaned it permanently — and as a full CoW reference it silently pins the source image's extents even after the source is gone, an invisible capacity leak in df-based `Stats`. `Delete`/`DeleteSnapshot` now reap the `.tmp` sibling, including when the main file never made it into place (`DeleteSnapshot` drops its `exists()` gate entirely — `rm -f` is the idempotency).

## Create wasn't crash-atomic

`truncate -s N file` is `open(O_CREAT)`+`ftruncate`; a crash between the two leaves a 0-byte image the retry's `exists()` accepts as complete, wedging the volume at loop-attach/`create-md` until manual cleanup — the exact class `reflinkAtomic`'s comment defends against. Create now uses the same tmp+rename pattern. Also: `--direct-io=on` now runs on the attach-reuse path too, so a crash between a fresh attach and the flag can't leave the volume double-caching for the attachment's lifetime.

## lvmthin: inactive pool after reboot broke Stats

Talos doesn't activate LVs at boot, and `Setup`'s already-exists path never activated the pool — so after a reboot of a node holding **no** miroir volumes (nothing else runs `lvchange`), `lvs` reports empty `data_percent`/`metadata_percent` and every `Stats` tick fails at `ParseFloat("")`: gauges vanish and the node sorts last in placement until a volume happens to land there. `Setup` now runs `lvchange --activate y` on the exists path (idempotent on an active pool). Also, the VG-absent error message steered operators at the removed `--lvm-device` flag; it now names `lvmthin.device`.

Plus the previously untested lvmthin snapshot-idempotency contract (zfs and loopfile both had the test; lvmthin's `exists→skip` guard was unexercised).

Full linux suite green, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loop-device configuration consistency when reusing existing devices.
  * Added safer volume creation to prevent incomplete backing images after crashes.
  * Prevented deletion of loop-backed volumes while they are mounted or in use.
  * Added cleanup for temporary files left by interrupted operations.
  * Made snapshot deletion and existing snapshot handling idempotent.
  * Ensured existing LVM thin pools are activated after reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->