### PR TITLE
feat(csi): support PVC clone via an internal clone-source snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ troubleshooting.
 - You're on 2-3 nodes and either have a spare disk per node (LVM), a
   ZFS pool (ZFS), or a few GB on the root filesystem (loopfile).
 - You want snapshots that actually work for replicated volumes
-  (both legs cut in lockstep, not whichever finishes first), up to
-  crash-consistent group snapshots across several PVCs at once.
+  (both legs cut in lockstep, not whichever finishes first), plus
+  restores, PVC clones, and crash-consistent group snapshots built
+  on them.
 
 ## When _not_ to use it
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,10 +63,15 @@ documented upstream.
 VolumeSnapshotClasses need only `driver: miroir.home-operations.com`
 and a `deletionPolicy`
 ([Quickstart](quickstart.md#4-snapshot-and-restore) has the manifest;
-the snapshot-controller and its CRDs deploy separately).
-VolumeGroupSnapshotClasses take exactly the same two fields, but the
-feature is off by default: it needs `groupSnapshots.enabled: true` in
-the chart plus the cluster-side group snapshot CRDs and feature gate —
+the snapshot-controller and its CRDs deploy separately). PVC clones
+(`dataSource: {kind: PersistentVolumeClaim}`) need no class of their
+own — the clone's StorageClass just has to match the source volume's
+`replicas` and `pool` ([Quickstart → Clone a
+PVC](quickstart.md#clone-a-pvc)).
+VolumeGroupSnapshotClasses take exactly the same two fields as a
+VolumeSnapshotClass, but the feature is off by default: it needs
+`groupSnapshots.enabled: true` in the chart plus the cluster-side
+group snapshot CRDs and feature gate —
 [Quickstart → Group snapshots](quickstart.md#group-snapshots) lists
 all three switches.
 
@@ -78,7 +83,7 @@ Each ZFS pool can tune properties for newly created zvols:
   `128K` (canonical spelling, uppercase `K`). It defaults to `4K`.
   OpenZFS requires `volsize` alignment, so miroir rounds new volume
   sizes up to this boundary. Expansion follows the existing zvol's
-  actual block size, including for snapshot clones.
+  actual block size, including for snapshot restores and PVC clones.
 - `zfs.compression` defaults to `lz4`. Set it to `inherit` to omit a
   per-zvol property and use the parent dataset policy. It also accepts
   OpenZFS `on`, `off`, `lzjb`, `zle`, `gzip` levels, `zstd` levels, and
@@ -99,8 +104,8 @@ spec:
 ```
 
 These settings apply only when miroir creates a zvol. Reconciliation does
-not mutate existing volumes, and restored snapshot clones retain their
-source properties.
+not mutate existing volumes, and snapshot restores and PVC clones retain
+their source volume's properties.
 
 ## The complete values.yaml
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,9 @@ current data.
 - You're on 2-3 nodes and either have a spare disk per node (LVM), a
   ZFS pool (ZFS), or a few GB on the root filesystem (loopfile).
 - You want snapshots that actually work for replicated volumes
-  (both legs cut in lockstep, not whichever finishes first), up to
-  crash-consistent group snapshots across several PVCs at once.
+  (both legs cut in lockstep, not whichever finishes first), plus
+  restores, PVC clones, and crash-consistent group snapshots built
+  on them.
 
 ## When _not_ to use it
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -290,6 +290,35 @@ DRBD briefly holds writes (a "write barrier"), so the two snapshots
 are taken at the same instant and are consistent with each other,
 not whichever leg happened to finish first.
 
+### Clone a PVC
+
+Point a new PVC directly at an existing one to copy it without an
+intermediate VolumeSnapshot:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: my-data-copy
+spec:
+    storageClassName: miroir-local
+    dataSource:
+        name: my-data
+        kind: PersistentVolumeClaim
+    accessModes: [ReadWriteOnce]
+    resources:
+        requests:
+            storage: 10Gi
+```
+
+Under the hood miroir cuts a hidden snapshot of the source volume
+(same write barrier as above) and restores from it, so the clone is
+a cheap copy-on-write copy that lands on the same nodes and pool as
+the source. That brings the same rules as a snapshot restore: the
+clone's StorageClass must ask for the source's replica count and
+pool, and its size must be at least the source's. The hidden
+snapshot is cleaned up when the clone is deleted.
+
 ### Group snapshots
 
 Snapshot several PVCs as one crash-consistent set (a database and

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -60,6 +60,14 @@ const (
 	// default pool (v1alpha1.DefaultPoolName).
 	ParamPool = "miroir.home-operations.com/pool"
 
+	// CloneSnapshotPrefix names the internal MiroirSnapshot that
+	// CreateVolume cuts on the source volume to serve a volume-clone
+	// content source (clone-<cloneVolumeID>). The prefix is reserved —
+	// CreateSnapshot refuses it and ListSnapshots hides it — so
+	// DeleteVolume can delete the clone's source snapshot blindly by
+	// name without ever touching a user snapshot.
+	CloneSnapshotPrefix = "clone-"
+
 	// LabelPVCName and LabelPVCNamespace record on a MiroirVolume the PVC
 	// it was provisioned for: CreateVolume stamps them from the
 	// provisioner's --extra-create-metadata parameters, the membership

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -868,6 +868,29 @@ func contentSourceIDs(req *csi.CreateVolumeRequest) (snapID, cloneVolID string, 
 // match the source must fail without freezing the source volume for a
 // snapshot round it would then leak.
 func (c *Controller) ensureCloneSnapshot(ctx context.Context, srcVolID, cloneVolID string, sizeBytes int64, replicas int, pool string) (string, error) {
+	snapName := constants.CloneSnapshotPrefix + cloneVolID
+	// A taken volume name that is not this clone can only end in
+	// handleCreateErr's AlreadyExists — refuse it BEFORE the cut, or the
+	// doomed request freezes the source for a snapshot round and leaks
+	// its result until the name's owner (or the source) is deleted. A
+	// name owned by this same clone proceeds: that is the idempotent
+	// retry, and any other parameter mismatch still surfaces through
+	// handleCreateErr exactly as before.
+	existing := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(ctx, types.NamespacedName{Name: cloneVolID}, existing); err == nil {
+		if existing.Spec.Source == nil || existing.Spec.Source.SnapshotName != snapName {
+			existingSource := ""
+			if existing.Spec.Source != nil {
+				existingSource = existing.Spec.Source.SnapshotName
+			}
+			return "", status.Errorf(codes.AlreadyExists,
+				"volume %s exists with source %q (requested a clone of volume %s)",
+				cloneVolID, existingSource, srcVolID)
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return "", status.Errorf(codes.Internal, "get existing volume: %v", err)
+	}
+
 	srcVol := &miroirv1alpha1.MiroirVolume{}
 	if err := c.Client.Get(ctx, types.NamespacedName{Name: srcVolID}, srcVol); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -890,7 +913,6 @@ func (c *Controller) ensureCloneSnapshot(ctx context.Context, srcVolID, cloneVol
 				src, pool)
 		}
 	}
-	snapName := constants.CloneSnapshotPrefix + cloneVolID
 	if _, err := c.ensureSnapshot(ctx, snapName, srcVol, true); err != nil {
 		return "", err
 	}

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -318,17 +318,42 @@ func (c *Controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return nil, status.Errorf(codes.Internal, "delete MiroirVolume: %v", err)
 	}
 	// A clone's internal source snapshot dies with the clone. Its name is
-	// deterministic and the prefix reserved, so the blind delete touches
-	// nothing on non-clone volumes and stays idempotent when the volume CR
-	// is already gone. The backends order the teardown themselves (ZFS
-	// defers the snapshot's destruction until the clone zvol goes).
-	cloneSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + req.GetVolumeId()},
-	}
-	if err := c.Client.Delete(ctx, cloneSnap); err != nil && !apierrors.IsNotFound(err) {
-		return nil, status.Errorf(codes.Internal, "delete clone-source MiroirSnapshot: %v", err)
+	// deterministic, so no volume read is needed even on an idempotent
+	// retry whose volume CR is already gone; the ownership guard keeps a
+	// legacy user snapshot that merely wears the prefix (created before
+	// the reservation) out of reach. The backends order the on-disk
+	// teardown themselves (ZFS defers the snapshot's destruction until
+	// the clone zvol goes).
+	cloneSnap := &miroirv1alpha1.MiroirSnapshot{}
+	err := c.Client.Get(ctx, types.NamespacedName{Name: constants.CloneSnapshotPrefix + req.GetVolumeId()}, cloneSnap)
+	switch {
+	case apierrors.IsNotFound(err):
+	case err != nil:
+		return nil, status.Errorf(codes.Internal, "get clone-source MiroirSnapshot: %v", err)
+	case isCloneSourceSnapshot(cloneSnap):
+		if err := c.Client.Delete(ctx, cloneSnap); err != nil && !apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.Internal, "delete clone-source MiroirSnapshot: %v", err)
+		}
 	}
 	return &csi.DeleteVolumeResponse{}, nil
+}
+
+// isCloneSourceSnapshot reports whether the snapshot is an internal
+// clone-source snapshot: the reserved name prefix AND the MiroirVolume
+// owner reference stamped at creation. The prefix alone is not proof —
+// a user snapshot named clone-<x> can predate the prefix reservation,
+// and treating it as internal would delete or hide user data.
+func isCloneSourceSnapshot(snap *miroirv1alpha1.MiroirSnapshot) bool {
+	if !strings.HasPrefix(snap.Name, constants.CloneSnapshotPrefix) {
+		return false
+	}
+	for _, ref := range snap.OwnerReferences {
+		if ref.Kind == "MiroirVolume" &&
+			strings.HasPrefix(ref.APIVersion, miroirv1alpha1.GroupVersion.Group) {
+			return true
+		}
+	}
+	return false
 }
 
 // ValidateVolumeCapabilities confirms RWO/RWOP mount and block support.
@@ -1160,6 +1185,13 @@ func (c *Controller) ensureSnapshot(ctx context.Context, name string, vol *miroi
 			return nil, status.Errorf(codes.AlreadyExists,
 				"snapshot %s exists for volume %s", name, existing.Spec.VolumeName)
 		}
+		if owned && !isCloneSourceSnapshot(existing) {
+			// A pre-reservation user snapshot occupying the reserved name:
+			// adopting it would clone whatever it captured back then
+			// instead of cutting fresh source data.
+			return nil, status.Errorf(codes.AlreadyExists,
+				"snapshot %s exists and is not an internal clone-source snapshot", name)
+		}
 		snap = existing
 	}
 	return snap, nil
@@ -1201,8 +1233,9 @@ func (c *Controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRe
 		s := &snaps.Items[i]
 		// Internal clone-source snapshots are an implementation detail of
 		// volume clones; listing them would invite the snapshotter to
-		// adopt objects whose lifecycle DeleteVolume owns.
-		if strings.HasPrefix(s.Name, constants.CloneSnapshotPrefix) {
+		// adopt objects whose lifecycle DeleteVolume owns. Legacy user
+		// snapshots that merely wear the prefix stay listed.
+		if isCloneSourceSnapshot(s) {
 			continue
 		}
 		if req.GetSnapshotId() != "" && s.Name != req.GetSnapshotId() {

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -942,7 +942,7 @@ func (c *Controller) ensureCloneSnapshot(ctx context.Context, srcVolID, cloneVol
 				src, pool)
 		}
 	}
-	if _, err := c.ensureSnapshot(ctx, snapName, srcVol, true); err != nil {
+	if _, err := c.ensureSnapshot(ctx, snapName, srcVol, "", true); err != nil {
 		return "", err
 	}
 	if err := c.waitSnapshotReady(ctx, snapName); err != nil {
@@ -1146,7 +1146,7 @@ func (c *Controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 		}
 		return nil, status.Errorf(codes.Internal, "get volume: %v", err)
 	}
-	snap, err := c.ensureSnapshot(ctx, req.GetName(), vol, false)
+	snap, err := c.ensureSnapshot(ctx, req.GetName(), vol, "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -1158,15 +1158,17 @@ func (c *Controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 
 // ensureSnapshot creates a MiroirSnapshot of vol, idempotent by name:
 // AlreadyExists resolves to the existing object when it captures the
-// same volume and is a terminal error otherwise. owned marks an
-// internal clone-source snapshot: it must not outlive its source
-// volume, and an abandoned provisioning (PVC deleted before
-// CreateVolume ever succeeded) never reaches DeleteVolume's cleanup —
-// the owner reference has garbage collection reap it with the source.
-func (c *Controller) ensureSnapshot(ctx context.Context, name string, vol *miroirv1alpha1.MiroirVolume, owned bool) (*miroirv1alpha1.MiroirSnapshot, error) {
+// same volume in the same group ("" for standalone snapshots) and is a
+// terminal error otherwise. group names the MiroirSnapshotGroup whose
+// round cuts a member. owned marks an internal clone-source snapshot:
+// it must not outlive its source volume, and an abandoned provisioning
+// (PVC deleted before CreateVolume ever succeeded) never reaches
+// DeleteVolume's cleanup — the owner reference has garbage collection
+// reap it with the source.
+func (c *Controller) ensureSnapshot(ctx context.Context, name string, vol *miroirv1alpha1.MiroirVolume, group string, owned bool) (*miroirv1alpha1.MiroirSnapshot, error) {
 	snap := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: vol.Name},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: vol.Name, Group: group},
 	}
 	if owned {
 		snap.OwnerReferences = []metav1.OwnerReference{
@@ -1177,6 +1179,12 @@ func (c *Controller) ensureSnapshot(ctx context.Context, name string, vol *miroi
 		snap.Finalizers = append(snap.Finalizers, constants.FinalizerPrefix+rep.Node)
 	}
 	if err := c.Client.Create(ctx, snap); err != nil {
+		if apierrors.IsInvalid(err) {
+			// A name the API server rejects (e.g. a derived group member
+			// name exceeding the 253-char cap) can never succeed;
+			// Internal would have the sidecar retry the refusal forever.
+			return nil, status.Errorf(codes.InvalidArgument, "create MiroirSnapshot: %v", err)
+		}
 		if !apierrors.IsAlreadyExists(err) {
 			return nil, status.Errorf(codes.Internal, "create MiroirSnapshot: %v", err)
 		}
@@ -1185,9 +1193,9 @@ func (c *Controller) ensureSnapshot(ctx context.Context, name string, vol *miroi
 			// Cache may lag the just-created object; retryable, not terminal.
 			return nil, status.Errorf(codes.Unavailable, "get existing snapshot: %v", err)
 		}
-		if existing.Spec.VolumeName != vol.Name {
+		if existing.Spec.VolumeName != vol.Name || existing.Spec.Group != group {
 			return nil, status.Errorf(codes.AlreadyExists,
-				"snapshot %s exists for volume %s", name, existing.Spec.VolumeName)
+				"snapshot %s exists for volume %s in group %q", name, existing.Spec.VolumeName, existing.Spec.Group)
 		}
 		if owned && !isCloneSourceSnapshot(existing) {
 			// A pre-reservation user snapshot occupying the reserved name:

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -116,6 +117,7 @@ const (
 func (c *Controller) ControllerGetCapabilities(_ context.Context, _ *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
 	caps := []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
 		csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
@@ -169,7 +171,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 
-	snapID, err := snapshotSourceID(req)
+	snapID, cloneSrc, err := c.resolveContentSource(ctx, req, sizeBytes, replicas, params.pool)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +272,29 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 
-	var contentSource *csi.VolumeContentSource
+	return &csi.CreateVolumeResponse{
+		Volume: &csi.Volume{
+			VolumeId:           vol.Name,
+			CapacityBytes:      sizeBytes,
+			AccessibleTopology: accessibleTopology(vol),
+			ContentSource:      responseContentSource(cloneSrc, source),
+		},
+	}, nil
+}
+
+// responseContentSource echoes the request's content source: the source
+// volume for a clone (its internal snapshot is an implementation
+// detail), else the snapshot the volume was restored from, else nil.
+func responseContentSource(cloneSrc string, source *miroirv1alpha1.VolumeSource) *csi.VolumeContentSource {
+	if cloneSrc != "" {
+		return &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: cloneSrc},
+			},
+		}
+	}
 	if source != nil && source.SnapshotName != "" {
-		contentSource = &csi.VolumeContentSource{
+		return &csi.VolumeContentSource{
 			Type: &csi.VolumeContentSource_Snapshot{
 				Snapshot: &csi.VolumeContentSource_SnapshotSource{
 					SnapshotId: source.SnapshotName,
@@ -280,14 +302,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			},
 		}
 	}
-	return &csi.CreateVolumeResponse{
-		Volume: &csi.Volume{
-			VolumeId:           vol.Name,
-			CapacityBytes:      sizeBytes,
-			AccessibleTopology: accessibleTopology(vol),
-			ContentSource:      contentSource,
-		},
-	}, nil
+	return nil
 }
 
 // DeleteVolume removes the MiroirVolume; agents tear down local state via
@@ -301,6 +316,17 @@ func (c *Controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	}
 	if err := c.Client.Delete(ctx, vol); err != nil && !apierrors.IsNotFound(err) {
 		return nil, status.Errorf(codes.Internal, "delete MiroirVolume: %v", err)
+	}
+	// A clone's internal source snapshot dies with the clone. Its name is
+	// deterministic and the prefix reserved, so the blind delete touches
+	// nothing on non-clone volumes and stays idempotent when the volume CR
+	// is already gone. The backends order the teardown themselves (ZFS
+	// defers the snapshot's destruction until the clone zvol goes).
+	cloneSnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + req.GetVolumeId()},
+	}
+	if err := c.Client.Delete(ctx, cloneSnap); err != nil && !apierrors.IsNotFound(err) {
+		return nil, status.Errorf(codes.Internal, "delete clone-source MiroirSnapshot: %v", err)
 	}
 	return &csi.DeleteVolumeResponse{}, nil
 }
@@ -795,17 +821,104 @@ func (c *Controller) handleCreateErr(ctx context.Context, err error, vol *miroir
 	return nil
 }
 
-// snapshotSourceID extracts the snapshot id from the request's content
-// source ("" when none), refusing the unimplemented volume-clone type:
-// only snapshot sources are advertised, and falling through would
-// provision a blank volume under a clone's name — then block a corrected
-// retry on AlreadyExists.
-func snapshotSourceID(req *csi.CreateVolumeRequest) (string, error) {
-	if src := req.GetVolumeContentSource(); src != nil && src.GetSnapshot() == nil {
-		return "", status.Error(codes.InvalidArgument,
-			"unsupported volume content source: only snapshot sources are supported")
+// resolveContentSource maps the request's content source onto the
+// snapshot the volume restores from: the named snapshot as-is, or for a
+// volume clone the internal snapshot this call cuts on the source
+// volume (waiting until every leg holds it). cloneSrc is the clone's
+// source volume id, "" for snapshot and blank sources.
+func (c *Controller) resolveContentSource(ctx context.Context, req *csi.CreateVolumeRequest, sizeBytes int64, replicas int, pool string) (snapID, cloneSrc string, err error) {
+	snapID, cloneSrc, err = contentSourceIDs(req)
+	if err != nil || cloneSrc == "" {
+		return snapID, cloneSrc, err
 	}
-	return req.GetVolumeContentSource().GetSnapshot().GetSnapshotId(), nil
+	snapID, err = c.ensureCloneSnapshot(ctx, cloneSrc, req.GetName(), sizeBytes, replicas, pool)
+	return snapID, cloneSrc, err
+}
+
+// contentSourceIDs extracts the request's content source ids. An empty
+// id or an unrecognized source type is refused: falling through would
+// provision a blank volume under the requested name and then block a
+// corrected retry on AlreadyExists.
+func contentSourceIDs(req *csi.CreateVolumeRequest) (snapID, cloneVolID string, err error) {
+	switch src := req.GetVolumeContentSource(); {
+	case src == nil:
+		return "", "", nil
+	case src.GetSnapshot() != nil:
+		if src.GetSnapshot().GetSnapshotId() == "" {
+			return "", "", status.Error(codes.InvalidArgument, "snapshot content source needs a snapshot id")
+		}
+		return src.GetSnapshot().GetSnapshotId(), "", nil
+	case src.GetVolume() != nil:
+		if src.GetVolume().GetVolumeId() == "" {
+			return "", "", status.Error(codes.InvalidArgument, "volume content source needs a volume id")
+		}
+		return "", src.GetVolume().GetVolumeId(), nil
+	default:
+		return "", "", status.Error(codes.InvalidArgument,
+			"unsupported volume content source: only snapshot and volume sources are supported")
+	}
+}
+
+// ensureCloneSnapshot realizes a volume-clone content source as an
+// internal snapshot of the source volume, so the clone rides the whole
+// snapshot-restore path (local CoW clone per leg, placement following
+// the source). The name is deterministic (clone-<cloneVolumeID>): retries
+// converge on one snapshot and DeleteVolume cleans it up by name alone.
+// The shape checks run before the cut — a clone whose class can never
+// match the source must fail without freezing the source volume for a
+// snapshot round it would then leak.
+func (c *Controller) ensureCloneSnapshot(ctx context.Context, srcVolID, cloneVolID string, sizeBytes int64, replicas int, pool string) (string, error) {
+	srcVol := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(ctx, types.NamespacedName{Name: srcVolID}, srcVol); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", status.Errorf(codes.NotFound, "clone source volume %s not found", srcVolID)
+		}
+		return "", status.Errorf(codes.Internal, "get clone source volume: %v", err)
+	}
+	if sizeBytes < srcVol.Spec.SizeBytes {
+		return "", status.Errorf(codes.InvalidArgument,
+			"requested %d below clone source volume size %d", sizeBytes, srcVol.Spec.SizeBytes)
+	}
+	if got := len(srcVol.Spec.DiskfulReplicas()); got != replicas {
+		return "", status.Errorf(codes.InvalidArgument,
+			"clone replica count %d must match source diskful replicas %d", replicas, got)
+	}
+	for _, rep := range srcVol.Spec.DiskfulReplicas() {
+		if src := nodemap.PoolOrDefault(rep.Pool); src != pool {
+			return "", status.Errorf(codes.InvalidArgument,
+				"clone must stay in the source volume's pool %q (CoW clones cannot cross pools); the class requests pool %q",
+				src, pool)
+		}
+	}
+	snapName := constants.CloneSnapshotPrefix + cloneVolID
+	if _, err := c.ensureSnapshot(ctx, snapName, srcVol, true); err != nil {
+		return "", err
+	}
+	if err := c.waitSnapshotReady(ctx, snapName); err != nil {
+		return "", err
+	}
+	return snapName, nil
+}
+
+// waitSnapshotReady blocks until the clone-source snapshot is cut on
+// every leg. DeadlineExceeded keeps the provisioner retrying: the
+// snapshot round continues in the background and the retry finds it
+// ready (or still converging).
+func (c *Controller) waitSnapshotReady(ctx context.Context, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, cmp.Or(c.ProvisionTimeout, defaultProvisionTimeout))
+	defer cancel()
+	err := wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true,
+		func(ctx context.Context) (bool, error) {
+			snap := &miroirv1alpha1.MiroirSnapshot{}
+			if err := c.Client.Get(ctx, types.NamespacedName{Name: name}, snap); err != nil {
+				return false, client.IgnoreNotFound(err) // cache lag → retry
+			}
+			return snap.Status.ReadyToUse, nil
+		})
+	if err != nil {
+		return status.Errorf(codes.DeadlineExceeded, "clone-source snapshot %s not ready: %v", name, err)
+	}
+	return nil
 }
 
 // expandWithinHeadroom applies CreateVolume's capacity guardrails to a
@@ -969,6 +1082,12 @@ func (c *Controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 	if req.GetName() == "" || req.GetSourceVolumeId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "snapshot name and source volume are required")
 	}
+	if strings.HasPrefix(req.GetName(), constants.CloneSnapshotPrefix) {
+		// Reserved so DeleteVolume's blind clone-<volumeID> delete can
+		// never hit a user snapshot.
+		return nil, status.Errorf(codes.InvalidArgument,
+			"snapshot name prefix %q is reserved for clone-source snapshots", constants.CloneSnapshotPrefix)
+	}
 	vol := &miroirv1alpha1.MiroirVolume{}
 	if err := c.Client.Get(ctx, types.NamespacedName{Name: req.GetSourceVolumeId()}, vol); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -976,10 +1095,32 @@ func (c *Controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 		}
 		return nil, status.Errorf(codes.Internal, "get volume: %v", err)
 	}
