### PR TITLE
fix(backend): heal missing lvmthin device nodes via vgmknodes

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -80,6 +80,7 @@ func (f *fakeExec) notCalledWith(t *testing.T, substr string) {
 const (
 	thinPoolName = "thinpool"
 	volumeGroup  = "vg-miroir"
+	blockdevCmd  = "blockdev"
 )
 
 var cfg = Config{VolumeGroup: volumeGroup, ThinPool: thinPoolName, Dataset: "tank/miroir"}
@@ -151,6 +152,98 @@ func TestLVMThinStats(t *testing.T) {
 	}
 	if s.MetaUsedPercent != 1.2 {
 		t.Fatalf("meta%% = %f", s.MetaUsedPercent)
+	}
+}
+
+// healingExec fails every blockdev call until a vgmknodes command has
+// been seen: a missing LV node (#281) only comes back by re-mknoding.
+func healingExec(fe *fakeExec, healed *bool) Exec {
+	return func(ctx context.Context, name string, args ...string) (string, error) {
+		if name == "lvm" && len(args) > 0 && args[0] == "vgmknodes" {
+			*healed = true
+		}
+		if name == blockdevCmd && !*healed {
+			return "", errors.New("blockdev: cannot open " + args[len(args)-1] + ": No such file or directory")
+		}
+		return fe.run(ctx, name, args...)
+	}
+}
+
+func TestLVMThinCreateHealsMissingDeviceNode(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lvs vg-miroir/pvc-1", "", errors.New("not found"))
+	healed := false
+	b := newLVMThin(cfg, healingExec(fe, &healed))
+
+	dev, err := b.Create(t.Context(), "pvc-1", 10<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dev != "/dev/vg-miroir/pvc-1" {
+		t.Fatalf("unexpected device path %q", dev)
+	}
+	fe.calledWith(t, "lvm vgmknodes vg-miroir")
+}
+
+func TestLVMThinCreateSkipsHealWhenNodeUsable(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lvs vg-miroir/pvc-1", "", errors.New("not found"))
+	b := newLVMThin(cfg, fe.run) // blockdev probe succeeds
+
+	if _, err := b.Create(t.Context(), "pvc-1", 10<<30); err != nil {
+		t.Fatal(err)
+	}
+	fe.notCalledWith(t, "vgmknodes")
+}
+
+func TestLVMThinCreateSurfacesUnhealableDeviceNode(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lvs vg-miroir/pvc-1", "", errors.New("not found"))
+	fe.respond("blockdev", "", errors.New("No such file or directory"))
+	b := newLVMThin(cfg, fe.run)
+
+	_, err := b.Create(t.Context(), "pvc-1", 10<<30)
+	if err == nil || !strings.Contains(err.Error(), "after vgmknodes") {
+		t.Fatalf("expected unhealable-node error, got %v", err)
+	}
+	fe.calledWith(t, "lvm vgmknodes vg-miroir")
+}
+
+func TestLVMThinCreateFromSnapshotHealsMissingDeviceNode(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lvs vg-miroir/pvc-2", "", errors.New("not found"))
+	healed := false
+	b := newLVMThin(cfg, healingExec(fe, &healed))
+
+	dev, err := b.CreateFromSnapshot(t.Context(), "pvc-2", "pvc-1", "snap-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dev != "/dev/vg-miroir/pvc-2" {
+		t.Fatalf("unexpected device path %q", dev)
+	}
+	fe.calledWith(t, "lvm vgmknodes vg-miroir")
+}
+
+func TestLVMThinSyncHealsMissingDeviceNode(t *testing.T) {
+	fe := &fakeExec{}
+	healed := false
+	flushes := 0
+	inner := healingExec(fe, &healed)
+	exec := func(ctx context.Context, name string, args ...string) (string, error) {
+		if name == blockdevCmd && args[0] == "--flushbufs" {
+			flushes++
+		}
+		return inner(ctx, name, args...)
+	}
+	b := newLVMThin(cfg, exec)
+
+	if err := b.Sync(t.Context(), "pvc-1"); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "lvm vgmknodes vg-miroir")
+	if flushes != 2 {
+		t.Fatalf("expected the flush retried once after the heal, got %d", flushes)
 	}
 }
 

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -139,6 +139,26 @@ func (l *lvmThin) DevicePath(vol string) string {
 	return fmt.Sprintf("/dev/%s/%s", l.vg, vol)
 }
 
