### PR TITLE
fix(agent): break the fast path when phase contradicts per-node status

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -342,7 +342,8 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // for replicated volumes — kernel state identical to the fingerprint. On
 // the hit it refreshes the metrics (cheap sets) and skips the status patch
 // entirely: the CRD already reflects this state, and phase converges via
-// whichever peer actually changed.
+// whichever peer actually changed, unless a sibling's stale apply already
+// overwrote that peer's phase; the recompute below catches that.
 func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, localDiskless bool) (bool, ctrl.Result) {
 	r.realizedMu.Lock()
 	entry, ok := r.realized[vol.Name]
@@ -350,6 +351,16 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 	if !ok || entry.generation != vol.Generation ||
 		time.Since(entry.fullPassAt) >= deepCheckInterval ||
 		(!localDiskless && vol.Status.PerNode[r.NodeName].SizeBytes != vol.Spec.SizeBytes) {
+		return false, ctrl.Result{}
+	}
+	// Phase is co-owned: every leg's full pass force-applies it from its
+	// own informer cache, and near-simultaneous passes (a resync
+	// completing) can land a stale value last, leaving the CR
+	// self-contradictory while every leg parks here until the deep check
+	// (issue #279). No kernel event re-breaks the fingerprint after that,
+	// so recompute from the cached CR and take the full pipeline to
+	// re-apply phase as soon as the informer shows the mismatch.
+	if computePhase(vol) != vol.Status.Phase {
 		return false, ctrl.Result{}
 	}
 	if !entry.replicated {

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -2124,6 +2124,43 @@ func TestReconcileFastPathInvalidatedByStatusDrift(t *testing.T) {
 	}
 }
 
+// A phase contradicting the per-node slots breaks the fingerprint: a
+// sibling's concurrent full pass can force-apply a phase computed from a
+// stale informer cache after this leg's correct write (issue #279), and no
+// later kernel event breaks statusEqual, so only the recompute can route
+// the repair through the full pipeline.
+func TestReconcileFastPathInvalidatedByStalePhase(t *testing.T) {
+	_, fe, r := steadyVolume(t)
+	reconcile(t, r, volPvc1) // full pass, stores the fingerprint
+	adjusts := countCalls(fe, "adjust")
+
+	// The peer's slot reached UpToDate but a stale apply left the phase
+	// behind at Degraded.
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err != nil {
+		t.Fatal(err)
+	}
+	got.Status.PerNode[nodeB] = miroirv1alpha1.ReplicaStatus{
+		DeviceCreated: true, DiskState: diskStateUpToDate, SizeBytes: 1 << 30,
+	}
+	got.Status.Phase = miroirv1alpha1.VolumeDegraded
+	if err := r.Status().Update(t.Context(), got); err != nil {
+		t.Fatal(err)
+	}
+
+	reconcile(t, r, volPvc1)
+	if n := countCalls(fe, "adjust"); n <= adjusts {
+		t.Fatalf("stale phase must force the full pipeline: %v", fe.calls)
+	}
+	after := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, after); err != nil {
+		t.Fatal(err)
+	}
+	if after.Status.Phase != miroirv1alpha1.VolumeReady {
+		t.Fatalf("phase = %q, want %q", after.Status.Phase, miroirv1alpha1.VolumeReady)
+	}
+}
+
 // A spec change (generation bump) breaks the fingerprint.
 func TestReconcileFastPathInvalidatedByGeneration(t *testing.T) {
 	v, fe, r := steadyVolume(t)


### PR DESCRIPTION
Addresses the phase-lag finding in #279 (the `REPLICAS` printcolumn observation is left for a follow-up issue).

## Problem

After a clone/restore resync completes, `MiroirVolume.status.phase` can stay `Degraded` for up to `deepCheckInterval` (5 min) while every `perNode` slot reads `UpToDate`.

The completion event itself is not swallowed: it breaks every leg's fingerprint (`DiskState`/`Resyncing` locally, `PeerDiskState` on peers), so all legs run full passes. The race is at the end of those passes. Phase is co-owned: each leg's `patchStatus` force-applies a phase computed from its own informer cache, and a sibling whose cache still shows the syncing leg `Inconsistent` can land a stale `Degraded` last, after the syncing leg's correct `Ready`. From then on no kernel event breaks `statusEqual` again, so every leg parks in the fast path and nothing revalidates phase until the deep check.

The race is bidirectional: the same overwrite can park a stale `Ready` over a real `Degraded`, which matters to the CSI health reporter and the auto-diskful gate, not just to consumers polling the CR.

## Fix

On every fast-path hit, recompute `computePhase(vol)` from the already-fetched cached object and take the full pipeline when it disagrees with `status.phase`. Peer status writes already re-trigger the reconcile on every node, so the first pass after an informer catches up repairs phase in seconds instead of minutes. Steady-state cost is zero (a pure function over the cached CR; no extra API or exec calls).

## Testing

- New `TestReconcileFastPathInvalidatedByStalePhase` primes the racy state (peer slot `UpToDate`, phase left `Degraded`) and asserts the next reconcile takes the full pipeline and lands `Ready`; verified it fails without the fix.
- Full `internal/agent` suite, `go vet`, `go build ./...` all pass.