### PR TITLE
feat(metrics): label volume series with their PVC and report the drbd-utils version

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodegroupspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodegroupspec.go
@@ -30,6 +30,9 @@ import (
 type MiroirNodeGroupSpecApplyConfiguration struct {
 	// NodeSelector picks the member nodes by label. An empty selector
 	// matches every node in the cluster (the Kubernetes convention).
+	// The expression rule mirrors what LabelSelectorAsSelector enforces at
+	// runtime — the LabelSelector schema alone admits combinations that
+	// would otherwise fail every reconcile.
 	NodeSelector *v1.LabelSelectorApplyConfiguration `json:"nodeSelector,omitempty"`
 	// Template is the MiroirNode spec applied to every member, with two
 	// per-node facts resolved from the Node object: an empty zone

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodestatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirnodestatus.go
@@ -36,6 +36,11 @@ type MiroirNodeStatusApplyConfiguration struct {
 	// module ships with the host, not the agent image, so this is the
 	// per-node view that makes mixed clusters visible mid-upgrade.
 	DRBDVersion *string `json:"drbdVersion,omitempty"`
+	// DRBDUtilsVersion is the drbd-utils userland version the agent
+	// probed at startup (e.g. "9.34.3"). Unlike the kernel module the
+	// utils ship in the agent image, so this varies per agent rollout
+	// rather than per host.
+	DRBDUtilsVersion *string `json:"drbdUtilsVersion,omitempty"`
 	// ObservedAt is when these figures were last sampled; the controller
 	// ignores stats older than a few poll intervals as unknown.
 	ObservedAt *v1.Time `json:"observedAt,omitempty"`
@@ -68,6 +73,14 @@ func (b *MiroirNodeStatusApplyConfiguration) WithPools(values ...*MiroirNodePool
 // If called multiple times, the DRBDVersion field is set to the value of the last call.
 func (b *MiroirNodeStatusApplyConfiguration) WithDRBDVersion(value string) *MiroirNodeStatusApplyConfiguration {
 	b.DRBDVersion = &value
+	return b
+}
+
+// WithDRBDUtilsVersion sets the DRBDUtilsVersion field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DRBDUtilsVersion field is set to the value of the last call.
+func (b *MiroirNodeStatusApplyConfiguration) WithDRBDUtilsVersion(value string) *MiroirNodeStatusApplyConfiguration {
+	b.DRBDUtilsVersion = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -205,6 +205,9 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Condition
           elementRelationship: atomic
+    - name: drbdUtilsVersion
+      type:
+        scalar: string
     - name: drbdVersion
       type:
         scalar: string

--- a/api/v1alpha1/miroirnode_types.go
+++ b/api/v1alpha1/miroirnode_types.go
@@ -156,6 +156,12 @@ type MiroirNodeStatus struct {
 	// per-node view that makes mixed clusters visible mid-upgrade.
 	// +optional
 	DRBDVersion string `json:"drbdVersion,omitempty"`
+	// DRBDUtilsVersion is the drbd-utils userland version the agent
+	// probed at startup (e.g. "9.34.3"). Unlike the kernel module the
+	// utils ship in the agent image, so this varies per agent rollout
+	// rather than per host.
+	// +optional
+	DRBDUtilsVersion string `json:"drbdUtilsVersion,omitempty"`
 	// ObservedAt is when these figures were last sampled; the controller
 	// ignores stats older than a few poll intervals as unknown.
 	// +optional
@@ -188,6 +194,7 @@ func (s MiroirNodeStatus) Pool(name string) *MiroirNodePoolStatus {
 // +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.pools[*].capacityBytes`
 // +kubebuilder:printcolumn:name="Allocated",type=string,JSONPath=`.status.pools[*].allocatedBytes`
 // +kubebuilder:printcolumn:name="DRBD",type=string,JSONPath=`.status.drbdVersion`
+// +kubebuilder:printcolumn:name="DRBD-Utils",type=string,JSONPath=`.status.drbdUtilsVersion`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MiroirNode declares one storage node's topology and publishes its pool

--- a/charts/miroir/crds/miroir.home-operations.com_miroirnodes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirnodes.yaml
@@ -32,6 +32,10 @@ spec:
     - jsonPath: .status.drbdVersion
       name: DRBD
       type: string
+    - jsonPath: .status.drbdUtilsVersion
+      name: DRBD-Utils
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -273,6 +277,13 @@ spec:
                   - type
                   type: object
                 type: array
+              drbdUtilsVersion:
+                description: |-
+                  DRBDUtilsVersion is the drbd-utils userland version the agent
+                  probed at startup (e.g. "9.34.3"). Unlike the kernel module the
+                  utils ship in the agent image, so this varies per agent rollout
+                  rather than per host.
+                type: string
               drbdVersion:
                 description: |-
                   DRBDVersion is the DRBD kernel module version the agent probed at

--- a/charts/miroir/dashboards/miroir.json
+++ b/charts/miroir/dashboards/miroir.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "description": "miroir — DRBD-replicated local storage: volume health, replication, pools, and operator activity.",
+  "description": "miroir \u2014 DRBD-replicated local storage: volume health, replication, pools, and operator activity.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -83,7 +83,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Volumes DRBD refuses to reconnect after divergence — manual resolution required.",
+      "description": "Volumes DRBD refuses to reconnect after divergence \u2014 manual resolution required.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -144,7 +144,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Freeze-policy legs that lost quorum and refuse writes — workloads on them are seeing I/O errors.",
+      "description": "Freeze-policy legs that lost quorum and refuse writes \u2014 workloads on them are seeing I/O errors.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -205,7 +205,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Legs latched failed after a backing-disk I/O error — replace the disk, then remove and re-add.",
+      "description": "Legs latched failed after a backing-disk I/O error \u2014 replace the disk, then remove and re-add.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -266,7 +266,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Diskful legs below UpToDate — resyncing, detached, or disconnected.",
+      "description": "Diskful legs below UpToDate \u2014 resyncing, detached, or disconnected.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -449,9 +449,9 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (volume) ((1 - miroir_volume_up_to_date{volume=~\"$volume\", pool=~\"$pool\"}) OR (1 - miroir_volume_connected{volume=~\"$volume\", pool=~\"$pool\"}))",
+          "expr": "sum by (volume, pvc, pvc_namespace) ((1 - miroir_volume_up_to_date{pvc=~\"$pvc\", pool=~\"$pool\"}) OR (1 - miroir_volume_connected{pvc=~\"$pvc\", pool=~\"$pool\"}))",
           "refId": "A",
-          "legendFormat": "{{volume}}"
+          "legendFormat": "{{pvc_namespace}}/{{pvc}}"
         }
       ],
       "title": "Unhealthy legs",
@@ -512,9 +512,9 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "min by (volume) (miroir_volume_resync_ratio{volume=~\"$volume\", pool=~\"$pool\"})",
+          "expr": "min by (volume, pvc, pvc_namespace) (miroir_volume_resync_ratio{pvc=~\"$pvc\", pool=~\"$pool\"})",
           "refId": "A",
-          "legendFormat": "{{volume}}"
+          "legendFormat": "{{pvc_namespace}}/{{pvc}}"
         }
       ],
       "title": "Resync progress",
@@ -525,7 +525,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Worst per-peer out-of-sync amount — exposure if the healthiest peer is lost; also counts online-verify findings.",
+      "description": "Worst per-peer out-of-sync amount \u2014 exposure if the healthiest peer is lost; also counts online-verify findings.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -573,9 +573,9 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (volume) (miroir_volume_out_of_sync_bytes{volume=~\"$volume\", pool=~\"$pool\"})",
+          "expr": "max by (volume, pvc, pvc_namespace) (miroir_volume_out_of_sync_bytes{pvc=~\"$pvc\", pool=~\"$pool\"})",
           "refId": "A",
-          "legendFormat": "{{volume}}"
+          "legendFormat": "{{pvc_namespace}}/{{pvc}}"
         }
       ],
       "title": "Out-of-sync bytes",
@@ -634,18 +634,18 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "miroir_volume_quorum{volume=~\"$volume\", pool=~\"$pool\"} == 0",
+          "expr": "miroir_volume_quorum{pvc=~\"$pvc\", pool=~\"$pool\"} == 0",
           "refId": "A",
-          "legendFormat": "quorum lost: {{volume}} on {{node}}"
+          "legendFormat": "quorum lost: {{pvc_namespace}}/{{pvc}} on {{node}}"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "miroir_volume_disk_failed{volume=~\"$volume\", pool=~\"$pool\"} == 1",
+          "expr": "miroir_volume_disk_failed{pvc=~\"$pvc\", pool=~\"$pool\"} == 1",
           "refId": "B",
-          "legendFormat": "disk failed: {{volume}} on {{node}}"
+          "legendFormat": "disk failed: {{pvc_namespace}}/{{pvc}} on {{node}}"
         }
       ],
       "title": "Quorum / disk-failed legs",
@@ -704,9 +704,9 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (volume) (miroir_volume_diskless_primary{volume=~\"$volume\"})",
+          "expr": "max by (volume, pvc, pvc_namespace) (miroir_volume_diskless_primary{pvc=~\"$pvc\"})",
           "refId": "A",
-          "legendFormat": "{{volume}}"
+          "legendFormat": "{{pvc_namespace}}/{{pvc}}"
         }
       ],
       "title": "Remote consumers (diskless Primary)",
@@ -839,9 +839,9 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "time() - max by (volume) (miroir_volume_verify_last_timestamp_seconds{volume=~\"$volume\", pool=~\"$pool\"})",
+          "expr": "time() - max by (volume, pvc, pvc_namespace) (miroir_volume_verify_last_timestamp_seconds{pvc=~\"$pvc\", pool=~\"$pool\"})",
           "refId": "A",
-          "legendFormat": "{{volume}}"
+          "legendFormat": "{{pvc_namespace}}/{{pvc}}"
         }
       ],
       "title": "Last verify age",
@@ -900,9 +900,9 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (volume) (miroir_volume_verify_out_of_sync_bytes{volume=~\"$volume\", pool=~\"$pool\"})",
+          "expr": "max by (volume, pvc, pvc_namespace) (miroir_volume_verify_out_of_sync_bytes{pvc=~\"$pvc\", pool=~\"$pool\"})",
           "refId": "A",
-          "legendFormat": "{{volume}}"
+          "legendFormat": "{{pvc_namespace}}/{{pvc}}"
         }
       ],
       "title": "Verify findings",
