### PR TITLE
fix(csi): expansion guardrails, forced NFS cleanup, and client-leg refusals

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -562,11 +562,16 @@ func main() {
 				msg = "MiroirNode declares no pools; running client-only node service"
 			}
 			setupLog.Info(msg, "node", nodeName)
-			// Client legs get DRBD configs rendered here too, so the
-			// kernel floor binds on client-only nodes as well.
+			// No volume reconciler runs here, so a client leg could never
+			// be realized: the node service refuses RWO remote-access
+			// staging outright (ClientOnly) — RWX/NFS staging needs no
+			// DRBD leg and still works. The driver is wired for the node
+			// service's status reads, none of which are reachable with
+			// client legs refused; the probe only logs what the node ships.
 			clientDRBD := &drbd.Driver{StateDir: drbdStateDir, Exec: backend.RealExec}
 			probeDRBD(clientDRBD)
 			node := csi.NewNode(mgr.GetClient(), nodeName, clientDRBD)
+			node.ClientOnly = true
 			serveCSI(mgr, csiSocket, identity, nil, node)
 			break
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -565,11 +565,11 @@ func main() {
 			// No volume reconciler runs here, so a client leg could never
 			// be realized: the node service refuses RWO remote-access
 			// staging outright (ClientOnly) — RWX/NFS staging needs no
-			// DRBD leg and still works. The driver is wired for the node
-			// service's status reads, none of which are reachable with
-			// client legs refused; the probe only logs what the node ships.
+			// DRBD leg and still works. No kernel-floor probe either: with
+			// client legs refused nothing touches DRBD on this node, and
+			// the probe's fatal below-floor exit would crash-loop a
+			// consumer-only node over a check that protects nothing here.
 			clientDRBD := &drbd.Driver{StateDir: drbdStateDir, Exec: backend.RealExec}
-			probeDRBD(clientDRBD)
 			node := csi.NewNode(mgr.GetClient(), nodeName, clientDRBD)
 			node.ClientOnly = true
 			serveCSI(mgr, csiSocket, identity, nil, node)

--- a/docs/remote-consumers.md
+++ b/docs/remote-consumers.md
@@ -38,11 +38,14 @@ Trade-offs to understand:
   (DRBD's diskless default is a 512-byte fiction dm-thin would
   silently drop), so in-pod `fstrim` and `-o discard` free thin-pool
   space as if the pod ran on a replica node.
-- **Consumers must run on nodes listed in `nodes`.** Agents only
-  start on mapped nodes, so a pod scheduled onto an unmapped node has
-  no CSI driver and wedges in `ContainerCreating`. Keep every
-  schedulable node in the map (a `loopfile` entry with a few spare GB
-  is enough) or set `allowRemoteVolumeAccess: "false"`.
+- **Consumers must run on nodes listed in `nodes`.** On an unmapped
+  node the agent runs only a client-only CSI service (for RWX/NFS
+  mounts) with no reconciler to realize a DRBD client leg, so staging
+  refuses with a clear `FailedPrecondition` and the pod stays in
+  `ContainerCreating` until it is rescheduled. Keep every schedulable
+  node in the map (a `loopfile` entry with a few spare GB is enough)
+  or set `allowRemoteVolumeAccess: "false"` so the PV's node affinity
+  keeps pods on replica nodes in the first place.
 - **A lost node can strand its client leg.** Its `spec.clients` entry
   blocks volume deletion until the node returns or the entry is
   removed by hand (it holds no quorum vote, so the volume itself

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -168,7 +168,10 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 
-	snapID := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()
+	snapID, err := snapshotSourceID(req)
+	if err != nil {
+		return nil, err
+	}
 	source, srcReplicas, sourceFormatted, err := c.resolveSource(ctx, snapID, sizeBytes, replicas, params.pool)
 	if err != nil {
 		return nil, err
@@ -756,6 +759,59 @@ func (c *Controller) handleCreateErr(ctx context.Context, err error, vol *miroir
 	return nil
 }
 
+// snapshotSourceID extracts the snapshot id from the request's content
+// source ("" when none), refusing the unimplemented volume-clone type:
+// only snapshot sources are advertised, and falling through would
+// provision a blank volume under a clone's name — then block a corrected
+// retry on AlreadyExists.
+func snapshotSourceID(req *csi.CreateVolumeRequest) (string, error) {
+	if src := req.GetVolumeContentSource(); src != nil && src.GetSnapshot() == nil {
+		return "", status.Error(codes.InvalidArgument,
+			"unsupported volume content source: only snapshot sources are supported")
+	}
+	return req.GetVolumeContentSource().GetSnapshot().GetSnapshotId(), nil
+}
+
+// expandWithinHeadroom applies CreateVolume's capacity guardrails to a
+// grow: expansion otherwise bypasses them entirely, and one PVC grown past
+// the pool ENOSPCs every thin volume sharing it — surfacing as DRBD I/O
+// errors and detached legs, not a clean refusal. Same accounting as
+// place(): the volume's own current size is excluded, its projected whole
+// size must fit; a node without fresh stats admits. Not under allocMu —
+// this is a guardrail against runaway growth, not an exact admission (a
+// concurrent CreateVolume can overshoot by one request, the same window
+// expansion always had).
+func (c *Controller) expandWithinHeadroom(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, newSize int64) error {
+	stats, err := c.poolStats(ctx)
+	if err != nil {
+		return err
+	}
+	list := &miroirv1alpha1.MiroirVolumeList{}
+	if err := c.Client.List(ctx, list); err != nil {
+		return status.Errorf(codes.Internal, "list MiroirVolumes: %v", err)
+	}
+	provisioned := provisionedPerPool(list.Items, vol.Name)
+	pool := nodemap.PoolOrDefault("")
+	if first := vol.Spec.FirstDiskfulReplica(); first != nil {
+		pool = nodemap.PoolOrDefault(first.Pool)
+	}
+	for _, rep := range vol.Spec.Replicas {
+		if rep.Diskless {
+			continue
+		}
+		room, known := c.poolHeadroom(stats[rep.Node].Pool(pool), provisioned[nodePool{rep.Node, pool}])
+		if !known || newSize <= room {
+			continue
+		}
+		overcommit, freeSpace := c.ratios()
+		return status.Errorf(codes.ResourceExhausted,
+			"pool %q on node %s has room for %d of the requested %d bytes "+
+				"(capacity×%g overcommit, free×%g free-space)",
+			pool, rep.Node, room, newSize, overcommit, freeSpace)
+	}
+	return nil
+}
+
 // errVolumeFailed marks a hard provisioning failure reported by an agent,
 // as opposed to "not ready yet".
 type errVolumeFailed struct{ detail string }
@@ -824,6 +880,9 @@ func (c *Controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	// block volume needs no filesystem grow — neither triggers node expansion.
 	nodeExpansion := req.GetVolumeCapability().GetBlock() == nil && vol.Spec.Export == nil
 	if newSize > vol.Spec.SizeBytes {
+		if err := c.expandWithinHeadroom(ctx, vol, newSize); err != nil {
+			return nil, err
+		}
 		base := vol.DeepCopy()
 		vol.Spec.SizeBytes = newSize
 		if err := c.Client.Patch(ctx, vol, client.MergeFrom(base)); err != nil {

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1434,3 +1434,178 @@ func TestParseAllowRemoteAccess(t *testing.T) {
 		})
 	}
 }
+
+// Expansion must honor the same capacity guardrails as CreateVolume: one
+// PVC grown past the pool ENOSPCs every thin volume sharing it.
+func TestControllerExpandRefusesBeyondHeadroom(t *testing.T) {
+	s := newScheme(t)
+	v := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 10 << 30,
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin},
+			},
+		},
+	}
+	c := &Controller{
+		Client: fake.NewClientBuilder().WithScheme(s).
+			WithObjects(v, miroirNodeObj(nodeA, 100*gib, 95*gib)).
+			WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build(),
+		ProvisionTimeout: time.Second,
+	}
+
+	_, err := c.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
+		VolumeId:      volPvc1,
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 10 << 40}, // 10 TiB
+	})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("a grow past the pool guardrails must refuse, got %v", err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.SizeBytes != 10<<30 {
+		t.Fatalf("a refused grow must not touch the spec: %d", got.Spec.SizeBytes)
+	}
+}
+
+// A node without fresh stats admits the grow, matching place().
+func TestControllerExpandAdmitsWithoutStats(t *testing.T) {
+	s := newScheme(t)
+	v := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 10 << 30,
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin},
+			},
+		},
+		Status: miroirv1alpha1.MiroirVolumeStatus{
+			PerNode: map[string]miroirv1alpha1.ReplicaStatus{
+				nodeA: {SizeBytes: 20 << 30}, // realization already caught up
+			},
+		},
+	}
+	c := &Controller{
+		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+			WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build(),
+		ProvisionTimeout: time.Second,
+	}
+
+	if _, err := c.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
+		VolumeId:      volPvc1,
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 20 << 30},
+	}); err != nil {
+		t.Fatalf("no fresh stats must admit: %v", err)
+	}
+}
+
+// A Volume-type content source (PVC clone) is not implemented; silently
+// ignoring it would provision a blank volume under a clone's name.
+func TestCreateVolumeRejectsVolumeContentSource(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: volCaps(),
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: "pvc-0"},
+			},
+		},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("a volume content source must be InvalidArgument, got %v", err)
+	}
+}
+
+// CreateSnapshot idempotency: a same-name retry with the same source
+// returns the existing snapshot; the same name for a different source is
+// AlreadyExists.
+func TestCreateSnapshotIdempotent(t *testing.T) {
+	s := newScheme(t)
+	v := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 10 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendZFS}},
+		},
+	}
+	other := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-2"},
+		Spec:       miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 1 << 30},
+	}
+	c := &Controller{
+		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(v, other).
+			WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}).Build(),
+	}
+
+	first, err := c.CreateSnapshot(t.Context(), &csi.CreateSnapshotRequest{
+		Name: snapSnap1, SourceVolumeId: volPvc1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	retry, err := c.CreateSnapshot(t.Context(), &csi.CreateSnapshotRequest{
+		Name: snapSnap1, SourceVolumeId: volPvc1,
+	})
+	if err != nil {
+		t.Fatalf("same-name same-source retry must succeed: %v", err)
+	}
+	if retry.Snapshot.SnapshotId != first.Snapshot.SnapshotId {
+		t.Fatalf("retry must return the existing snapshot: %+v", retry.Snapshot)
+	}
+
+	_, err = c.CreateSnapshot(t.Context(), &csi.CreateSnapshotRequest{
+		Name: snapSnap1, SourceVolumeId: "pvc-2",
+	})
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("same name for a different source must be AlreadyExists, got %v", err)
+	}
+}
+
+// Tokens are positional: pages must neither skip nor duplicate, and a
+// garbage or out-of-range token is Aborted per the CSI spec.
+func TestListVolumesPagination(t *testing.T) {
+	s := newScheme(t)
+	objs := make([]client.Object, 0, 3)
+	for _, name := range []string{"pvc-b", "pvc-a", "pvc-c"} {
+		objs = append(objs, &miroirv1alpha1.MiroirVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 1 << 30},
+		})
+	}
+	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()}
+
+	page1, err := c.ListVolumes(t.Context(), &csi.ListVolumesRequest{MaxEntries: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page1.Entries) != 2 || page1.Entries[0].Volume.VolumeId != "pvc-a" ||
+		page1.Entries[1].Volume.VolumeId != "pvc-b" {
+		t.Fatalf("page 1 must be the first two in stable order: %+v", page1.Entries)
+	}
+	if page1.NextToken == "" {
+		t.Fatal("a truncated page must return a token")
+	}
+
+	page2, err := c.ListVolumes(t.Context(), &csi.ListVolumesRequest{
+		MaxEntries: 2, StartingToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2.Entries) != 1 || page2.Entries[0].Volume.VolumeId != "pvc-c" ||
+		page2.NextToken != "" {
+		t.Fatalf("page 2 must hold the remainder with no token: %+v", page2)
+	}
+
+	for _, token := range []string{"9", "x", "-1"} {
+		if _, err := c.ListVolumes(t.Context(), &csi.ListVolumesRequest{StartingToken: token}); status.Code(err) != codes.Aborted {
+			t.Fatalf("token %q must be Aborted, got %v", token, err)
+		}
+	}
+}

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -53,6 +53,13 @@ type Node struct {
 	// reconciler lags, and staging on a stale UpToDate mounts (or worse,
 	// formats) a diverged replica.
 	DRBD stage.DRBDStatus
+	// ClientOnly marks a node with no MiroirNode: no volume reconciler
+	// runs there, so an added client leg would never be realized — the
+	// pod would wedge in ContainerCreating, the spec entry would burn one
+	// of the two client slots, and its teardown finalizer would block the
+	// volume's deletion forever. RWO remote-access staging refuses
+	// instead; RWX (NFS) staging needs no DRBD leg and still works.
+	ClientOnly bool
 }
 
 // NewNode wires a Node service with the host mount/format tooling.
@@ -136,6 +143,15 @@ func (n *Node) devicePath(ctx context.Context, volumeID string) (string, *miroir
 // reconciler completes the entry and the agent realizes it; until then the
 // stage returns Unavailable and the CO retries.
 func (n *Node) clientDevicePath(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) (string, *miroirv1alpha1.MiroirVolume, error) {
+	if n.ClientOnly {
+		// No reconciler would ever realize the leg (see ClientOnly);
+		// refuse loudly instead of polluting the spec with an entry that
+		// wedges the pod and blocks the volume's deletion.
+		return "", nil, status.Errorf(codes.FailedPrecondition,
+			"volume %s cannot be consumed remotely from node %s: the node is not in the storage topology "+
+				"(add it under the Helm `nodes` value, or set allowRemoteVolumeAccess: \"false\" on the class "+
+				"to pin pods to replica nodes)", vol.Name, n.NodeName)
+	}
 	if vol.Spec.ClientForNode(n.NodeName) == nil {
 		if err := n.addClientLeg(ctx, vol); err != nil {
 			return "", nil, err
@@ -402,26 +418,17 @@ func (n *Node) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRe
 // wedge NodeUnstageVolume indefinitely.
 const nfsUnmountTimeout = 30 * time.Second
 
-// NodeUnstageVolume unmounts the staging path. Idempotent. An export
-// volume's staging mount is NFS: if its gateway has died a plain unmount
-// blocks, so force it with a deadline. The volume lookup is best-effort —
-// a volume already deleted falls back to the normal cleanup.
+// NodeUnstageVolume unmounts the staging path. Idempotent. Cleanup is
+// forced (deadline-bounded) whenever the mounter supports it: an export
+// volume's staging mount is NFS, and when its gateway is gone a plain
+// unmount hangs — worst exactly when the MiroirVolume is already deleted,
+// which is why the force path must not be gated on a CR lookup. Forcing
+// is harmless for local block staging mounts.
 func (n *Node) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	if req.GetVolumeId() == "" || req.GetStagingTargetPath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id and staging path are required")
 	}
-	target := req.GetStagingTargetPath()
-
-	vol := &miroirv1alpha1.MiroirVolume{}
-	if err := n.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err == nil && vol.Spec.Export != nil {
-		if forcer, ok := n.Mounter.Interface.(mount.MounterForceUnmounter); ok {
-			if err := mount.CleanupMountWithForce(target, forcer, true, nfsUnmountTimeout); err != nil {
-				return nil, status.Errorf(codes.Internal, "unstage: %v", err)
-			}
-			return &csi.NodeUnstageVolumeResponse{}, nil
-		}
-	}
-	if err := mount.CleanupMountPoint(target, n.Mounter, true); err != nil {
+	if err := cleanupMount(req.GetStagingTargetPath(), n.Mounter); err != nil {
 		return nil, status.Errorf(codes.Internal, "unstage: %v", err)
 	}
 	// A client leg follows its consumer: with the device released, drop the
@@ -488,15 +495,28 @@ func (n *Node) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolume
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-// NodeUnpublishVolume removes the pod bind mount. Idempotent.
+// NodeUnpublishVolume removes the pod bind mount. Idempotent. Forced for
+// the same reason as NodeUnstageVolume — a bind of a dead-gateway NFS
+// staging mount hangs a plain unmount.
 func (n *Node) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	if req.GetVolumeId() == "" || req.GetTargetPath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id and target path are required")
 	}
-	if err := mount.CleanupMountPoint(req.GetTargetPath(), n.Mounter, true); err != nil {
+	if err := cleanupMount(req.GetTargetPath(), n.Mounter); err != nil {
 		return nil, status.Errorf(codes.Internal, "unpublish: %v", err)
 	}
 	return &csi.NodeUnpublishVolumeResponse{}, nil
+}
+
+// cleanupMount unmounts and removes target, with a deadline-bounded
+// forced unmount when the mounter supports it — a hung hard-NFS mount
+// (dead gateway) blocks the plain path's umount indefinitely, piling
+// kubelet retries onto more hung RPCs.
+func cleanupMount(target string, mounter *mount.SafeFormatAndMount) error {
+	if forcer, ok := mounter.Interface.(mount.MounterForceUnmounter); ok {
+		return mount.CleanupMountWithForce(target, forcer, true, nfsUnmountTimeout)
+	}
+	return mount.CleanupMountPoint(target, mounter, true)
 }
 
 // NodeGetVolumeStats reports capacity on a published volume via statfs.

--- a/internal/csi/node_test.go
+++ b/internal/csi/node_test.go
@@ -19,7 +19,9 @@ package csi
 import (
 	"context"
 	"path/filepath"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -464,5 +466,98 @@ func TestDevicePathDisklessStaleSplitSlotIgnored(t *testing.T) {
 	n := newNode(t, v, fakeDRBDStatus{st: healthyRemoteStatus()})
 	if _, _, err := n.devicePath(t.Context(), volPvc1); err != nil {
 		t.Fatalf("live diskless leg must stage despite a stale slot: %v", err)
+	}
+}
+
+// A client-only node (no MiroirNode, no reconciler) must refuse remote
+// staging instead of adding a client leg nothing would ever realize —
+// the entry would burn one of two client slots and its finalizer would
+// block the volume's deletion forever.
+func TestDevicePathClientOnlyNodeRefuses(t *testing.T) {
+	n := newNode(t, remoteVolume(), fakeDRBDStatus{})
+	n.ClientOnly = true
+
+	_, _, err := n.devicePath(t.Context(), volPvc1)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("client-only node must refuse remote access, got %v", err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := n.Client.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Spec.Clients) != 0 {
+		t.Fatalf("refusal must not pollute the spec: %+v", got.Spec.Clients)
+	}
+}
+
+// The NFS staging mount options are load-bearing: hard keeps a gateway
+// failover from surfacing EIO into the app, noresvport lets the mount
+// survive the Service endpoint moving to the replacement pod.
+func TestStageNFSMountOptions(t *testing.T) {
+	v := remoteVolume()
+	v.Spec.Export = &miroirv1alpha1.ExportSpec{FSType: "ext4"}
+	v.Status.Export = &miroirv1alpha1.ExportStatus{Address: "10.96.0.10"}
+	n := newNode(t, v, fakeDRBDStatus{})
+	fm := mount.NewFakeMounter(nil)
+	n.Mounter = mount.NewSafeFormatAndMount(fm, utilexec.New())
+
+	if _, err := n.NodeStageVolume(t.Context(), &csi.NodeStageVolumeRequest{
+		VolumeId:          volPvc1,
+		StagingTargetPath: filepath.Join(t.TempDir(), "staging"),
+		VolumeCapability:  mountCap(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	log := fm.GetLog()
+	if len(log) != 1 || log[0].Action != mount.FakeActionMount {
+		t.Fatalf("expected one mount, got %+v", log)
+	}
+	if log[0].FSType != "nfs4" {
+		t.Fatalf("fstype = %q, want nfs4", log[0].FSType)
+	}
+	mounted, err := fm.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, opt := range []string{"hard", "noresvport"} {
+		if !slices.Contains(mounted[0].Opts, opt) {
+			t.Fatalf("mount options must include %q: %v", opt, mounted[0].Opts)
+		}
+	}
+	if mounted[0].Device != "10.96.0.10:/"+volPvc1 {
+		t.Fatalf("source = %q", mounted[0].Device)
+	}
+}
+
+// forceFakeMounter records that the deadline-bounded unmount was taken —
+// the path that cannot hang on a dead-gateway hard NFS mount.
+type forceFakeMounter struct {
+	*mount.FakeMounter
+	forced bool
+}
+
+func (f *forceFakeMounter) UnmountWithForce(target string, _ time.Duration) error {
+	f.forced = true
+	return f.Unmount(target)
+}
+
+// Unstage takes the forced (deadline-bounded) unmount whenever the
+// mounter supports it — even when the MiroirVolume is already gone, the
+// case where the old CR-gated path fell back to a hangable plain unmount.
+func TestNodeUnstageForcesWhenVolumeGone(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).Build() // no volume
+	target := t.TempDir()
+	fm := &forceFakeMounter{FakeMounter: mount.NewFakeMounter([]mount.MountPoint{{Path: target}})}
+	n := &Node{Client: c, NodeName: nodeA,
+		Mounter: mount.NewSafeFormatAndMount(fm, utilexec.New())}
+
+	if _, err := n.NodeUnstageVolume(t.Context(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          volPvc1,
+		StagingTargetPath: target,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !fm.forced {
+		t.Fatal("unstage must take the deadline-bounded force path")
 	}
 }


### PR DESCRIPTION
PR D of the sixth review cycle: the four CSI findings, all verified end to end.

## ControllerExpandVolume bypassed every capacity guardrail

CreateVolume refuses when a pool's virtual (×overcommit) or physical (×free-space) headroom is exceeded — and the comment on `poolHeadroom` explains why that matters for thin pools: exhaustion surfaces as DRBD I/O errors under *live* volumes, not a clean refusal. Expansion had none of that: it patched `spec.sizeBytes` unconditionally, and the agents' resize paths (`lvextend`, `zfs set volsize`, `truncate`) succeed on thin volumes regardless of pool room. Growing one 50Gi PVC to 5TiB was accepted; later writes ENOSPC the shared pool and detach legs of every volume on it.

`expandWithinHeadroom` now applies `place()`'s exact accounting to the grow: the volume's own current size is excluded from the provisioned sum, its projected whole size must fit each diskful replica node's headroom, and a node without fresh stats admits (matching place). Refusal is `ResourceExhausted` naming the room and the ratio knobs. Deliberately not under `allocMu` — it's a guardrail against runaway growth, not an exact admission; a concurrent CreateVolume can overshoot by one request, the same window expansion always had.

## NodeUnstage/NodeUnpublish hung on dead-gateway NFS mounts

The deadline-bounded force-unmount path was gated on `Get(volume) == nil && Export != nil` — but when the MiroirVolume is already deleted (node down during a PV force-delete; kubelet reconstructing mounts after restart), that lookup NotFounds and cleanup fell back to `CleanupMountPoint`, whose plain `umount` hangs on a `hard` NFS mount whose gateway is gone — precisely the case the force path exists for. Both unstage and unpublish (a bind of the same NFS mount) now take `CleanupMountWithForce` whenever the mounter implements `MounterForceUnmounter`; forcing is harmless for local block staging mounts.

## Client-only nodes: refuse instead of wedging the volume

A node with no MiroirNode runs the CSI node service but **no volume reconciler**, and nothing else realizes DRBD legs — the old main.go comment "client legs get DRBD configs rendered here too" was simply false (the node service's DRBD interface is status-only; verified nothing in csi/stage renders or ups a resource). With `allowRemoteAccess` defaulting on for replicated classes, a pod scheduled onto a non-storage node added a client leg that was never realized: pod stuck in ContainerCreating, one of the two `MaxItems=2` client slots burned, and the node's teardown finalizer **blocked the volume's deletion forever** (no reconciler exists to release it).

The node service now carries a `ClientOnly` flag and refuses RWO remote-access staging with a `FailedPrecondition` that names both fixes (map the node, or pin pods with `allowRemoteVolumeAccess: "false"`); RWX/NFS staging is untouched. I went with the refusal over wiring a client-leg reconciler on unmapped nodes — the safe, docs-consistent behavior; if you'd rather make remote consumption genuinely work from any agent node, that's a follow-up feature. `docs/remote-consumers.md` rewritten accordingly (it still described the pre-#164 "no CSI driver on unmapped nodes" mechanism).

## Volume-type content source was silently ignored

`GetVolumeContentSource().GetSnapshot().GetSnapshotId()` yields "" for a Volume-type source (PVC clone — not advertised), so the request fell through to fresh provisioning: a blank volume under the clone's name, with the CR then blocking any corrected retry on AlreadyExists. Now `InvalidArgument` per spec (`snapshotSourceID` helper — also keeps CreateVolume under the gocyclo ceiling).

## Tests

Expand refusal (spec untouched) + no-stats admit; client-only refusal with no spec pollution; forced unstage with the volume gone (the exact previously-hanging case, via a force-capable fake mounter); `stageNFS` pins `nfs4` + `hard`/`noresvport` (failover-load-bearing options that had zero coverage); CreateSnapshot same-source retry and different-source AlreadyExists; ListVolumes pagination — stable order, token continuity, no skip/duplicate, `Aborted` on garbage/out-of-range tokens (the positional-token invariant had zero tests).

Full linux suite green, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Volume expansion now validates storage headroom and blocks growth that would exceed capacity safeguards.
  * Added client-only node behavior to support RWX/NFS mounts while refusing remote diskless client leg staging.
* **Bug Fixes**
  * Improved NFS staging and mount cleanup, including deadline-bounded forced unmounts and safer unstage/unpublish behavior.
  * Unsupported volume clone content sources now return validation errors.
  * Snapshot retries are now idempotent; volume listing now follows CSI pagination rules with correct token handling.
* **Documentation**
  * Clarified failure behavior and recovery guidance for workloads scheduled on unmapped nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->