### PR TITLE
fix(agent): never lift a barrier a sibling round co-holds when closing a round

### DIFF
--- a/internal/agent/groupsnapshot.go
+++ b/internal/agent/groupsnapshot.go
@@ -208,7 +208,7 @@ func (r *GroupSnapshotReconciler) reconcileRound(ctx context.Context, grp *miroi
 	case grp.Status.IOSuspended && expired && kernelSuspended:
 		// Dead round, driver gone before voiding it: self-expire the
 		// local barriers; the void patch stays the driver's.
-		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.resumeMine(ctx, mine)
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.resumeMine(ctx, grp, mine)
 
 	case !grp.Status.IOSuspended && kernelSuspended:
 		// The round ended (voided) while local barriers were still up —
@@ -290,7 +290,7 @@ func (r *GroupSnapshotReconciler) raiseBarriers(ctx context.Context, grp *miroir
 		if err := r.suspendIO(ctx, m.vol.Name); err != nil {
 			// A half-raised node must not stay half-frozen behind a failed
 			// raise; the retry re-raises the lot.
-			_ = r.resumeMine(ctx, suspended)
+			_ = r.resumeMine(ctx, grp, suspended)
 			return r.barrierFailed(ctx, grp, m.vol, err)
 		}
 		suspended = append(suspended, m)
@@ -320,7 +320,7 @@ func (r *GroupSnapshotReconciler) raiseBarriers(ctx context.Context, grp *miroir
 	if err != nil {
 		// The barrier is only real once recorded; a failed patch must not
 		// leave IO frozen until the retry.
-		_ = r.resumeMine(ctx, mine)
+		_ = r.resumeMine(ctx, grp, mine)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: time.Second}, nil
@@ -376,8 +376,9 @@ func (r *GroupSnapshotReconciler) collectSlots(ctx context.Context, grp *miroirv
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 	// Resume before reporting anything else: a frozen volume is an
-	// outage, a late group snapshot is just not ready.
-	if err := r.resumeMine(ctx, mine); err != nil {
+	// outage, a late group snapshot is just not ready. A barrier a
+	// sibling round co-holds stays for the sibling (see resumeMine).
+	if err := r.resumeMine(ctx, grp, mine); err != nil {
 		return ctrl.Result{}, err
 	}
 	if done == total {
@@ -523,10 +524,17 @@ func allSlotsSuspended(grp *miroirv1alpha1.MiroirSnapshotGroup, members []groupM
 	return true
 }
 
-// resumeMine lifts this node's barriers on the given members' volumes.
-func (r *GroupSnapshotReconciler) resumeMine(ctx context.Context, mine []groupMember) error {
+// resumeMine lifts this node's barriers on the given members' volumes —
+// except one a sibling round co-holds. Two opens over a shared volume
+// can race past each other's guards (a round is invisible between its
+// suspend-io and its status patch landing); both then freeze the volume
+// through the one kernel flag, and the first round to close must leave
+// the flag for the sibling to lift at its own close, or the sibling's
+// remaining legs are cut over live writes. The ReadyToUse and
+// voided-round branches re-check and lift once nothing holds it.
+func (r *GroupSnapshotReconciler) resumeMine(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, mine []groupMember) error {
 	for _, m := range mine {
-		if err := r.resumeIO(ctx, m.vol.Name); err != nil {
+		if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name); err != nil {
 			return err
 		}
 	}

--- a/internal/agent/groupsnapshot_test.go
+++ b/internal/agent/groupsnapshot_test.go
@@ -222,6 +222,54 @@ func TestGroupSnapshotVoidsExpiredRound(t *testing.T) {
 	}
 }
 
+// The group collect must not lift a shared volume's barrier while a
+// standalone sibling round co-holds it — the opens can race past each
+// other's guards, and lifting would cut the sibling's remaining legs
+// over live writes. The rest resumes, the group still seals, and the
+// deferred barrier lifts once the sibling closes.
+func TestGroupCollectDefersResumeToSiblingRound(t *testing.T) {
+	grp := groupObj()
+	now := metav1.Now()
+	grp.Status.IOSuspended = true
+	grp.Status.SuspendedAt = &now
+	grp.Status.PerLeg = map[string]miroirv1alpha1.SnapshotNodeState{
+		slotKey(volPvc1, nodeA): miroirv1alpha1.SnapshotDone,
+		slotKey(volPvc2, nodeA): miroirv1alpha1.SnapshotDone,
+		slotKey(volPvc1, nodeB): miroirv1alpha1.SnapshotDone,
+		slotKey(volPvc2, nodeB): miroirv1alpha1.SnapshotDone,
+	}
+	sibling := snapObj("snap-solo", volPvc1, nodeA, nodeB)
+	sibling.Status.IOSuspended = true
+	c := groupClient(t, groupVol(volPvc1), groupVol(volPvc2),
+		memberObj(memberOf1, volPvc1), memberObj(memberOf2, volPvc2), grp, sibling)
+
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"any","role":"Primary","suspended-user":true,
+		"devices":[{"disk-state":"UpToDate"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	r := &GroupSnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+
+	reconcileGroup(t, r)
+
+	fe.notCalledWith(t, "resume-io "+volPvc1)
+	fe.calledWith(t, "drbdadm resume-io "+volPvc2)
+	got := &miroirv1alpha1.MiroirSnapshotGroup{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: groupG1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.ReadyToUse || got.Status.IOSuspended {
+		t.Fatalf("the group must still seal ready: %+v", got.Status)
+	}
+
+	// The sibling closes → the sealed group's stray-lift pass takes it.
+	sibling.Status.IOSuspended = false
+	if err := c.Status().Update(t.Context(), sibling); err != nil {
+		t.Fatal(err)
+	}
+	reconcileGroup(t, r)
+	fe.calledWith(t, "resume-io "+volPvc1)
+}
+
 // The group must not open its round while a standalone snapshot's round
 // holds any member volume, and vice versa — the kernel suspend flag is
 // per-resource and shared between the two protocols.

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -354,7 +354,9 @@ func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miro
 	case snap.Status.IOSuspended && expired && st.Suspended:
 		// Dead round, coordinator gone before voiding it: self-expire
 		// the local barrier; the void patch stays the coordinator's.
-		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.resumeIO(ctx, vol.Name)
+		// Never a barrier a sibling round co-holds — a round that raced
+		// past this one's open guards may own the kernel flag by now.
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.resumeUnlessSiblingRound(ctx, snap, vol)
 
 	case !snap.Status.IOSuspended && st.Suspended:
 		// The round ended (voided) while the local barrier was still up —
@@ -409,8 +411,9 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 	}
 	if err != nil {
 		// The barrier is only real once recorded; a failed patch must
-		// not leave IO frozen until the retry.
-		_ = r.resumeIO(ctx, vol.Name)
+		// not leave IO frozen until the retry — but a barrier a sibling
+		// round co-holds is the sibling's to lift, not this round's.
+		_ = r.resumeUnlessSiblingRound(ctx, snap, vol)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: time.Second}, nil
@@ -464,8 +467,14 @@ func (r *SnapshotReconciler) collectLegs(ctx context.Context, snap *miroirv1alph
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 	// Resume before reporting anything else: a frozen volume is an
-	// outage, a late snapshot is just not ready.
-	if err := r.resumeIO(ctx, vol.Name); err != nil {
+	// outage, a late snapshot is just not ready. Unless a sibling round
+	// co-holds the kernel flag: two opens over one volume can race past
+	// each other's guards (a round is invisible between its suspend-io
+	// and its status patch landing), and lifting the shared flag here
+	// would let writes into legs the sibling has yet to cut. The lift is
+	// then the sibling's, at its own close; the ReadyToUse branch and
+	// the voided-round case re-check and lift once nothing holds it.
+	if err := r.resumeUnlessSiblingRound(ctx, snap, vol); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, r.patchSnap(ctx, snap, func(s *miroirv1alpha1.MiroirSnapshot) {

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -924,6 +924,65 @@ func TestSnapshotVoidedResumeDefersToSiblingRound(t *testing.T) {
 	fe.notCalledWith(t, "resume-io")
 }
 
+// The collect phase must not lift a barrier a concurrently opened group
+// round co-holds — two opens over one volume can race past each other's
+// guards, and the first round to close would let writes into legs the
+// sibling has yet to cut. The seal still proceeds; the leftover barrier
+// lifts once the sibling closes.
+func TestSnapshotCollectDefersResumeToSiblingGroupRound(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	now := metav1.Now()
+	snap := snapObj("snap-a", volPvc1, nodeA, nodeB)
+	snap.Status.IOSuspended = true
+	snap.Status.SuspendedAt = &now
+	snap.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{
+		nodeA: miroirv1alpha1.SnapshotDone,
+		nodeB: miroirv1alpha1.SnapshotDone,
+	}
+	member := snapObj("g1-"+volPvc1, volPvc1, nodeA, nodeB)
+	member.Spec.Group = "g1"
+	sibling := &miroirv1alpha1.MiroirSnapshotGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1"},
+		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{member.Name}},
+		Status:     miroirv1alpha1.MiroirSnapshotGroupStatus{IOSuspended: true},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snap, member, sibling).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{},
+			&miroirv1alpha1.MiroirSnapshotGroup{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+	reconcileSnap(t, r, "snap-a")
+
+	fe.notCalledWith(t, "resume-io")
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: "snap-a"}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.ReadyToUse || got.Status.IOSuspended {
+		t.Fatalf("the round must still seal ready: %+v", got.Status)
+	}
+
+	// The sibling closes → the ReadyToUse pass lifts the leftover barrier.
+	sibling.Status.IOSuspended = false
+	if err := c.Status().Update(t.Context(), sibling); err != nil {
+		t.Fatal(err)
+	}
+	reconcileSnap(t, r, "snap-a")
+	fe.calledWith(t, "drbdadm resume-io "+volPvc1)
+}
+
 func TestSnapshotPeerWaitsForBarrier(t *testing.T) {
 	s := newScheme(t)
 	v := vol(volPvc1, nodeA, nodeB)


### PR DESCRIPTION
Closes #273.

Two barrier rounds over one volume can open concurrently: a round is invisible between its suspend-io and its status patch landing, and with group snapshots the kernel-truth open guard no longer covers every case — the group driver may hold no leg of a shared member volume, and the snapshot and group reconcilers are separate controllers on possibly different nodes (pre-#268, same-volume rounds shared one coordinator node and one worker, which made the guard pair airtight). Both rounds then freeze the volume through the one shared kernel flag, and whichever finished first resumed IO **unconditionally**, releasing the other round's barrier mid-cut. The survivor's legs were cut over live writes — non-identical standalone legs, or a group without its shared instant — and sealed `readyToUse` with nothing to flag it.

Rather than trying to close the millisecond open window, this makes concurrent rounds harmless: every round-closing resume is now sibling-aware, like the stray-lift paths already were. The collect phase, the dead-round self-expiry, and the failed-raise unwind leave a co-held flag for the sibling to lift at its own close. The shared volume then stays frozen through the union of the rounds, so each round's cuts still happen under a continuous freeze and both results are consistent; the `ReadyToUse` and voided-round branches lift the leftover barrier once nothing holds it (each seal/void patch re-triggers the reconciles that run those branches, so the lift converges without polling).

Liveness is unchanged: a deferred lift only happens while a sibling round holds `ioSuspended`, and that sibling's own close — or its deadline void, or its deletion — releases the flag; every skip site re-checks on requeue or on the next status event. Cost is one uncached read per resumed volume at round close, the same read `openRound` already does.

Tests: `TestSnapshotCollectDefersResumeToSiblingGroupRound` and `TestGroupCollectDefersResumeToSiblingRound` pin both directions — seal proceeds, the co-held barrier stays, and it lifts once the sibling closes. `mise run test` and `mise run test-integration` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/home-operations/codesmith/miroir/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786937281&installation_id=147322112&pr_number=275&repository=home-operations%2Fmiroir&return_to=https%3A%2F%2Fgithub.com%2Fhome-operations%2Fmiroir%2Fpull%2F275&signature=26613818a29cd71d493194f46f34df14fa0740feef874f7a51cfd936f5902b86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->