+// ensureDevice returns vol's device path once its node is usable. With
+// udev disabled, lvm mknods /dev/<vg>/ entries itself at activation; a
+// node lost after that never reappears on its own (#281), so a failed
+// probe is repaired with vgmknodes rather than waited out. LINSTOR guards
+// the same edge (waitUntilDeviceCreated after every create) but can rely
+// on udev to deliver the node; this environment has no udev to wait for.
+func (l *lvmThin) ensureDevice(ctx context.Context, vol string) (string, error) {
+	dev := l.DevicePath(vol)
+	if _, err := l.exec(ctx, "blockdev", "--getsize64", dev); err == nil {
+		return dev, nil
+	}
+	if _, err := l.lvm(ctx, "vgmknodes", l.vg); err != nil {
+		return "", fmt.Errorf("vgmknodes %s: %w", l.vg, err)
+	}
+	if _, err := l.exec(ctx, "blockdev", "--getsize64", dev); err != nil {
+		return "", fmt.Errorf("device node %s unusable after vgmknodes: %w", dev, err)
+	}
+	return dev, nil
+}
+
 // ref is the "vg/lv" reference lvm commands take for a logical volume.
 func (l *lvmThin) ref(lv string) string {
 	return fmt.Sprintf("%s/%s", l.vg, lv)
@@ -176,7 +196,7 @@ func (l *lvmThin) Create(ctx context.Context, vol string, sizeBytes int64) (stri
 		if err != nil {
 			return "", fmt.Errorf("lvcreate %s: %w", vol, err)
 		}
-		return l.DevicePath(vol), nil
+		return l.ensureDevice(ctx, vol)
 	}
 	// Talos does not activate foreign LVs at boot, so an LV surviving a
 	// node reboot exists in metadata but has no device node until
@@ -185,7 +205,7 @@ func (l *lvmThin) Create(ctx context.Context, vol string, sizeBytes int64) (stri
 		l.ref(vol)); err != nil {
 		return "", fmt.Errorf("activate %s: %w", vol, err)
 	}
-	return l.DevicePath(vol), nil
+	return l.ensureDevice(ctx, vol)
 }
 
 func (l *lvmThin) Resize(ctx context.Context, vol string, sizeBytes int64) error {
@@ -208,6 +228,14 @@ func (l *lvmThin) Sync(ctx context.Context, vol string) error {
 	// No global sync(2): it deadlocks against filesystems frozen on the
 	// suspended DRBD device above this LV (see zfsBackend.Sync).
 	_, err := l.exec(ctx, "blockdev", "--flushbufs", l.DevicePath(vol))
+	if err != nil && strings.Contains(err.Error(), "No such file or directory") {
+		// The LV may have been active long before the cut; a node missing
+		// since then (#281) would otherwise fail every retry.
+		if _, herr := l.ensureDevice(ctx, vol); herr != nil {
+			return herr
+		}
+		_, err = l.exec(ctx, "blockdev", "--flushbufs", l.DevicePath(vol))
+	}
 	return err
 }
 
@@ -268,7 +296,7 @@ func (l *lvmThin) CreateFromSnapshot(ctx context.Context, vol, _ /* sourceVol */
 		"--ignoreactivationskip", l.ref(vol)); err != nil {
 		return "", fmt.Errorf("activate %s: %w", vol, err)
 	}
-	return l.DevicePath(vol), nil
+	return l.ensureDevice(ctx, vol)
 }
 
 func (l *lvmThin) Delete(ctx context.Context, vol string) error {


### PR DESCRIPTION
Fixes #281. Removes the trigger behind the 2h suspend-io freeze of #280 (the missing deadline itself stays open there).

## Problem

With udev disabled, lvm mknods `/dev/<vg>/` entries itself at activation. A node lost after that (boot-time activation race, #281 — observed to persist across a reboot) never reappears on its own, and every path-based command ENOENT-loops: through the snapshot cut path this held `ai/hermes` IO-suspended for 2h+ until a manual `vgmknodes`.

## Change

New `ensureDevice` in the lvmthin backend: probe the node with `blockdev --getsize64` (the zfs backend's `awaitDevice` probe), on failure repair with `vgmknodes` through the serialized lvm gate, re-probe, and fail loudly if the node is still unusable. Wired into:

- `Create` (both branches, covering boot-time reactivation of surviving LVs)
- `CreateFromSnapshot` (after clone activation)
- `Sync` (the incident's failing call: heal on ENOENT and retry the flush once)

LINSTOR guards the same edge with `AbsStorageProvider.waitUntilDeviceCreated` after every create/clone/snapshot activation, but can rely on host udev to deliver the node — waiting is useless here, so the probe failure triggers the repair instead.

Builds on the serialized lvm gate from #277 (now on main).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/home-operations/codesmith/miroir/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786960600&installation_id=147322112&pr_number=282&repository=home-operations%2Fmiroir&return_to=https%3A%2F%2Fgithub.com%2Fhome-operations%2Fmiroir%2Fpull%2F282&signature=6f1f4fb36945204c9e53d6a57e7b94f484587721d9e95fdf5a400781772f64f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->