### PR TITLE
feat(api): show a ready/total count in the Replicas printcolumn

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirvolumestatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/miroirvolumestatus.go
@@ -30,6 +30,11 @@ import (
 type MiroirVolumeStatusApplyConfiguration struct {
 	// Phase summarizes the volume state for the controller and humans.
 	Phase *apiv1alpha1.VolumePhase `json:"phase,omitempty"`
+	// ReadyReplicas summarizes diskful replica readiness as "ready/total"
+	// (diskless tie-breakers and client legs excluded, like Phase). A
+	// preformatted string because CRD printcolumns cannot combine two
+	// integer fields into one cell.
+	ReadyReplicas *string `json:"readyReplicas,omitempty"`
 	// PerNode maps node name to that agent's observed state.
 	PerNode map[string]ReplicaStatusApplyConfiguration `json:"perNode,omitempty"`
 	// Export is the observed state of the NFS gateway, set only on RWX
@@ -62,6 +67,14 @@ func MiroirVolumeStatus() *MiroirVolumeStatusApplyConfiguration {
 // If called multiple times, the Phase field is set to the value of the last call.
 func (b *MiroirVolumeStatusApplyConfiguration) WithPhase(value apiv1alpha1.VolumePhase) *MiroirVolumeStatusApplyConfiguration {
 	b.Phase = &value
+	return b
+}
+
+// WithReadyReplicas sets the ReadyReplicas field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ReadyReplicas field is set to the value of the last call.
+func (b *MiroirVolumeStatusApplyConfiguration) WithReadyReplicas(value string) *MiroirVolumeStatusApplyConfiguration {
+	b.ReadyReplicas = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -405,6 +405,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: phase
       type:
         namedType: com.github.home-operations.miroir.api.v1alpha1.VolumePhase
+    - name: readyReplicas
+      type:
+        scalar: string
 - name: com.github.home-operations.miroir.api.v1alpha1.QuorumPolicy
   scalar: string
 - name: com.github.home-operations.miroir.api.v1alpha1.Replica

--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -347,6 +347,12 @@ type MiroirVolumeStatus struct {
 	// Phase summarizes the volume state for the controller and humans.
 	// +optional
 	Phase VolumePhase `json:"phase,omitempty"`
+	// ReadyReplicas summarizes diskful replica readiness as "ready/total"
+	// (diskless tie-breakers and client legs excluded, like Phase). A
+	// preformatted string because CRD printcolumns cannot combine two
+	// integer fields into one cell.
+	// +optional
+	ReadyReplicas string `json:"readyReplicas,omitempty"`
 	// PerNode maps node name to that agent's observed state.
 	// +optional
 	PerNode map[string]ReplicaStatus `json:"perNode,omitempty"`
@@ -377,7 +383,7 @@ type MiroirVolumeStatus struct {
 // +kubebuilder:resource:scope=Cluster,shortName=miv
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Size",type=integer,JSONPath=`.spec.sizeBytes`
-// +kubebuilder:printcolumn:name="Replicas",type=string,JSONPath=`.spec.replicas[*].node`,priority=1
+// +kubebuilder:printcolumn:name="Replicas",type=string,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Pools",type=string,JSONPath=`.spec.replicas[*].pool`,priority=1
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -20,9 +20,8 @@ spec:
     - jsonPath: .spec.sizeBytes
       name: Size
       type: integer
-    - jsonPath: .spec.replicas[*].node
+    - jsonPath: .status.readyReplicas
       name: Replicas
-      priority: 1
       type: string
     - jsonPath: .spec.replicas[*].pool
       name: Pools
@@ -537,6 +536,13 @@ spec:
               phase:
                 description: Phase summarizes the volume state for the controller
                   and humans.
+                type: string
+              readyReplicas:
+                description: |-
+                  ReadyReplicas summarizes diskful replica readiness as "ready/total"
+                  (diskless tie-breakers and client legs excluded, like Phase). A
+                  preformatted string because CRD printcolumns cannot combine two
+                  integer fields into one cell.
                 type: string
             type: object
         required:

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -20,9 +20,8 @@ spec:
     - jsonPath: .spec.sizeBytes
       name: Size
       type: integer
-    - jsonPath: .spec.replicas[*].node
+    - jsonPath: .status.readyReplicas
       name: Replicas
-      priority: 1
       type: string
     - jsonPath: .spec.replicas[*].pool
       name: Pools
@@ -537,6 +536,13 @@ spec:
               phase:
                 description: Phase summarizes the volume state for the controller
                   and humans.
+                type: string
+              readyReplicas:
+                description: |-
+                  ReadyReplicas summarizes diskful replica readiness as "ready/total"
+                  (diskless tie-breakers and client legs excluded, like Phase). A
+                  preformatted string because CRD printcolumns cannot combine two
+                  integer fields into one cell.
                 type: string
             type: object
         required:

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -353,14 +353,16 @@ func (r *VolumeReconciler) fastPath(ctx context.Context, vol *miroirv1alpha1.Mir
 		(!localDiskless && vol.Status.PerNode[r.NodeName].SizeBytes != vol.Spec.SizeBytes) {
 		return false, ctrl.Result{}
 	}
-	// Phase is co-owned: every leg's full pass force-applies it from its
-	// own informer cache, and near-simultaneous passes (a resync
-	// completing) can land a stale value last, leaving the CR
-	// self-contradictory while every leg parks here until the deep check
-	// (issue #279). No kernel event re-breaks the fingerprint after that,
-	// so recompute from the cached CR and take the full pipeline to
-	// re-apply phase as soon as the informer shows the mismatch.
-	if computePhase(vol) != vol.Status.Phase {
+	// Phase and ReadyReplicas are co-owned: every leg's full pass
+	// force-applies them from its own informer cache, and
+	// near-simultaneous passes (a resync completing) can land a stale
+	// value last, leaving the CR self-contradictory while every leg parks
+	// here until the deep check (issue #279). No kernel event re-breaks
+	// the fingerprint after that, so recompute from the cached CR and take
+	// the full pipeline to re-apply them as soon as the informer shows the
+	// mismatch.
+	if phase, readyReplicas := computePhase(vol); phase != vol.Status.Phase ||
+		readyReplicas != vol.Status.ReadyReplicas {
 		return false, ctrl.Result{}
 	}
 	if !entry.replicated {
@@ -1098,11 +1100,12 @@ func (r *VolumeReconciler) patchStatus(ctx context.Context, vol *miroirv1alpha1.
 		vol.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{}
 	}
 	vol.Status.PerNode[r.NodeName] = mine
-	vol.Status.Phase = computePhase(vol)
+	vol.Status.Phase, vol.Status.ReadyReplicas = computePhase(vol)
 
 	ac := acv1alpha1.MiroirVolume(vol.Name).
 		WithStatus(acv1alpha1.MiroirVolumeStatus().
 			WithPhase(vol.Status.Phase).
+			WithReadyReplicas(vol.Status.ReadyReplicas).
 			WithPerNode(map[string]acv1alpha1.ReplicaStatusApplyConfiguration{
 				r.NodeName: *replicaStatusAC(mine),
 			}))
@@ -1243,10 +1246,12 @@ func detachedDiskMessage(diskFailed bool) string {
 }
 
 // computePhase aggregates per-node states into the volume phase the CSI
-// controller waits on.
-func computePhase(vol *miroirv1alpha1.MiroirVolume) miroirv1alpha1.VolumePhase {
+// controller waits on, plus the "ready/total" diskful summary backing the
+// Replicas printcolumn.
+func computePhase(vol *miroirv1alpha1.MiroirVolume) (miroirv1alpha1.VolumePhase, string) {
 	diskfulReplicas := vol.Spec.DiskfulReplicas()
 	ready := 0
+	failed := false
 	for _, rep := range diskfulReplicas {
 		st, ok := vol.Status.PerNode[rep.Node]
 		replicated := vol.Spec.DRBD != nil
@@ -1258,16 +1263,19 @@ func computePhase(vol *miroirv1alpha1.MiroirVolume) miroirv1alpha1.VolumePhase {
 			// Hard failure: the backing device never materialised.
 			// Errors after that point (DRBD connect retries, status
 			// hiccups) are transient and must not fail provisioning.
-			return miroirv1alpha1.VolumeFailed
+			failed = true
 		}
 	}
+	readyReplicas := fmt.Sprintf("%d/%d", ready, len(diskfulReplicas))
 	switch {
+	case failed:
+		return miroirv1alpha1.VolumeFailed, readyReplicas
 	case ready == len(diskfulReplicas):
-		return miroirv1alpha1.VolumeReady
+		return miroirv1alpha1.VolumeReady, readyReplicas
 	case ready > 0:
-		return miroirv1alpha1.VolumeDegraded
+		return miroirv1alpha1.VolumeDegraded, readyReplicas
 	default:
-		return miroirv1alpha1.VolumeCreating
+		return miroirv1alpha1.VolumeCreating, readyReplicas
 	}
 }
 

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1691,10 +1691,12 @@ func TestRemovalSnapshotGateSkipsTieBreaker(t *testing.T) {
 // covering its mixed-state logic here means a regression breaks the
 // test that mirrors the live behaviour, not a synthetic helper.
 func TestComputePhaseMixing(t *testing.T) {
+	const oneOfTwo = "1/2"
 	cases := []struct {
-		name string
-		vol  *miroirv1alpha1.MiroirVolume
-		want miroirv1alpha1.VolumePhase
+		name      string
+		vol       *miroirv1alpha1.MiroirVolume
+		want      miroirv1alpha1.VolumePhase
+		wantReady string
 	}{
 		{
 			name: "all replicas ready (unreplicated)",
@@ -1709,7 +1711,8 @@ func TestComputePhaseMixing(t *testing.T) {
 					},
 				},
 			},
-			want: miroirv1alpha1.VolumeReady,
+			want:      miroirv1alpha1.VolumeReady,
+			wantReady: "1/1",
 		},
 		{
 			name: "one ready, one not (replicated, degraded)",
@@ -1726,7 +1729,8 @@ func TestComputePhaseMixing(t *testing.T) {
 					},
 				},
 			},
-			want: miroirv1alpha1.VolumeDegraded,
+			want:      miroirv1alpha1.VolumeDegraded,
+			wantReady: oneOfTwo,
 		},
 		{
 			name: "all replicas Inconsistent (creating)",
@@ -1743,7 +1747,8 @@ func TestComputePhaseMixing(t *testing.T) {
 					},
 				},
 			},
-			want: miroirv1alpha1.VolumeCreating,
+			want:      miroirv1alpha1.VolumeCreating,
+			wantReady: "0/2",
 		},
 		{
 			name: "hard failure (no device, message set)",
@@ -1759,7 +1764,8 @@ func TestComputePhaseMixing(t *testing.T) {
 					},
 				},
 			},
-			want: miroirv1alpha1.VolumeFailed,
+			want:      miroirv1alpha1.VolumeFailed,
+			wantReady: oneOfTwo,
 		},
 		{
 			name: "transient error after device exists (stays Degraded, not Failed)",
@@ -1776,7 +1782,8 @@ func TestComputePhaseMixing(t *testing.T) {
 					},
 				},
 			},
-			want: miroirv1alpha1.VolumeDegraded,
+			want:      miroirv1alpha1.VolumeDegraded,
+			wantReady: oneOfTwo,
 		},
 		{
 			name: "diskless tie-breaker ignored (ready on diskful legs alone)",
@@ -1798,13 +1805,18 @@ func TestComputePhaseMixing(t *testing.T) {
 					},
 				},
 			},
-			want: miroirv1alpha1.VolumeReady,
+			want:      miroirv1alpha1.VolumeReady,
+			wantReady: "2/2",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := computePhase(tc.vol); got != tc.want {
+			got, gotReady := computePhase(tc.vol)
+			if got != tc.want {
 				t.Fatalf("phase = %s, want %s", got, tc.want)
+			}
+			if gotReady != tc.wantReady {
+				t.Fatalf("readyReplicas = %q, want %q", gotReady, tc.wantReady)
 			}
 		})
 	}