+	snap, err := c.ensureSnapshot(ctx, req.GetName(), vol, false)
+	if err != nil {
+		return nil, err
+	}
+	// Report the size captured at snapshot time once known; the live
+	// volume may have been expanded since.
+	size := cmp.Or(snap.Status.SizeBytes, vol.Spec.SizeBytes)
+	return &csi.CreateSnapshotResponse{Snapshot: csiSnapshot(snap, size)}, nil
+}
 
+// ensureSnapshot creates a MiroirSnapshot of vol, idempotent by name:
+// AlreadyExists resolves to the existing object when it captures the
+// same volume and is a terminal error otherwise. owned marks an
+// internal clone-source snapshot: it must not outlive its source
+// volume, and an abandoned provisioning (PVC deleted before
+// CreateVolume ever succeeded) never reaches DeleteVolume's cleanup —
+// the owner reference has garbage collection reap it with the source.
+func (c *Controller) ensureSnapshot(ctx context.Context, name string, vol *miroirv1alpha1.MiroirVolume, owned bool) (*miroirv1alpha1.MiroirSnapshot, error) {
 	snap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: req.GetName()},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: req.GetSourceVolumeId()},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: vol.Name},
+	}
+	if owned {
+		snap.OwnerReferences = []metav1.OwnerReference{
+			*metav1.NewControllerRef(vol, miroirv1alpha1.GroupVersion.WithKind("MiroirVolume")),
+		}
 	}
 	for _, rep := range vol.Spec.Replicas {
 		snap.Finalizers = append(snap.Finalizers, constants.FinalizerPrefix+rep.Node)
@@ -989,20 +1130,17 @@ func (c *Controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 			return nil, status.Errorf(codes.Internal, "create MiroirSnapshot: %v", err)
 		}
 		existing := &miroirv1alpha1.MiroirSnapshot{}
-		if err := c.reader().Get(ctx, types.NamespacedName{Name: req.GetName()}, existing); err != nil {
+		if err := c.reader().Get(ctx, types.NamespacedName{Name: name}, existing); err != nil {
 			// Cache may lag the just-created object; retryable, not terminal.
 			return nil, status.Errorf(codes.Unavailable, "get existing snapshot: %v", err)
 		}
-		if existing.Spec.VolumeName != req.GetSourceVolumeId() {
+		if existing.Spec.VolumeName != vol.Name {
 			return nil, status.Errorf(codes.AlreadyExists,
-				"snapshot %s exists for volume %s", req.GetName(), existing.Spec.VolumeName)
+				"snapshot %s exists for volume %s", name, existing.Spec.VolumeName)
 		}
 		snap = existing
 	}
-	// Report the size captured at snapshot time once known; the live
-	// volume may have been expanded since.
-	size := cmp.Or(snap.Status.SizeBytes, vol.Spec.SizeBytes)
-	return &csi.CreateSnapshotResponse{Snapshot: csiSnapshot(snap, size)}, nil
+	return snap, nil
 }
 
 // DeleteSnapshot removes the MiroirSnapshot; agents drop the backend
