### PR TITLE
fix(csi): stop group snapshot deletion from stranding suspend-io barriers

### DIFF
--- a/internal/agent/groupsnapshot.go
+++ b/internal/agent/groupsnapshot.go
@@ -114,12 +114,9 @@ func (r *GroupSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// A group deleted mid-round must not strand barriers. Lift every
 		// local member barrier the kernel still holds — keyed on kernel
 		// state, and never one a sibling round now owns.
-		for _, m := range members {
-			if m.vol.Spec.DRBD == nil || !diskfulOn(m.vol, r.NodeName) {
-				continue
-			}
-			if st, err := r.drbdStatus(ctx, m.vol.Name); err == nil && st.Suspended {
-				if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name); err != nil {
+		for _, volume := range r.sweepVolumes(grp, members) {
+			if st, err := r.drbdStatus(ctx, volume); err == nil && st.Suspended {
+				if err := r.resumeUnlessOtherRound(ctx, grp, volume); err != nil {
 					return ctrl.Result{}, err
 				}
 			}
@@ -460,6 +457,32 @@ func (r *GroupSnapshotReconciler) members(ctx context.Context, grp *miroirv1alph
 		members = append(members, groupMember{snap: snap, vol: vol})
 	}
 	return members, missing, nil
+}
+
+// sweepVolumes names the volumes whose local barrier the deletion path
+// must check: this node's diskful legs of every still-resolvable member,
+// plus the volumes in this node's status.perLeg slot keys. A member
+// deleted before the group (its own deletion defers the lift to the
+// live round, then the group can no longer resolve it — issue #272) is
+// invisible to the member walk, and its slot key is the only record
+// left of the leg this node froze. A slot whose DRBD resource is
+// already torn down costs one failing status read and nothing else.
+func (r *GroupSnapshotReconciler) sweepVolumes(grp *miroirv1alpha1.MiroirSnapshotGroup, members []groupMember) []string {
+	seen := map[string]bool{}
+	var vols []string
+	for _, m := range members {
+		if m.vol.Spec.DRBD != nil && diskfulOn(m.vol, r.NodeName) && !seen[m.vol.Name] {
+			seen[m.vol.Name] = true
+			vols = append(vols, m.vol.Name)
+		}
+	}
+	for key := range grp.Status.PerLeg {
+		if volume, node, ok := strings.Cut(key, "/"); ok && node == r.NodeName && !seen[volume] {
+			seen[volume] = true
+			vols = append(vols, volume)
+		}
+	}
+	return vols
 }
 
 // myLegs filters the members whose volume has a diskful leg on this node.

--- a/internal/agent/groupsnapshot_test.go
+++ b/internal/agent/groupsnapshot_test.go
@@ -342,3 +342,38 @@ func TestGroupSnapshotDeletionLiftsBarriers(t *testing.T) {
 		}
 	}
 }
+
+// Deleting a group whose members are already gone must still lift this
+// node's barriers: mid-round, each member's own deletion defers the lift
+// to the live group round, so once the members vanish the perLeg slot
+// keys are the only record of the legs this node froze (issue #272).
+func TestGroupSnapshotDeletionLiftsBarriersWithoutMembers(t *testing.T) {
+	grp := groupObj()
+	now := metav1.NewTime(time.Now())
+	grp.DeletionTimestamp = &now
+	grp.Status.IOSuspended = true
+	grp.Status.PerLeg = map[string]miroirv1alpha1.SnapshotNodeState{
+		slotKey(volPvc1, nodeA): miroirv1alpha1.SnapshotSuspended,
+		slotKey(volPvc2, nodeA): miroirv1alpha1.SnapshotDone,
+		slotKey(volPvc1, nodeB): miroirv1alpha1.SnapshotSuspended,
+	}
+	c := groupClient(t, grp)
+
+	fe := &fakeDRBDExec{statusJSON: groupStatusPeer} // kernel: suspended
+	r := &GroupSnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+
+	reconcileGroup(t, r)
+
+	fe.calledWith(t, "drbdadm resume-io "+volPvc1)
+	fe.calledWith(t, "drbdadm resume-io "+volPvc2)
+	got := &miroirv1alpha1.MiroirSnapshotGroup{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: groupG1}, got); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range got.Finalizers {
+		if f == constants.FinalizerPrefix+nodeA {
+			t.Fatalf("this node's finalizer must be released: %v", got.Finalizers)
+		}
+	}
+}

--- a/internal/csi/groupcontroller.go
+++ b/internal/csi/groupcontroller.go
@@ -199,8 +199,15 @@ func (c *Controller) cleanupStrayMembers(ctx context.Context, names, owned []str
 	}
 }
 
-// DeleteVolumeGroupSnapshot removes the members and the group; agents
-// drop backend snapshots and barriers via finalizers. Idempotent.
+// DeleteVolumeGroupSnapshot removes the group and then its members;
+// agents drop backend snapshots and barriers via finalizers. The group
+// goes first: mid-round, a member's own deletion defers lifting the
+// kernel barrier to the live group round, and the group's teardown can
+// only lift barriers for members it can still resolve — so members
+// deleted first could vanish before a node's group teardown runs and
+// strand their volumes suspended (issue #272). Group-first, every agent
+// sees the group's deletion while the members still exist, and a member
+// deleted after the group is gone lifts its own barrier. Idempotent.
 func (c *Controller) DeleteVolumeGroupSnapshot(ctx context.Context, req *csi.DeleteVolumeGroupSnapshotRequest) (*csi.DeleteVolumeGroupSnapshotResponse, error) {
 	if req.GetGroupSnapshotId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "group snapshot id is required")
