### PR TITLE
fix(drbd): release swept orphans' minors, dedupe status fetches

### DIFF
--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -299,6 +299,21 @@ func virginMetadata(dump, name string) bool {
 // removes — keep in sync with everything Apply and ensureMetadata write.
 var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted"}
 
+// listStatus runs `drbdsetup status --json [name]` and parses the result —
+// the one fetch every kernel-view consumer shares.
+func (d *Driver) listStatus(ctx context.Context, name ...string) ([]jsonStatus, error) {
+	args := append([]string{"status", "--json"}, name...)
+	out, err := d.Exec(ctx, "drbdsetup", args...)
+	if err != nil {
+		return nil, fmt.Errorf("status: %w", err)
+	}
+	var parsed []jsonStatus
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		return nil, fmt.Errorf("parse status: %w", err)
+	}
+	return parsed, nil
+}
+
 // SweepOrphans tears down kernel resources and rendered config files with
 // no owning volume on this node — leftovers of an agent crash between up
 // and down, which would otherwise hold backing devices open forever. Best
@@ -306,15 +321,13 @@ var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted"
 // strand the rest. An unreadable kernel view aborts the whole sweep,
 // files included — without it a live resource is indistinguishable from a
 // stale file, and stripping its config is the state this sweep's own
-// stuck-guard exists to prevent.
+// stuck-guard exists to prevent. The sweep runs once per agent start: an
+// orphan skipped as wedged (or mid-detach, which wears the same
+// signature) stays configured and is retried at the next restart.
 func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool) error {
-	out, err := d.Exec(ctx, "drbdsetup", "status", "--json")
+	parsed, err := d.listStatus(ctx)
 	if err != nil {
-		return fmt.Errorf("status: %w", err)
-	}
-	var parsed []jsonStatus
-	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
-		return fmt.Errorf("parse status: %w", err)
+		return err
 	}
 	var errs []error
 	stuck := map[string]bool{}
@@ -354,6 +367,12 @@ func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool)
 				errs = append(errs, err)
 			}
 		}
+		// The orphaned volume never comes back to Down on this node, so
+		// its minor.assign entry would leak — and permanently burn a
+		// minor — for the StateDir's lifetime.
+		if err := d.releaseMinor(name); err != nil {
+			errs = append(errs, fmt.Errorf("release minor of orphan %s: %w", name, err))
+		}
 	}
 	return errors.Join(errs...)
 }
@@ -361,18 +380,13 @@ func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool)
 // DownSecondaries brings down every resource this node holds Secondary,
 // releasing its backing device so the backend pool can export on shutdown.
 // Primary (open) resources are skipped: drbdsetup down refuses an open