@@ -1039,6 +1177,12 @@ func (c *Controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRe
 	resp := &csi.ListSnapshotsResponse{}
 	for i := range snaps.Items {
 		s := &snaps.Items[i]
+		// Internal clone-source snapshots are an implementation detail of
+		// volume clones; listing them would invite the snapshotter to
+		// adopt objects whose lifecycle DeleteVolume owns.
+		if strings.HasPrefix(s.Name, constants.CloneSnapshotPrefix) {
+			continue
+		}
 		if req.GetSnapshotId() != "" && s.Name != req.GetSnapshotId() {
 			continue
 		}

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -338,6 +338,10 @@ func (c *Controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	return &csi.DeleteVolumeResponse{}, nil
 }
 
+// volumeKind is the owner-reference kind stamped on internal
+// clone-source snapshots.
+const volumeKind = "MiroirVolume"
+
 // isCloneSourceSnapshot reports whether the snapshot is an internal
 // clone-source snapshot: the reserved name prefix AND the MiroirVolume
 // owner reference stamped at creation. The prefix alone is not proof —
@@ -348,7 +352,7 @@ func isCloneSourceSnapshot(snap *miroirv1alpha1.MiroirSnapshot) bool {
 		return false
 	}
 	for _, ref := range snap.OwnerReferences {
-		if ref.Kind == "MiroirVolume" &&
+		if ref.Kind == volumeKind &&
 			strings.HasPrefix(ref.APIVersion, miroirv1alpha1.GroupVersion.Group) {
 			return true
 		}
@@ -1166,7 +1170,7 @@ func (c *Controller) ensureSnapshot(ctx context.Context, name string, vol *miroi
 	}
 	if owned {
 		snap.OwnerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(vol, miroirv1alpha1.GroupVersion.WithKind("MiroirVolume")),
+			*metav1.NewControllerRef(vol, miroirv1alpha1.GroupVersion.WithKind(volumeKind)),
 		}
 	}
 	for _, rep := range vol.Spec.Replicas {

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1869,3 +1869,48 @@ func TestListSnapshotsHidesCloneSourceSnapshots(t *testing.T) {
 		t.Fatalf("internal clone-source snapshots must stay hidden: %+v", resp.Entries)
 	}
 }
+
+// A clone whose volume name is already taken by something that is not
+// this clone can only end in AlreadyExists — it must be refused before
+// the cut, or the doomed request freezes the source for a snapshot
+// round and leaks its result.
+func TestCreateVolumeCloneNameCollisionCutsNothing(t *testing.T) {
+	s := newScheme(t)
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
+		},
+	}
+	taken := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volNew},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
+		},
+	}
+	cl := cloneReadyClient(s, srcVol, taken)
+	c := &Controller{Client: cl, Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volNew,
+		VolumeCapabilities: volCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: volSrc},
+			},
+		},
+	})
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("a taken non-clone name must be AlreadyExists, got %v", err)
+	}
+	snaps := &miroirv1alpha1.MiroirSnapshotList{}
+	if err := cl.List(t.Context(), snaps); err != nil {
+		t.Fatal(err)
+	}
+	if len(snaps.Items) != 0 {
+		t.Fatalf("the refused clone must not cut a snapshot: %+v", snaps.Items)
+	}
+}

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -60,6 +60,10 @@ const (
 	volSrc     = "pvc-src"
 	volNew     = "pvc-new"
 	snapSnap1  = "snap-1"
+	// Replica addresses captured at the source volume's creation; the
+	// restore path re-resolves them against the live Nodes.
+	staleAddrA = "10.0.0.1"
+	staleAddrB = "10.0.0.2"
 )
 
 func newScheme(t *testing.T) *runtime.Scheme {
@@ -741,9 +745,9 @@ func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
 			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "10.0.0.1"},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
 				// node-b joined after creation: FullSync stuck in the spec.