@@ -209,15 +216,15 @@ func (c *Controller) DeleteVolumeGroupSnapshot(ctx context.Context, req *csi.Del
 	if err != nil {
 		return nil, err
 	}
+	grp := &miroirv1alpha1.MiroirSnapshotGroup{ObjectMeta: metav1.ObjectMeta{Name: req.GetGroupSnapshotId()}}
+	if err := c.Client.Delete(ctx, grp); err != nil && !apierrors.IsNotFound(err) {
+		return nil, status.Errorf(codes.Internal, "delete MiroirSnapshotGroup: %v", err)
+	}
 	for _, name := range members {
 		snap := &miroirv1alpha1.MiroirSnapshot{ObjectMeta: metav1.ObjectMeta{Name: name}}
 		if err := c.Client.Delete(ctx, snap); err != nil && !apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.Internal, "delete member MiroirSnapshot: %v", err)
 		}
-	}
-	grp := &miroirv1alpha1.MiroirSnapshotGroup{ObjectMeta: metav1.ObjectMeta{Name: req.GetGroupSnapshotId()}}
-	if err := c.Client.Delete(ctx, grp); err != nil && !apierrors.IsNotFound(err) {
-		return nil, status.Errorf(codes.Internal, "delete MiroirSnapshotGroup: %v", err)
 	}
 	return &csi.DeleteVolumeGroupSnapshotResponse{}, nil
 }

--- a/internal/csi/groupcontroller_test.go
+++ b/internal/csi/groupcontroller_test.go
@@ -382,6 +382,46 @@ func TestDeleteVolumeGroupSnapshotDeletesMembersAndGroup(t *testing.T) {
 	}
 }
 
+// The group must be deleted before its members: agents process deletion
+// events in issue order, and the group's barrier-lifting teardown needs
+// the member snapshots still resolvable — members-first can strand a
+// mid-round suspend-io barrier forever (issue #272).
+func TestDeleteVolumeGroupSnapshotDeletesGroupFirst(t *testing.T) {
+	s := newScheme(t)
+	m1 := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1 + "-" + volSrc},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
+	}
+	grp := &miroirv1alpha1.MiroirSnapshotGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1},
+		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{m1.Name}},
+	}
+	var deletes []string
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(m1, grp).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				switch obj.(type) {
+				case *miroirv1alpha1.MiroirSnapshotGroup:
+					deletes = append(deletes, "group/"+obj.GetName())
+				case *miroirv1alpha1.MiroirSnapshot:
+					deletes = append(deletes, "member/"+obj.GetName())
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	c := &Controller{Client: cl}
+
+	if _, err := c.DeleteVolumeGroupSnapshot(t.Context(), &csi.DeleteVolumeGroupSnapshotRequest{
+		GroupSnapshotId: groupGsnap1, SnapshotIds: []string{m1.Name},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(deletes) != 2 || deletes[0] != "group/"+groupGsnap1 {
+		t.Fatalf("the group must be deleted before its members: %v", deletes)
+	}
+}
+
 func TestDeleteVolumeGroupSnapshotRejectsForeignMember(t *testing.T) {
 	s := newScheme(t)
 	foreign := &miroirv1alpha1.MiroirSnapshot{


### PR DESCRIPTION
Closes #272.

Deleting a VolumeGroupSnapshot mid-round could strand DRBD suspend-io barriers, freezing member volumes until a manual `drbdadm resume-io`: members were deleted before the group, each member's own deletion deferred the lift to the live group round (`volumeRoundActive` counts the member's own group as a sibling), and the group's teardown lifted barriers only for members it could still resolve. Once a member CR fully vanished, its volume name was unrecoverable and nothing in the system ever called resume-io again. The window is widest exactly when users delete: a group stuck not-ready spends most of each open/void/backoff cycle mid-round with barriers up.

Two complementary fixes, either of which closes the CSI path on its own:

- **Group before members** in `DeleteVolumeGroupSnapshot`. Agents process deletion events in issue order, so each node runs the group's barrier-lifting teardown while the member snapshots are still resolvable; a member deleted after the group is gone lifts its own barrier (its `volumeRoundActive` check treats a NotFound group as no round). The delete-retry path already tolerates a missing group via the `snapshotIds` fallback.
- **perLeg sweep** in the group deletion branch. Slot keys are `"<volume>/<node>"`, so the node can recover the legs it froze without resolving members — covering any ordering (direct kubectl member deletes, partial delete retries). Still keyed on kernel state and guarded by `resumeUnlessOtherRound`; a slot whose DRBD resource is already torn down costs one failing status read.

Tests: `TestGroupSnapshotDeletionLiftsBarriersWithoutMembers` reproduces the strand (members gone, only perLeg left) and `TestDeleteVolumeGroupSnapshotDeletesGroupFirst` pins the RPC's delete order. `mise run test` and `mise run test-integration` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/home-operations/codesmith/miroir/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786936959&installation_id=147322112&pr_number=274&repository=home-operations%2Fmiroir&return_to=https%3A%2F%2Fgithub.com%2Fhome-operations%2Fmiroir%2Fpull%2F274&signature=9322511e7577df1aaa1b14fb16b6cdbbf39ab601e4cbf36baaa8e30918a7eea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->