-// device, and downing a leg a workload still holds — here, or on a peer this
-// node feeds as SyncSource — would drop live redundancy. Rendered config
-// stays so the successor re-ups. Best effort: errors are joined so one stuck
-// resource cannot strand the rest.
+// device, and a local Primary is a leg a workload here still holds.
+// Rendered config stays so the successor re-ups. Best effort: errors are
+// joined so one stuck resource cannot strand the rest.
 func (d *Driver) DownSecondaries(ctx context.Context) error {
-	out, err := d.Exec(ctx, "drbdsetup", "status", "--json")
+	parsed, err := d.listStatus(ctx)
 	if err != nil {
-		return fmt.Errorf("status: %w", err)
-	}
-	var parsed []jsonStatus
-	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
-		return fmt.Errorf("parse status: %w", err)
+		return err
 	}
 	var errs []error
 	for _, res := range parsed {
@@ -761,12 +775,8 @@ func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32)
 // Empty/false when the resource is down or the status is unreadable
 // (nothing to disconnect).
 func (d *Driver) liveTeardownView(ctx context.Context, name string) (peerIDs []int32, wedged bool) {
-	out, err := d.Exec(ctx, "drbdsetup", "status", "--json", name)
+	parsed, err := d.listStatus(ctx, name)
 	if err != nil {
-		return nil, false
-	}
-	var parsed []jsonStatus
-	if json.Unmarshal([]byte(out), &parsed) != nil {
 		return nil, false
 	}
 	for _, res := range parsed {
@@ -856,6 +866,9 @@ const diskDetaching = "Detaching"
 // reconnecting to. drbdsetup disconnect refuses it (-9), so a StandAlone
 // entry can linger in status through every teardown attempt.
 const connStandAlone = "StandAlone"
+
+// connConnected is the fully established connection state.
+const connConnected = "Connected"
 
 // rolePrimary is the DRBD role of a node that holds the device open.
 const rolePrimary = "Primary"
@@ -974,13 +987,9 @@ func (s jsonStatus) peerIDs() []int32 {
 
 // Status parses `drbdsetup status --json <res>`.
 func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
-	out, err := d.Exec(ctx, "drbdsetup", "status", "--json", name)
+	parsed, err := d.listStatus(ctx, name)
 	if err != nil {
-		return Status{}, fmt.Errorf("status %s: %w", name, err)
-	}
-	var parsed []jsonStatus
-	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
-		return Status{}, fmt.Errorf("parse status %s: %w", name, err)
+		return Status{}, fmt.Errorf("%s: %w", name, err)
 	}
 	if len(parsed) == 0 {
 		return Status{}, fmt.Errorf("resource %s not in status output", name)
@@ -1022,8 +1031,8 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 		if len(c.PeerDevices) > 0 {
 			s.PeerDiskState[c.PeerNodeID] = c.PeerDevices[0].PeerDiskState
 		}
-		s.PeerConnected[c.PeerNodeID] = c.ConnectionState == "Connected"
-		if c.ConnectionState == "StandAlone" {
+		s.PeerConnected[c.PeerNodeID] = c.ConnectionState == connConnected
+		if c.ConnectionState == connStandAlone {
 			s.SplitBrain = true
 		}
 	}
@@ -1113,13 +1122,9 @@ func (d *Driver) DiscardGranularity(ctx context.Context, dev string) (int64, err
 // kernel is the authority here: a crash between suspend-io and the status
 // patch leaves a frozen device that no snapshot status records.
 func (d *Driver) UserSuspended(ctx context.Context) ([]string, error) {
-	out, err := d.Exec(ctx, "drbdsetup", "status", "--json")
+	parsed, err := d.listStatus(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("status: %w", err)
-	}
-	var parsed []jsonStatus
-	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
-		return nil, fmt.Errorf("parse status: %w", err)
+		return nil, err
 	}
 	var names []string
 	for _, r := range parsed {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	volPvc1            = "pvc-1"
+	volPvc2            = "pvc-2"
 	cmdDrbdsetupStatus = "drbdsetup status"
 	cmdAdmVersion      = "drbdadm --version"
 	cmdDumpMD          = "dump-md"
@@ -91,7 +92,7 @@ func TestParseEvent2(t *testing.T) {
 	cases := []struct{ line, want string }{
 		{"exists resource name:pvc-1 role:Secondary suspended:no", volPvc1},
 		{"change connection name:pvc-1 peer-node-id:1 connection:StandAlone", volPvc1},
-		{"change device name:pvc-2 volume:0 minor:1000 disk:UpToDate", "pvc-2"},
+		{"change device name:pvc-2 volume:0 minor:1000 disk:UpToDate", volPvc2},
 		{"destroy resource name:pvc-3", "pvc-3"},
 		{"change peer-device name:pvc-1 peer-node-id:1 replication:SyncTarget", volPvc1},
 		{"exists -", ""},
@@ -186,7 +187,7 @@ func TestDay0GIDeterministicAndEven(t *testing.T) {
 	if a != b || len(a) != 16 {
 		t.Fatalf("unstable or malformed day0 GI: %q %q", a, b)
 	}
-	if Day0GI("pvc-2") == a {
+	if Day0GI(volPvc2) == a {
 		t.Fatal("different volumes must get different GIs")
 	}
 	last := a[len(a)-1]
@@ -862,7 +863,7 @@ func TestDownSecondariesContinuesOnError(t *testing.T) {
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 
 	err := d.DownSecondaries(t.Context())
-	if err == nil || !strings.Contains(err.Error(), "pvc-2") {
+	if err == nil || !strings.Contains(err.Error(), volPvc2) {
 		t.Fatalf("want a joined error naming pvc-2, got %v", err)
 	}
 	// One stuck resource must not strand the rest of the sweep.
@@ -880,7 +881,7 @@ func TestSweepOrphansContinuesOnError(t *testing.T) {
 		errOn: map[string]error{"down pvc-1": errors.New("signal: killed")},
 	}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
-	for _, name := range []string{volPvc1, "pvc-2"} {
+	for _, name := range []string{volPvc1, volPvc2} {
 		if err := os.WriteFile(d.path(name+".res"), nil, 0o640); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/drbd/events_test.go
+++ b/internal/drbd/events_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drbd
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The scanner's 1 MiB buffer lifts bufio's 64 KiB token cap: a single
+// overlong line must not end the stream, and events on both sides of it
+// must still be delivered.
+func TestScanSurvivesLongLines(t *testing.T) {
+	var got []string
+	w := &EventWatcher{Notify: func(_ context.Context, name string) {
+		got = append(got, name)
+	}}
+	input := "exists resource name:" + volPvc1 + " role:Secondary\n" +
+		"change - " + strings.Repeat("x", 500*1024) + "\n" +
+		"exists resource name:" + volPvc2 + " role:Secondary\n"
+	if err := w.scan(t.Context(), strings.NewReader(input)); err != nil {
+		t.Fatalf("a long line within the buffer must not error: %v", err)
+	}
+	if !slices.Equal(got, []string{volPvc1, volPvc2}) {
+		t.Fatalf("events on both sides of the long line must deliver: %v", got)
+	}
+
+	// Past the 1 MiB cap the scanner errors — surfaced so Start respawns
+	// the stream instead of wedging on a filling pipe.
+	if err := w.scan(t.Context(), strings.NewReader(strings.Repeat("y", 2<<20))); err == nil {
+		t.Fatal("an over-cap line must surface the scanner error")
+	}
+}

--- a/internal/drbd/minor_test.go
+++ b/internal/drbd/minor_test.go
@@ -116,7 +116,7 @@ func TestDownReleasesMinorAssignment(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A fresh volume reclaims the freed minor instead of advancing past it.
-	reused, err := d.AllocateMinor("pvc-2")
+	reused, err := d.AllocateMinor(volPvc2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,5 +162,35 @@ func TestAllocateMinorSkipsMinorsUsedInResFiles(t *testing.T) {
 	}
 	if got != minorBase+2 {
 		t.Errorf("minor = %d, want %d (must skip 1000/1001 held by legacy.res)", got, minorBase+2)
+	}
+}
+
+// The orphan sweep is the last owner of a crash leftover's minor: the
+// volume never comes back to Down on this node, so the sweep must release
+// the assignment or the minor is burned for the StateDir's lifetime.
+func TestSweepOrphansReleasesMinorAssignment(t *testing.T) {
+	dir := t.TempDir()
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"pvc-1","role":"Secondary","connections":[]}]`,
+	}}
+	d := &Driver{StateDir: dir, Exec: fe.run, Mknod: fakeMknod}
+
+	first, err := d.AllocateMinor("pvc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pvc-1.res"), []byte("resource \"pvc-1\" {}\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.SweepOrphans(t.Context(), func(string) bool { return false }); err != nil {
+		t.Fatal(err)
+	}
+	reused, err := d.AllocateMinor(volPvc2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused != first {
+		t.Fatalf("swept orphan's minor %d must be reused, got %d", first, reused)
 	}
 }


### PR DESCRIPTION
PR E of the sixth review cycle: the drbd-package findings.

## SweepOrphans leaked minors permanently

`Down` releases a volume's `minor.assign` entry because "without it the map grows for the lifetime of the StateDir" — but `SweepOrphans`, the path built for crash leftovers (where stale assignments are most likely), removed the `.res` and marker files while leaving the assignment behind. The orphaned volume never comes back to `Down` on this node, so each swept orphan permanently burned one minor (`scanUsedMinors` keeps honoring the entry). The sweep now releases the assignment for swept, non-stuck names; a new test pins that the freed minor is reused by the next allocation.

## One status fetch, not five

The `drbdsetup status --json` exec + unmarshal + error-wrap existed five times (`SweepOrphans`, `DownSecondaries`, `liveTeardownView`, `Status`, `UserSuspended`); they now share a variadic `listStatus(ctx, name...)`.

## The 1 MiB scanner buffer gets its test

`EventWatcher.scan`'s comment claims the buffer lifts bufio's 64 KiB token cap so a long line can't silently end the stream — untested until now. The new test feeds a 500 KiB line between two real events (both must deliver, no error) and a 2 MiB line (the scanner error must surface so `Start` respawns the stream instead of wedging on a filling pipe).

## Comments and consts

- `DownSecondaries` claimed skipping protects "a peer this node feeds as SyncSource" — the code only checks the *local* role; the false clause is cut (the behavior itself is right for a shutdown sweep).
- `SweepOrphans`' doc now states the once-per-agent-start retry semantics for orphans skipped as wedged or mid-detach (the review's draining-orphan edge: rare double-crash timing, retried at next restart by design rather than engineering a retry into the startup path).
- The remaining literal `"Connected"`/`"StandAlone"` connection states in the status fold now use consts.

Full linux unit suite green, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DRBD resource status handling for more consistent teardown, inspection, and connection-state reporting.
  - Fixed orphaned resource cleanup so minor assignments are released and can be reused.
  - Improved resilience when processing unusually long DRBD event lines, preventing stalled event monitoring.

- **Tests**
  - Added coverage for orphan cleanup, minor assignment reuse, status handling, and long-line event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->