### PR TITLE
fix(backend): treat a mid-delete vanished zfs snapshot as success

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -580,6 +580,61 @@ func TestZFSDeleteSnapshotFindsMigratedSnapshot(t *testing.T) {
 	fe.calledWith(t, "zfs destroy -d tank/miroir/pvc-clone@snap-1")
 }
 
+// A deferred snapshot listed by DeleteSnapshot can be auto-removed by ZFS
+// before the destroy runs (its last restore clone went away concurrently).
+// The contract says "succeeds if already absent", so the not-found destroy
+// must map to success, not a permanent reconcile error (#263).
+func TestZFSDeleteSnapshotVanishedMidCallIsSuccess(t *testing.T) {
+	lists := 0
+	run := func(_ context.Context, name string, args ...string) (string, error) {
+		line := name + " " + strings.Join(args, " ")
+		if strings.Contains(line, "zfs list") {
+			lists++
+			if lists == 1 {
+				return "tank/miroir/pvc-1@snap-1\n", nil
+			}
+			return "", nil // gone by the re-check
+		}
+		if strings.Contains(line, "zfs destroy -d") {
+			return "", errors.New("could not find any snapshots to destroy; check snapshot names.")
+		}
+		return "", nil
+	}
+	b := newZFS(cfg, run)
+
+	if err := b.DeleteSnapshot(t.Context(), "pvc-1", "snap-1"); err != nil {
+		t.Fatalf("vanished snapshot must be success, got %v", err)
+	}
+}
+
+// The same not-found destroy is NOT success when the snapshot merely
+// migrated (a concurrent promote reparented it under the clone between the
+// list and the destroy): swallowing it would leak the snapshot and block
+// the clone's destroy forever. The error must surface so the retry finds
+// the snapshot at its new name.
+func TestZFSDeleteSnapshotMigratedMidCallSurfacesError(t *testing.T) {
+	lists := 0
+	run := func(_ context.Context, name string, args ...string) (string, error) {
+		line := name + " " + strings.Join(args, " ")
+		if strings.Contains(line, "zfs list") {
+			lists++
+			if lists == 1 {
+				return "tank/miroir/pvc-src@snap-1\n", nil
+			}
+			return "tank/miroir/pvc-clone@snap-1\n", nil // reparented, not gone
+		}
+		if strings.Contains(line, "zfs destroy -d") {
+			return "", errors.New("could not find any snapshots to destroy; check snapshot names.")
+		}
+		return "", nil
+	}
+	b := newZFS(cfg, run)
+
+	if err := b.DeleteSnapshot(t.Context(), "pvc-src", "snap-1"); err == nil {
+		t.Fatal("a migrated snapshot's failed destroy must surface, not false-succeed")
+	}
+}
+
 func TestZFSDeleteSnapshotAbsentIsNoop(t *testing.T) {
 	fe := &fakeExec{}
 	fe.respond("zfs list -Hpo name -t snapshot -r tank/miroir",

--- a/internal/backend/zfs.go
+++ b/internal/backend/zfs.go
@@ -260,26 +260,54 @@ func (z *zfsBackend) promoteClones(ctx context.Context, vol string) error {
 	return nil
 }
 
-func (z *zfsBackend) DeleteSnapshot(ctx context.Context, vol, snap string) error {
-	// The snapshot may have migrated: deleting a volume with restore
-	// clones promotes them, and zfs promote reparents every snapshot
-	// at-or-older than the clone's origin onto the clone. Snapshot names
-	// are CR names — cluster-unique — so match by @suffix anywhere under
-	// the parent dataset; without this, a migrated snapshot's deletion
-	// false-succeeds and the leftover blocks its clone's destroy forever.
+// snapshotsMatching lists every snapshot under the parent dataset whose
+// name ends in "@"+snap. The snapshot may have migrated: deleting a volume
+// with restore clones promotes them, and zfs promote reparents every
+// snapshot at-or-older than the clone's origin onto the clone. Snapshot
+// names are CR names — cluster-unique — so matching by @suffix anywhere
+// under the dataset finds the migrated copy; without this, a migrated
+// snapshot's deletion false-succeeds and the leftover blocks its clone's
+// destroy forever.
+func (z *zfsBackend) snapshotsMatching(ctx context.Context, snap string) ([]string, error) {
 	out, err := z.exec(ctx, "zfs", "list", "-Hpo", "name", "-t", "snapshot", "-r", z.dataset)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for line := range strings.SplitSeq(out, "\n") {
+		name := strings.TrimSpace(line)
+		if strings.HasSuffix(name, "@"+snap) {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+func (z *zfsBackend) DeleteSnapshot(ctx context.Context, vol, snap string) error {
+	names, err := z.snapshotsMatching(ctx, snap)
 	if err != nil {
 		return err
 	}
-	for line := range strings.SplitSeq(out, "\n") {
-		name := strings.TrimSpace(line)
-		if !strings.HasSuffix(name, "@"+snap) {
-			continue
-		}
+	for _, name := range names {
 		// -d defers destruction while restore clones still reference the
 		// snapshot (ZFS removes it with the last clone); immediate otherwise.
-		if _, err := z.exec(ctx, "zfs", "destroy", "-d", name); err != nil {
+		_, destroyErr := z.exec(ctx, "zfs", "destroy", "-d", name)
+		if destroyErr == nil {
+			continue
+		}
+		// The listed name can be stale by destroy time: a concurrent clone
+		// teardown removes a deferred snapshot with its last clone, and a
+		// concurrent promote reparents it under the clone. Re-list to tell
+		// gone (the contract's "succeeds if already absent") from migrated:
+		// a survivor means the destroy genuinely failed or the snapshot
+		// lives under a new name, so surface the error and let the retry
+		// find it.
+		still, err := z.snapshotsMatching(ctx, snap)
+		if err != nil {
 			return err
+		}
+		if len(still) > 0 {
+			return destroyErr
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Fixes #263.

`zfsBackend.DeleteSnapshot` listed snapshots under the parent dataset and destroyed each `@suffix` match, returning any destroy failure as a permanent error. A snapshot given `zfs destroy -d` while a restore clone holds it stays listed until ZFS auto-removes it with the last clone, so a concurrent clone teardown between the list and the destroy made `zfs destroy` exit 1 with `could not find any snapshots to destroy` — a hard reconcile error violating the backend contract's "succeeds if already absent" (`internal/backend/backend.go`). The lvmthin and loopfile backends already honor that contract; the ZFS backend was the outlier.

## Approach

On destroy failure, re-run the suffix search instead of string-matching stderr:

- **No survivor**: the snapshot is gone; the delete reached its goal state, so continue (success).
- **A survivor**: the destroy genuinely failed, or a concurrent `zfs promote` (volume teardown) reparented the snapshot under its clone mid-call. The error still surfaces so the retry finds the snapshot at its new name — blindly swallowing the not-found message here would false-succeed and leak a snapshot that blocks its clone's destroy forever (the exact failure the suffix matching was added to prevent).

The existing pre-call absence behavior (`TestZFSDeleteSnapshotAbsentIsNoop`) and permanent-error surfacing (`TestZFSDeleteSnapshotSurfacesPermanentError`) are unchanged.

## Testing

- `go test ./internal/backend/` — all pass, including two new tests:
  - `TestZFSDeleteSnapshotVanishedMidCallIsSuccess`: destroy hits not-found, re-list shows it gone → success.
  - `TestZFSDeleteSnapshotMigratedMidCallSurfacesError`: destroy hits not-found, re-list shows the snapshot reparented under the clone → error surfaces.
- `go build ./...`, `go vet ./internal/backend/` clean.