@@ -983,7 +983,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Exports without a serving gateway — their NFS clients are hanging right now.",
+      "description": "Exports without a serving gateway \u2014 their NFS clients are hanging right now.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1044,7 +1044,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "1 while the volume's NFS gateway is serving (pod available, address published); dips are failovers — clients hang until the line returns to 1.",
+      "description": "1 while the volume's NFS gateway is serving (pod available, address published); dips are failovers \u2014 clients hang until the line returns to 1.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1094,9 +1094,9 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "min by (volume) (miroir_export_ready{volume=~\"$volume\"})",
+          "expr": "min by (volume, pvc, pvc_namespace) (miroir_export_ready{pvc=~\"$pvc\"})",
           "refId": "A",
-          "legendFormat": "{{volume}}"
+          "legendFormat": "{{pvc_namespace}}/{{pvc}}"
         }
       ],
       "title": "Export availability",
@@ -1329,7 +1329,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Agent pods failing scrapes — every miroir_* series from those nodes is absent, so the per-volume panels and alerts are blind there. A crash-loop after a node change usually means the DRBD kernel module is below the agent's floor.",
+      "description": "Agent pods failing scrapes \u2014 every miroir_* series from those nodes is absent, so the per-volume panels and alerts are blind there. A crash-loop after a node change usually means the DRBD kernel module is below the agent's floor.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1390,7 +1390,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "DRBD kernel module version probed at each agent's startup. Mixed versions mean a partially upgraded fleet; a node missing here has no reporting agent (down, or no DRBD module). The agent refuses to start below its kernel floor.",
+      "description": "DRBD kernel module and drbd-utils versions probed at each agent's startup. Mixed versions mean a partially upgraded fleet; a node missing here has no reporting agent (down, or no DRBD module). The agent refuses to start below its kernel floor.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1454,12 +1454,13 @@
             },
             "renameByName": {
               "node": "Node",
-              "version": "DRBD kernel"
+              "version": "DRBD kernel",
+              "utils_version": "drbd-utils"
             }
           }
         }
       ],