-				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "10.0.0.2", FullSync: true},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: staleAddrB, FullSync: true},
 			},
 		},
 	}
@@ -923,8 +927,8 @@ func TestCreateVolumeFromSnapshotFullSyncsPostSnapshotReplica(t *testing.T) {
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
 			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
 			Replicas: []miroirv1alpha1.Replica{
-				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: "10.0.0.1"},
-				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: "10.0.0.2"},
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: staleAddrB},
 			},
 		},
 	}
@@ -1457,24 +1461,6 @@ func TestControllerExpandAdmitsWithoutStats(t *testing.T) {
 
 // A Volume-type content source (PVC clone) is not implemented; silently
 // ignoring it would provision a blank volume under a clone's name.
-func TestCreateVolumeRejectsVolumeContentSource(t *testing.T) {
-	s := newScheme(t)
-	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
-
-	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
-		Name:               volPvc1,
-		VolumeCapabilities: volCaps(),
-		VolumeContentSource: &csi.VolumeContentSource{
-			Type: &csi.VolumeContentSource_Volume{
-				Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: "pvc-0"},
-			},
-		},
-	})
-	if status.Code(err) != codes.InvalidArgument {
-		t.Fatalf("a volume content source must be InvalidArgument, got %v", err)
-	}
-}
-
 // CreateSnapshot idempotency: a same-name retry with the same source
 // returns the existing snapshot; the same name for a different source is
 // AlreadyExists.
