### PR TITLE
fix(backend): keep thin snapshot LVs inactive and serialize lvm commands

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -299,7 +299,86 @@ func TestLVMThinCloneReactivates(t *testing.T) {
 		t.Fatal(err)
 	}
 	fe.notCalledWith(t, "lvcreate")
-	fe.calledWith(t, "lvchange --activate y vg-miroir/pvc-2")
+	fe.calledWith(t, "lvchange --activate y --ignoreactivationskip vg-miroir/pvc-2")
+}
+
+// Snapshot LVs are created inactive with the activation-skip flag set:
+// nothing opens their device node, and an active snapshot is dm-suspended
+// when a clone lvcreate uses it as origin (the in-kernel wedge of #276).
+func TestLVMThinSnapshotCreatedInactive(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lvs vg-miroir/miroir-snap-1", "", errors.New("Failed to find logical volume"))
+	b := newLVMThin(cfg, fe.run)
+
+	if err := b.Snapshot(t.Context(), "pvc-1", "snap-1"); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "lvcreate --snapshot --name miroir-snap-1 --setactivationskip y --activate n vg-miroir/pvc-1")
+}
+
+// A fresh clone deactivates its origin snapshot first (pre-fix snapshots
+// are active), creates the clone LV inactive, and activates it in a
+// separate step, LINSTOR's restore shape (#276).
+func TestLVMThinCloneAvoidsActiveOrigin(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lvs vg-miroir/pvc-2", "", errors.New("Failed to find logical volume"))
+	b := newLVMThin(cfg, fe.run)
+
+	dev, err := b.CreateFromSnapshot(t.Context(), "pvc-2", "pvc-1", "snap-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dev != "/dev/vg-miroir/pvc-2" {
+		t.Fatalf("unexpected device path %q", dev)
+	}
+	fe.calledWith(t, "lvchange --activate n vg-miroir/miroir-snap-1")
+	fe.calledWith(t, "lvcreate --snapshot --name pvc-2 vg-miroir/miroir-snap-1")
+	fe.calledWith(t, "lvchange --activate y --ignoreactivationskip vg-miroir/pvc-2")
+	// The deactivate must precede the lvcreate, and the lvcreate itself
+	// must not activate the clone (activation is the separate last step).
+	var order []string
+	for _, c := range fe.calls {
+		if strings.Contains(c, "lvchange --activate n") || strings.Contains(c, "lvcreate") {
+			order = append(order, c)
+		}
+	}
+	if len(order) != 2 || !strings.Contains(order[0], "lvchange --activate n") {
+		t.Fatalf("expected deactivate-then-lvcreate, got %v", order)
+	}
+	if strings.Contains(order[1], "--activate") || strings.Contains(order[1], "--setactivationskip") {
+		t.Fatalf("clone lvcreate must not carry activation flags: %q", order[1])
+	}
+}
+
+// One wedged lvm command must not silently absorb every follower: a waiter
+// timing out on the serialization gate names the in-flight command it was
+// queued behind (#276).
+func TestLVMGateQueuedErrorNamesHolder(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	run := func(_ context.Context, _ string, _ ...string) (string, error) {
+		close(entered)
+		<-release
+		return "", nil
+	}
+	b := newLVMThin(cfg, run)
+
+	go func() {
+		defer close(done)
+		_, _ = b.Stats(context.Background())
+	}()
+	<-entered
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	_, err := b.Create(ctx, "pvc-1", 1<<30)
+	close(release)
+	<-done
+	if err == nil || !strings.Contains(err.Error(), "queued behind") ||
+		!strings.Contains(err.Error(), "lv_size,data_percent") {
+		t.Fatalf("expected an error naming the in-flight lvs, got %v", err)
+	}
 }
 
 func TestLVMThinSnapshotAvoidsReservedName(t *testing.T) {

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"time"
 )
 
 // lvmThin provisions thin LVs in a dm-thin pool.
@@ -95,11 +97,41 @@ func (l *lvmThin) Setup(ctx context.Context) error {
 	return nil
 }
 
+// lvmGate serializes lvm invocations process-wide, as LINSTOR does (its
+// LvmCommands methods are synchronized): concurrent commands only contend
+// on the VG lock in the kernel anyway, and when the holder wedges there (a
+// D-state lvcreate, #276) every parallel command burns a full exec timeout
+// against it. Queued here instead, waiters stay cancellable and the error
+// names the command they were stuck behind.
+var (
+	lvmGate     = make(chan struct{}, 1)
+	lvmInflight atomic.Pointer[lvmCall]
+)
+
+type lvmCall struct {
+	cmd   string
+	since time.Time
+}
+
 // lvm runs an lvm subcommand. Udev handling is disabled centrally in the
 // image's /etc/lvm/lvmlocal.conf (the agent container has no udev daemon);
 // per-command --noudevsync is both redundant and invalid on several
 // subcommands (pvcreate rejects it).
 func (l *lvmThin) lvm(ctx context.Context, args ...string) (string, error) {
+	select {
+	case lvmGate <- struct{}{}:
+	case <-ctx.Done():
+		if c := lvmInflight.Load(); c != nil {
+			return "", fmt.Errorf("lvm %s: queued behind %q for %s: %w",
+				args[0], c.cmd, time.Since(c.since).Round(time.Second), ctx.Err())
+		}
+		return "", ctx.Err()
+	}
+	lvmInflight.Store(&lvmCall{cmd: "lvm " + strings.Join(args, " "), since: time.Now()})
+	defer func() {
+		lvmInflight.Store(nil)
+		<-lvmGate
+	}()
 	return l.exec(ctx, "lvm", args...)
 }
 