-      "title": "DRBD kernel module by node",
+      "title": "DRBD versions by node",
       "type": "table"
     },
     {
@@ -1541,7 +1542,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "A sustained error rate means a wedged reconcile — check the owning pod's logs.",
+      "description": "A sustained error rate means a wedged reconcile \u2014 check the owning pod's logs.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1645,7 +1646,7 @@
         "sort": 1
       },
       {
-        "name": "volume",
+        "name": "pvc",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -1653,7 +1654,7 @@
         },
         "query": {
           "qryType": 1,
-          "query": "label_values(miroir_volume_up_to_date{pool=~\"$pool\"}, volume)",
+          "query": "label_values(miroir_volume_up_to_date{pool=~\"$pool\"}, pvc)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "current": {},
@@ -1674,7 +1675,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "miroir — replicated storage",
+  "title": "miroir \u2014 replicated storage",
   "uid": "miroir-overview",
   "version": 1,
   "weekStart": ""

--- a/charts/miroir/templates/controller.tpl
+++ b/charts/miroir/templates/controller.tpl
@@ -120,6 +120,7 @@ spec:
             - --timeout={{ .Values.sidecars.provisioner.timeout }}
             - --leader-election={{ include "miroir.leaderElectionEnabled" . }}
             - --default-fstype=ext4
+            - --extra-create-metadata
             {{- if .Values.storageCapacity.enabled }}
             - --enable-capacity
             - --capacity-ownerref-level=2

--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -64,7 +64,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              Volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               (pool {{ "{{" }} $labels.pool {{ "}}" }}) is split-brain on
               {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
@@ -87,7 +87,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              Volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               (pool {{ "{{" }} $labels.pool {{ "}}" }}) lost quorum on
               {{ "{{" }} $labels.node {{ "}}" }} — writes are failing
             description: >-
@@ -112,7 +112,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              Volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               (pool {{ "{{" }} $labels.pool {{ "}}" }}) IO has been
               suspended for 10m on {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
@@ -136,7 +136,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }} teardown is wedged
+              Volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }} teardown is wedged
               in the DRBD kernel module on {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
               The kernel can no longer tear down this volume's DRBD resource
@@ -160,7 +160,7 @@ spec:
           annotations:
             summary: >-
               Backing disk failed for volume
-              {{ "{{" }} $labels.volume {{ "}}" }}
+              {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               (pool {{ "{{" }} $labels.pool {{ "}}" }}) on
               {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
@@ -183,7 +183,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Replica of {{ "{{" }} $labels.volume {{ "}}" }}
+              Replica of {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               (pool {{ "{{" }} $labels.pool {{ "}}" }}) on
               {{ "{{" }} $labels.node {{ "}}" }} is not UpToDate
             description: >-
@@ -206,7 +206,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              Volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               (pool {{ "{{" }} $labels.pool {{ "}}" }}) replication links
               down from {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
@@ -228,7 +228,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              Volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               (pool {{ "{{" }} $labels.pool {{ "}}" }}) has
               {{ "{{" }} $value | humanize1024 {{ "}}" }}B out of sync on
               {{ "{{" }} $labels.node {{ "}}" }}
@@ -253,7 +253,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }} is consumed remotely
+              Volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }} is consumed remotely
               from {{ "{{" }} $labels.node {{ "}}" }}
             description: >-
               The pod runs on a diskless DRBD leg at replication-network
@@ -278,7 +278,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              Volume {{ "{{" }} $labels.volume {{ "}}" }}
+              Volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               (pool {{ "{{" }} $labels.pool {{ "}}" }}) has not completed
               an online verify in {{ "{{" }} $value | humanizeDuration {{ "}}" }}
             description: >-
@@ -356,7 +356,7 @@ spec:
             {{- include "miroir.alertRuleLabels" $rule | nindent 12 }}
           annotations:
             summary: >-
-              RWX export for volume {{ "{{" }} $labels.volume {{ "}}" }}
+              RWX export for volume {{ "{{" }} $labels.pvc_namespace {{ "}}" }}/{{ "{{" }} $labels.pvc {{ "}}" }}
               is unavailable — NFS clients are hanging
             description: >-
               The NFS gateway has no available pod (or no published export

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -141,6 +141,7 @@ tests:
               - "--timeout=75s"
               - "--leader-election=false"
               - "--default-fstype=ext4"
+              - "--extra-create-metadata"
       - contains:
           any: true
           path: spec.template.spec.containers

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -626,7 +626,7 @@ func main() {
 		// it proactively on nodes that ship it) and run without the DRBD
 		// machinery when the kernel side is absent — otherwise the events
 		// watcher hot-loops "exit status 20" every 5s forever.
-		drbdKernel, drbdReady := probeDRBD(drbdDriver)
+		drbdKernel, drbdUtils, drbdReady := probeDRBD(drbdDriver)
 		if !drbdReady {
 			setupLog.Info("DRBD kernel module unavailable; running local-only " +
 				"(no events watcher, no orphan/barrier/shutdown sweeps)")
@@ -705,12 +705,13 @@ func main() {
 		}
 		// Publishes this node's pool capacities for capacity-aware placement.
 		if err := mgr.Add(&agent.PoolStatsPublisher{
-			Client:      mgr.GetClient(),
-			NodeName:    nodeName,
-			Pools:       pools,
-			Interval:    poolStatsInterval,
-			Recorder:    mgr.GetEventRecorder("miroir-agent"),
-			DRBDVersion: drbdKernel,
+			Client:           mgr.GetClient(),
+			NodeName:         nodeName,
+			Pools:            pools,
+			Interval:         poolStatsInterval,
+			Recorder:         mgr.GetEventRecorder("miroir-agent"),
+			DRBDVersion:      drbdKernel,
+			DRBDUtilsVersion: drbdUtils,
 		}); err != nil {
 			setupLog.Error(err, "unable to add pool stats publisher")
 			os.Exit(1)
@@ -906,20 +907,20 @@ func resumeStaleBarriers(driver *drbd.Driver, apiBudget time.Duration) error {
 }
 
 // probeDRBD reports whether the DRBD kernel side is usable and, when it
-// is, the module version — exiting below drbd.KernelFloor: a 9.3.1-era
-// option rendered against an older module errors drbdadm for every
-// resource on the node, so failing fast here beats poisoning them all
-// later. Talos ≥ 1.13.0 ships a module at the floor.
-func probeDRBD(driver *drbd.Driver) (version string, ready bool) {
+// is, the module and drbd-utils versions — exiting below drbd.KernelFloor:
+// a 9.3.1-era option rendered against an older module errors drbdadm for
+// every resource on the node, so failing fast here beats poisoning them
+// all later. Talos ≥ 1.13.0 ships a module at the floor.
+func probeDRBD(driver *drbd.Driver) (version, utilsVersion string, ready bool) {
 	if !driver.KernelAvailable(context.Background()) {
-		return "", false
+		return "", "", false
 	}
 	v, err := driver.KernelVersion(context.Background())
 	if err != nil {
 		// The module answered but the version read flaked; running
 		// unchecked beats refusing a working node.
 		setupLog.Error(err, "cannot read DRBD kernel module version; skipping floor check")
-		return "", true
+		return "", "", true
 	}
 	if drbd.BelowKernelFloor(v) {
 		setupLog.Error(nil, "DRBD kernel module is below the supported floor; upgrade the node (Talos >= 1.13.0)",
@@ -928,11 +929,11 @@ func probeDRBD(driver *drbd.Driver) (version string, ready bool) {
 	}
 	utils, err := driver.UtilsVersion(context.Background())
 	if err != nil {
-		// Informational only: an empty label beats refusing a working node.
+		// Informational only: an empty value beats refusing a working node.
 		setupLog.Error(err, "cannot read drbd-utils version")
 	}
 	agent.RecordDRBDVersions(v, utils)
-	return v, true
+	return v, utils, true
 }
 
 // csiRunnable marks the CSI server as running on every replica rather than

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,7 +93,7 @@ func init() {
 func setupMembership(mgr ctrl.Manager, nodes nodemap.Source, autoTieBreaker bool,
 	autoDiskfulAfter, autoEvictAfter time.Duration,
 ) error {
-	r := &membership.Reconciler{Client: mgr.GetClient(), Nodes: nodes}
+	r := &membership.Reconciler{Client: mgr.GetClient(), Nodes: nodes, PVs: mgr.GetAPIReader()}
 	if err := r.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("membership reconciler: %w", err)
 	}
@@ -926,7 +926,12 @@ func probeDRBD(driver *drbd.Driver) (version string, ready bool) {
 			"version", v, "floor", drbd.KernelFloor)
 		os.Exit(1)
 	}
-	agent.RecordDRBDKernelVersion(v)
+	utils, err := driver.UtilsVersion(context.Background())
+	if err != nil {
+		// Informational only: an empty label beats refusing a working node.
+		setupLog.Error(err, "cannot read drbd-utils version")
+	}
+	agent.RecordDRBDVersions(v, utils)
 	return v, true
 }
 

--- a/config/crd/bases/miroir.home-operations.com_miroirnodes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirnodes.yaml
@@ -32,6 +32,10 @@ spec:
     - jsonPath: .status.drbdVersion
       name: DRBD
       type: string
+    - jsonPath: .status.drbdUtilsVersion
+      name: DRBD-Utils
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -273,6 +277,13 @@ spec:
                   - type
                   type: object
                 type: array
+              drbdUtilsVersion:
+                description: |-
+                  DRBDUtilsVersion is the drbd-utils userland version the agent
+                  probed at startup (e.g. "9.34.3"). Unlike the kernel module the
+                  utils ship in the agent image, so this varies per agent rollout
+                  rather than per host.
+                type: string
               drbdVersion:
                 description: |-
                   DRBDVersion is the DRBD kernel module version the agent probed at

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -17,8 +17,16 @@ health to a pool (the shipped dashboard's `pool` variable does
 exactly that). `miroir_volume_diskless_primary` and
 `miroir_volume_wedged` are the exceptions: a diskless leg holds no
 backing device in any pool, and a wedged teardown's pool can be
-unknowable, so both stay volume-only. The agent exports, per volume
-on that node:
+unknowable, so both carry no pool label.
+
+Every volume series also carries `pvc` and `pvc_namespace`: the
+PersistentVolumeClaim the volume serves, so dashboards and alerts
+read the claim's name instead of the opaque `pvc-<uuid>` volume
+name (which stays available as the `volume` label). The pair is
+recorded on the `MiroirVolume` at provisioning time and backfilled
+onto pre-existing volumes from their PV; a volume whose claim is
+unknown falls back to its volume name in `pvc`, with an empty
+`pvc_namespace`. The agent exports, per volume on that node:
 
 | Metric                                        | Meaning                                                                                                                                   |
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -42,8 +50,9 @@ Each agent additionally exports its pool capacities
 `pool` label), the same sample that feeds capacity-aware placement
 and the `PoolUsageHigh` condition. Pool exhaustion is alertable,
 and two pools on one node stay distinguishable, not just an Event.
-It also exports `miroir_node_drbd_kernel_info` (always 1, `version`
-label): the DRBD kernel module version probed at startup, from
+It also exports `miroir_node_drbd_kernel_info` (always 1): the DRBD
+kernel module version probed at startup (`version` label) plus the
+agent image's drbd-utils version (`utils_version` label), from
 client-only nodes too (which have no `MiroirNode` status). Query it
 for fleet version skew before a release raises the kernel floor.
 

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -17,78 +17,146 @@ limitations under the License.
 package agent
 
 import (
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/constants"
 )
 
 // Exposed on the agent's metrics endpoint; the split-brain gauge is the
 // alerting hook for the last-man-standing failure mode.
+//
+// Every volume series carries pvc/pvc_namespace alongside the CR name:
+// dashboards and alerts read the claim the volume serves, not the opaque
+// pvc-<uuid>. The pair comes from the CreateVolume-stamped CR labels; a
+// volume without them falls back to its CR name (see refOf).
 const (
-	volumeLabel = "volume"
-	poolLabel   = "pool"
+	volumeLabel       = "volume"
+	poolLabel         = "pool"
+	pvcLabel          = "pvc"
+	pvcNamespaceLabel = "pvc_namespace"
 )
+
+var (
+	diskfulLabels    = []string{volumeLabel, poolLabel, pvcLabel, pvcNamespaceLabel}
+	volumeOnlyLabels = []string{volumeLabel, pvcLabel, pvcNamespaceLabel}
+)
+
+// volumeRef is the label identity a volume's series carry. pvc falls back
+// to the CR name (and pvc_namespace to empty) when the volume has no
+// PVC-ref labels — created before the labels existed and not yet
+// backfilled, or a PVC name too long for a label value — so legends never
+// go blank.
+type volumeRef struct {
+	name, pvc, namespace string
+}
+
+func refOf(vol *miroirv1alpha1.MiroirVolume) volumeRef {
+	pvc, namespace := constants.PVCRef(vol.Name, vol.Labels)
+	return volumeRef{name: vol.Name, pvc: pvc, namespace: namespace}
+}
+
+func (r volumeRef) with(pool string) prometheus.Labels {
+	return prometheus.Labels{
+		volumeLabel: r.name, poolLabel: pool,
+		pvcLabel: r.pvc, pvcNamespaceLabel: r.namespace,
+	}
+}
+
+func (r volumeRef) labels() prometheus.Labels {
+	return prometheus.Labels{
+		volumeLabel: r.name, pvcLabel: r.pvc, pvcNamespaceLabel: r.namespace,
+	}
+}
+
+// seenRefs tracks the identity each volume's series were last recorded
+// under. The controller backfills the PVC-ref labels onto legacy volumes
+// after their series already exist, and without a drop on that transition
+// the old identity would keep reporting its last values alongside the new
+// series. The one-time drop also clears the verify series; they reappear
+// at the next verify pass.
+var (
+	seenRefsMu sync.Mutex
+	seenRefs   = map[string]volumeRef{}
+)
+
+// syncRef resolves a volume's label identity, retiring series recorded
+// under a previous one.
+func syncRef(vol *miroirv1alpha1.MiroirVolume) volumeRef {
+	ref := refOf(vol)
+	seenRefsMu.Lock()
+	prev, ok := seenRefs[ref.name]
+	seenRefs[ref.name] = ref
+	seenRefsMu.Unlock()
+	if ok && prev != ref {
+		deleteVolumeSeries(ref.name)
+	}
+	return ref
+}
 
 var (
 	// Diskful volume gauges carry the pool backing this node's leg (pools
 	// are per-node, so peers' legs of the same volume may report different
 	// pool values). Diskless legs have no backing pool, so
-	// miroir_volume_diskless_primary stays volume-only.
+	// miroir_volume_diskless_primary carries no pool label.
 	metricUpToDate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_up_to_date",
 		Help: "1 when this node's replica is UpToDate (unreplicated volumes are always 1 once created).",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricConnected = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_connected",
 		Help: "1 when all replication links from this node to diskful peers are established (a diskless tie-breaker's link is excluded).",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricSplitBrain = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_split_brain",
 		Help: "1 when DRBD refused to reconnect after divergence; manual resolution required.",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricSuspended = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_suspended",
 		Help: "1 while a user suspend-io (the snapshot write barrier) freezes this node's IO; sustained means a stranded barrier (snapshot rounds last seconds).",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricResyncRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_resync_ratio",
 		Help: "Fraction in sync (0-1) of the least-synced diskful peer while resyncing; 1 when fully in sync (unreplicated volumes report 1).",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricQuorum = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_quorum",
 		Help: "1 when this node's replica sees DRBD quorum; 0 while a freeze-policy volume has lost quorum and refuses writes with I/O errors (on-no-quorum io-error; always 1 under last-man-standing, and for unreplicated volumes).",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricDiskFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_disk_failed",
 		Help: "1 when this leg's backing disk was detached after an I/O error and is latched failed — replace the disk, then remove and re-add the replica.",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricOutOfSyncBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_out_of_sync_bytes",
 		Help: "Largest per-peer out-of-sync amount in bytes: the exposure if the healthiest peer is lost. Grows while a peer is down with no resync running; also counts online-verify findings.",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricVerifyTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_verify_last_timestamp_seconds",
 		Help: "Unix time of the last completed scheduled online verify for this volume; absent until the first verify runs. Alert on staleness to catch a verify schedule that stopped firing.",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricVerifyOutOfSyncBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_verify_out_of_sync_bytes",
 		Help: "Out-of-sync bytes the last scheduled verify found (0 = clean). Findings also surface in miroir_volume_out_of_sync_bytes until a disconnect/connect resync clears them.",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricPrimary = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_primary",
 		Help: "1 while this node's diskful leg is DRBD Primary: the consumer pod or the RWX gateway runs here and this leg serves the I/O. Diskless legs report miroir_volume_diskless_primary instead; unreplicated volumes have no DRBD role and always report 0.",
-	}, []string{volumeLabel, poolLabel})
+	}, diskfulLabels)
 	metricDisklessPrimary = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_diskless_primary",
 		Help: "1 while this node's diskless leg (client or tie-breaker) is DRBD Primary: a consumer runs here and every read and write crosses the replication network. Sustained 1 means the workload pays network I/O — auto-diskful (autoDiskfulAfter) converts the leg to a local replica when the node has storage capacity.",
-	}, []string{volumeLabel})
-	// Volume-only, like miroir_volume_diskless_primary: the pool a wedged
+	}, volumeOnlyLabels)
+	// Pool-less, like miroir_volume_diskless_primary: the pool a wedged
 	// teardown reported under can be unknowable (see dropVolumeMetrics).
 	metricWedged = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_volume_wedged",
 		Help: "1 when the kernel can no longer tear down this volume's DRBD resource (device stuck Detaching after a refcount underflow, LINBIT/drbd#137); teardown is parked at a slow retry and only a node reboot clears the state.",
-	}, []string{volumeLabel})
+	}, volumeOnlyLabels)
 
 	// Pool gauges carry the pool name; the PodMonitor stamps a node label
 	// on every series, so (node, pool) identifies one pool.