@@ -1606,5 +1592,280 @@ func TestCreateVolumeStampsPVCRefLabels(t *testing.T) {
 	}
 	if len(vol.Labels) != 0 {
 		t.Fatalf("volume without PVC metadata must stay unlabeled: %v", vol.Labels)
+	}
+}
+
+// cloneReadyClient simulates the agents for the clone path: volumes flip
+// Ready and snapshots flip ReadyToUse (every diskful leg Done, size and
+// formatted flag captured from the source volume) on Get.
+func cloneReadyClient(s *runtime.Scheme, objs ...client.Object) client.WithWatch {
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}, &miroirv1alpha1.MiroirSnapshot{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				switch o := obj.(type) {
+				case *miroirv1alpha1.MiroirVolume:
+					o.Status.Phase = miroirv1alpha1.VolumeReady
+				case *miroirv1alpha1.MiroirSnapshot:
+					vol := &miroirv1alpha1.MiroirVolume{}
+					if err := c.Get(ctx, client.ObjectKey{Name: o.Spec.VolumeName}, vol); err != nil {
+						return nil //nolint:nilerr // volume gone: leave the snapshot untouched
+					}
+					o.Status.ReadyToUse = true
+					o.Status.SizeBytes = vol.Spec.SizeBytes
+					o.Status.SourceFormatted = vol.Status.Formatted
+					if o.Status.PerNode == nil {
+						o.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{}
+					}
+					for _, rep := range vol.Spec.DiskfulReplicas() {
+						o.Status.PerNode[rep.Node] = miroirv1alpha1.SnapshotDone
+					}
+				}
+				return nil
+			},
+		}).
+		Build()
+}
+
+// A volume content source rides the snapshot-restore path through an
+// internal clone-source snapshot: deterministic name, owner reference to
+// the source volume, and a response echoing the volume source.
+func TestCreateVolumeCloneCutsInternalSnapshot(t *testing.T) {
+	s := newScheme(t)
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendZFS, NodeID: 1, Address: staleAddrB},
+			},
+		},
+	}
+	cl := cloneReadyClient(s, srcVol, nodeObj(nodeA, addrA), nodeObj(nodeB, addrB))
+	c := &Controller{Client: cl, Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volNew,
+		VolumeCapabilities: volCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+		Parameters:         map[string]string{constants.ParamReplicas: "2"},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: volSrc},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := resp.Volume.ContentSource.GetVolume().GetVolumeId(); got != volSrc {
+		t.Fatalf("response must echo the volume content source, got %+v", resp.Volume.ContentSource)
+	}
+
+	snapName := constants.CloneSnapshotPrefix + volNew
+	snap := &miroirv1alpha1.MiroirSnapshot{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: snapName}, snap); err != nil {
+		t.Fatal(err)
+	}
+	if snap.Spec.VolumeName != volSrc {
+		t.Fatalf("internal snapshot must capture the source volume, got %q", snap.Spec.VolumeName)
+	}
+	if len(snap.OwnerReferences) != 1 || snap.OwnerReferences[0].Name != volSrc ||
+		snap.OwnerReferences[0].Kind != "MiroirVolume" {
+		t.Fatalf("internal snapshot must be owned by the source volume: %+v", snap.OwnerReferences)
+	}
+
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: volNew}, vol); err != nil {
+		t.Fatal(err)
+	}
+	if vol.Spec.Source == nil || vol.Spec.Source.SnapshotName != snapName {
+		t.Fatalf("clone must restore from the internal snapshot: %+v", vol.Spec.Source)
+	}
+	nodes := map[string]bool{}
+	for _, rep := range vol.Spec.Replicas {
+		nodes[rep.Node] = true
+		if rep.FullSync {
+			t.Fatalf("clone legs restore from local snapshots, not FullSync: %+v", rep)
+		}
+	}
+	if !nodes[nodeA] || !nodes[nodeB] {
+		t.Fatalf("clone placement must follow the source, got %+v", vol.Spec.Replicas)
+	}
+}
+
+func TestCreateVolumeCloneIdempotent(t *testing.T) {
+	s := newScheme(t)
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
+		},
+	}
+	c := &Controller{Client: cloneReadyClient(s, srcVol), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+	req := &csi.CreateVolumeRequest{
+		Name:               volNew,
+		VolumeCapabilities: volCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: volSrc},
+			},
+		},
+	}
+
+	if _, err := c.CreateVolume(t.Context(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.CreateVolume(t.Context(), req); err != nil {
+		t.Fatalf("identical clone retry must succeed: %v", err)
+	}
+}
+
+// The clone shape checks run before anything is cut: a class that can
+// never match the source must not leave an internal snapshot behind.
+func TestCreateVolumeCloneShapeChecksRunBeforeCut(t *testing.T) {
+	s := newScheme(t)
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
+		},
+	}
+
+	cases := []struct {
+		name   string
+		source string
+		size   int64
+		params map[string]string
+		want   codes.Code
+	}{
+		{name: "replica count mismatch", source: volSrc, size: 5 << 30,
+			params: map[string]string{constants.ParamReplicas: "2"}, want: codes.InvalidArgument},
+		{name: "smaller than source", source: volSrc, size: 1 << 30, want: codes.InvalidArgument},
+		{name: "cross pool", source: volSrc, size: 5 << 30,
+			params: map[string]string{constants.ParamPool: poolFast}, want: codes.InvalidArgument},
+		{name: "missing source volume", source: "pvc-missing", size: 5 << 30, want: codes.NotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := cloneReadyClient(s, srcVol.DeepCopy())
+			c := &Controller{Client: cl, Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+			_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+				Name:               volNew,
+				VolumeCapabilities: volCaps(),
+				CapacityRange:      &csi.CapacityRange{RequiredBytes: tc.size},
+				Parameters:         tc.params,
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Volume{
+						Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: tc.source},
+					},
+				},
+			})
+			if status.Code(err) != tc.want {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+			snaps := &miroirv1alpha1.MiroirSnapshotList{}
+			if err := cl.List(t.Context(), snaps); err != nil {
+				t.Fatal(err)
+			}
+			if len(snaps.Items) != 0 {
+				t.Fatalf("a refused clone must not cut a snapshot: %+v", snaps.Items)
+			}
+		})
+	}
+}
+
+func TestCreateVolumeRejectsEmptyVolumeSourceID(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: volCaps(),
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{},
+			},
+		},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("an empty volume source id must be InvalidArgument, got %v", err)
+	}
+}
+
+// DeleteVolume of a clone also deletes its internal source snapshot; a
+// non-clone volume's delete leaves user snapshots alone.
+func TestDeleteVolumeCleansCloneSourceSnapshot(t *testing.T) {
+	s := newScheme(t)
+	vol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volNew},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Source:    &miroirv1alpha1.VolumeSource{SnapshotName: constants.CloneSnapshotPrefix + volNew},
+		},
+	}
+	cloneSnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + volNew},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+	}
+	userSnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volNew},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(vol, cloneSnap, userSnap).Build()
+	c := &Controller{Client: cl}
+
+	if _, err := c.DeleteVolume(t.Context(), &csi.DeleteVolumeRequest{VolumeId: volNew}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: cloneSnap.Name}, &miroirv1alpha1.MiroirSnapshot{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("the internal clone-source snapshot must die with the clone: %v", err)
+	}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, &miroirv1alpha1.MiroirSnapshot{}); err != nil {
+		t.Fatalf("user snapshots must survive the volume delete: %v", err)
+	}
+}
+
+func TestCreateSnapshotRejectsReservedPrefix(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).Build()}
+
+	_, err := c.CreateSnapshot(t.Context(), &csi.CreateSnapshotRequest{
+		Name: constants.CloneSnapshotPrefix + "x", SourceVolumeId: volPvc1,
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("the clone- prefix is reserved, got %v", err)
+	}
+}
+
+func TestListSnapshotsHidesCloneSourceSnapshots(t *testing.T) {
+	s := newScheme(t)
+	userSnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+	}
+	cloneSnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + volNew},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+	}
+	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).WithObjects(userSnap, cloneSnap).Build()}
+
+	resp, err := c.ListSnapshots(t.Context(), &csi.ListSnapshotsRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Entries) != 1 || resp.Entries[0].Snapshot.SnapshotId != snapSnap1 {
+		t.Fatalf("internal clone-source snapshots must stay hidden: %+v", resp.Entries)
 	}
 }

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1679,7 +1679,7 @@ func TestCreateVolumeCloneCutsInternalSnapshot(t *testing.T) {
 		t.Fatalf("internal snapshot must capture the source volume, got %q", snap.Spec.VolumeName)
 	}
 	if len(snap.OwnerReferences) != 1 || snap.OwnerReferences[0].Name != volSrc ||
