### PR TITLE
feat(api)!: drop the deprecated flat MiroirNodeStatus capacity fields

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodestatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodestatus.go
@@ -31,22 +31,6 @@ import (
 type MiroirNodeStatusApplyConfiguration struct {
 	// Pools carries one capacity entry per storage pool on this node.
 	Pools []MiroirNodePoolStatusApplyConfiguration `json:"pools,omitempty"`
-	// CapacityBytes is the pre-multi-pool single-pool figure. Kept in the
-	// schema so a mixed-version rollout (new controller, old agent) does
-	// not prune the old agent's stats into "fresh but empty" — Pool()
-	// folds these into the default pool entry. Never written by current
-	// agents; drop after one release.
-	//
-	// Deprecated: superseded by Pools.
-	CapacityBytes *int64 `json:"capacityBytes,omitempty"`
-	// AllocatedBytes is the pre-multi-pool twin of CapacityBytes.
-	//
-	// Deprecated: superseded by Pools.
-	AllocatedBytes *int64 `json:"allocatedBytes,omitempty"`
-	// MetaUsedPercent is the pre-multi-pool twin of CapacityBytes.
-	//
-	// Deprecated: superseded by Pools.
-	MetaUsedPercent *int32 `json:"metaUsedPercent,omitempty"`
 	// DRBDVersion is the DRBD kernel module version the agent probed at
 	// startup (e.g. "9.3.2"); absent on nodes without the module. The
 	// module ships with the host, not the agent image, so this is the
@@ -76,30 +60,6 @@ func (b *MiroirNodeStatusApplyConfiguration) WithPools(values ...*MiroirNodePool
 		}
 		b.Pools = append(b.Pools, *values[i])
 	}
-	return b
-}
-
-// WithCapacityBytes sets the CapacityBytes field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the CapacityBytes field is set to the value of the last call.
-func (b *MiroirNodeStatusApplyConfiguration) WithCapacityBytes(value int64) *MiroirNodeStatusApplyConfiguration {
-	b.CapacityBytes = &value
-	return b
-}
-
-// WithAllocatedBytes sets the AllocatedBytes field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the AllocatedBytes field is set to the value of the last call.
-func (b *MiroirNodeStatusApplyConfiguration) WithAllocatedBytes(value int64) *MiroirNodeStatusApplyConfiguration {
-	b.AllocatedBytes = &value
-	return b
-}
-
-// WithMetaUsedPercent sets the MetaUsedPercent field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the MetaUsedPercent field is set to the value of the last call.
-func (b *MiroirNodeStatusApplyConfiguration) WithMetaUsedPercent(value int32) *MiroirNodeStatusApplyConfiguration {
-	b.MetaUsedPercent = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -157,12 +157,6 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.home-operations.miroir.api.v1alpha1.MiroirNodeStatus
   map:
     fields:
-    - name: allocatedBytes
-      type:
-        scalar: numeric
-    - name: capacityBytes
-      type:
-        scalar: numeric
     - name: conditions
       type:
         list:
@@ -172,9 +166,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: drbdVersion
       type:
         scalar: string
-    - name: metaUsedPercent
-      type:
-        scalar: numeric
     - name: observedAt
       type:
         namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time

--- a/api/v1alpha1/miroirnode_types.go
+++ b/api/v1alpha1/miroirnode_types.go
@@ -152,25 +152,6 @@ type MiroirNodeStatus struct {
 	// +listType=map
 	// +listMapKey=name
 	Pools []MiroirNodePoolStatus `json:"pools,omitempty"`
-	// CapacityBytes is the pre-multi-pool single-pool figure. Kept in the
-	// schema so a mixed-version rollout (new controller, old agent) does
-	// not prune the old agent's stats into "fresh but empty" — Pool()
-	// folds these into the default pool entry. Never written by current
-	// agents; drop after one release.
-	//
-	// Deprecated: superseded by Pools.
-	// +optional
-	CapacityBytes int64 `json:"capacityBytes,omitempty"`
-	// AllocatedBytes is the pre-multi-pool twin of CapacityBytes.
-	//
-	// Deprecated: superseded by Pools.
-	// +optional
-	AllocatedBytes int64 `json:"allocatedBytes,omitempty"`
-	// MetaUsedPercent is the pre-multi-pool twin of CapacityBytes.
-	//
-	// Deprecated: superseded by Pools.
-	// +optional
-	MetaUsedPercent int32 `json:"metaUsedPercent,omitempty"`
 	// DRBDVersion is the DRBD kernel module version the agent probed at
 	// startup (e.g. "9.3.2"); absent on nodes without the module. The
 	// module ships with the host, not the agent image, so this is the
@@ -189,8 +170,6 @@ type MiroirNodeStatus struct {
 
 // Pool returns the named pool's capacity entry, or nil. Empty means the
 // default pool, matching the CRD adoption rule for pre-multi-pool objects.
-// A status still published in the pre-multi-pool flat shape (an agent not
-// yet rolled to this release) reads as the default pool.
 func (s MiroirNodeStatus) Pool(name string) *MiroirNodePoolStatus {
 	if name == "" {
 		name = DefaultPoolName
@@ -198,14 +177,6 @@ func (s MiroirNodeStatus) Pool(name string) *MiroirNodePoolStatus {
 	for i := range s.Pools {
 		if s.Pools[i].Name == name {
 			return &s.Pools[i]
-		}
-	}
-	if name == DefaultPoolName && len(s.Pools) == 0 && s.CapacityBytes > 0 {
-		return &MiroirNodePoolStatus{
-			Name:            DefaultPoolName,
-			CapacityBytes:   s.CapacityBytes,
-			AllocatedBytes:  s.AllocatedBytes,
-			MetaUsedPercent: s.MetaUsedPercent,
 		}
 	}
 	return nil

--- a/charts/miroir/crds/miroir.home-operations.com_miroirnodes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirnodes.yaml
@@ -224,24 +224,6 @@ spec:
               MiroirNodeStatus is the pool capacity this node's agent publishes for
               capacity-aware placement and overcommit guardrails.
             properties:
-              allocatedBytes:
-                description: |-
-                  AllocatedBytes is the pre-multi-pool twin of CapacityBytes.
-
-                  Deprecated: superseded by Pools.
-                format: int64
-                type: integer
-              capacityBytes:
-                description: |-
-                  CapacityBytes is the pre-multi-pool single-pool figure. Kept in the
-                  schema so a mixed-version rollout (new controller, old agent) does
-                  not prune the old agent's stats into "fresh but empty" — Pool()
-                  folds these into the default pool entry. Never written by current
-                  agents; drop after one release.
-
-                  Deprecated: superseded by Pools.
-                format: int64
-                type: integer
               conditions:
                 description: |-
                   Conditions follow the standard Kubernetes condition conventions;
@@ -308,13 +290,6 @@ spec:
                   module ships with the host, not the agent image, so this is the
                   per-node view that makes mixed clusters visible mid-upgrade.
                 type: string
-              metaUsedPercent:
-                description: |-
-                  MetaUsedPercent is the pre-multi-pool twin of CapacityBytes.
-
-                  Deprecated: superseded by Pools.
-                format: int32
-                type: integer
               observedAt:
                 description: |-
                   ObservedAt is when these figures were last sampled; the controller

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -88,7 +88,7 @@ spec:
                     membership reconciler like a replica, removed at unstage. Unlike a
                     diskless tie-breaker it is not placed for quorum, and it is rendered
                     with "tiebreaker no" so DRBD never counts its vote — attach/detach
-                    leaves the majority threshold alone (see README).
+                    leaves the majority threshold alone (docs: remote-consumers).
                   properties:
                     addedAt:
                       description: |-

--- a/config/crd/bases/miroir.home-operations.com_miroirnodes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirnodes.yaml
@@ -224,24 +224,6 @@ spec:
               MiroirNodeStatus is the pool capacity this node's agent publishes for
               capacity-aware placement and overcommit guardrails.
             properties:
-              allocatedBytes:
-                description: |-
-                  AllocatedBytes is the pre-multi-pool twin of CapacityBytes.
-
-                  Deprecated: superseded by Pools.
-                format: int64
-                type: integer
-              capacityBytes:
-                description: |-
-                  CapacityBytes is the pre-multi-pool single-pool figure. Kept in the
-                  schema so a mixed-version rollout (new controller, old agent) does
-                  not prune the old agent's stats into "fresh but empty" — Pool()
-                  folds these into the default pool entry. Never written by current
-                  agents; drop after one release.
-
-                  Deprecated: superseded by Pools.
-                format: int64
-                type: integer
               conditions:
                 description: |-
                   Conditions follow the standard Kubernetes condition conventions;
@@ -308,13 +290,6 @@ spec:
                   module ships with the host, not the agent image, so this is the
                   per-node view that makes mixed clusters visible mid-upgrade.
                 type: string
-              metaUsedPercent:
-                description: |-
-                  MetaUsedPercent is the pre-multi-pool twin of CapacityBytes.
-
-                  Deprecated: superseded by Pools.
-                format: int32
-                type: integer
               observedAt:
                 description: |-
                   ObservedAt is when these figures were last sampled; the controller

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -88,7 +88,7 @@ spec:
                     membership reconciler like a replica, removed at unstage. Unlike a
                     diskless tie-breaker it is not placed for quorum, and it is rendered
                     with "tiebreaker no" so DRBD never counts its vote — attach/detach
-                    leaves the majority threshold alone (see README).
+                    leaves the majority threshold alone (docs: remote-consumers).
                   properties:
                     addedAt:
                       description: |-

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -218,6 +218,12 @@ CRDs and run the upgrade again.
   seconds instead of Kubernetes' 300 default, so a dead node stops
   provisioning for seconds rather than five minutes
   (`unreachableNodeTolerationSeconds` restores the old value if you want it).
+- The deprecated flat `MiroirNode.status.capacityBytes` /
+  `status.allocatedBytes` / `status.metaUsedPercent` fields are gone from
+  the schema, along with the controller's fold of them into the default
+  pool. They existed for the 0.9→0.10 rollout skew; 0.10 agents already
+  publish (and read) only `status.pools`. Anything scraping the flat paths
+  directly has been broken since 0.10 — use `status.pools[*]`.
 
 ## 0.9.x → 0.10.0: named storage pools
 

--- a/internal/agent/poolstats.go
+++ b/internal/agent/poolstats.go
@@ -142,10 +142,6 @@ func (p *PoolStatsPublisher) publish(ctx context.Context) error {
 			}
 			cur.Status.Pools = append(cur.Status.Pools, entry)
 		}
-		// Clear the deprecated pre-multi-pool figures a not-yet-rolled
-		// agent may have written: the pools list supersedes them, and
-		// stale flat values frozen in status would mislead readers.
-		cur.Status.CapacityBytes, cur.Status.AllocatedBytes, cur.Status.MetaUsedPercent = 0, 0, 0 //nolint:staticcheck // deliberately clears the deprecated skew-compat fields
 		cur.Status.DRBDVersion = p.DRBDVersion
 		now := metav1.Now()
 		cur.Status.ObservedAt = &now

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -648,28 +648,6 @@ func TestGetCapacityAgreesWithPlacement(t *testing.T) {
 	}
 }
 
-// Regression (review): a not-yet-upgraded agent publishes the flat
-// pre-multi-pool figures; the controller folds them into the default pool
-// so a mixed-version rollout does not zero the node's capacity.
-func TestGetCapacityReadsLegacyFlatStatus(t *testing.T) {
-	s := newScheme(t)
-	now := metav1.Now()
-	legacy := &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeA},
-		Status: miroirv1alpha1.MiroirNodeStatus{
-			CapacityBytes: 10 * gib, ObservedAt: &now,
-		},
-	}
-	c := &Controller{Client: placementClient(s, legacy), Nodes: testNodes}
-	resp, err := c.GetCapacity(t.Context(), topologySegment(nodeA))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.GetAvailableCapacity() != 20*gib {
-		t.Fatalf("legacy flat status must fold into the default pool, got %d", resp.GetAvailableCapacity())
-	}
-}
-
 // A node without fresh stats, an unknown segment, and a non-storage node all
 // report zero so the scheduler steers elsewhere until stats land.
 func TestGetCapacityUnknownIsZero(t *testing.T) {


### PR DESCRIPTION
PR G — the last item from the sixth review cycle, taking the deprecation window the 0.11 breaking release opens.

`status.capacityBytes` / `status.allocatedBytes` / `status.metaUsedPercent` existed for exactly one thing: the 0.9→0.10 rollout skew, where a not-yet-rolled agent published the flat pre-multi-pool figures and the new controller folded them into the default pool so a mixed-version cluster didn't read as "fresh but empty". Their own doc comment said "drop after one release".

The window is closed: 0.10 agents publish (and read) only `status.pools` and actively zeroed the flat fields on every heartbeat, and `docs/upgrading.md` mandates crossing minors one at a time — so no supported 0.11 rollout has a flat-fields writer left. Removed together, since each existed only for the others:

- the three schema fields (CRDs + applyconfigurations regenerated; the chart copy is byte-identical to `config/crd/bases`),
- `MiroirNodeStatus.Pool()`'s fold of the flat shape into the default pool,
- the agent's per-heartbeat clearing write (with its `//nolint:staticcheck`),
- `TestGetCapacityReadsLegacyFlatStatus`, which pinned the fold.

The 0.11 upgrade notes call it out under "Also breaking, but unlikely to affect you" — anything scraping the flat CR paths directly has effectively been broken since 0.10 (the fields were always zero), and the 0.10 notes already directed readers to `status.pools[*]`.

The miroirvolumes CRD hunk is a regen artifact catching up with #253's `VolumeClient` doc-comment change. Full linux suite green, lint clean.