@@ -110,8 +178,8 @@ var (
 	// the pool stats publisher (storage nodes) updates.
 	metricDRBDKernelInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "miroir_node_drbd_kernel_info",
-		Help: "Always 1, labelled with the DRBD kernel module version probed at agent startup; absent on nodes without the module. Query it for fleet version skew before a kernel floor raise.",
-	}, []string{"version"})
+		Help: "Always 1, labelled with the DRBD kernel module version probed at agent startup (version) and the agent image's drbd-utils version (utils_version); absent on nodes without the module. Query it for fleet version skew before a kernel floor raise.",
+	}, []string{"version", "utils_version"})
 )
 
 func init() {
@@ -124,7 +192,8 @@ func init() {
 	)
 }
 
-func recordVolumeMetrics(volume, pool string, st miroirReplicaView) {
+func recordVolumeMetrics(vol *miroirv1alpha1.MiroirVolume, pool string, st miroirReplicaView) {
+	ref := syncRef(vol)
 	// This leg is diskful, so clear any diskless-primary series a prior life
 	// of it left behind: auto-diskful and auto-evict convert a diskless
 	// tie-breaker/client leg into a diskful replica in place, without the
@@ -132,16 +201,17 @@ func recordVolumeMetrics(volume, pool string, st miroirReplicaView) {
 	// alone the stale series reads its last value until the volume is deleted.
 	// The reverse (diskful to diskless) only happens via removal, which drops
 	// every series, so no symmetric clear is needed. Cheap no-op when absent.
-	metricDisklessPrimary.DeleteLabelValues(volume)
-	metricUpToDate.WithLabelValues(volume, pool).Set(boolGauge(st.upToDate))
-	metricConnected.WithLabelValues(volume, pool).Set(boolGauge(st.connected))
-	metricSplitBrain.WithLabelValues(volume, pool).Set(boolGauge(st.splitBrain))
-	metricSuspended.WithLabelValues(volume, pool).Set(boolGauge(st.suspended))
-	metricResyncRatio.WithLabelValues(volume, pool).Set(st.resyncRatio)
-	metricQuorum.WithLabelValues(volume, pool).Set(boolGauge(st.quorum))
-	metricDiskFailed.WithLabelValues(volume, pool).Set(boolGauge(st.diskFailed))
-	metricOutOfSyncBytes.WithLabelValues(volume, pool).Set(st.outOfSyncBytes)
-	metricPrimary.WithLabelValues(volume, pool).Set(boolGauge(st.primary))
+	metricDisklessPrimary.DeletePartialMatch(prometheus.Labels{volumeLabel: ref.name})
+	l := ref.with(pool)
+	metricUpToDate.With(l).Set(boolGauge(st.upToDate))
+	metricConnected.With(l).Set(boolGauge(st.connected))
+	metricSplitBrain.With(l).Set(boolGauge(st.splitBrain))
+	metricSuspended.With(l).Set(boolGauge(st.suspended))
+	metricResyncRatio.With(l).Set(st.resyncRatio)
+	metricQuorum.With(l).Set(boolGauge(st.quorum))
+	metricDiskFailed.With(l).Set(boolGauge(st.diskFailed))
+	metricOutOfSyncBytes.With(l).Set(st.outOfSyncBytes)
+	metricPrimary.With(l).Set(boolGauge(st.primary))
 }
 
 // recordPoolMetrics publishes one pool's sample. The pool set is fixed per
@@ -153,10 +223,17 @@ func recordPoolMetrics(pool string, capacityBytes, allocatedBytes int64, metaUse
 	metricPoolMetaUsedRatio.WithLabelValues(pool).Set(metaUsedRatio)
 }
 
-// dropVolumeMetrics deletes by volume alone (partial match): the pool a
-// torn-down leg reported under can be unknowable here, for the same reason
-// deletions sweep every pool — see Pools.SweepDelete.
+// dropVolumeMetrics deletes by volume alone (partial match): the pool and
+// PVC ref a torn-down leg reported under can be unknowable here, for the
+// same reason deletions sweep every pool — see Pools.SweepDelete.
 func dropVolumeMetrics(volume string) {
+	seenRefsMu.Lock()
+	delete(seenRefs, volume)
+	seenRefsMu.Unlock()
+	deleteVolumeSeries(volume)
+}
+
+func deleteVolumeSeries(volume string) {
 	byVolume := prometheus.Labels{volumeLabel: volume}
 	metricUpToDate.DeletePartialMatch(byVolume)
 	metricConnected.DeletePartialMatch(byVolume)
@@ -169,31 +246,43 @@ func dropVolumeMetrics(volume string) {
 	metricPrimary.DeletePartialMatch(byVolume)
 	metricVerifyTimestamp.DeletePartialMatch(byVolume)
 	metricVerifyOutOfSyncBytes.DeletePartialMatch(byVolume)
-	metricDisklessPrimary.DeleteLabelValues(volume)
-	metricWedged.DeleteLabelValues(volume)
+	metricDisklessPrimary.DeletePartialMatch(byVolume)
+	metricWedged.DeletePartialMatch(byVolume)
 }
 
 // recordDisklessMetrics publishes a diskless leg's view. Deliberately not
 // the diskful gauges: a tie-breaker reading up_to_date=0 or losing its own
 // quorum would fire the data-leg alerts for a leg that holds no data.
-func recordDisklessMetrics(volume string, primary bool) {
-	metricDisklessPrimary.WithLabelValues(volume).Set(boolGauge(primary))
+func recordDisklessMetrics(vol *miroirv1alpha1.MiroirVolume, primary bool) {
+	metricDisklessPrimary.With(syncRef(vol).labels()).Set(boolGauge(primary))
 }
 
-// RecordDRBDKernelVersion publishes the module version probed at agent
-// startup. Set once per process: a module change means a node reboot and
-// thus a fresh agent, so startup is current enough (same contract as
+// recordWedged raises the wedged gauge; clearWedged retires it by volume
+// alone, so a wedge recorded before a PVC-ref backfill still clears.
+func recordWedged(vol *miroirv1alpha1.MiroirVolume) {
+	metricWedged.With(syncRef(vol).labels()).Set(1)
+}
+
+func clearWedged(volume string) {
+	metricWedged.DeletePartialMatch(prometheus.Labels{volumeLabel: volume})
+}
+
+// RecordDRBDVersions publishes the module and drbd-utils versions probed
+// at agent startup. Set once per process: a module change means a node
+// reboot and thus a fresh agent, and the utils only change with the agent
+// image, so startup is current enough (same contract as
 // PoolStatsPublisher.DRBDVersion).
-func RecordDRBDKernelVersion(version string) {
-	metricDRBDKernelInfo.WithLabelValues(version).Set(1)
+func RecordDRBDVersions(kernel, utils string) {
+	metricDRBDKernelInfo.WithLabelValues(kernel, utils).Set(1)
 }
 
 // recordVerifyMetrics publishes the outcome of a completed verify pass. The
 // coordinator sets these directly (they are event-driven, not part of the
 // per-poll recordVolumeMetrics view).
-func recordVerifyMetrics(volume, pool string, at time.Time, outOfSyncBytes int64) {
-	metricVerifyTimestamp.WithLabelValues(volume, pool).Set(float64(at.Unix()))
-	metricVerifyOutOfSyncBytes.WithLabelValues(volume, pool).Set(float64(outOfSyncBytes))
+func recordVerifyMetrics(vol *miroirv1alpha1.MiroirVolume, pool string, at time.Time, outOfSyncBytes int64) {
+	l := syncRef(vol).with(pool)
+	metricVerifyTimestamp.With(l).Set(float64(at.Unix()))
+	metricVerifyOutOfSyncBytes.With(l).Set(float64(outOfSyncBytes))
 }
 
 type miroirReplicaView struct {

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -21,7 +21,11 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/constants"
 )
 
 // hasSeries reports whether the controller-runtime registry currently
@@ -49,13 +53,22 @@ func hasSeries(t *testing.T, family, volume string) bool {
 	return false
 }
 
+// metricsVol is an unlabeled volume: its series fall back to the CR name
+// as the pvc label.
+func metricsVol(name string) *miroirv1alpha1.MiroirVolume {
+	return &miroirv1alpha1.MiroirVolume{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+const familyUpToDate = "miroir_volume_up_to_date"
+
 // The gauges must track the recorded view exactly and vanish from the
 // scrape once dropped — a replica removed from this node must not keep
 // serving stale health series.
 func TestVolumeMetricsLifecycle(t *testing.T) {
 	const volume = "pvc-metrics-lifecycle"
 	const pool = "fast"
-	recordVolumeMetrics(volume, pool, miroirReplicaView{
+	vol := metricsVol(volume)
+	recordVolumeMetrics(vol, pool, miroirReplicaView{
 		upToDate:       true,
 		connected:      false,
 		splitBrain:     true,
@@ -67,43 +80,43 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 		outOfSyncBytes: 2048 * 1024,
 	})
 
-	recordVerifyMetrics(volume, pool, time.Unix(1700000000, 0), 512)
-	recordDisklessMetrics(volume, true)
+	recordVerifyMetrics(vol, pool, time.Unix(1700000000, 0), 512)
+	recordDisklessMetrics(vol, true)
 
-	if got := testutil.ToFloat64(metricUpToDate.WithLabelValues(volume, pool)); got != 1 {
+	if got := testutil.ToFloat64(metricUpToDate.WithLabelValues(volume, pool, volume, "")); got != 1 {
 		t.Fatalf("up_to_date = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricConnected.WithLabelValues(volume, pool)); got != 0 {
+	if got := testutil.ToFloat64(metricConnected.WithLabelValues(volume, pool, volume, "")); got != 0 {
 		t.Fatalf("connected = %v, want 0", got)
 	}
-	if got := testutil.ToFloat64(metricSplitBrain.WithLabelValues(volume, pool)); got != 1 {
+	if got := testutil.ToFloat64(metricSplitBrain.WithLabelValues(volume, pool, volume, "")); got != 1 {
 		t.Fatalf("split_brain = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricSuspended.WithLabelValues(volume, pool)); got != 0 {
+	if got := testutil.ToFloat64(metricSuspended.WithLabelValues(volume, pool, volume, "")); got != 0 {
 		t.Fatalf("suspended = %v, want 0", got)
 	}
-	if got := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volume, pool)); got != 0.425 {
+	if got := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volume, pool, volume, "")); got != 0.425 {
 		t.Fatalf("resync_ratio = %v, want 0.425", got)
 	}
-	if got := testutil.ToFloat64(metricQuorum.WithLabelValues(volume, pool)); got != 1 {
+	if got := testutil.ToFloat64(metricQuorum.WithLabelValues(volume, pool, volume, "")); got != 1 {
 		t.Fatalf("quorum = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volume, pool)); got != 1 {
+	if got := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volume, pool, volume, "")); got != 1 {
 		t.Fatalf("disk_failed = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricOutOfSyncBytes.WithLabelValues(volume, pool)); got != 2048*1024 {
+	if got := testutil.ToFloat64(metricOutOfSyncBytes.WithLabelValues(volume, pool, volume, "")); got != 2048*1024 {
 		t.Fatalf("out_of_sync_bytes = %v, want %v", got, 2048*1024)
 	}
-	if got := testutil.ToFloat64(metricPrimary.WithLabelValues(volume, pool)); got != 1 {
+	if got := testutil.ToFloat64(metricPrimary.WithLabelValues(volume, pool, volume, "")); got != 1 {
 		t.Fatalf("primary = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(metricVerifyTimestamp.WithLabelValues(volume, pool)); got != 1700000000 {
+	if got := testutil.ToFloat64(metricVerifyTimestamp.WithLabelValues(volume, pool, volume, "")); got != 1700000000 {
 		t.Fatalf("verify_last_timestamp_seconds = %v, want 1700000000", got)
 	}
-	if got := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volume, pool)); got != 512 {
+	if got := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volume, pool, volume, "")); got != 512 {
 		t.Fatalf("verify_out_of_sync_bytes = %v, want 512", got)
 	}
-	if got := testutil.ToFloat64(metricDisklessPrimary.WithLabelValues(volume)); got != 1 {
+	if got := testutil.ToFloat64(metricDisklessPrimary.WithLabelValues(volume, volume, "")); got != 1 {
 		t.Fatalf("diskless_primary = %v, want 1", got)
 	}
 
@@ -111,7 +124,7 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 	// under — the partial-match delete must still clear every family.
 	dropVolumeMetrics(volume)
 	for _, family := range []string{
-		"miroir_volume_up_to_date",
+		familyUpToDate,
 		"miroir_volume_connected",
 		"miroir_volume_split_brain",
 		"miroir_volume_suspended",
@@ -130,13 +143,13 @@ func TestVolumeMetricsLifecycle(t *testing.T) {
 	}
 }
 
-// The kernel info gauge must expose the probed version as a label with a
+// The kernel info gauge must expose the probed versions as labels with a
 // constant 1 — the shape "up{version=...}"-style queries and the fleet
 // skew table depend on.
-func TestRecordDRBDKernelVersion(t *testing.T) {
-	RecordDRBDKernelVersion("9.3.2")
-	if got := testutil.ToFloat64(metricDRBDKernelInfo.WithLabelValues("9.3.2")); got != 1 {
-		t.Fatalf("drbd_kernel_info{version=9.3.2} = %v, want 1", got)
+func TestRecordDRBDVersions(t *testing.T) {
+	RecordDRBDVersions("9.3.2", "9.34.3")
+	if got := testutil.ToFloat64(metricDRBDKernelInfo.WithLabelValues("9.3.2", "9.34.3")); got != 1 {
+		t.Fatalf("drbd_kernel_info{version=9.3.2,utils_version=9.34.3} = %v, want 1", got)
 	}
 }
 
@@ -147,23 +160,69 @@ func TestRecordDRBDKernelVersion(t *testing.T) {
 func TestDisklessMetricClearedWhenLegBecomesDiskful(t *testing.T) {
 	const volume = "pvc-diskless-to-diskful"
 	const pool = "default"
+	vol := metricsVol(volume)
 
 	// Diskless tie-breaker / client leg: only the diskless-primary series.
-	recordDisklessMetrics(volume, true)
+	recordDisklessMetrics(vol, true)
 	if !hasSeries(t, "miroir_volume_diskless_primary", volume) {
 		t.Fatal("diskless_primary series missing after recordDisklessMetrics")
 	}
 
 	// Converted to a diskful replica: it now publishes the diskful view, and
 	// the diskless-primary series must be gone from the scrape.
-	recordVolumeMetrics(volume, pool, miroirReplicaView{
+	recordVolumeMetrics(vol, pool, miroirReplicaView{
 		upToDate: true, connected: true, quorum: true, resyncRatio: 1,
 	})
 	if hasSeries(t, "miroir_volume_diskless_primary", volume) {
 		t.Fatal("diskless_primary series still exposed after the leg became diskful")
 	}
-	if got := testutil.ToFloat64(metricUpToDate.WithLabelValues(volume, pool)); got != 1 {
+	if got := testutil.ToFloat64(metricUpToDate.WithLabelValues(volume, pool, volume, "")); got != 1 {
 		t.Fatalf("up_to_date = %v, want 1", got)
+	}
+
+	dropVolumeMetrics(volume)
+}
+
+// When the PVC-ref labels land on a volume whose series already exist
+// unlabeled (the controller's backfill), the old identity must leave the
+// scrape — otherwise it would keep reporting its last values alongside
+// the new series and double-count in aggregations.
+func TestPVCRefBackfillRetiresUnlabeledSeries(t *testing.T) {
+	const volume = "pvc-backfill-transition"
+	const pool = "default"
+	vol := metricsVol(volume)
+	recordVolumeMetrics(vol, pool, miroirReplicaView{
+		upToDate: true, connected: true, quorum: true, resyncRatio: 1,
+	})
+
+	vol.Labels = map[string]string{
+		constants.LabelPVCName:      "config-jellyfin",
+		constants.LabelPVCNamespace: "media",
+	}
+	recordVolumeMetrics(vol, pool, miroirReplicaView{
+		upToDate: true, connected: true, quorum: true, resyncRatio: 1,
+	})
+
+	families, err := metrics.Registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range families {
+		if f.GetName() != familyUpToDate {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range m.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+			if labels[volumeLabel] != volume {
+				continue
+			}
+			if labels[pvcLabel] != "config-jellyfin" || labels[pvcNamespaceLabel] != "media" {
+				t.Fatalf("stale identity still exposed after backfill: %v", labels)
+			}
+		}
 	}
 
 	dropVolumeMetrics(volume)

--- a/internal/agent/poolstats.go
+++ b/internal/agent/poolstats.go
@@ -69,6 +69,10 @@ type PoolStatsPublisher struct {
 	// empty on nodes without the module. A module change means a node
 	// reboot and thus an agent restart, so startup is current enough.
 	DRBDVersion string
+	// DRBDUtilsVersion is the drbd-utils userland version probed at the
+	// same startup; it ships in the agent image, so it only changes with
+	// an agent rollout (which also restarts the publisher).
+	DRBDUtilsVersion string
 }
 
 // Start publishes once promptly, then on the interval until ctx is done.
@@ -143,6 +147,7 @@ func (p *PoolStatsPublisher) publish(ctx context.Context) error {
 			cur.Status.Pools = append(cur.Status.Pools, entry)
 		}
 		cur.Status.DRBDVersion = p.DRBDVersion
+		cur.Status.DRBDUtilsVersion = p.DRBDUtilsVersion
 		now := metav1.Now()
 		cur.Status.ObservedAt = &now
 

--- a/internal/agent/poolstats_test.go
+++ b/internal/agent/poolstats_test.go
@@ -68,6 +68,7 @@ func TestPoolStatsPublisherPublishes(t *testing.T) {
 	fb.stats = backend.PoolStats{SizeBytes: 100 * poolGiB, UsedBytes: 50 * poolGiB}
 	p, get := newPublisher(t, singlePool(fb), nil)
 	p.DRBDVersion = "9.3.2"
+	p.DRBDUtilsVersion = "9.34.3"
 
 	if err := p.publish(t.Context()); err != nil {
 		t.Fatal(err)
@@ -82,6 +83,9 @@ func TestPoolStatsPublisherPublishes(t *testing.T) {
 	}
 	if n.Status.DRBDVersion != "9.3.2" {
 		t.Fatalf("drbdVersion = %q, want 9.3.2", n.Status.DRBDVersion)
+	}
+	if n.Status.DRBDUtilsVersion != "9.34.3" {
+		t.Fatalf("drbdUtilsVersion = %q, want 9.34.3", n.Status.DRBDUtilsVersion)
 	}
 	if n.Status.ObservedAt == nil {
 		t.Fatal("ObservedAt must be set")

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -223,7 +223,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// resyncRatio 1 and quorum true, not the zero values: an
 			// unreplicated volume is fully in sync with itself and has no
 			// quorum to lose — zeros would perma-fire the alerts.
-			recordVolumeMetrics(vol.Name, poolName, miroirReplicaView{
+			recordVolumeMetrics(vol, poolName, miroirReplicaView{
 				upToDate: true, connected: true, quorum: true, resyncRatio: 1,
 			})
 			if err := r.patchStatus(ctx, vol, miroirv1alpha1.ReplicaStatus{
@@ -300,9 +300,9 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	splitActive := r.handleSplitBrain(ctx, vol, resource, st, connected)
 	diskFailed := diskFailedLatch(vol, r.NodeName, st, localDiskless)
 	if !localDiskless {
-		recordVolumeMetrics(vol.Name, poolName, replicaView(st, vol, r.NodeName, localDiskless))
+		recordVolumeMetrics(vol, poolName, replicaView(st, vol, r.NodeName, localDiskless))
 	} else {
-		recordDisklessMetrics(vol.Name, st.Primary)
+		recordDisklessMetrics(vol, st.Primary)
 	}
 	statusPool := poolName
 	if localDiskless {
@@ -353,7 +353,7 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 		return false, ctrl.Result{}
 	}
 	if !entry.replicated {
-		recordVolumeMetrics(vol.Name, volumePoolOn(vol, r.NodeName), miroirReplicaView{
+		recordVolumeMetrics(vol, volumePoolOn(vol, r.NodeName), miroirReplicaView{
 			upToDate: true, connected: true, quorum: true, resyncRatio: 1,
 		})
 		// Same drift net as the full pass: nothing else wakes an
@@ -379,9 +379,9 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 		return false, ctrl.Result{}
 	}
 	if !localDiskless {
-		recordVolumeMetrics(vol.Name, volumePoolOn(vol, r.NodeName), replicaView(st, vol, r.NodeName, localDiskless))
+		recordVolumeMetrics(vol, volumePoolOn(vol, r.NodeName), replicaView(st, vol, r.NodeName, localDiskless))
 	} else {
-		recordDisklessMetrics(vol.Name, st.Primary)
+		recordDisklessMetrics(vol, st.Primary)
 	}
 	return true, ctrl.Result{RequeueAfter: drbdPollInterval}
 }
@@ -931,7 +931,7 @@ func (r *VolumeReconciler) reportWedged(ctx context.Context, vol *miroirv1alpha1
 			"DRBD cannot tear down %s: device stuck Detaching with connections gone (LINBIT/drbd#137); reboot node %s to clear it",
 			vol.Name, r.NodeName)
 	}
-	metricWedged.WithLabelValues(vol.Name).Set(1)
+	recordWedged(vol)
 	return r.parkWithMessage(ctx, vol, cause, wedgedRequeue)
 }
 
@@ -961,7 +961,7 @@ func (r *VolumeReconciler) handleTeardownError(ctx context.Context, vol *miroirv
 	// Any other outcome means a previously reported wedge is gone — e.g.
 	// the reboot happened and the device is now merely held open — so the
 	// critical alert must stop paging for it.
-	metricWedged.DeleteLabelValues(vol.Name)
+	clearWedged(vol.Name)
 	if errors.Is(err, backend.ErrBusy) {
 		// A still-staged (or force-deleted) pod holds the device open;
 		// NodeUnstage releases it once the consumer moves off this node.

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -227,7 +227,7 @@ func TestReconcileRealizesReplica(t *testing.T) {
 	}
 	// No peers means fully in sync: the zero value would perma-fire any
 	// <1 resync alert for every unreplicated volume.
-	if ratio := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); ratio != 1 {
+	if ratio := testutil.ToFloat64(metricResyncRatio.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName, volPvc1, "")); ratio != 1 {
 		t.Fatalf("unreplicated resync_ratio = %v, want 1", ratio)
 	}
 }
@@ -1224,7 +1224,7 @@ func TestReconcileTeardownWedgedParksRetry(t *testing.T) {
 	default:
 		t.Fatal("want a TeardownWedged warning event")
 	}
-	if got := testutil.ToFloat64(metricWedged.WithLabelValues(volPvc1)); got != 1 {
+	if got := testutil.ToFloat64(metricWedged.WithLabelValues(volPvc1, volPvc1, "")); got != 1 {
 		t.Fatalf("wedged gauge = %v, want 1", got)
 	}
 	got := &miroirv1alpha1.MiroirVolume{}
@@ -1259,7 +1259,7 @@ func TestReconcileVolumeGoneDropsMetrics(t *testing.T) {
 	s := newScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend())}
-	metricWedged.WithLabelValues(volPvc1).Set(1)
+	metricWedged.WithLabelValues(volPvc1, volPvc1, "").Set(1)
 	t.Cleanup(func() { dropVolumeMetrics(volPvc1) })
 
 	if _, err := r.Reconcile(t.Context(),
@@ -1356,7 +1356,7 @@ func TestReconcileLatchedDiskSkipsReAttach(t *testing.T) {
 		t.Fatalf("latch must stay set while the leg is Diskless: %+v", st)
 	}
 	// The latch is the actionable hardware-failure alert signal.
-	if v := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 1 {
+	if v := testutil.ToFloat64(metricDiskFailed.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName, volPvc1, "")); v != 1 {
 		t.Fatalf("miroir_volume_disk_failed = %v, want 1", v)
 	}
 }
@@ -1415,11 +1415,11 @@ func TestReconcileQuorumLostExportsGauge(t *testing.T) {
 
 	reconcile(t, r, volPvc1)
 
-	if v := testutil.ToFloat64(metricQuorum.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 0 {
+	if v := testutil.ToFloat64(metricQuorum.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName, volPvc1, "")); v != 0 {
 		t.Fatalf("miroir_volume_quorum = %v, want 0 on quorum loss", v)
 	}
 	// Local disk is fine — up_to_date must stay 1 (quorum is the signal).
-	if v := testutil.ToFloat64(metricUpToDate.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 1 {
+	if v := testutil.ToFloat64(metricUpToDate.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName, volPvc1, "")); v != 1 {
 		t.Fatalf("miroir_volume_up_to_date = %v, want 1", v)
 	}
 }
@@ -2641,7 +2641,7 @@ func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 	if st.DevicePath == "" {
 		t.Fatal("client slot must record the DRBD device path for staging")
 	}
-	if v := testutil.ToFloat64(metricDisklessPrimary.WithLabelValues(volPvc1)); v != 0 {
+	if v := testutil.ToFloat64(metricDisklessPrimary.WithLabelValues(volPvc1, volPvc1, "")); v != 0 {
 		t.Fatalf("diskless_primary = %v, want 0 while Secondary", v)
 	}
 
@@ -2652,7 +2652,7 @@ func TestReconcileClientLegRealizesDiskless(t *testing.T) {
 		"devices":[{"disk-state":"` + diskStateDiskless + `"}],
 		"connections":[{"peer-node-id":0,"connection-state":"Connected"},{"peer-node-id":1,"connection-state":"Connected"}]}]`
 	reconcile(t, r, volPvc1)
-	if v := testutil.ToFloat64(metricDisklessPrimary.WithLabelValues(volPvc1)); v != 1 {
+	if v := testutil.ToFloat64(metricDisklessPrimary.WithLabelValues(volPvc1, volPvc1, "")); v != 1 {
 		t.Fatalf("diskless_primary = %v, want 1 while Primary", v)
 	}
 }

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -181,7 +181,7 @@ func (v *VerifyScheduler) verifyVolume(ctx context.Context, vol *miroirv1alpha1.
 // per-node slot apply.
 func (v *VerifyScheduler) recordResult(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, oosBytes int64) error {
 	now := metav1.Now()
-	recordVerifyMetrics(vol.Name, volumePoolOn(vol, v.NodeName), now.Time, oosBytes)
+	recordVerifyMetrics(vol, volumePoolOn(vol, v.NodeName), now.Time, oosBytes)
 	if oosBytes > 0 && v.Recorder != nil {
 		v.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "VerifyOutOfSync", "Verify",
 			"online verify found %d out-of-sync bytes; a disconnect/connect cycle is needed to resync", oosBytes)

--- a/internal/agent/verify_test.go
+++ b/internal/agent/verify_test.go
@@ -186,7 +186,7 @@ func TestVerifyHappyPathRecordsCleanResult(t *testing.T) {
 	if st.LastVerifyOutOfSyncBytes == nil || *st.LastVerifyOutOfSyncBytes != 0 {
 		t.Fatalf("clean verify must record 0 out-of-sync bytes, got %v", st.LastVerifyOutOfSyncBytes)
 	}
-	if v := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 0 {
+	if v := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName, volPvc1, "")); v != 0 {
 		t.Fatalf("verify oos gauge = %v, want 0", v)
 	}
 	select {
@@ -211,7 +211,7 @@ func TestVerifyOutOfSyncRecordsAndEvents(t *testing.T) {
 	if st.LastVerifyOutOfSyncBytes == nil || *st.LastVerifyOutOfSyncBytes != 256*1024 {
 		t.Fatalf("verify must record 256 KiB out of sync, got %v", st.LastVerifyOutOfSyncBytes)
 	}
-	if v := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName)); v != 256*1024 {
+	if v := testutil.ToFloat64(metricVerifyOutOfSyncBytes.WithLabelValues(volPvc1, miroirv1alpha1.DefaultPoolName, volPvc1, "")); v != 256*1024 {
 		t.Fatalf("verify oos gauge = %v, want %d", v, 256*1024)
 	}
 	select {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -59,4 +59,36 @@ const (
 	// replica of a volume lands in this pool on its node. Absent means the
 	// default pool (v1alpha1.DefaultPoolName).
 	ParamPool = "miroir.home-operations.com/pool"
+
+	// LabelPVCName and LabelPVCNamespace record on a MiroirVolume the PVC
+	// it was provisioned for: CreateVolume stamps them from the
+	// provisioner's --extra-create-metadata parameters, the membership
+	// reconciler backfills older volumes from their PV's claimRef, and the
+	// agents surface them as the pvc / pvc_namespace metric labels.
+	LabelPVCName      = "miroir.home-operations.com/pvc-name"
+	LabelPVCNamespace = "miroir.home-operations.com/pvc-namespace"
 )
+
+// PVCRef reads a volume's PVC-ref labels back for its metric series,
+// falling back to the CR name (and an empty namespace) when they are
+// absent so legends never go blank on unlabeled volumes.
+func PVCRef(volumeName string, labels map[string]string) (pvc, namespace string) {
+	if v := labels[LabelPVCName]; v != "" {
+		return v, labels[LabelPVCNamespace]
+	}
+	return volumeName, ""
+}
+
+// PVCRefLabels builds the PVC-ref label pair, or nil when the reference
+// is incomplete or the PVC name cannot be a label value (RFC 1123 allows
+// 253-char PVC names; label values cap at 63). A volume left unlabeled
+// falls back to its CR name in the metric labels.
+func PVCRefLabels(name, namespace string) map[string]string {
+	if name == "" || namespace == "" || len(name) > 63 {
+		return nil
+	}
+	return map[string]string{
+		LabelPVCName:      name,
+		LabelPVCNamespace: namespace,
+	}
+}

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -214,7 +214,12 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		}
 	}
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: req.GetName()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: req.GetName(),
+			Labels: constants.PVCRefLabels(
+				req.GetParameters()[paramPVCName],
+				req.GetParameters()[paramPVCNamespace]),
+		},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: sizeBytes,
 			Replicas:  placed,
@@ -1354,6 +1359,14 @@ func parseAllowRemoteAccess(params map[string]string, replicas int) (bool, error
 	}
 	return enabled, nil
 }
+
+// The external-provisioner injects these parameters when it runs with
+// --extra-create-metadata (the chart always passes it); they identify the
+// PVC a CreateVolume serves.
+const (
+	paramPVCName      = "csi.storage.k8s.io/pvc/name"
+	paramPVCNamespace = "csi.storage.k8s.io/pvc/namespace"
+)
 
 // classParams is the StorageClass-driven shape of a CreateVolume request.
 type classParams struct {

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1562,3 +1562,49 @@ func TestListVolumesPagination(t *testing.T) {
 		}
 	}
 }
+
+// CreateVolume stamps the PVC-ref labels from the provisioner's
+// --extra-create-metadata parameters; without them the CR stays unlabeled
+// (the membership reconciler backfills from the PV instead).
+func TestCreateVolumeStampsPVCRefLabels(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{
+		Client:           readyOnGet(s, nodeObj(nodeA, addrA), nodeObj(nodeB, "192.168.1.42")),
+		Nodes:            testNodes,
+		ProvisionTimeout: 2 * time.Second,
+	}
+
+	if _, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               "pvc-labeled",
+		VolumeCapabilities: volCaps(),
+		Parameters: map[string]string{
+			constants.ParamReplicas: "2",
+			paramPVCName:            "config-jellyfin",
+			paramPVCNamespace:       "media",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: "pvc-labeled"}, vol); err != nil {
+		t.Fatal(err)
+	}
+	if vol.Labels[constants.LabelPVCName] != "config-jellyfin" ||
+		vol.Labels[constants.LabelPVCNamespace] != "media" {
+		t.Fatalf("PVC-ref labels not stamped: %v", vol.Labels)
+	}
+
+	if _, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               "pvc-unlabeled",
+		VolumeCapabilities: volCaps(),
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: "pvc-unlabeled"}, vol); err != nil {
+		t.Fatal(err)
+	}
+	if len(vol.Labels) != 0 {
+		t.Fatalf("volume without PVC metadata must stay unlabeled: %v", vol.Labels)
+	}
+}

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -1063,16 +1063,30 @@ const KernelFloor = "9.3.1"
 // KernelAvailable: with no module loaded drbdadm falls back to a
 // compile-time guess.
 func (d *Driver) KernelVersion(ctx context.Context) (string, error) {
+	return d.admVersionField(ctx, "DRBD_KERNEL_VERSION")
+}
+
+// UtilsVersion reports the drbd-utils userland version via drbdadm's
+// DRBDADM_VERSION. Unlike the kernel module, the utils ship in the agent
+// image, so this is the container's toolchain version, not the host's.
+func (d *Driver) UtilsVersion(ctx context.Context) (string, error) {
+	return d.admVersionField(ctx, "DRBDADM_VERSION")
+}
+
+// admVersionField pulls one KEY=value line out of drbdadm --version. The
+// "=" is part of the match so DRBDADM_VERSION never picks up the
+// DRBDADM_VERSION_CODE line.
+func (d *Driver) admVersionField(ctx context.Context, key string) (string, error) {
 	out, err := d.Exec(ctx, "drbdadm", "--version")
 	if err != nil {
 		return "", fmt.Errorf("drbdadm --version: %w", err)
 	}
 	for line := range strings.SplitSeq(out, "\n") {
-		if v, ok := strings.CutPrefix(strings.TrimSpace(line), "DRBD_KERNEL_VERSION="); ok {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), key+"="); ok {
 			return strings.TrimSpace(v), nil
 		}
 	}
-	return "", errors.New("no DRBD_KERNEL_VERSION in drbdadm --version output")
+	return "", fmt.Errorf("no %s in drbdadm --version output", key)
 }
 
 // kernelFloor is KernelFloor pre-parsed for comparisons.

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -384,6 +384,13 @@ func TestKernelVersion(t *testing.T) {
 	if v != "9.3.2" {
 		t.Fatalf("version = %q, want 9.3.2", v)
 	}
+	u, err := d.UtilsVersion(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u != "9.34.3" {
+		t.Fatalf("utils version = %q, want 9.34.3 (must not match DRBDADM_VERSION_CODE)", u)
+	}
 
 	fe = &fakeExec{responses: map[string]string{cmdAdmVersion: "DRBDADM_VERSION=9.34.3\n"}}
 	d = &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}

--- a/internal/export/metrics.go
+++ b/internal/export/metrics.go
@@ -19,6 +19,9 @@ package export
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/constants"
 )
 
 // The RWX serving signal. The agents' miroir_volume_* gauges track DRBD
@@ -27,25 +30,32 @@ import (
 // Published from the controller (this reconciler owns the gateway workloads
 // and already watches them): the gateway's own /metrics vanishes exactly
 // when the gateway is down, which is the state this gauge must report.
+const volumeLabel = "volume"
+
 var metricExportReady = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "miroir_export_ready",
 	Help: "1 when the RWX volume's NFS gateway is serving (gateway pod available and export address published); 0 while clients cannot reach the export — a failover in progress, or a gateway that cannot run.",
-}, []string{"volume"})
+}, []string{volumeLabel, "pvc", "pvc_namespace"})
 
 func init() {
 	metrics.Registry.MustRegister(metricExportReady)
 }
 
-func recordExportReady(volume string, ready bool) {
+func recordExportReady(vol *miroirv1alpha1.MiroirVolume, ready bool) {
 	var v float64
 	if ready {
 		v = 1
 	}
-	metricExportReady.WithLabelValues(volume).Set(v)
+	// Retire any series recorded before the PVC-ref labels landed on the
+	// volume (the controller backfill changes the series identity); one
+	// series per RWX volume, so the sweep is cheap.
+	dropExportMetrics(vol.Name)
+	pvc, namespace := constants.PVCRef(vol.Name, vol.Labels)
+	metricExportReady.WithLabelValues(vol.Name, pvc, namespace).Set(v)
 }
 
 // dropExportMetrics removes a volume's series; a deleted volume must not
 // leave a stale 0 behind (it would fire MiroirExportUnavailable forever).
 func dropExportMetrics(volume string) {
-	metricExportReady.DeleteLabelValues(volume)
+	metricExportReady.DeletePartialMatch(prometheus.Labels{volumeLabel: volume})
 }

--- a/internal/export/reconciler.go
+++ b/internal/export/reconciler.go
@@ -91,7 +91,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Serving means a gateway pod is up and the address consumers mount is
 	// published; the owned-Deployment watch re-runs this on availability
 	// flips, so the gauge tracks failovers without polling.
-	recordExportReady(vol.Name, available && addr != "")
+	recordExportReady(vol, available && addr != "")
 	log.Info("reconciled RWX gateway", "volume", vol.Name, "address", addr, "available", available)
 	return ctrl.Result{}, nil
 }

--- a/internal/export/reconciler.go
+++ b/internal/export/reconciler.go
@@ -162,13 +162,19 @@ func (r *Reconciler) publishAddress(ctx context.Context, vol *miroirv1alpha1.Mir
 	return r.Status().Patch(ctx, vol, client.MergeFrom(base))
 }
 
-// SetupWithManager registers the reconciler. Generation-filtered on the
-// volume (status churn from agents carries nothing this reconciler reads),
-// and it owns its Deployment/Service so drift on those heals.
+// SetupWithManager registers the reconciler. The volume watch passes
+// generation changes (status churn from agents carries nothing this
+// reconciler reads) and label changes — the PVC-ref backfill is a
+// label-only patch, and without it an existing RWX volume's
+// miroir_export_ready series would keep its fallback pvc label until an
+// unrelated workload event. It owns its Deployment/Service so drift on
+// those heals.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&miroirv1alpha1.MiroirVolume{},
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(predicate.Or[client.Object](
+				predicate.GenerationChangedPredicate{},
+				predicate.LabelChangedPredicate{}))).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Named("export").

--- a/internal/membership/reconciler.go
+++ b/internal/membership/reconciler.go
@@ -28,8 +28,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -51,6 +53,10 @@ type Reconciler struct {
 	// Nodes yields the storage topology — the same map CreateVolume
 	// places from — folded from the MiroirNode CRs per reconcile.
 	Nodes nodemap.Source
+	// PVs reads PersistentVolumes uncached (the manager's APIReader):
+	// the PVC-ref backfill needs one PV per unlabeled volume, once, not
+	// a cluster-wide PV informer.
+	PVs client.Reader
 }
 
 // Reconcile fills in NodeID/Address/FullSync for incomplete replica
@@ -62,7 +68,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := r.Get(ctx, req.NamespacedName, vol); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	if !vol.DeletionTimestamp.IsZero() || vol.Spec.DRBD == nil {
+	if !vol.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+	if err := r.ensurePVCRef(ctx, vol); err != nil {
+		return ctrl.Result{}, err
+	}
+	if vol.Spec.DRBD == nil {
 		// Unreplicated volumes cannot change membership: DRBD internal
 		// metadata cannot be slipped under a live filesystem (the CRD
 		// validation rule already blocks such edits).
@@ -133,6 +145,36 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // (unknown node, duplicate), as opposed to a transient one (Node not
 // registered yet) that must be retried.
 var errBadPlacement = errors.New("replica placement is invalid")
+
+// ensurePVCRef stamps the PVC-ref labels on volumes created before the
+// provisioner passed PVC metadata: the bound PV shares the volume's name
+// and carries the claim in its claimRef. New volumes are labeled by
+// CreateVolume itself, so this reads at most one PV per legacy volume. A
+// missing PV, a foreign one, or an empty claimRef leaves the volume
+// unlabeled — nothing to requeue on, metrics fall back to the CR name.
+func (r *Reconciler) ensurePVCRef(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) error {
+	if vol.Labels[constants.LabelPVCName] != "" {
+		return nil
+	}
+	pv := &corev1.PersistentVolume{}
+	if err := r.PVs.Get(ctx, types.NamespacedName{Name: vol.Name}, pv); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != constants.DriverName ||
+		pv.Spec.CSI.VolumeHandle != vol.Name || pv.Spec.ClaimRef == nil {
+		return nil
+	}
+	labels := constants.PVCRefLabels(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
+	if labels == nil {
+		return nil
+	}
+	patch := client.MergeFrom(vol.DeepCopy())
+	if vol.Labels == nil {
+		vol.Labels = map[string]string{}
+	}
+	maps.Copy(vol.Labels, labels)
+	return r.Patch(ctx, vol, patch)
+}
 
 // complete fills one added entry in place. NodeID takes the lowest id not
 // used by the other entries — freed ids may be reused; the joiner's

--- a/internal/membership/reconciler_test.go
+++ b/internal/membership/reconciler_test.go
@@ -18,6 +18,7 @@ package membership
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -130,7 +131,7 @@ func TestCompletesAddedReplicaInheritsVolumePool(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeC, addrC)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: {Pools: map[string]nodemap.Pool{
 			poolDefault: {Backend: miroirv1alpha1.BackendLVMThin},
 			poolFast:    {Backend: miroirv1alpha1.BackendZFS},
@@ -154,7 +155,7 @@ func TestCompleteRejectsCrossPoolReplica(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeC, addrC)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: {Pools: map[string]nodemap.Pool{
 			poolDefault: {Backend: miroirv1alpha1.BackendLVMThin},
 			poolFast:    {Backend: miroirv1alpha1.BackendZFS},
@@ -177,7 +178,7 @@ func TestCompleteRejectsUnknownPool(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeC, addrC)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: storageNode(miroirv1alpha1.BackendLVMThin), // default pool only
 	}}
 
@@ -192,7 +193,7 @@ func TestCompletesAddedReplica(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(replicatedVol(), node(nodeC, addrC)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: storageNode(miroirv1alpha1.BackendLVMThin),
 	}}
 
@@ -222,7 +223,7 @@ func TestCompletesAddedReplicaWithAddressOverride(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(replicatedVol()). // no node-c Node object
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: storageNodeAt(miroirv1alpha1.BackendLVMThin, "10.0.100.43"),
 	}}
 
@@ -239,7 +240,7 @@ func TestReusesLowestFreeNodeID(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeC, addrC)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: storageNode(miroirv1alpha1.BackendZFS),
 	}}
 
@@ -258,7 +259,7 @@ func TestCompletesDisklessReplica(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeC, addrC)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: storageNode(miroirv1alpha1.BackendZFS),
 	}}
 
@@ -280,7 +281,7 @@ func TestUnknownNodeLeavesSpecUntouched(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(replicatedVol()).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{}} // node-c not a storage node
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{}} // node-c not a storage node
 
 	reconcile(t, r, "pvc-1")
 
@@ -296,7 +297,7 @@ func TestConflictedNodeStopsWithoutRequeue(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(replicatedVol()).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: {
 			Address:         "10.0.100.9",
 			AddressConflict: true,
@@ -331,7 +332,7 @@ func TestRequeuesWhenNodeNotReady(t *testing.T) {
 			}
 			c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 				WithObjects(objs...).Build()
-			r := &Reconciler{Client: c, Nodes: nodemap.Map{
+			r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 				nodeC: storageNode(miroirv1alpha1.BackendZFS),
 			}}
 
@@ -352,7 +353,7 @@ func TestIgnoresUnreplicatedVolume(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeC, addrC)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: storageNode(miroirv1alpha1.BackendZFS),
 	}}
 
@@ -373,7 +374,7 @@ func TestCompletesClientLeg(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeBergen, addrBergen)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{}} // bergen is not a storage node
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{}} // bergen is not a storage node
 
 	reconcile(t, r, "pvc-1")
 
@@ -397,7 +398,7 @@ func TestClientLegNodeIDSkipsReplicaIDs(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeBergen, addrBergen)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{}}
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{}}
 
 	reconcile(t, r, "pvc-1")
 
@@ -414,7 +415,7 @@ func TestCompletesReplicaAndClientWithDistinctIDs(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(v, node(nodeC, addrC), node(nodeBergen, addrBergen)).
 		Build()
-	r := &Reconciler{Client: c, Nodes: nodemap.Map{
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{
 		nodeC: storageNode(miroirv1alpha1.BackendZFS),
 	}}
 
@@ -427,5 +428,70 @@ func TestCompletesReplicaAndClientWithDistinctIDs(t *testing.T) {
 	}
 	if rep.NodeID == cl.NodeID {
 		t.Fatalf("legs completed in one pass must get distinct node ids, both got %d", rep.NodeID)
+	}
+}
+
+// boundPV is the PV the provisioner created for a volume of the same
+// name, bound to a claim.
+func boundPV(volName, ns, claim string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volName},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{Namespace: ns, Name: claim},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       constants.DriverName,
+					VolumeHandle: volName,
+				},
+			},
+		},
+	}
+}
+
+// A volume created before the provisioner passed PVC metadata gets its
+// PVC-ref labels backfilled from the PV's claimRef — unreplicated volumes
+// too, so the backfill must run before the membership gate.
+func TestBackfillsPVCRefFromPV(t *testing.T) {
+	v := replicatedVol()
+	v.Spec.DRBD = nil
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(v, boundPV("pvc-1", "media", "config-jellyfin")).
+		Build()
+	r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{}}
+
+	reconcile(t, r, "pvc-1")
+
+	got := get(t, r, "pvc-1")
+	if got.Labels[constants.LabelPVCName] != "config-jellyfin" ||
+		got.Labels[constants.LabelPVCNamespace] != "media" {
+		t.Fatalf("PVC-ref labels not backfilled from the PV claimRef: %v", got.Labels)
+	}
+}
+
+// No PV, a foreign driver's PV, or a claim name that overflows a label
+// value all leave the volume unlabeled without erroring the reconcile.
+func TestBackfillSkipsUnusablePVs(t *testing.T) {
+	foreign := boundPV("pvc-1", "media", "config-jellyfin")
+	foreign.Spec.CSI.Driver = "other.example.com"
+	long := boundPV("pvc-1", "media", strings.Repeat("x", 64))
+	for name, pv := range map[string]*corev1.PersistentVolume{
+		"missing PV": nil, "foreign driver": foreign, "overlong claim name": long,
+	} {
+		t.Run(name, func(t *testing.T) {
+			v := replicatedVol()
+			v.Spec.DRBD = nil
+			b := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(v)
+			if pv != nil {
+				b = b.WithObjects(pv)
+			}
+			c := b.Build()
+			r := &Reconciler{Client: c, PVs: c, Nodes: nodemap.Map{}}
+
+			reconcile(t, r, "pvc-1")
+
+			if labels := get(t, r, "pvc-1").Labels; len(labels) != 0 {
+				t.Fatalf("volume must stay unlabeled: %v", labels)
+			}
+		})
 	}
 }

--- a/internal/membership/tiebreaker_test.go
+++ b/internal/membership/tiebreaker_test.go
@@ -85,7 +85,7 @@ func TestTieBreakerRetrofitsAndMembershipCompletes(t *testing.T) {
 
 	tbReconcile(t, tb)
 
-	mr := &Reconciler{Client: c, Nodes: nodes}
+	mr := &Reconciler{Client: c, PVs: c, Nodes: nodes}
 	got := get(t, mr, volTB)
 	if len(got.Spec.Replicas) != 3 {
 		t.Fatalf("tie-breaker not added: %+v", got.Spec.Replicas)
@@ -139,7 +139,7 @@ func TestTieBreakerWaitsForInFlightRemoval(t *testing.T) {
 	if res.RequeueAfter == 0 {
 		t.Fatal("must requeue: the finalizer release does not bump the generation")
 	}
-	got := get(t, &Reconciler{Client: c}, volTB)
+	got := get(t, &Reconciler{Client: c, PVs: c}, volTB)
 	if len(got.Spec.Replicas) != 2 {
 		t.Fatalf("no tie-breaker may be added mid-removal: %+v", got.Spec.Replicas)
 	}
@@ -198,7 +198,7 @@ func TestTieBreakerSkips(t *testing.T) {
 
 			tbReconcile(t, tb)
 
-			got := get(t, &Reconciler{Client: c}, volTB)
+			got := get(t, &Reconciler{Client: c, PVs: c}, volTB)
 			if len(got.Spec.Replicas) != want {
 				t.Fatalf("replicas must stay unchanged: %+v", got.Spec.Replicas)
 			}
@@ -226,7 +226,7 @@ func TestTieBreakerRetrofitWithClientLeg(t *testing.T) {
 
 	tbReconcile(t, r)
 
-	got := get(t, &Reconciler{Client: c}, volTB)
+	got := get(t, &Reconciler{Client: c, PVs: c}, volTB)
 	idx := slices.IndexFunc(got.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
 		return rep.Node == nodeC
 	})
@@ -256,7 +256,7 @@ func TestTieBreakerSkipsClientNode(t *testing.T) {
 
 	tbReconcile(t, r)
 
-	got := get(t, &Reconciler{Client: c}, volTB)
+	got := get(t, &Reconciler{Client: c, PVs: c}, volTB)
 	if len(got.Spec.Replicas) != 2 {
 		t.Fatalf("the client's node must not receive the tie-breaker: %+v", got.Spec.Replicas)
 	}


### PR DESCRIPTION
## What

**PVC-readable metrics.** Every `miroir_volume_*` series and `miroir_export_ready` now carry `pvc` and `pvc_namespace` labels alongside `volume`, and the Grafana dashboard reads them: legends are `{{pvc_namespace}}/{{pvc}}` instead of `pvc-<uuid>`, and the `volume` template variable is now a `pvc` variable.

- `CreateVolume` stamps `miroir.home-operations.com/pvc-name` / `pvc-namespace` labels on the MiroirVolume from the provisioner's `--extra-create-metadata` parameters (the chart now passes the flag).
- The membership reconciler backfills pre-existing volumes from their PV's `claimRef` — one uncached PV `Get` per unlabeled volume, no PV informer, no new RBAC. Existing volumes show real names right after the upgrade.
- When the labels land after a volume's series already exist (the backfill case), the agent retires the old series identity so nothing double-counts. A volume whose claim is unknown (missing PV, or a PVC name longer than the 63-char label cap) falls back to its CR name so legends never go blank.
- Alert summaries print the claim too (`Volume media/config-jellyfin (pool default) is split-brain on node-a`); the runbook references that name the CR or the gateway Deployment (`kubectl describe miroirvolume …`, `miroir-share-…`) keep `$labels.volume`.

**drbd-utils version.** The agent probes `DRBDADM_VERSION` next to the kernel module version and reports it in three places: a `utils_version` label on `miroir_node_drbd_kernel_info`, a drbd-utils column in the dashboard's version table (now "DRBD versions by node"), and `status.drbdUtilsVersion` on MiroirNode next to `drbdVersion` (wide printer column). The utils ship in the agent image rather than the host, so the pair makes module/toolchain skew visible per node.

Also carries a 3-line comment sync in the generated `miroirnodegroupspec.go` applyconfiguration — pre-existing drift that `mise run generate` reproduces on every run.

## Verification

- `go test` across all packages and the envtest integration suite (26/26)
- `golangci-lint`: 0 issues
- helm-unittest: 115 passing; `helm lint` and the strict MkDocs build clean