-		snap.OwnerReferences[0].Kind != "MiroirVolume" {
+		snap.OwnerReferences[0].Kind != volumeKind {
 		t.Fatalf("internal snapshot must be owned by the source volume: %+v", snap.OwnerReferences)
 	}
 
@@ -1936,7 +1936,7 @@ func TestCreateVolumeCloneNameCollisionCutsNothing(t *testing.T) {
 func volumeOwnerRef(volume string) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: miroirv1alpha1.GroupVersion.String(),
-		Kind:       "MiroirVolume",
+		Kind:       volumeKind,
 		Name:       volume,
 		UID:        "uid-" + types.UID(volume),
 	}

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1816,8 +1816,11 @@ func TestDeleteVolumeCleansCloneSourceSnapshot(t *testing.T) {
 		},
 	}
 	cloneSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + volNew},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            constants.CloneSnapshotPrefix + volNew,
+			OwnerReferences: []metav1.OwnerReference{volumeOwnerRef(volSrc)},
+		},
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 	}
 	userSnap := &miroirv1alpha1.MiroirSnapshot{
 		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
@@ -1856,17 +1859,30 @@ func TestListSnapshotsHidesCloneSourceSnapshots(t *testing.T) {
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 	}
 	cloneSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + volNew},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            constants.CloneSnapshotPrefix + volNew,