@@ -2158,6 +2170,9 @@ func TestReconcileFastPathInvalidatedByStalePhase(t *testing.T) {
 	}
 	if after.Status.Phase != miroirv1alpha1.VolumeReady {
 		t.Fatalf("phase = %q, want %q", after.Status.Phase, miroirv1alpha1.VolumeReady)
+	}
+	if after.Status.ReadyReplicas != "2/2" {
+		t.Fatalf("readyReplicas = %q, want %q", after.Status.ReadyReplicas, "2/2")
 	}
 }
 


### PR DESCRIPTION
Fixes #284. Stacked on #283 — merge that first; this PR's base is `fix/agent-fastpath-stale-phase` and only the top commit is new.

## Problem

The `Replicas` printcolumn pointed at `.spec.replicas[*].node`, and the apiextensions table converter renders only the first element of a wildcard JSONPath, so a healthy 2-replica volume printed a single node name and read as under-replicated.

## Change

- New `status.readyReplicas` field: a preformatted `ready/total` string over the diskful replicas (tie-breakers and client legs excluded, same as phase), since printcolumns cannot combine two integer fields into one cell. Computed in the same aggregation as phase and applied in the same status patch.
- The `Replicas` printcolumn now points at it and is default-visible (no `priority`), reading next to `PHASE` like a Deployment's `READY` column.
- Because the field is co-owned by every leg exactly like phase, the fast-path recompute guard from #283 covers it too: a stale count breaks the fingerprint and re-converges through the full pipeline instead of parking until the deep check. This also backfills the field on upgrade — existing volumes have it empty, which reads as a mismatch and routes the first reconcile through the full pass.
- `computePhase` now finishes the count on a hard provisioning failure instead of returning early; the phase result is unchanged.

The `Pools` column has the same wildcard limitation but no meaningful count representation, so it is left alone.

## Testing

- `TestComputePhaseMixing` extended with `ready/total` expectations across all six cases; the fast-path stale-phase test now also asserts the count is repaired.
- Full unit suite, `go vet`, `go build ./...` pass; CRDs and applyconfigurations regenerated via `mise run generate` / `mise run helm-crds`.