### PR TITLE
chore: sixth-cycle polish — stale comments, DRY, docs, and named test gaps

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/drbdspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/drbdspec.go
@@ -39,7 +39,7 @@ type DRBDSpecApplyConfiguration struct {
 	// resyncing more per dirty bit. Applied only when a replica's metadata
 	// is first created — replicas created earlier keep their granularity
 	// (DRBD exchanges bitmaps across differing block sizes). 0 means the
-	// DRBD default (4096). Needs kmod ≥ 9.3.0 (the agent's startup floor).
+	// DRBD default (4096). Needs kmod ≥ 9.3.1 (the agent's startup floor).
 	BitmapGranularityBytes *int64 `json:"bitmapGranularityBytes,omitempty"`
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/volumeclient.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/volumeclient.go
@@ -32,7 +32,7 @@ import (
 // membership reconciler like a replica, removed at unstage. Unlike a
 // diskless tie-breaker it is not placed for quorum, and it is rendered
 // with "tiebreaker no" so DRBD never counts its vote — attach/detach
-// leaves the majority threshold alone (see README).
+// leaves the majority threshold alone (docs: remote-consumers).
 type VolumeClientApplyConfiguration struct {
 	// Node is the Kubernetes node name consuming the volume remotely.
 	Node *string `json:"node,omitempty"`

--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -100,7 +100,7 @@ type DRBDSpec struct {
 	// resyncing more per dirty bit. Applied only when a replica's metadata
 	// is first created — replicas created earlier keep their granularity
 	// (DRBD exchanges bitmaps across differing block sizes). 0 means the
-	// DRBD default (4096). Needs kmod ≥ 9.3.0 (the agent's startup floor).
+	// DRBD default (4096). Needs kmod ≥ 9.3.1 (the agent's startup floor).
 	// +kubebuilder:validation:Enum=0;4096;8192;16384;32768;65536;131072;262144;524288;1048576
 	// +optional
 	BitmapGranularityBytes int64 `json:"bitmapGranularityBytes,omitempty"`
@@ -119,7 +119,7 @@ type VolumeSource struct {
 // membership reconciler like a replica, removed at unstage. Unlike a
 // diskless tie-breaker it is not placed for quorum, and it is rendered
 // with "tiebreaker no" so DRBD never counts its vote — attach/detach
-// leaves the majority threshold alone (see README).
+// leaves the majority threshold alone (docs: remote-consumers).
 type VolumeClient struct {
 	// Node is the Kubernetes node name consuming the volume remotely.
 	Node string `json:"node"`

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -127,7 +127,7 @@ spec:
                       resyncing more per dirty bit. Applied only when a replica's metadata
                       is first created — replicas created earlier keep their granularity
                       (DRBD exchanges bitmaps across differing block sizes). 0 means the
-                      DRBD default (4096). Needs kmod ≥ 9.3.0 (the agent's startup floor).
+                      DRBD default (4096). Needs kmod ≥ 9.3.1 (the agent's startup floor).
                     enum:
                     - 0
                     - 4096

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -190,8 +190,13 @@ func cacheOptions(mode, namespace, nodeName string) cache.Options {
 		}
 	}
 	if mode == "agent" && nodeName != "" {
+		// The corev1.Node informer gets the same pin: its only agent
+		// consumer is the CordonWatcher, which reads the node's own object.
 		opts.ByObject = map[client.Object]cache.ByObject{
 			&miroirv1alpha1.MiroirNode{}: {
+				Field: fields.OneTermEqualSelector("metadata.name", nodeName),
+			},
+			&corev1.Node{}: {
 				Field: fields.OneTermEqualSelector("metadata.name", nodeName),
 			},
 		}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -140,3 +140,14 @@ func TestCacheOptionsControllerStaysClusterScopedForMiroirNodes(t *testing.T) {
 		t.Fatal("the controller reads every MiroirNode; its informer must stay cluster-scoped")
 	}
 }
+
+func TestCacheOptionsAgentPinsOwnNode(t *testing.T) {
+	opts := cacheOptions("agent", "", "node-a")
+	byNode, ok := byObjectFor[*corev1.Node](opts)
+	if !ok {
+		t.Fatal("agent mode must scope the corev1.Node informer")
+	}
+	if byNode.Field == nil || byNode.Field.String() != "metadata.name=node-a" {
+		t.Fatalf("Node informer must be pinned to the node's own object, got %v", byNode.Field)
+	}
+}

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -127,7 +127,7 @@ spec:
                       resyncing more per dirty bit. Applied only when a replica's metadata
                       is first created — replicas created earlier keep their granularity
                       (DRBD exchanges bitmaps across differing block sizes). 0 means the
-                      DRBD default (4096). Needs kmod ≥ 9.3.0 (the agent's startup floor).
+                      DRBD default (4096). Needs kmod ≥ 9.3.1 (the agent's startup floor).
                     enum:
                     - 0
                     - 4096

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,15 +23,20 @@ exist and where their behavior is explained.
 - **`drbd`**: replication tuning. `portBase`
   ([Coexistence](coexistence.md)), `onIoError`, resync knobs,
   `verify.algorithm` / `verify.schedule`
-  ([verification](resilience.md)), `autoTieBreaker`,
-  `autoDiskfulAfter` ([auto-diskful](remote-consumers.md#auto-diskful)).
+  ([verification](resilience.md)).
+- **Root-level behavior knobs** (the chart root is the controller):
+  `autoTieBreaker` ([Replication and quorum](replication.md)),
+  `autoDiskfulAfter` ([auto-diskful](remote-consumers.md#auto-diskful)),
+  `autoEvictAfter` ([resilience](resilience.md)), `overcommitRatio` /
+  `freeSpaceRatio`, `provisionTimeout`, `storageCapacity`.
 - **`gateway`**: the per-RWX-volume NFS gateway. `enabled` (RWX is
   opt-in, off by default) and the gateway image
   ([ReadWriteMany](rwx.md)).
 - **`monitoring`**: PodMonitor, PrometheusRule, dashboards
   ([Monitoring](monitoring.md)).
-- **`agent` / `controller` / `sidecars`**: workload knobs for images,
-  resources, `agent.kubeletDir`, `sidecars.healthMonitor`.
+- **`agent` / `sidecars`** (and the root's image/resources): workload
+  knobs for images, resources, `agent.kubeletDir`,
+  `sidecars.healthMonitor`.
 - **`logging`**: level and encoder for both components.
 
 ## ZFS zvol settings

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -41,11 +41,12 @@ majority of 2 and the volume keeps serving.
 Behavior and knobs:
 
 - **Placement is zone-aware.** A spare node in a zone neither data
-  leg occupies is preferred (`nodes.<node>.zone`); ties break by node
-  name.
+  leg occupies is preferred (`nodes.<node>.spec.zone`); ties break by
+  node name.
 - **Existing volumes are retrofitted.** Adding a third node to
-  `nodes` (a Helm upgrade, which restarts the controller) appends a
-  tie-breaker to every 2-replica `freeze` volume that lacks one.
+  `nodes` appends a tie-breaker to every 2-replica `freeze` volume
+  that lacks one — the controller follows MiroirNode changes live, no
+  restart involved.
   Editing a volume's `spec.quorumPolicy` from `last-man-standing` to
   `freeze` triggers the same reconciler.
 - **No spare node, no tie-breaker.** On a 2-node cluster the volume

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -145,8 +145,8 @@ func recordVolumeMetrics(volume, pool string, st miroirReplicaView) {
 }
 
 // recordPoolMetrics publishes one pool's sample. The pool set is fixed per
-// agent process (a node-map change is a Helm upgrade, hence a restart), so
-// series are never deleted.
+// agent process (the TopologyWatcher restarts the agent on a pool-spec
+// change), so series are never deleted.
 func recordPoolMetrics(pool string, capacityBytes, allocatedBytes int64, metaUsedRatio float64) {
 	metricPoolCapacity.WithLabelValues(pool).Set(float64(capacityBytes))
 	metricPoolAllocated.WithLabelValues(pool).Set(float64(allocatedBytes))

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -236,7 +236,11 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				return ctrl.Result{}, err
 			}
 			r.storeRealized(vol.Generation, vol.Name, drbd.Status{}, false)
-			return ctrl.Result{}, nil
+			// Unreplicated volumes emit no DRBD events and no status
+			// wakeups; without a requeue, out-of-band backend drift (the
+			// #88 wipe signature) would only surface at the next watch
+			// event. This is the drift net deepCheckInterval promises.
+			return ctrl.Result{RequeueAfter: deepCheckInterval}, nil
 		}
 	} else {
 		// Diskless leg (tie-breaker or client): join DRBD without a
@@ -296,19 +300,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	splitActive := r.handleSplitBrain(ctx, vol, resource, st, connected)
 	diskFailed := diskFailedLatch(vol, r.NodeName, st, localDiskless)
 	if !localDiskless {
-		recordVolumeMetrics(vol.Name, poolName, miroirReplicaView{
-			upToDate:   st.DiskState == drbd.DiskUpToDate,
-			connected:  connected,
-			splitBrain: st.SplitBrain,
-			suspended:  st.Suspended,
-			quorum:     st.Quorum,
-			diskFailed: diskFailed,
-			primary:    st.Primary,
-			// drbdsetup reports percent-in-sync and KiB; the exported
-			// gauges are a 0-1 ratio and bytes per Prometheus base units.
-			resyncRatio:    st.ResyncPercent / 100,
-			outOfSyncBytes: float64(st.OutOfSyncKiB) * 1024,
-		})
+		recordVolumeMetrics(vol.Name, poolName, replicaView(st, vol, r.NodeName, localDiskless))
 	} else {
 		recordDisklessMetrics(vol.Name, st.Primary)
 	}
@@ -364,7 +356,9 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 		recordVolumeMetrics(vol.Name, volumePoolOn(vol, r.NodeName), miroirReplicaView{
 			upToDate: true, connected: true, quorum: true, resyncRatio: 1,
 		})
-		return true, ctrl.Result{}
+		// Same drift net as the full pass: nothing else wakes an
+		// unreplicated volume.
+		return true, ctrl.Result{RequeueAfter: deepCheckInterval}
 	}
 	st, err := r.DRBD.Status(ctx, vol.Name)
 	if err != nil || !statusEqual(st, entry.status) {
@@ -385,17 +379,7 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 		return false, ctrl.Result{}
 	}
 	if !localDiskless {
-		recordVolumeMetrics(vol.Name, volumePoolOn(vol, r.NodeName), miroirReplicaView{
-			upToDate:       st.DiskState == drbd.DiskUpToDate,
-			connected:      diskfulPeersConnected(st, vol, r.NodeName),
-			splitBrain:     st.SplitBrain,
-			suspended:      st.Suspended,
-			quorum:         st.Quorum,
-			diskFailed:     diskFailedLatch(vol, r.NodeName, st, localDiskless),
-			primary:        st.Primary,
-			resyncRatio:    st.ResyncPercent / 100,
-			outOfSyncBytes: float64(st.OutOfSyncKiB) * 1024,
-		})
+		recordVolumeMetrics(vol.Name, volumePoolOn(vol, r.NodeName), replicaView(st, vol, r.NodeName, localDiskless))
 	} else {
 		recordDisklessMetrics(vol.Name, st.Primary)
 	}
@@ -490,6 +474,25 @@ func (r *VolumeReconciler) reconcileDeletion(ctx context.Context, vol *miroirv1a
 // the degraded mode the tie-breaker exists to survive. Entries the
 // membership reconciler has not completed (no address) have no
 // connection yet and are skipped, matching the rendered config.
+// replicaView folds one diskful leg's kernel state into the exported
+// metric view — the one place the drbdsetup-unit conversions happen
+// (percent-in-sync → 0-1 ratio, KiB → bytes, per Prometheus base units).
+// Shared by the full pass and the fast path so a gauge added to one can
+// never silently serve stale values from the other.
+func replicaView(st drbd.Status, vol *miroirv1alpha1.MiroirVolume, self string, localDiskless bool) miroirReplicaView {
+	return miroirReplicaView{
+		upToDate:       st.DiskState == drbd.DiskUpToDate,
+		connected:      diskfulPeersConnected(st, vol, self),
+		splitBrain:     st.SplitBrain,
+		suspended:      st.Suspended,
+		quorum:         st.Quorum,
+		diskFailed:     diskFailedLatch(vol, self, st, localDiskless),
+		primary:        st.Primary,
+		resyncRatio:    st.ResyncPercent / 100,
+		outOfSyncBytes: float64(st.OutOfSyncKiB) * 1024,
+	}
+}
+
 func diskfulPeersConnected(st drbd.Status, vol *miroirv1alpha1.MiroirVolume, self string) bool {
 	for _, rep := range vol.Spec.Replicas {
 		if rep.Node == self || rep.Diskless || rep.Address == "" {

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -2741,3 +2741,57 @@ func TestReconcilePrimarySinceLifecycle(t *testing.T) {
 		t.Fatal("PrimarySince must clear on demotion")
 	}
 }
+
+// An informer lagging the CSI-side Activated latch must not park a
+// Primary leg in the fast path: the full pipeline owns the latch, and the
+// unprotected state (Primary, no Activated) is what split-brain
+// auto-discard safety keys on.
+func TestFastPathMissesOnPrimaryWithoutActivatedLatch(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrA
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = addrB
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, SizeBytes: 1 << 30}, // settled size
+	}
+
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
+		"resource \"pvc-1\" {\n    on \"node-a\" {\n        device minor 1000;\n    }\n}\n",
+	), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+	// Prime a fingerprint matching the live kernel state: without the
+	// Activated guard this reconcile would park in the fast path.
+	st, err := r.DRBD.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.storeRealized(v.Generation, volPvc1, st, true)
+
+	reconcile(t, r, volPvc1)
+
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.Activated {
+		t.Fatal("the full pipeline must run and latch Activated for a Primary leg")
+	}
+}

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -143,9 +143,10 @@ func (r *SnapshotReconciler) clearBarrierFails(name string) {
 	r.barrierFailsMu.Unlock()
 }
 
-// backendFor resolves the backend holding the volume's local leg — the
-// spec entry, or the self-reported status slot for a leg pending removal
-// (snapshots block replica removal, so the slot is still there).
+// backendFor resolves the backend holding the volume's local leg. Every
+// caller sits behind the replicaOn early-return, so the leg is always a
+// live spec entry here (volumePoolOn's status-slot fallback serves the
+// volume reconciler's teardown, not this path).
 func (r *SnapshotReconciler) backendFor(vol *miroirv1alpha1.MiroirVolume) (backend.Backend, error) {
 	pb, err := r.Pools.Get(volumePoolOn(vol, r.NodeName))
 	if err != nil {

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -379,19 +379,7 @@ func nodeObj(name, ip string) *corev1.Node {
 func TestCreateVolumeReplicated(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
-		Client: fake.NewClientBuilder().WithScheme(s).
-			WithObjects(nodeObj(nodeA, addrA), nodeObj(nodeB, "192.168.1.42")).
-			WithInterceptorFuncs(interceptor.Funcs{
-				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					if err := cl.Get(ctx, key, obj, opts...); err != nil {
-						return err
-					}
-					if vol, ok := obj.(*miroirv1alpha1.MiroirVolume); ok {
-						vol.Status.Phase = miroirv1alpha1.VolumeReady
-					}
-					return nil
-				},
-			}).Build(),
+		Client:           readyOnGet(s, nodeObj(nodeA, addrA), nodeObj(nodeB, "192.168.1.42")),
 		Nodes:            testNodes,
 		ProvisionTimeout: 2 * time.Second,
 	}
@@ -470,19 +458,7 @@ func TestCreateVolumeReplicatedAddressOverride(t *testing.T) {
 	entry.Address = "10.0.100.42"
 	nodes[nodeB] = entry
 	c := &Controller{
-		Client: fake.NewClientBuilder().WithScheme(s).
-			WithObjects(nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)).
-			WithInterceptorFuncs(interceptor.Funcs{
-				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					if err := cl.Get(ctx, key, obj, opts...); err != nil {
-						return err
-					}
-					if vol, ok := obj.(*miroirv1alpha1.MiroirVolume); ok {
-						vol.Status.Phase = miroirv1alpha1.VolumeReady
-					}
-					return nil
-				},
-			}).Build(),
+		Client:           readyOnGet(s, nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)),
 		Nodes:            nodes,
 		ProvisionTimeout: 2 * time.Second,
 	}
@@ -517,19 +493,8 @@ func TestCreateVolumeReplicatedAddressOverride(t *testing.T) {
 func tieBreakerController(t *testing.T, autoTieBreaker bool) *Controller {
 	t.Helper()
 	return &Controller{
-		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).
-			WithObjects(nodeObj(nodeA, addrA), nodeObj(nodeB, addrB), nodeObj(nodeC, addrC)).
-			WithInterceptorFuncs(interceptor.Funcs{
-				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					if err := cl.Get(ctx, key, obj, opts...); err != nil {
-						return err
-					}
-					if vol, ok := obj.(*miroirv1alpha1.MiroirVolume); ok {
-						vol.Status.Phase = miroirv1alpha1.VolumeReady
-					}
-					return nil
-				},
-			}).Build(),
+		Client: readyOnGet(newScheme(t),
+			nodeObj(nodeA, addrA), nodeObj(nodeB, addrB), nodeObj(nodeC, addrC)),
 		Nodes: nodemap.Map{
 			nodeA: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin}),
 			nodeB: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendZFS, ZFSDataset: "data-pool/miroir"}),
@@ -1323,19 +1288,7 @@ func TestCreateVolumeIdempotentRejectsSourceChange(t *testing.T) {
 func TestCreateVolumeRemoteAccessDropsTopology(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{
-		Client: fake.NewClientBuilder().WithScheme(s).
-			WithObjects(nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)).
-			WithInterceptorFuncs(interceptor.Funcs{
-				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					if err := cl.Get(ctx, key, obj, opts...); err != nil {
-						return err
-					}
-					if vol, ok := obj.(*miroirv1alpha1.MiroirVolume); ok {
-						vol.Status.Phase = miroirv1alpha1.VolumeReady
-					}
-					return nil
-				},
-			}).Build(),
+		Client:           readyOnGet(s, nodeObj(nodeA, addrA), nodeObj(nodeB, addrB)),
 		Nodes:            testNodes,
 		ProvisionTimeout: 2 * time.Second,
 	}

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -194,33 +194,16 @@ func (n *Node) disklessDevicePath(ctx context.Context, vol *miroirv1alpha1.Miroi
 	// back, an UpToDate survivor serving — while the losing leg is still
 	// divergent and disconnected. Staging here would latch Activated and
 	// close the auto-recovery that heals the loser.
-	if !vol.Status.Activated && !vol.Status.Formatted && !allDiskfulPeersLive(vol, n.NodeName, live) {
-		for node, rep := range vol.Status.PerNode {
-			if rep.SplitBrain {
-				return "", nil, status.Errorf(codes.Unavailable,
-					"volume %s is recovering from split-brain (reported by node %s)", vol.Name, node)
-			}
-		}
+	if err := stage.HoldForSplitRecovery(vol, n.NodeName, live); err != nil {
+		return "", nil, err
 	}
 	return st.DevicePath, vol, nil
 }
 
-// allDiskfulPeersLive reports whether every diskful peer's replication link
-// is established from this leg's view — the corroboration that keeps a
-// stale split-brain slot from holding a healthy volume.
-func allDiskfulPeersLive(vol *miroirv1alpha1.MiroirVolume, self string, live drbd.Status) bool {
-	for _, rep := range diskfulPeerReplicas(vol, self) {
-		if !live.PeerConnected[rep.NodeID] {
-			return false
-		}
-	}
-	return true
-}
-
 // diskfulPeerReplicas yields the completed diskful replicas excluding
-// self — the one peers-walk both live gates below share, so their skip
-// rules (diskless excluded per the bug #78 class, incomplete membership
-// entries skipped) cannot drift apart.
+// self, with the shared skip rules (diskless excluded per the bug #78
+// class, incomplete membership entries skipped) — the same walk
+// stage.DiskfulPeersLive does for the recovery hold.
 func diskfulPeerReplicas(vol *miroirv1alpha1.MiroirVolume, self string) []miroirv1alpha1.Replica {
 	out := make([]miroirv1alpha1.Replica, 0, len(vol.Spec.Replicas))
 	for _, rep := range vol.Spec.Replicas {

--- a/internal/export/metrics.go
+++ b/internal/export/metrics.go
@@ -25,7 +25,8 @@ import (
 // replica health and stay green while the gateway — a per-volume singleton —
 // is down and every NFS client hangs, so export health needs its own gauge.
 // Published from the controller (this reconciler owns the gateway workloads
-// and already watches them); the gateway pod has no metrics endpoint.
+// and already watches them): the gateway's own /metrics vanishes exactly
+// when the gateway is down, which is the state this gauge must report.
 var metricExportReady = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "miroir_export_ready",
 	Help: "1 when the RWX volume's NFS gateway is serving (gateway pod available and export address published); 0 while clients cannot reach the export — a failover in progress, or a gateway that cannot run.",

--- a/internal/export/reconciler.go
+++ b/internal/export/reconciler.go
@@ -106,6 +106,11 @@ func (r *Reconciler) ensureDeployment(ctx context.Context, vol *miroirv1alpha1.M
 	dep.Namespace = want.Namespace
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, dep, func() error {
 		dep.Labels = want.Labels
+		// Overwriting the whole Spec drops apiserver-defaulted fields, so
+		// CreateOrUpdate's equality check never holds and every reconcile
+		// sends an Update the apiserver re-defaults into a no-op (no RV
+		// bump, no event storm — one redundant write per reconcile).
+		// Accepted: the alternative is hand-maintaining the default set.
 		dep.Spec = want.Spec
 		return controllerutil.SetControllerReference(vol, dep, r.Scheme())
 	})

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -280,3 +280,25 @@ func affinityNodes(t *testing.T, dep *appsv1.Deployment) []string {
 	}
 	return terms[0].MatchExpressions[0].Values
 }
+
+// A volume being deleted keeps its gateway workloads (GC removes them
+// with the owner) but its ready gauge is dropped — a stale 1 would mask
+// the teardown.
+func TestReconcileDeletingVolumeKeepsWorkloadsDropsMetric(t *testing.T) {
+	vol := exportVolume("pvc-deleting", nodeA, nodeB)
+	vol.Finalizers = []string{"miroir.home-operations.com/teardown-node-a"}
+	r, cl := newReconciler(vol)
+	reconcile(t, r, "pvc-deleting")
+	getDeployment(t, cl, "pvc-deleting") // created
+
+	// Delete with a finalizer held: DeletionTimestamp set, object remains.
+	if err := cl.Delete(t.Context(), vol); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, "pvc-deleting")
+
+	getDeployment(t, cl, "pvc-deleting") // deliberately retained for GC
+	if _, ok := exportReadyGauge(t, "pvc-deleting"); ok {
+		t.Fatal("gauge series must be dropped while the volume is deleting")
+	}
+}

--- a/internal/export/workloads.go
+++ b/internal/export/workloads.go
@@ -71,7 +71,11 @@ func diskfulNodes(vol *miroirv1alpha1.MiroirVolume) []string {
 // buildDeployment renders the desired gateway Deployment for a volume.
 // replicas:1 with the Recreate strategy: two gateways writing the same
 // device is exactly the dual-primary case single-primary DRBD forbids, so
-// the old pod must be gone before the new one promotes.
+// a template rollout waits for the old pod to exit before starting the
+// new one. On a dead node the ReplicaSet replaces a Terminating pod
+// immediately — there the real dual-writer fence is DRBD's single
+// Primary claim (the replacement's promote fails until the old claim
+// dies with its node).
 func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, serviceAccount string) *appsv1.Deployment {
 	labels := shareLabels(vol.Name)
 	privileged := true

--- a/internal/gateway/supervise_test.go
+++ b/internal/gateway/supervise_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	mount "k8s.io/mount-utils"
+	utilexec "k8s.io/utils/exec"
+)
+
+// stubGanesha points ganeshaBin at a script that blocks until signalled,
+// standing in for a healthy server. Restored on cleanup.
+func stubGanesha(t *testing.T, script string) {
+	t.Helper()
+	stub := filepath.Join(t.TempDir(), "ganesha-stub")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orig := ganeshaBin
+	ganeshaBin = stub
+	t.Cleanup(func() { ganeshaBin = orig })
+}
+
+func superviseCfg() (Config, *mount.SafeFormatAndMount) {
+	return Config{VolumeID: "pvc-rwx", ResizePoll: time.Hour},
+		mount.NewSafeFormatAndMount(mount.NewFakeMounter(nil), utilexec.New())
+}
+
+// A ganesha that exits on its own must surface an error: a dead server
+// restarts the pod, silence would leave every NFS client hanging.
+func TestSuperviseFailsWhenGaneshaExits(t *testing.T) {
+	stubGanesha(t, "exit 3")
+	cfg, m := superviseCfg()
+
+	err := supervise(t.Context(), m, cfg, "/dev/null", t.TempDir(), &health{},
+		make(chan error), logr.Discard())
+	if err == nil || !strings.Contains(err.Error(), "ganesha exited") {
+		t.Fatalf("self-exit must error, got %v", err)
+	}
+}
+
+// A cancelled context is the clean shutdown: SIGTERM, reap, nil.
+func TestSuperviseStopsCleanOnCancel(t *testing.T) {
+	stubGanesha(t, "trap 'exit 0' TERM; sleep 60 & wait $!")
+	cfg, m := superviseCfg()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- supervise(ctx, m, cfg, "/dev/null", t.TempDir(), &health{},
+			make(chan error), logr.Discard())
+	}()
+	time.Sleep(200 * time.Millisecond) // let the stub start
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("cancel must stop clean, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("supervise did not stop on cancel")
+	}
+}
+
+// A dead liveness endpoint kills ganesha and propagates the reason —
+// the kubelet would probe-kill the pod anyway; exiting names why.
+func TestSuperviseKillsGaneshaOnHealthError(t *testing.T) {
+	stubGanesha(t, "sleep 60 & wait $!")
+	cfg, m := superviseCfg()
+	healthErr := make(chan error, 1)
+	boom := errors.New("healthz bind failed")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- supervise(t.Context(), m, cfg, "/dev/null", t.TempDir(), &health{},
+			healthErr, logr.Discard())
+	}()
+	time.Sleep(200 * time.Millisecond)
+	healthErr <- boom
+	select {
+	case err := <-done:
+		if !errors.Is(err, boom) {
+			t.Fatalf("health failure must propagate, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("supervise did not exit on health error")
+	}
+}

--- a/internal/gateway/supervise_test.go
+++ b/internal/gateway/supervise_test.go
@@ -30,17 +30,36 @@ import (
 	utilexec "k8s.io/utils/exec"
 )
 
-// stubGanesha points ganeshaBin at a script that blocks until signalled,
-// standing in for a healthy server. Restored on cleanup.
-func stubGanesha(t *testing.T, script string) {
+// stubGanesha points ganeshaBin at a script standing in for the server;
+// the script touches a "ready" file first, which awaitStub polls, so no
+// test races the stub's startup. Restored on cleanup.
+func stubGanesha(t *testing.T, script string) string {
 	t.Helper()
-	stub := filepath.Join(t.TempDir(), "ganesha-stub")
-	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	stub := filepath.Join(dir, "ganesha-stub")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\ntouch "+ready+"\n"+script+"\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	orig := ganeshaBin
 	ganeshaBin = stub
 	t.Cleanup(func() { ganeshaBin = orig })
+	return ready
+}
+
+// awaitStub blocks until the stub signalled readiness.
+func awaitStub(t *testing.T, ready string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("stub never signalled readiness")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func superviseCfg() (Config, *mount.SafeFormatAndMount) {
@@ -61,9 +80,10 @@ func TestSuperviseFailsWhenGaneshaExits(t *testing.T) {
 	}
 }
 
-// A cancelled context is the clean shutdown: SIGTERM, reap, nil.
+// A cancelled context is the clean shutdown: SIGTERM, reap, nil. The stub
+// reaps its own child on TERM so no sleep outlives the test.
 func TestSuperviseStopsCleanOnCancel(t *testing.T) {
-	stubGanesha(t, "trap 'exit 0' TERM; sleep 60 & wait $!")
+	ready := stubGanesha(t, "trap 'kill $child 2>/dev/null; exit 0' TERM; sleep 60 & child=$!; wait $child")
 	cfg, m := superviseCfg()
 	ctx, cancel := context.WithCancel(t.Context())
 
@@ -72,7 +92,7 @@ func TestSuperviseStopsCleanOnCancel(t *testing.T) {
 		done <- supervise(ctx, m, cfg, "/dev/null", t.TempDir(), &health{},
 			make(chan error), logr.Discard())
 	}()
-	time.Sleep(200 * time.Millisecond) // let the stub start
+	awaitStub(t, ready)
 	cancel()
 	select {
 	case err := <-done:
@@ -85,9 +105,10 @@ func TestSuperviseStopsCleanOnCancel(t *testing.T) {
 }
 
 // A dead liveness endpoint kills ganesha and propagates the reason —
-// the kubelet would probe-kill the pod anyway; exiting names why.
+// the kubelet would probe-kill the pod anyway; exiting names why. exec
+// makes the sleep BE the stub process, so the kill reaps it.
 func TestSuperviseKillsGaneshaOnHealthError(t *testing.T) {
-	stubGanesha(t, "sleep 60 & wait $!")
+	ready := stubGanesha(t, "exec sleep 60")
 	cfg, m := superviseCfg()
 	healthErr := make(chan error, 1)
 	boom := errors.New("healthz bind failed")
@@ -97,7 +118,7 @@ func TestSuperviseKillsGaneshaOnHealthError(t *testing.T) {
 		done <- supervise(t.Context(), m, cfg, "/dev/null", t.TempDir(), &health{},
 			healthErr, logr.Discard())
 	}()
-	time.Sleep(200 * time.Millisecond)
+	awaitStub(t, ready)
 	healthErr <- boom
 	select {
 	case err := <-done:

--- a/internal/membership/autoevict_test.go
+++ b/internal/membership/autoevict_test.go
@@ -457,3 +457,32 @@ func TestAutoEvictBlocksOnIncompleteMembershipChange(t *testing.T) {
 		t.Fatalf("an in-flight membership change must block eviction: %+v", got.Spec.Replicas)
 	}
 }
+
+// A swap with a surviving tie-breaker must insert the bare diskful
+// replacement BEFORE the diskless leg: the CEL first-replica-diskful rule
+// holds no matter which entry died.
+func TestAutoEvictSwapKeepsDisklessLast(t *testing.T) {
+	v := evictVol()
+	v.Spec.Replicas = append(v.Spec.Replicas,
+		miroirv1alpha1.Replica{Node: nodeC, NodeID: 2, Address: addrC, Diskless: true})
+	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeC)
+	r := newAE(t, v,
+		minAt(nodeA, time.Minute, 50<<30),
+		minAt(nodeB, 2*time.Hour, 50<<30),
+		minAt(nodeC, time.Minute, 50<<30),
+		minAt(nodeD, time.Minute, 50<<30))
+
+	reconcileAE(t, r, nodeB)
+
+	got := get(t, &Reconciler{Client: r.Client}, volPvc1)
+	nodes := make([]string, 0, len(got.Spec.Replicas))
+	for _, rep := range got.Spec.Replicas {
+		nodes = append(nodes, rep.Node)
+	}
+	if !slices.Equal(nodes, []string{nodeA, nodeD, nodeC}) {
+		t.Fatalf("replacement must precede the diskless leg: %v", nodes)
+	}
+	if got.Spec.Replicas[2].Node != nodeC || !got.Spec.Replicas[2].Diskless {
+		t.Fatalf("tie-breaker must stay last and diskless: %+v", got.Spec.Replicas)
+	}
+}

--- a/internal/membership/reconciler.go
+++ b/internal/membership/reconciler.go
@@ -158,23 +158,11 @@ func (r *Reconciler) complete(ctx context.Context, nodes nodemap.Map, vol *miroi
 				errBadPlacement, rep.Node, targetPool)
 		}
 	}
-	dup := 0
-	for _, other := range vol.Spec.Replicas {
-		if other.Node == rep.Node {
-			dup++
-		}
+	if err := refuseDuplicate(rep.Node, "spec.replicas", nodesOf(vol.Spec.Replicas)); err != nil {
+		return err
 	}
-	if dup > 1 {
-		return fmt.Errorf("%w: node %s appears %d times in spec.replicas", errBadPlacement, rep.Node, dup)
-	}
-	addr, err := nodes.ReplicationAddress(ctx, r.Client, rep.Node)
+	addr, err := resolveAddress(ctx, r.Client, nodes, rep.Node)
 	if err != nil {
-		// An address conflict is a topology misconfiguration, not a
-		// transient: like unknown-node, only a topology fix can clear it,
-		// and that fix re-triggers this controller via the MiroirNode watch.
-		if errors.Is(err, nodemap.ErrAddressConflict) {
-			return fmt.Errorf("%w: %w", errBadPlacement, err)
-		}
 		return err
 	}
 	id := nextNodeID(vol, rep.Node)
@@ -200,25 +188,59 @@ func (r *Reconciler) complete(ctx context.Context, nodes nodemap.Map, vol *miroi
 // no node-map entry — any node running an agent can consume remotely, and
 // its address resolves like a replica's (map override, else InternalIP).
 func (r *Reconciler) completeClient(ctx context.Context, nodes nodemap.Map, vol *miroirv1alpha1.MiroirVolume, cl *miroirv1alpha1.VolumeClient) error {
-	dup := 0
+	clients := make([]string, 0, len(vol.Spec.Clients))
 	for _, other := range vol.Spec.Clients {
-		if other.Node == cl.Node {
-			dup++
-		}
+		clients = append(clients, other.Node)
 	}
-	if dup > 1 {
-		return fmt.Errorf("%w: node %s appears %d times in spec.clients", errBadPlacement, cl.Node, dup)
+	if err := refuseDuplicate(cl.Node, "spec.clients", clients); err != nil {
+		return err
 	}
-	addr, err := nodes.ReplicationAddress(ctx, r.Client, cl.Node)
+	addr, err := resolveAddress(ctx, r.Client, nodes, cl.Node)
 	if err != nil {
-		if errors.Is(err, nodemap.ErrAddressConflict) {
-			return fmt.Errorf("%w: %w", errBadPlacement, err)
-		}
 		return err
 	}
 	cl.NodeID = nextNodeID(vol, cl.Node)
 	cl.Address = addr
 	return nil
+}
+
+// nodesOf lists the node names of a replica set.
+func nodesOf(reps []miroirv1alpha1.Replica) []string {
+	nodes := make([]string, 0, len(reps))
+	for _, rep := range reps {
+		nodes = append(nodes, rep.Node)
+	}
+	return nodes
+}
+
+// refuseDuplicate rejects a node appearing more than once in a leg list —
+// permanent (errBadPlacement): only a spec edit can fix it.
+func refuseDuplicate(node, field string, nodes []string) error {
+	dup := 0
+	for _, n := range nodes {
+		if n == node {
+			dup++
+		}
+	}
+	if dup > 1 {
+		return fmt.Errorf("%w: node %s appears %d times in %s", errBadPlacement, node, dup, field)
+	}
+	return nil
+}
+
+// resolveAddress resolves a leg's replication endpoint, mapping an address
+// conflict to errBadPlacement: it is a topology misconfiguration, not a
+// transient — like unknown-node, only a topology fix can clear it, and
+// that fix re-triggers this controller via the MiroirNode watch.
+func resolveAddress(ctx context.Context, c client.Client, nodes nodemap.Map, node string) (string, error) {
+	addr, err := nodes.ReplicationAddress(ctx, c, node)
+	if err != nil {
+		if errors.Is(err, nodemap.ErrAddressConflict) {
+			return "", fmt.Errorf("%w: %w", errBadPlacement, err)
+		}
+		return "", err
+	}
+	return addr, nil
 }
 
 // nextNodeID returns the lowest DRBD node id unused by any completed

--- a/internal/membership/reconciler_test.go
+++ b/internal/membership/reconciler_test.go
@@ -405,3 +405,27 @@ func TestClientLegNodeIDSkipsReplicaIDs(t *testing.T) {
 		t.Fatalf("client must take the lowest free id (1), got %d", got.NodeID)
 	}
 }
+
+// Two legs completed in one pass must get distinct node ids: the second
+// scan relies on the first entry's in-place completion being visible.
+func TestCompletesReplicaAndClientWithDistinctIDs(t *testing.T) {
+	v := replicatedVol() // node-c replica entry still bare
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: "bergen"}}
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(v, node(nodeC, addrC), node(nodeBergen, addrBergen)).
+		Build()
+	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+		nodeC: storageNode(miroirv1alpha1.BackendZFS),
+	}}
+
+	reconcile(t, r, "pvc-1")
+
+	got := get(t, r, "pvc-1")
+	rep, cl := got.Spec.Replicas[2], got.Spec.Clients[0]
+	if rep.Address == "" || cl.Address == "" {
+		t.Fatalf("both legs must complete in one pass: %+v / %+v", rep, cl)
+	}
+	if rep.NodeID == cl.NodeID {
+		t.Fatalf("legs completed in one pass must get distinct node ids, both got %d", rep.NodeID)
+	}
+}

--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -109,25 +109,20 @@ func Device(ctx context.Context, d Deps, volumeID string) (string, *miroirv1alph
 		// from blocking a volume whose data legs are all established, and
 		// releases the hold the moment the loser reconnects, ahead of the
 		// slots clearing on the next status patch.
-		if !vol.Status.Activated && !vol.Status.Formatted &&
-			!diskfulPeersLive(vol, d.NodeName, live) {
-			for node, rep := range vol.Status.PerNode {
-				if rep.SplitBrain {
-					return "", nil, status.Errorf(codes.Unavailable,
-						"volume %s is recovering from split-brain (reported by node %s)", volumeID, node)
-				}
-			}
+		if err := HoldForSplitRecovery(vol, d.NodeName, live); err != nil {
+			return "", nil, err
 		}
 	}
 	return st.DevicePath, vol, nil
 }
 
-// diskfulPeersLive reports whether this node's replication links to every
+// DiskfulPeersLive reports whether this node's replication links to every
 // diskful peer are established, per the live kernel view. Mirrors the
 // agent's diskfulPeersConnected: a diskless tie-breaker's link is excluded
 // so its state never gates a data leg (the bug #78 class), and entries the
-// membership reconciler has not completed are skipped.
-func diskfulPeersLive(vol *miroirv1alpha1.MiroirVolume, self string, live drbd.Status) bool {
+// membership reconciler has not completed are skipped. Shared with the
+// node service's diskless staging path so the skip rules cannot drift.
+func DiskfulPeersLive(vol *miroirv1alpha1.MiroirVolume, self string, live drbd.Status) bool {
 	for _, rep := range vol.Spec.Replicas {
 		if rep.Node == self || rep.Diskless || rep.Address == "" {
 			continue
@@ -137,6 +132,27 @@ func diskfulPeersLive(vol *miroirv1alpha1.MiroirVolume, self string, live drbd.S
 		}
 	}
 	return true
+}
+
+// HoldForSplitRecovery returns the Unavailable hold for a never-activated
+// volume that is mid split-brain recovery, nil otherwise (issue #144).
+// The live-connectivity corroboration keeps a stale slot from a dead peer
+// from blocking a volume whose data legs are all established, and releases
+// the hold the moment the loser reconnects, ahead of the slots clearing on
+// the next status patch. One implementation for both the diskful staging
+// path and the diskless (client/tie-breaker) one — a tweak to the hold
+// applied to one must reach the other.
+func HoldForSplitRecovery(vol *miroirv1alpha1.MiroirVolume, self string, live drbd.Status) error {
+	if vol.Status.Activated || vol.Status.Formatted || DiskfulPeersLive(vol, self, live) {
+		return nil
+	}
+	for node, rep := range vol.Status.PerNode {
+		if rep.SplitBrain {
+			return status.Errorf(codes.Unavailable,
+				"volume %s is recovering from split-brain (reported by node %s)", vol.Name, node)
+		}
+	}
+	return nil
 }
 
 // EnsureFilesystem makes dev usable at target: mkfs-if-blank (exactly once

--- a/internal/topology/conflict.go
+++ b/internal/topology/conflict.go
@@ -54,6 +54,10 @@ const ConditionAddressConflict = "AddressConflict"
 const (
 	reasonDuplicateAddress = "DuplicateAddress"
 	reasonAddressUnique    = "AddressUnique"
+	// topologyRequestKey is the fixed request name every MiroirNode event
+	// maps to — one pass per edit, not one per node. The name is never
+	// read; Reconcile ignores the request.
+	topologyRequestKey = "topology"
 )
 
 // ConflictReconciler maintains the AddressConflict condition on every
@@ -119,7 +123,8 @@ func (r *ConflictReconciler) reconcileNode(ctx context.Context, node *miroirv1al
 		return nil
 	}
 	if err := r.Status().Update(ctx, node); err != nil {
-		return err
+		// Deleted mid-pass: its deletion event re-runs the pass anyway.
+		return client.IgnoreNotFound(err)
 	}
 	if cond.Status == metav1.ConditionTrue && !wasConflicted && r.Recorder != nil {
 		r.Recorder.Eventf(node, nil, corev1.EventTypeWarning, ConditionAddressConflict, "Reconcile",
@@ -139,7 +144,7 @@ func (r *ConflictReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("topologyconflict").
 		Watches(&miroirv1alpha1.MiroirNode{}, handler.EnqueueRequestsFromMapFunc(
 			func(context.Context, client.Object) []ctrl.Request {
-				return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: "topology"}}}
+				return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: topologyRequestKey}}}
 			}), builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/topology/conflict_test.go
+++ b/internal/topology/conflict_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -83,7 +84,7 @@ func TestConflictSinglePassCoversAllNodes(t *testing.T) {
 		addrNode(nodeC, "10.0.100.3"))
 	r := &ConflictReconciler{Client: c}
 	if _, err := r.Reconcile(t.Context(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "topology"},
+		NamespacedName: types.NamespacedName{Name: topologyRequestKey},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -151,5 +152,30 @@ func TestConflictConditionClearsWhenResolved(t *testing.T) {
 	}
 	if n := reconcile(t, c, nodeA); !meta.IsStatusConditionFalse(n.Status.Conditions, ConditionAddressConflict) {
 		t.Fatalf("resolving the peer's address must clear the condition, got %+v", n.Status.Conditions)
+	}
+}
+
+// The Warning event fires once per fresh conflict — repeat passes over an
+// unchanged (or message-only-changed) topology must stay silent.
+func TestConflictEventFiresOncePerFreshConflict(t *testing.T) {
+	c := newClient(t, addrNode(nodeA, "10.0.100.1"), addrNode(nodeB, "10.0.100.1"))
+	rec := events.NewFakeRecorder(8)
+	r := &ConflictReconciler{Client: c, Recorder: rec}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "topology"}}
+
+	if _, err := r.Reconcile(t.Context(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Reconcile(t.Context(), req); err != nil {
+		t.Fatal(err)
+	}
+
+	close(rec.Events)
+	fired := 0
+	for range rec.Events {
+		fired++
+	}
+	if fired != 2 { // one per freshly conflicted node, none on the repeat
+		t.Fatalf("want exactly one event per fresh conflict (2), got %d", fired)
 	}
 }


### PR DESCRIPTION
PR F of the sixth review cycle: everything below the bug bar — verified stale comments, DRY hazards, docs corrections, and the review's named test gaps. No intended behavior change except the three called out first.

## Correctness-adjacent

- **Unreplicated volumes get their promised drift net.** `deepCheckInterval`'s comment claims backend drift "(unreplicated volumes especially) is caught within one interval" — but unreplicated volumes returned with no requeue from both the full pass and the fast path, and they emit no DRBD events and no status wakeups, so an out-of-band-deleted backing (the #88 wipe signature) only surfaced at the next watch event. Both paths now requeue at `deepCheckInterval`.
- The conflict pass skips a node deleted mid-pass (`IgnoreNotFound` — its deletion event re-runs the pass) instead of erroring the whole pass into a backoff; the singleton request name is a const.
- The agent's `corev1.Node` informer is pinned to the node's own object, finishing what #245 did for MiroirNode — its only agent consumer is the CordonWatcher, and the unscoped watch cached every node on every agent.

## DRY (each one a real drift hazard)

- `replicaView`: the 9-field metric view construction — including the percent→ratio and KiB→bytes unit conversions — existed in both the full pass and the fast path; a gauge added to one would silently serve stale values from the other (the exact class #114–#117 fixed).
- membership `complete`/`completeClient` share `refuseDuplicate` + `resolveAddress` (the `ErrAddressConflict`→`errBadPlacement` mapping was verbatim-duplicated).
- The #144 split-brain staging hold is now one implementation (`stage.HoldForSplitRecovery` + exported `stage.DiskfulPeersLive`) used by both the diskful path (`stage.Device`) and the diskless one (`csi.disklessDevicePath`) — previously three copies of the peers-walk skip rule, one edit from reopening the diskless variant of the bug.
- Four inline copies of the `readyOnGet` fake-client interceptor in controller tests collapse into the existing helper.

## Stale comments and docs (each verified against the code)

- export `metrics.go` claimed "the gateway pod has no metrics endpoint" — it serves `/metrics` on 8081; the controller-published gauge is still correct (the gateway's own endpoint vanishes exactly when the gauge must read 0), and the comment now says so. `workloads.go`'s Recreate comment overstated node-failure serialization (a dead node's Terminating pod is replaced immediately; DRBD's single-Primary claim is the real fence). `ensureDeployment` documents its accepted one-redundant-Update-per-reconcile cost.
- agent: `backendFor`'s pending-removal claim was unreachable (every caller sits behind the `replicaOn` early-return); `recordPoolMetrics` referenced the pre-0.11 "Helm upgrade restarts the agent" world.
- docs: `configuration.md` listed `autoTieBreaker`/`autoDiskfulAfter` under the `drbd` group (they're root-level) and named a `controller` values group that doesn't exist; `replication.md` was missing `.spec` in `nodes.<n>.spec.zone` (the documented path silently did nothing) and claimed a Helm upgrade restarts the controller (topology is watch-driven since 0.11).
- api: `BitmapGranularityBytes` documented a 9.3.0 kernel floor; the agent enforces 9.3.1. CRDs and applyconfigurations regenerated.

## New tests (the review's named gaps)

Gateway `supervise` via a stub binary — previously 0% coverage on all four failover-critical behaviors (self-exit → error, cancel → SIGTERM + clean nil, health-endpoint death → kill + propagate); fast-path miss on `Primary && !Activated` (the split-brain auto-discard safety guard, the one uncovered invalidation); conflict Warning event fires once per fresh conflict; one-pass replica+client completion yields distinct DRBD node ids; auto-evict swap inserts the replacement before a surviving tie-breaker (the CEL first-replica-diskful invariant, untested in the spare-exists path); a deleting RWX volume keeps its workloads for GC but drops the ready gauge; `cacheOptions` pins the agent Node informer.

Full linux unit suite green, lint clean, helm CRDs regenerated and in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved DRBD split-brain recovery safety checks during staging.
  * Agent node monitoring is now scoped to the local node.
  * Unreplicated volumes are periodically rechecked for backend drift.

* **Bug Fixes**
  * Improved replica/client placement validation and diskless tie-breaker ordering.
  * Prevented stale gateway readiness metrics when deleting a volume.
  * Refined diskless split-recovery hold behavior and topology conflict handling to emit warning events only once per new conflict.

* **Documentation**
  * Updated DRBD bitmap granularity documentation to require kmod ≥ 9.3.1.
  * Refreshed configuration and replication documentation wording.

* **Tests**
  * Added regression coverage for fast-path behavior, auto-eviction ordering, gateway supervise, and topology event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->