+			OwnerReferences: []metav1.OwnerReference{volumeOwnerRef(volSrc)},
+		},
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+	}
+	// Named like an internal snapshot but created before the prefix
+	// reservation: no owner reference, so it is the user's.
+	legacySnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + "legacy"},
 		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 	}
-	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).WithObjects(userSnap, cloneSnap).Build()}
+	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).WithObjects(userSnap, cloneSnap, legacySnap).Build()}
 
 	resp, err := c.ListSnapshots(t.Context(), &csi.ListSnapshotsRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(resp.Entries) != 1 || resp.Entries[0].Snapshot.SnapshotId != snapSnap1 {
-		t.Fatalf("internal clone-source snapshots must stay hidden: %+v", resp.Entries)
+	listed := map[string]bool{}
+	for _, e := range resp.Entries {
+		listed[e.Snapshot.SnapshotId] = true
+	}
+	if len(listed) != 2 || !listed[snapSnap1] || !listed[legacySnap.Name] {
+		t.Fatalf("only the owned internal snapshot must stay hidden: %+v", resp.Entries)
 	}
 }
 
@@ -1912,5 +1928,74 @@ func TestCreateVolumeCloneNameCollisionCutsNothing(t *testing.T) {
 	}
 	if len(snaps.Items) != 0 {
 		t.Fatalf("the refused clone must not cut a snapshot: %+v", snaps.Items)
+	}
+}
+
+// volumeOwnerRef is the marker an internal clone-source snapshot wears:
+// the owner reference ensureSnapshot stamps for garbage collection.
+func volumeOwnerRef(volume string) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: miroirv1alpha1.GroupVersion.String(),
+		Kind:       "MiroirVolume",
+		Name:       volume,
+		UID:        "uid-" + types.UID(volume),
+	}
+}
+
+// A user snapshot that merely wears the clone- prefix (created before
+// the reservation) must survive the deletion of a volume whose derived
+// internal name collides with it.
+func TestDeleteVolumeSparesLegacyPrefixedSnapshot(t *testing.T) {
+	s := newScheme(t)
+	vol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volNew},
+		Spec:       miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 5 << 30},
+	}
+	legacySnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + volNew},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(vol, legacySnap).Build()
+	c := &Controller{Client: cl}
+
+	if _, err := c.DeleteVolume(t.Context(), &csi.DeleteVolumeRequest{VolumeId: volNew}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: legacySnap.Name}, &miroirv1alpha1.MiroirSnapshot{}); err != nil {
+		t.Fatalf("a legacy user snapshot wearing the prefix must survive: %v", err)
+	}
+}
+
+// A clone must never adopt a pre-reservation user snapshot occupying its
+// reserved name: it would clone whatever that snapshot captured back
+// then instead of cutting fresh source data.
+func TestCreateVolumeCloneRefusesLegacyPrefixedSnapshot(t *testing.T) {
+	s := newScheme(t)
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
+		},
+	}
+	legacySnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + volNew},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Status:     miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
+	}
+	c := &Controller{Client: cloneReadyClient(s, srcVol, legacySnap), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	_, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volNew,
+		VolumeCapabilities: volCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: volSrc},
+			},
+		},
+	})
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("a legacy snapshot on the reserved name must refuse the clone, got %v", err)
 	}
 }

