### PR TITLE
fix(image): reject NBD devices in the lvm global_filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,9 +73,10 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     rm -rf /var/lib/apt/lists/*
 # No udevd is reachable from the container: stop libdevmapper from waiting
 # on udev cookies and lvm from querying udev for the device list.
-# global_filter rejects DRBD devices: lvm's device scan would block in D
-# state on a suspended one, wedging the reconciler and then pod shutdown.
-RUN printf 'activation { udev_sync = 0\nudev_rules = 0 }\ndevices { obtain_device_list_from_udev = 0\nglobal_filter = [ "r|^/dev/drbd|" ] }\n' \
+# global_filter rejects DRBD and NBD devices: lvm's device scan would block
+# in D state on a suspended DRBD leg or a dead NBD device, wedging the
+# reconciler and then pod shutdown.
+RUN printf 'activation { udev_sync = 0\nudev_rules = 0 }\ndevices { obtain_device_list_from_udev = 0\nglobal_filter = [ "r|^/dev/drbd|", "r|^/dev/nbd|" ] }\n' \
     > /etc/lvm/lvmlocal.conf
 COPY --from=build /miroir /usr/local/bin/miroir
 ENTRYPOINT ["/usr/local/bin/miroir"]


### PR DESCRIPTION
## Overview

Adds `/dev/nbd*` to the lvm `global_filter` reject list in the agent image, next to the existing `/dev/drbd*` entry.

lvm's device scan opens every block device it can see. In the incident in #256, an lvm process hung in D state while closing a dead NBD device (`nbd_release → nbd_clear_sock → __synchronize_srcu`; the device's userspace server was gone) and held the scan lock, wedging every subsequent lvm call on the node. `lvchange --activate` in `NodeStageVolume` never returned, so all mounts of miroir volumes on that node failed with `DeadlineExceeded` until a forced reboot.

NBD devices are never miroir PVs, so rejecting them cannot hide a real PV. Same rationale and mechanism as the existing drbd entry, which was added for the identical D-state scan hazard.

## Additional information

Full incident analysis with kernel stacks: #256. This fixes the lvm-scan wedge only; the `suspend-io`/`freeze_super` deadlock described there is a separate follow-up.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES - the incident investigation, the one-line change, and this PR text were prepared with Claude Code and reviewed by the submitter