@@ -188,10 +220,15 @@ func (l *lvmThin) Snapshot(ctx context.Context, vol, snap string) error {
 	if err != nil || ok {
 		return err
 	}
+	// Created inactive: nothing ever opens a snapshot device node, and
+	// cloning dm-suspends an active origin, a suspend that can wedge
+	// in-kernel with the VG lock held (#276). LINSTOR keeps snapshots
+	// active only because its backup shipping reads them.
 	_, err = l.lvm(ctx, "lvcreate",
 		"--snapshot",
 		"--name", snapLV(snap),
-		"--setactivationskip", "n",
+		"--setactivationskip", "y",
+		"--activate", "n",
 		l.ref(vol))
 	if err != nil {
 		return fmt.Errorf("snapshot %s of %s: %w", snap, vol, err)
@@ -205,22 +242,30 @@ func (l *lvmThin) CreateFromSnapshot(ctx context.Context, vol, _ /* sourceVol */
 		return "", err
 	}
 	if !ok {
+		// Snapshots predating the inactive-at-birth change in Snapshot may
+		// still be active; lvcreate dm-suspends an active origin, the
+		// wedge window of #276. Idempotent on an inactive LV.
+		if _, err := l.lvm(ctx, "lvchange", "--activate", "n",
+			l.ref(snapLV(snap))); err != nil {
+			return "", fmt.Errorf("deactivate origin %s: %w", snapLV(snap), err)
+		}
 		// A writable thin snapshot of the snapshot is the clone: instant
-		// CoW within the same pool, no data copy.
+		// CoW within the same pool, no data copy. Created inactive and
+		// activated separately below, LINSTOR's restore shape.
 		_, err = l.lvm(ctx, "lvcreate",
 			"--snapshot",
 			"--name", vol,
-			"--setactivationskip", "n",
 			l.ref(snapLV(snap)))
 		if err != nil {
 			return "", err
 		}
-		return l.DevicePath(vol), nil
 	}
-	// Same reboot gap as Create: the clone survives in LVM metadata but
-	// inactive, with no device node until activated.
+	// Fresh clones are born inactive; pre-existing ones survive a reboot
+	// in LVM metadata but inactive (Talos activates no foreign LVs at
+	// boot). Snapshot-born LVs carry the activation-skip flag, hence
+	// --ignoreactivationskip (LINSTOR activates the same way).
 	if _, err := l.lvm(ctx, "lvchange", "--activate", "y",
-		l.ref(vol)); err != nil {
+		"--ignoreactivationskip", l.ref(vol)); err != nil {
 		return "", fmt.Errorf("activate %s: %w", vol, err)
 	}
 	return l.DevicePath(vol), nil


### PR DESCRIPTION
Fixes #276.

On 2026-07-18 a clone `lvcreate --snapshot` wedged in D-state in `__dm_suspend → synchronize_srcu` while suspending its origin (the clone-source snapshot LV). The dead process held the vg-miroir VG lock, so every LVM command on the node timed out with `signal: killed` and all scheduled VolumeSnapshots failed cluster-wide until a reboot. Full incident details in #276.

The suspend only happens because the origin is active. Snapshot LVs never need to be: no code path opens a snapshot device node (`DevicePath(snapLV(...))` has zero call sites). LINSTOR keeps its snapshot LVs active, but only because its backup shipping reads them directly; without that requirement the device node is pure exposure.

Three changes to the lvmthin backend:

1. **`Snapshot()` creates snapshot LVs inactive** (`--setactivationskip y --activate n`). An origin with no dm device cannot be suspended, so the wedge window on the clone/restore path is gone.

2. **`CreateFromSnapshot()` follows LINSTOR's restore sequence** (`restoreFromSnapshot` + `activateVolume -ay -K` in `LvmThinProvider`):
   - `lvchange --activate n` on the origin first, covering snapshots created before this change that are still active (idempotent otherwise);
   - bare `lvcreate --snapshot` with no activation flags, so the clone is born inactive;
   - a separate `lvchange --activate y --ignoreactivationskip` that also replaces the post-reboot reactivation branch. The `--ignoreactivationskip` is required because snapshot-born LVs now carry the skip flag, and is a no-op on pre-existing clones that do not.

3. **LVM invocations are serialized process-wide** behind a gate, mirroring LINSTOR's `synchronized LvmCommands`. Concurrent commands only queue on the VG lock in the kernel anyway; queued in userspace instead, a waiter whose context expires fails fast with an error naming the in-flight command and how long it has been running (`lvm lvs: queued behind "lvm lvcreate --snapshot ..." for 9h2m: ...`). A repeat of the incident produces one clear signature instead of hundreds of `signal: killed` reconcile errors, and that error is the hook for the follow-up D-state containment (reportWedged for LVM).

The suspend of a *live PVC* origin during regular snapshot creation is unchanged: that quiesce is what makes thin snapshots crash-consistent, and LINSTOR behaves the same way there.

Tested with the backend unit tests (including `-race` for the new gate) and the envtest integration suite; new tests cover the inactive snapshot flags, the deactivate-create-activate clone sequence and its ordering, and the queued-behind error naming the gate holder.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/home-operations/codesmith/miroir/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786955573&installation_id=147322112&pr_number=277&repository=home-operations%2Fmiroir&return_to=https%3A%2F%2Fgithub.com%2Fhome-operations%2Fmiroir%2Fpull%2F277&signature=0790c41960fc69f29e2fae16ac43613e9f62d68a9055d95ba037147c518ffeaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->