### PR TITLE
fix(csi): pin only the scheduler-selected node, rank the rest by headroom

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -438,31 +438,53 @@ func (c *Controller) place(ctx context.Context, nodes nodemap.Map, reqs *csi.Top
 		}
 		return sizeBytes > room
 	}
-	// freeBytes is the pool headroom used to rank candidates; 0 (sorts
-	// last) when stats are unknown.
-	freeBytes := func(node string) int64 {
+	// headroom ranks candidates by the same allowance the admission guard
+	// computes: provisioned counts volumes committed moments ago under
+	// allocMu, so a burst spreads across nodes instead of piling onto
+	// whichever one the ~minutely pool stats still call emptiest. Unknown
+	// stats rank last (0) but stay admitted.
+	headroom := func(node string) int64 {
+		room, known := c.poolHeadroom(stats[node].Pool(pool), provisioned[nodePool{node, pool}])
+		if !known {
+			return 0
+		}
+		return room
+	}
+	// physicalFree breaks headroom ties: the virtual overcommit bound
+	// usually binds first on freshly provisioned pools, flattening real
+	// free-space differences that should still steer placement.
+	physicalFree := func(node string) int64 {
 		st := stats[node].Pool(pool)
 		if st == nil {
 			return 0
 		}
-		if free := st.CapacityBytes - st.AllocatedBytes; free > 0 {
-			return free
-		}
-		return 0
+		return max(0, st.CapacityBytes-st.AllocatedBytes)
 	}
 
+	// Pin only the scheduler-selected node: with delayed binding the
+	// provisioner sends the whole cluster topology rotated so the selected
+	// node leads the preferred list — everything behind it is rotation
+	// artifact, not scheduler intent. Honoring the full list replayed the
+	// rotation verbatim: every second replica landed on selected+1 and the
+	// capacity ranking below never ran, starving the rotation's tail node
+	// (#258). The pinned node is kept even if it later fails the
+	// overcommit guard, so a topology-pinned volume refuses rather than
+	// silently landing on a node the pod can't reach.
 	ordered := make([]string, 0, len(candidates))
-	// Scheduler-selected topology first — kept in place even if it later
-	// fails the overcommit guard, so a topology-pinned volume refuses
-	// rather than silently landing on a node the pod can't reach.
+	topologyMatched := false
 	for _, t := range append(reqs.GetPreferred(), reqs.GetRequisite()...) {
-		if n, ok := t.GetSegments()[constants.TopologyKey]; ok {
-			if _, ok := candidates[n]; ok && !slices.Contains(ordered, n) {
-				ordered = append(ordered, n)
-			}
+		n, ok := t.GetSegments()[constants.TopologyKey]
+		if !ok {
+			continue
 		}
+		if _, ok := candidates[n]; !ok {
+			continue
+		}
+		topologyMatched = true
+		ordered = append(ordered, n)
+		break
 	}
-	if reqs != nil && len(reqs.GetRequisite()) > 0 && len(ordered) == 0 && !remoteAccess {
+	if reqs != nil && len(reqs.GetRequisite()) > 0 && !topologyMatched && !remoteAccess {
 		// On a remote-access volume the scheduler may pick a non-storage
 		// node for the first consumer (the PV will carry no affinity);
 		// fall through to capacity-ranked placement — the pod attaches
@@ -471,7 +493,9 @@ func (c *Controller) place(ctx context.Context, nodes nodemap.Map, reqs *csi.Top
 		return nil, status.Errorf(codes.ResourceExhausted,
 			"no node carrying storage pool %q satisfies the requested topology", pool)
 	}
-	// Remaining eligible nodes, most free space first (ties by name).
+	// Remaining eligible nodes, largest headroom first; ties break by
+	// physical free space, then least provisioned (all a node has before
+	// its first stats publish), then name.
 	rest := make([]string, 0, len(candidates))
 	for n := range candidates {
 		if slices.Contains(ordered, n) || overcommitted(n) {
@@ -480,7 +504,13 @@ func (c *Controller) place(ctx context.Context, nodes nodemap.Map, reqs *csi.Top
 		rest = append(rest, n)
 	}
 	slices.SortFunc(rest, func(a, b string) int {
-		if d := cmp.Compare(freeBytes(b), freeBytes(a)); d != 0 {
+		if d := cmp.Compare(headroom(b), headroom(a)); d != 0 {
+			return d
+		}
+		if d := cmp.Compare(physicalFree(b), physicalFree(a)); d != 0 {
+			return d
+		}
+		if d := cmp.Compare(provisioned[nodePool{a, pool}], provisioned[nodePool{b, pool}]); d != 0 {
 			return d
 		}
 		return cmp.Compare(a, b)

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csi
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -751,5 +752,111 @@ func TestGetCapacityReplicatedNeedsAllLegs(t *testing.T) {
 	if resp.GetAvailableCapacity() != 0 {
 		t.Fatalf("2-replica class with one full peer must report 0, got %d",
 			resp.GetAvailableCapacity())
+	}
+}
+
+// rotatedTopology mimics the external-provisioner without
+// --strict-topology: requisite carries every node's segment, preferred
+// the same list rotated so the scheduler-selected node leads it.
+func rotatedTopology(selected string, all ...string) *csi.TopologyRequirement {
+	i := slices.Index(all, selected)
+	order := append(slices.Clone(all[i:]), all[:i]...)
+	req := &csi.TopologyRequirement{}
+	for _, n := range all {
+		req.Requisite = append(req.Requisite,
+			&csi.Topology{Segments: map[string]string{constants.TopologyKey: n}})
+	}
+	for _, n := range order {
+		req.Preferred = append(req.Preferred,
+			&csi.Topology{Segments: map[string]string{constants.TopologyKey: n}})
+	}
+	return req
+}
+
+// threeEqualNodes is a 3-node topology with one default lvmthin pool each.
+func threeEqualNodes() nodemap.Map {
+	return nodemap.Map{
+		nodeA: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin, Device: "/dev/a"}),
+		nodeB: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin, Device: "/dev/b"}),
+		nodeC: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin, Device: "/dev/c"}),
+	}
+}
+
+// Only the head of the provisioner's preferred list is scheduler intent —
+// the entries behind it are the rotation of every remaining node. Pinning
+// them all replayed the rotation verbatim: the second replica always
+// landed on selected+1 and the emptiest node lost every placement it
+// should have won, no matter what its stats said (#258).
+func TestPlaceSecondReplicaByCapacityNotRotation(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{
+		Client: placementClient(s,
+			miroirNodeObj(nodeA, 100*gib, 0), // empty pool: the #258 starved node
+			miroirNodeObj(nodeB, 100*gib, 5*gib),
+			miroirNodeObj(nodeC, 100*gib, 5*gib),
+			nodeObj(nodeA, addrA),
+			nodeObj(nodeB, addrB),
+			nodeObj(nodeC, addrC),
+		),
+		Nodes: threeEqualNodes(),
+	}
+
+	// Consumer on node-b: the provisioner sends [b, c, a].
+	got, err := c.place(t.Context(), placeNodes(t, c), rotatedTopology(nodeB, nodeA, nodeB, nodeC),
+		2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Node != nodeB {
+		t.Fatalf("the scheduler-selected node must stay pinned first, got %+v", got)
+	}
+	if got[1].Node != nodeA {
+		t.Fatalf("second replica must go to the emptiest node (node-a), not the rotation's next (node-c): %+v", got)
+	}
+}
+
+// A burst of volumes for consumers on one node must spread its second
+// replicas: each committed volume's provisioned bytes count immediately
+// (under allocMu), long before the ~minutely pool stats tick shows any
+// thin allocation.
+func TestPlaceBurstSpreadsSecondReplicas(t *testing.T) {
+	s := newScheme(t)
+	cl := placementClient(s,
+		miroirNodeObj(nodeA, 100*gib, 0),
+		miroirNodeObj(nodeB, 100*gib, 0),
+		miroirNodeObj(nodeC, 100*gib, 0),
+		nodeObj(nodeA, addrA),
+		nodeObj(nodeB, addrB),
+		nodeObj(nodeC, addrC),
+	)
+	c := &Controller{Client: cl, Nodes: threeEqualNodes()}
+	rotation := rotatedTopology(nodeB, nodeA, nodeB, nodeC)
+
+	seconds := make([]string, 0, 4)
+	for i := range 4 {
+		name := fmt.Sprintf("pvc-burst-%d", i)
+		got, err := c.place(t.Context(), placeNodes(t, c), rotation,
+			2, 5*gib, name, placementVols(t, cl), false, poolDefault)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got[0].Node != nodeB {
+			t.Fatalf("volume %d: selected node not pinned: %+v", i, got)
+		}
+		seconds = append(seconds, got[1].Node)
+		vol := &miroirv1alpha1.MiroirVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: miroirv1alpha1.MiroirVolumeSpec{
+				SizeBytes: 5 * gib,
+				Replicas:  []miroirv1alpha1.Replica{{Node: got[0].Node}, {Node: got[1].Node}},
+			},
+		}
+		if err := cl.Create(t.Context(), vol); err != nil {
+			t.Fatal(err)
+		}
+	}
+	slices.Sort(seconds)
+	if !slices.Equal(seconds, []string{nodeA, nodeA, nodeC, nodeC}) {
+		t.Fatalf("burst must alternate second replicas between node-a and node-c, got %v", seconds)
 	}
 }


### PR DESCRIPTION
Fixes #258

## Determination

The starvation in #258 is real, but the diagnosed mechanism is not: `allocatedBytes` is an `int64` with `omitempty`, and a field omitted at zero decodes back to `0` on the controller side — an empty pool already ranked as *most* free, and ties broke alphabetically in `k8s-0`'s favor. The scorer never saw "unknown" for that node.

What actually starved it: without `--strict-topology` (miroir does not set it), external-provisioner v6.3.0 sends the **whole cluster topology** in `accessibility_requirements`, with `preferred` rotated so the scheduler-selected node leads it ([topology.go](https://github.com/kubernetes-csi/external-provisioner/blob/v6.3.0/pkg/controller/topology.go): `preferredTerms = append(requisiteTerms[i:], requisiteTerms[:i]...)`). `place()` pinned *every* entry in that order, so with consumers on `k8s-1` the request was always `[k8s-1, k8s-2, k8s-0]`, the capacity ranking never ran, and every volume landed on `k8s-1`+`k8s-2`. It also explains both isolation steps in the issue: a consumer on `k8s-2` rotates to `[k8s-2, k8s-0, k8s-1]`, which is why the second replica "suddenly" went to `k8s-0` — coincident with, not caused by, `allocatedBytes` appearing.

## Fix

- Pin only the **first** preferred segment that is a placement candidate (the scheduler-selected node under delayed binding); every other candidate competes on capacity. The pinned node keeps its hard overcommit refusal.
- Rank candidates by the admission guard's **headroom** (capacity×overcommit − provisioned, bounded by physical free space): `provisioned` counts volumes committed moments ago under `allocMu`, so a burst spreads across nodes instead of piling onto whichever node the ~minutely pool-stats tick still calls emptiest. Ties break by physical free space, then least provisioned, then name. Unknown stats still rank last but stay admitted, per the issue's suggested direction ("reserve unknown for genuinely stale/missing pool stats").

## Verification

- New regression tests reproduce the report on the old code: `TestPlaceSecondReplicaByCapacityNotRotation` fails with the second replica on the rotation's next node, and `TestPlaceBurstSpreadsSecondReplicas` fails with `[node-c node-c node-c node-c]` — the exact 15-volume streak from the issue. Both pass with the fix.
- Full unit suite, envtest integration (26/26), and `golangci-lint` clean.