--- a/internal/csi/groupcontroller.go
+++ b/internal/csi/groupcontroller.go
@@ -95,7 +95,7 @@ func (c *Controller) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.Cre
 
 	snaps := make([]*miroirv1alpha1.MiroirSnapshot, 0, len(vols))
 	for i, vol := range vols {
-		snap, err := c.ensureGroupMember(ctx, names[i], req.GetName(), vol)
+		snap, err := c.ensureSnapshot(ctx, names[i], vol, req.GetName(), false)
 		if err != nil {
 			c.cleanupPartialMembers(ctx, req.GetName(), names[:i])
 			return nil, err
@@ -197,41 +197,6 @@ func (c *Controller) cleanupStrayMembers(ctx context.Context, names, owned []str
 			log.Error(err, "cannot delete stray group member snapshot", "snapshot", name)
 		}
 	}
-}
-
-// ensureGroupMember creates one member snapshot (<group>-<volumeID>),
-// idempotent by name like ensureSnapshot but carrying the group
-// reference; grouped members are cut by the group's round, never their
-// own.
-func (c *Controller) ensureGroupMember(ctx context.Context, name, group string, vol *miroirv1alpha1.MiroirVolume) (*miroirv1alpha1.MiroirSnapshot, error) {
-	snap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: vol.Name, Group: group},
-	}
-	for _, rep := range vol.Spec.Replicas {
-		snap.Finalizers = append(snap.Finalizers, constants.FinalizerPrefix+rep.Node)
-	}
-	if err := c.Client.Create(ctx, snap); err != nil {
-		if apierrors.IsInvalid(err) {
-			// A derived name the API server rejects (e.g. group + volume
-			// exceeding the 253-char cap) can never succeed; Internal
-			// would have the snapshotter retry the same refusal forever.
-			return nil, status.Errorf(codes.InvalidArgument, "create member MiroirSnapshot: %v", err)
-		}
-		if !apierrors.IsAlreadyExists(err) {
-			return nil, status.Errorf(codes.Internal, "create member MiroirSnapshot: %v", err)
-		}
-		existing := &miroirv1alpha1.MiroirSnapshot{}
-		if err := c.reader().Get(ctx, types.NamespacedName{Name: name}, existing); err != nil {
-			return nil, status.Errorf(codes.Unavailable, "get existing member snapshot: %v", err)
-		}
-		if existing.Spec.VolumeName != vol.Name || existing.Spec.Group != group {
-			return nil, status.Errorf(codes.AlreadyExists,
-				"snapshot %s exists for volume %s in group %q", name, existing.Spec.VolumeName, existing.Spec.Group)
-		}
-		snap = existing
-	}
-	return snap, nil
 }
 
 // DeleteVolumeGroupSnapshot removes the members and the group; agents

--- a/test/conformance/testdriver-local.yaml
+++ b/test/conformance/testdriver-local.yaml
@@ -22,7 +22,7 @@ DriverInfo:
     onlineExpansion: true
     offlineExpansion: true
     snapshotDataSource: true
-    pvcDataSource: false
+    pvcDataSource: true
     topology: true
     singleNodeVolume: true
     # RWX needs the replicated (DRBD) path; the local driver can't exercise it.

--- a/test/conformance/testdriver.yaml
+++ b/test/conformance/testdriver.yaml
@@ -25,7 +25,7 @@ DriverInfo:
     onlineExpansion: true
     offlineExpansion: true
     snapshotDataSource: true
-    pvcDataSource: false
+    pvcDataSource: true
     topology: true
     singleNodeVolume: false
     # RWX is implemented (NFS gateway over a replicated volume) but the


### PR DESCRIPTION
Closes #269.

Implements the CSI `CLONE_VOLUME` capability (PVC `dataSource: PersistentVolumeClaim`), closing the most user-visible gap in the driver's CSI feature coverage.

## Design

A volume clone is a snapshot restore with the snapshot's lifetime tied to the clone:

- `CreateVolume` with a volume content source cuts a hidden `MiroirSnapshot` named `clone-<cloneVolumeID>` on the source volume, waits for every leg to hold it (same crash-consistent write barrier as user snapshots), then flows into the existing restore path: local CoW clones placed on the source's nodes and pool.
- The **shape checks run before the cut**: a class whose replica count, pool, or size can never match the source fails `InvalidArgument` without freezing the source volume for a snapshot round it would then leak.
- The `clone-` prefix is **reserved**: `CreateSnapshot` refuses it and `ListSnapshots` hides it, so `DeleteVolume` can blind-delete `clone-<volumeID>` idempotently without ever touching a user snapshot.
- The internal snapshot is **owner-referenced to the source volume**, so a provisioning abandoned before first success (the one path that never reaches `DeleteVolume`) is reaped by GC when the source goes.
- No agent or backend changes: ZFS already defers a snapshot's destruction until its last clone dies and promotes clones on source deletion; lvmthin/loopfile snapshots are independent of their clones.

Restore-path semantics (clone must match the source's replica count and pool, size ≥ source) are documented in the quickstart alongside a new clone example.

## Testing

- Unit tests: clone provisioning end-to-end against the fake client (internal snapshot shape, owner ref, placement following source, content-source echo), idempotent retry, all four shape refusals (each asserting no snapshot was cut), `DeleteVolume` cleanup, reserved-prefix refusal, `ListSnapshots` hiding.
- `mise run test`, `test-integration` (envtest), `lint`, `docs` all green.
- Conformance testdrivers now declare `pvcDataSource: true`, so the upstream external-storage suite exercises clones in e2e.
