### PR TITLE
fix(agent): freeze mounted filesystems before snapshot cuts

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -646,7 +646,7 @@ func main() {
 			}
 			// Lift any IO barrier left by a previous agent crash; same
 			// fatal-only-on-API-failure contract.
-			if err := resumeStaleBarriers(drbdDriver, apiStartupWait); err != nil {
+			if err := resumeStaleBarriers(drbdDriver, agent.NewFreezer(), nodeName, apiStartupWait); err != nil {
 				setupLog.Error(err, "barrier resume sweep failed")
 				os.Exit(1)
 			}
@@ -660,7 +660,7 @@ func main() {
 		}
 		var drbdEvents chan event.GenericEvent
 		if drbdReady {
-			shutdownSweep = func() { agentShutdownSweep(cordon, drbdDriver) }
+			shutdownSweep = func() { agentShutdownSweep(cordon, drbdDriver, nodeName) }
 			// events2 turns kernel state changes into immediate reconciles;
 			// the 30s poll remains as the safety net.
 			drbdEvents = make(chan event.GenericEvent, 64)
@@ -691,6 +691,7 @@ func main() {
 			setupLog.Error(err, "unable to set up agent reconciler")
 			os.Exit(1)
 		}
+		freezer := agent.NewFreezer()
 		snapReconciler := &agent.SnapshotReconciler{
 			Client:   mgr.GetClient(),
 			NodeName: nodeName,
@@ -698,6 +699,7 @@ func main() {
 			DRBD:     drbdDriver,
 			Reader:   mgr.GetAPIReader(),
 			Recorder: mgr.GetEventRecorder("miroir-agent"),
+			Freezer:  freezer,
 		}
 		if err := snapReconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to set up snapshot reconciler")
@@ -710,6 +712,7 @@ func main() {
 			DRBD:     drbdDriver,
 			Reader:   mgr.GetAPIReader(),
 			Recorder: mgr.GetEventRecorder("miroir-agent"),
+			Freezer:  freezer,
 		}
 		if err := groupReconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to set up group snapshot reconciler")
@@ -819,7 +822,7 @@ func transientAPIError(err error) bool {
 // ungated teardown would disconnect idle replicas on every pod rollout. A
 // leftover write barrier is also kernel state that must not outlive the
 // process.
-func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver) {
+func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver, nodeName string) {
 	if cordon.Cordoned() {
 		ctx, cancel := context.WithTimeout(context.Background(), drbdShutdownTimeout)
 		defer cancel()
@@ -832,7 +835,7 @@ func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver) {
 	// manager stop + DownSecondaries already spend up to 45s of it. A
 	// stranded barrier missed here is lifted by the startup sweep on the
 	// next boot.
-	if err := resumeStaleBarriers(driver, apiShutdownWait); err != nil {
+	if err := resumeStaleBarriers(driver, agent.NewFreezer(), nodeName, apiShutdownWait); err != nil {
 		setupLog.Error(err, "shutdown barrier sweep failed")
 	}
 }
@@ -880,7 +883,7 @@ func sweepOrphans(nodeName string, driver *drbd.Driver) error {
 // Returns an error only when the snapshot list cannot be fetched; resume
 // failures are per-resource, logged here — one wedged resource must not
 // strand the other frozen volumes' barriers (issue #195).
-func resumeStaleBarriers(driver *drbd.Driver, apiBudget time.Duration) error {
+func resumeStaleBarriers(driver *drbd.Driver, freezer *agent.Freezer, nodeName string, apiBudget time.Duration) error {
 	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
 	if err != nil {
 		return err
@@ -904,16 +907,40 @@ func resumeStaleBarriers(driver *drbd.Driver, apiBudget time.Duration) error {
 		return nil
 	}
 	var errs []error
+	var stale []string
 	for _, vol := range suspended {
 		if fresh[vol] {
 			continue
 		}
+		stale = append(stale, vol)
 		if err := driver.ResumeIO(context.Background(), vol); err != nil {
 			errs = append(errs, fmt.Errorf("resume stale barrier on %s: %w", vol, err))
 		}
 	}
 	if err := errors.Join(errs...); err != nil {
 		setupLog.Error(err, "barrier resume sweep incomplete")
+	}
+	// A crash mid-round can leave the filesystem freeze behind exactly
+	// like the barrier; the reconcilers only thaw volumes whose snapshot
+	// objects still exist, so the sweep covers the rest. Fresh rounds
+	// keep their freeze — their own close lifts it.
+	if len(stale) > 0 && freezer != nil {
+		vols := &miroirv1alpha1.MiroirVolumeList{}
+		if err := listWithRetry(c, vols, apiBudget); err != nil {
+			setupLog.Error(err, "cannot list volumes; skipping freeze thaw sweep")
+			return nil
+		}
+		paths := map[string]string{}
+		for i := range vols.Items {
+			paths[vols.Items[i].Name] = vols.Items[i].Status.PerNode[nodeName].DevicePath
+		}
+		for _, name := range stale {
+			if device := paths[name]; device != "" {
+				if err := freezer.Thaw(device); err != nil {
+					setupLog.Error(err, "cannot thaw stale filesystem freeze", "volume", name)
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,6 +30,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -897,6 +898,35 @@ func resumeStaleBarriers(driver *drbd.Driver, freezer *agent.Freezer, nodeName s
 		if s.Status.IOSuspended && s.Status.SuspendedAt != nil &&
 			time.Since(s.Status.SuspendedAt.Time) < agent.SuspendDeadline {
 			fresh[s.Spec.VolumeName] = true
+		}
+	}
+	// A group round's ioSuspended lives on the group object, not on its
+	// member snapshots — without this, every volume of a live group round
+	// reads as stale and the sweep resumes (and thaws) mid-cut. Member
+	// volumes come from the member snapshots; perLeg slot keys
+	// ("<volume>/<node>") cover a member already torn out of the list.
+	groups := &miroirv1alpha1.MiroirSnapshotGroupList{}
+	if err := listWithRetry(c, groups, apiBudget); err != nil {
+		return err
+	}
+	snapVol := map[string]string{}
+	for _, s := range snaps.Items {
+		snapVol[s.Name] = s.Spec.VolumeName
+	}
+	for _, g := range groups.Items {
+		if !g.Status.IOSuspended || g.Status.SuspendedAt == nil ||
+			time.Since(g.Status.SuspendedAt.Time) >= agent.SuspendDeadline {
+			continue
+		}
+		for _, name := range g.Spec.SnapshotNames {
+			if vol := snapVol[name]; vol != "" {
+				fresh[vol] = true
+			}
+		}
+		for key := range g.Status.PerLeg {
+			if vol, _, ok := strings.Cut(key, "/"); ok {
+				fresh[vol] = true
+			}
 		}
 	}
 	suspended, err := driver.UserSuspended(context.Background())

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -255,13 +255,14 @@ Requires the cluster-wide `snapshot-controller` and `volumesnapshot`
 CRDs (see the [CSI snapshot docs](https://kubernetes-csi.github.io/docs/snapshots.html)),
 plus a VolumeSnapshotClass (the `miroir-snap` manifest above).
 
-Snapshots of a mounted filesystem are filesystem-consistent: on the
-node where the volume is mounted, the agent freezes the filesystem
-(flushing every cached write) just before the cut and thaws it right
-after, so even data an application wrote without `fsync` is in the
-snapshot. Raw block volumes are crash-consistent — miroir cannot know
-what the application considers a consistent instant there; quiesce
-writes yourself if you need more.
+Snapshots of a mounted filesystem are filesystem-consistent: for
+replicated volumes the agent freezes the filesystem (flushing every
+cached write) on the node where it is mounted just before the cut and
+thaws it right after, and for `replicas: 1` lvmthin volumes the cut
+itself suspends the device with the same flush-and-freeze effect — so
+even data an application wrote without `fsync` is in the snapshot.
+Unreplicated `zfs` and `loopfile` snapshots and all raw block volumes
+are crash-consistent; quiesce writes yourself if you need more there.
 
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -255,6 +255,14 @@ Requires the cluster-wide `snapshot-controller` and `volumesnapshot`
 CRDs (see the [CSI snapshot docs](https://kubernetes-csi.github.io/docs/snapshots.html)),
 plus a VolumeSnapshotClass (the `miroir-snap` manifest above).
 
+Snapshots of a mounted filesystem are filesystem-consistent: on the
+node where the volume is mounted, the agent freezes the filesystem
+(flushing every cached write) just before the cut and thaws it right
+after, so even data an application wrote without `fsync` is in the
+snapshot. Raw block volumes are crash-consistent — miroir cannot know
+what the application considers a consistent instant there; quiesce
+writes yourself if you need more.
+
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot

--- a/internal/agent/fsfreeze.go
+++ b/internal/agent/fsfreeze.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+// FIFREEZE/FITHAW from linux/fs.h (_IOWR('X', 119/120, int)); x/sys/unix
+// does not export them.
+const (
+	fiFreeze = 0xc0045877
+	fiThaw   = 0xc0045878
+)
+
+// freezeTimeout bounds the FIFREEZE ioctl: it blocks until the
+// filesystem's dirty pages are written back, which on a struggling
+// device can outlast the whole barrier round. A freeze abandoned on
+// timeout is self-canceling (see Freeze), so the round can retry
+// without risking a filesystem left frozen with no owner.
+const freezeTimeout = 30 * time.Second
+
+// Freezer freezes and thaws the filesystem mounted on a block device,
+// upgrading a snapshot cut from crash-consistent to
+// filesystem-consistent: FIFREEZE writes back all dirty pages and
+// quiesces new writes above the block layer, so the data an
+// application wrote before the cut — synced or not — is on the device
+// when the barrier rises (issue #291).
+//
+// The device is matched against live mounts by device number, so any
+// alias path (/dev/drbd1000, /dev/mapper/…, /dev/zvol/…) finds its
+// mount. A device mounted more than once (staging plus pod binds)
+// shares one superblock; freezing any mountpoint freezes them all.
+type Freezer struct {
+	// mountinfo, devNumber and ioctl are the syscall surface, injectable
+	// in tests.
+	mountinfo func() ([]byte, error)
+	devNumber func(path string) (uint64, bool, error)
+	ioctl     func(mountpoint string, req uint) error
+}
+
+// NewFreezer returns a Freezer backed by /proc/self/mountinfo and real
+// ioctls. The agent's mount namespace sees the kubelet staging mounts
+// it created (the kubelet dir hostPath propagates them).
+func NewFreezer() *Freezer {
+	return &Freezer{
+		mountinfo: func() ([]byte, error) { return os.ReadFile("/proc/self/mountinfo") },
+		devNumber: realDevNumber,
+		ioctl:     freezeIoctl,
+	}
+}
+
+// Freeze freezes the filesystem mounted from device, returning the
+// mountpoint it froze ("" when the device is not fs-mounted here — a
+// Secondary leg, a raw-block volume, or an unstaged device). A
+// filesystem already frozen (EBUSY) counts as success: the freeze is
+// shared state exactly like the kernel's suspend-io flag, and the
+// paired Thaw tolerates the mirror case. On timeout the ioctl cannot
+// be interrupted, so a watcher thaws the late freeze the moment it
+// lands: a failed Freeze never leaves the filesystem frozen.
+func (f *Freezer) Freeze(ctx context.Context, device string) (string, error) {
+	mp, err := f.mountpointOf(device)
+	if err != nil || mp == "" {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, freezeTimeout)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- f.ioctl(mp, fiFreeze) }()
+	select {
+	case err := <-done:
+		if errors.Is(err, unix.EBUSY) {
+			return mp, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("freeze %s (%s): %w", mp, device, err)
+		}
+		return mp, nil
+	case <-ctx.Done():
+		go func() {
+			if err := <-done; err == nil {
+				_ = f.ioctl(mp, fiThaw)
+			}
+		}()
+		return "", fmt.Errorf("freeze %s (%s): %w", mp, device, ctx.Err())
+	}
+}
+
+// Thaw lifts the freeze on the filesystem mounted from device. Not
+// mounted or not frozen (EINVAL) are successes: thaw is called from
+// every path that closes or abandons a barrier round, most of which
+// never froze anything.
+func (f *Freezer) Thaw(device string) error {
+	mp, err := f.mountpointOf(device)
+	if err != nil || mp == "" {
+		return err
+	}
+	if err := f.ioctl(mp, fiThaw); err != nil && !errors.Is(err, unix.EINVAL) {
+		return fmt.Errorf("thaw %s (%s): %w", mp, device, err)
+	}
+	return nil
+}
+
+// mountpointOf finds the first mountpoint whose filesystem is backed by
+// device, matching by device number so alias paths resolve. Filesystems
+// not backed by a block device (devtmpfs bind mounts of the device node
+// included) never match: their mountinfo st_dev is not the device's
+// rdev.
+func (f *Freezer) mountpointOf(device string) (string, error) {
+	rdev, isDev, err := f.devNumber(device)
+	if err != nil || !isDev {
+		// A device that vanished mid-round has nothing mounted left to
+		// freeze or thaw.
+		return "", nil
+	}
+	data, err := f.mountinfo()
+	if err != nil {
+		return "", err
+	}
+	want := fmt.Sprintf("%d:%d", unix.Major(rdev), unix.Minor(rdev))
+	for line := range strings.Lines(string(data)) {
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		if fields[2] == want {
+			return fields[4], nil
+		}
+	}
+	return "", nil
+}
+
+// freezeMounted freezes the volume's locally mounted filesystem (a
+// no-op on nodes where it is not mounted — only the Primary mounts).
+// Ordering is the whole point: the freeze's writeback happens before
+// this node's own suspend-io, and suspend-io only blocks writes where
+// they originate, so the flushed pages replicate to every leg before
+// any barrier that matters to them rises.
+func freezeMounted(ctx context.Context, f *Freezer, node string, vol *miroirv1alpha1.MiroirVolume) error {
+	if f == nil {
+		return nil
+	}
+	device := vol.Status.PerNode[node].DevicePath
+	if device == "" {
+		return nil
+	}
+	_, err := f.Freeze(ctx, device)
+	return err
+}
+
+// thawMounted lifts the local filesystem freeze; best-effort (not
+// mounted or not frozen are successes), logged so a persistently
+// failing thaw — a frozen workload — is never silent.
+func thawMounted(ctx context.Context, f *Freezer, node string, vol *miroirv1alpha1.MiroirVolume) {
+	if f == nil {
+		return
+	}
+	device := vol.Status.PerNode[node].DevicePath
+	if device == "" {
+		return
+	}
+	if err := f.Thaw(device); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "cannot thaw the snapshot filesystem freeze", "volume", vol.Name)
+	}
+}
+
+// realDevNumber stats path and returns its device number; isDev is
+// false for anything but a block device (including a missing path).
+func realDevNumber(path string) (uint64, bool, error) {
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		return 0, false, nil
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFBLK {
+		return 0, false, nil
+	}
+	return st.Rdev, true, nil
+}
+
+// freezeIoctl opens the mountpoint and issues the freeze/thaw ioctl.
+func freezeIoctl(mountpoint string, req uint) error {
+	fd, err := unix.Open(mountpoint, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	return unix.IoctlSetInt(fd, req, 0)
+}

--- a/internal/agent/fsfreeze_test.go
+++ b/internal/agent/fsfreeze_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	devDrbd1000 = "/dev/drbd1000"
+	mntStage1   = "/mnt/stage-1"
+	callFreeze1 = "freeze " + mntStage1
+	callThaw1   = "thaw " + mntStage1
+)
+
+// testMountinfo mirrors /proc/self/mountinfo: the drbd device (147:0)
+// carries an ext4 staging mount plus a pod bind of the same superblock;
+// devtmpfs (0:6) hosts the raw-block bind of a device node.
+const testMountinfo = `21 1 8:1 / / rw,relatime - ext4 /dev/sda1 rw
+36 21 147:0 / /var/lib/kubelet/plugins/kubernetes.io/csi/miroir/abc/globalmount rw,relatime - ext4 /dev/drbd1000 rw
+37 21 147:0 / /var/lib/kubelet/pods/x/volumes/kubernetes.io~csi/pvc-1/mount rw,relatime - ext4 /dev/drbd1000 rw
+40 21 0:6 /drbd1001 /var/lib/kubelet/pods/y/volumeDevices/pvc-2 rw - devtmpfs devtmpfs rw
+`
+
+// ioctlRecorder captures freeze/thaw ioctls and answers from a scripted
+// error queue (nil when exhausted).
+type ioctlRecorder struct {
+	mu    sync.Mutex
+	calls []string
+	errs  []error
+}
+
+func (r *ioctlRecorder) ioctl(mountpoint string, req uint) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	op := "thaw"
+	if req == fiFreeze {
+		op = "freeze"
+	}
+	r.calls = append(r.calls, op+" "+mountpoint)
+	if len(r.errs) == 0 {
+		return nil
+	}
+	err := r.errs[0]
+	r.errs = r.errs[1:]
+	return err
+}
+
+func (r *ioctlRecorder) recorded() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+// mountedFreezer builds a Freezer that sees each device mounted at its
+// mountpoint, recording freezes and thaws into rec. An empty map is a
+// node where nothing is mounted (a Secondary).
+func mountedFreezer(rec *ioctlRecorder, mounts map[string]string) *Freezer {
+	devs := map[string]uint64{}
+	var info strings.Builder
+	i := uint32(0)
+	for dev, mp := range mounts {
+		i++
+		devs[dev] = unix.Mkdev(147, i)
+		fmt.Fprintf(&info, "%d 1 147:%d / %s rw - ext4 %s rw\n", 35+i, i, mp, dev)
+	}
+	lines := info.String()
+	return &Freezer{
+		mountinfo: func() ([]byte, error) { return []byte(lines), nil },
+		devNumber: func(path string) (uint64, bool, error) {
+			d, ok := devs[path]
+			return d, ok, nil
+		},
+		ioctl: rec.ioctl,
+	}
+}
+
+func testFreezer(rec *ioctlRecorder) *Freezer {
+	return &Freezer{
+		mountinfo: func() ([]byte, error) { return []byte(testMountinfo), nil },
+		devNumber: func(path string) (uint64, bool, error) {
+			if path == devDrbd1000 {
+				return unix.Mkdev(147, 0), true, nil
+			}
+			return 0, false, nil
+		},
+		ioctl: rec.ioctl,
+	}
+}
+
+func TestFreezeFreezesTheStagingMount(t *testing.T) {
+	rec := &ioctlRecorder{}
+	f := testFreezer(rec)
+	mp, err := f.Freeze(t.Context(), devDrbd1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(mp, "/globalmount") {
+		t.Fatalf("must freeze the first mount of the device, got %q", mp)
+	}
+	if calls := rec.recorded(); len(calls) != 1 || calls[0] != "freeze "+mp {
+		t.Fatalf("unexpected ioctls: %v", calls)
+	}
+}
+
+func TestFreezeSkipsUnmountedDevice(t *testing.T) {
+	rec := &ioctlRecorder{}
+	f := testFreezer(rec)
+	// Not a block device here (a torn-down volume) — never an error.
+	mp, err := f.Freeze(t.Context(), "/dev/drbd9999")
+	if err != nil || mp != "" {
+		t.Fatalf("unmounted device must be a no-op, got %q, %v", mp, err)
+	}
+	if len(rec.recorded()) != 0 {
+		t.Fatalf("no ioctl may run without a mount: %v", rec.recorded())
+	}
+}
+
+func TestFreezeTreatsAlreadyFrozenAsSuccess(t *testing.T) {
+	rec := &ioctlRecorder{errs: []error{unix.EBUSY}}
+	f := testFreezer(rec)
+	mp, err := f.Freeze(t.Context(), devDrbd1000)
+	if err != nil || mp == "" {
+		t.Fatalf("EBUSY (already frozen) must count as success, got %q, %v", mp, err)
+	}
+}
+
+func TestFreezeTimeoutSelfCancels(t *testing.T) {
+	rec := &ioctlRecorder{}
+	release := make(chan struct{})
+	thawed := make(chan struct{})
+	f := testFreezer(rec)
+	inner := f.ioctl
+	f.ioctl = func(mp string, req uint) error {
+		if req == fiFreeze {
+			<-release
+		}
+		err := inner(mp, req)
+		if req == fiThaw {
+			close(thawed)
+		}
+		return err
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := f.Freeze(ctx, devDrbd1000); err == nil {
+		t.Fatal("a freeze past the deadline must fail the round")
+	}
+	// The abandoned ioctl lands later; its success must be thawed away.
+	close(release)
+	select {
+	case <-thawed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("late freeze was never self-canceled")
+	}
+}
+
+func TestThawToleratesNotFrozen(t *testing.T) {
+	rec := &ioctlRecorder{errs: []error{unix.EINVAL}}
+	f := testFreezer(rec)
+	if err := f.Thaw(devDrbd1000); err != nil {
+		t.Fatalf("EINVAL (not frozen) must be a success: %v", err)
+	}
+}
+
+func TestThawSurfacesRealErrors(t *testing.T) {
+	rec := &ioctlRecorder{errs: []error{errors.New("io error")}}
+	f := testFreezer(rec)
+	if err := f.Thaw(devDrbd1000); err == nil {
+		t.Fatal("a real thaw failure must surface (a frozen workload)")
+	}
+}
+
+func TestRawBlockBindNeverMatches(t *testing.T) {
+	rec := &ioctlRecorder{}
+	f := testFreezer(rec)
+	f.devNumber = func(path string) (uint64, bool, error) {
+		// The raw-block device node exists, but no filesystem is backed
+		// by it — the devtmpfs bind's st_dev is devtmpfs's, not 147:1.
+		return unix.Mkdev(147, 1), true, nil
+	}
+	mp, err := f.Freeze(t.Context(), "/dev/drbd1001")
+	if err != nil || mp != "" {
+		t.Fatalf("raw-block volumes have nothing to freeze, got %q, %v", mp, err)
+	}
+}

--- a/internal/agent/groupsnapshot.go
+++ b/internal/agent/groupsnapshot.go
@@ -80,6 +80,10 @@ type GroupSnapshotReconciler struct {
 	Reader client.Reader
 	// Recorder emits the BarrierStuck warning; optional.
 	Recorder events.EventRecorder
+	// Freezer freezes each locally mounted member filesystem before this
+	// node's barrier on it rises (issue #291); optional (nil skips,
+	// crash-consistent as before).
+	Freezer *Freezer
 
 	// barrierFails parks a group whose barrier path fails persistently,
 	// mirroring SnapshotReconciler.barrierFails.
@@ -114,9 +118,13 @@ func (r *GroupSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// A group deleted mid-round must not strand barriers. Lift every
 		// local member barrier the kernel still holds — keyed on kernel
 		// state, and never one a sibling round now owns.
+		vols := map[string]*miroirv1alpha1.MiroirVolume{}
+		for _, m := range members {
+			vols[m.vol.Name] = m.vol
+		}
 		for _, volume := range r.sweepVolumes(grp, members) {
 			if st, err := r.drbdStatus(ctx, volume); err == nil && st.Suspended {
-				if err := r.resumeUnlessOtherRound(ctx, grp, volume); err != nil {
+				if err := r.resumeUnlessOtherRound(ctx, grp, volume, vols[volume]); err != nil {
 					return ctrl.Result{}, err
 				}
 			}
@@ -144,10 +152,14 @@ func (r *GroupSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// ones — unless a sibling round owns the kernel flag by now.
 		for _, m := range mine {
 			if st, err := r.drbdStatus(ctx, m.vol.Name); err == nil && st.Suspended {
-				if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name); err != nil {
+				if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name, m.vol); err != nil {
 					return ctrl.Result{}, err
 				}
+				continue
 			}
+			// A freeze can outlive the barrier (a crash mid-round whose
+			// stale barrier the startup sweep resumed).
+			thawMounted(ctx, r.Freezer, r.NodeName, m.vol)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -212,7 +224,7 @@ func (r *GroupSnapshotReconciler) reconcileRound(ctx context.Context, grp *miroi
 		// unless a sibling round owns one of them by now.
 		for _, m := range mine {
 			if sts[m.vol.Name].Suspended {
-				if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name); err != nil {
+				if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name, m.vol); err != nil {
 					return ctrl.Result{RequeueAfter: 2 * time.Second}, err
 				}
 			}
@@ -284,9 +296,17 @@ func (r *GroupSnapshotReconciler) raiseBarriers(ctx context.Context, grp *miroir
 	}
 	suspended := make([]groupMember, 0, len(mine))
 	for _, m := range mine {
+		// Freeze strictly before this leg's suspend (see the per-snapshot
+		// round's twin): the writeback must replicate while the leg still
+		// accepts IO.
+		if err := freezeMounted(ctx, r.Freezer, r.NodeName, m.vol); err != nil {
+			_ = r.resumeMine(ctx, grp, suspended)
+			return r.barrierFailed(ctx, grp, m.vol, err)
+		}
 		if err := r.suspendIO(ctx, m.vol.Name); err != nil {
 			// A half-raised node must not stay half-frozen behind a failed
 			// raise; the retry re-raises the lot.
+			thawMounted(ctx, r.Freezer, r.NodeName, m.vol)
 			_ = r.resumeMine(ctx, grp, suspended)
 			return r.barrierFailed(ctx, grp, m.vol, err)
 		}
@@ -557,7 +577,7 @@ func allSlotsSuspended(grp *miroirv1alpha1.MiroirSnapshotGroup, members []groupM
 // voided-round branches re-check and lift once nothing holds it.
 func (r *GroupSnapshotReconciler) resumeMine(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, mine []groupMember) error {
 	for _, m := range mine {
-		if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name); err != nil {
+		if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name, m.vol); err != nil {
 			return err
 		}
 	}
@@ -566,12 +586,21 @@ func (r *GroupSnapshotReconciler) resumeMine(ctx context.Context, grp *miroirv1a
 
 // resumeUnlessOtherRound lifts the local barrier on volume unless a
 // sibling round — a standalone snapshot's or another group's — owns it.
-func (r *GroupSnapshotReconciler) resumeUnlessOtherRound(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, volume string) error {
+// The filesystem freeze thaws under the same rule (the round that lifts
+// the barrier lifts the freeze); vol is nil for a slot-key ghost whose
+// volume object is gone — its device (and any mount) went with it.
+func (r *GroupSnapshotReconciler) resumeUnlessOtherRound(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, volume string, vol *miroirv1alpha1.MiroirVolume) error {
 	active, err := volumeRoundActive(ctx, r.reader(), volume, "", grp.Name)
 	if err != nil || active {
 		return err
 	}
-	return r.resumeIO(ctx, volume)
+	if err := r.resumeIO(ctx, volume); err != nil {
+		return err
+	}
+	if vol != nil {
+		thawMounted(ctx, r.Freezer, r.NodeName, vol)
+	}
+	return nil
 }
 
 // backendFor resolves the backend holding the volume's local leg.

--- a/internal/agent/groupsnapshot_test.go
+++ b/internal/agent/groupsnapshot_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agent
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -423,5 +424,52 @@ func TestGroupSnapshotDeletionLiftsBarriersWithoutMembers(t *testing.T) {
 		if f == constants.FinalizerPrefix+nodeA {
 			t.Fatalf("this node's finalizer must be released: %v", got.Finalizers)
 		}
+	}
+}
+
+// The group round freezes every locally mounted member filesystem
+// before its barrier rises and thaws them all when the round seals; a
+// node without mounts (the Secondary) never freezes.
+func TestGroupFreezeBracketsRound(t *testing.T) {
+	v1, v2 := groupVol(volPvc1), groupVol(volPvc2)
+	for i, v := range []*miroirv1alpha1.MiroirVolume{v1, v2} {
+		st := v.Status.PerNode[nodeA]
+		st.DevicePath = fmt.Sprintf("/dev/drbd100%d", i)
+		v.Status.PerNode[nodeA] = st
+	}
+	c := groupClient(t, v1, v2,
+		memberObj(memberOf1, volPvc1), memberObj(memberOf2, volPvc2), groupObj())
+
+	recK := &ioctlRecorder{}
+	feK := &fakeDRBDExec{statusJSON: groupStatusPrimary}
+	rK := &GroupSnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feK.run},
+		Freezer: mountedFreezer(recK, map[string]string{
+			devDrbd1000: mntStage1, "/dev/drbd1001": "/mnt/stage-2"})}
+	recP := &ioctlRecorder{}
+	feP := &fakeDRBDExec{statusJSON: groupStatusPeer}
+	rP := &GroupSnapshotReconciler{Client: c, NodeName: nodeB, Pools: poolsOf(newFakeBackend()),
+		DRBD:    &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run},
+		Freezer: mountedFreezer(recP, nil)}
+
+	// Driver opens the round: both mounted members freeze first.
+	reconcileGroup(t, rK)
+	calls := recK.recorded()
+	if len(calls) != 2 || calls[0] != callFreeze1 || calls[1] != "freeze /mnt/stage-2" {
+		t.Fatalf("the driver must freeze every mounted member at the raise: %v", calls)
+	}
+	// Peer raises, both cut, driver collects: every freeze thaws.
+	reconcileGroup(t, rP)
+	reconcileGroup(t, rK)
+	reconcileGroup(t, rP)
+	reconcileGroup(t, rK)
+	feK.calledWith(t, "drbdadm resume-io "+volPvc1)
+	calls = recK.recorded()
+	if len(calls) != 4 || calls[2] != callThaw1 || calls[3] != "thaw /mnt/stage-2" {
+		t.Fatalf("sealing the round must thaw every freeze: %v", calls)
+	}
+	reconcileGroup(t, rP)
+	if calls := recP.recorded(); len(calls) != 0 {
+		t.Fatalf("the unmounted Secondary must never freeze or thaw: %v", calls)
 	}
 }

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -475,7 +475,7 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	st := got.Status.PerNode[nodeA]
-	if st.DevicePath != "/dev/drbd1000" {
+	if st.DevicePath != devDrbd1000 {
 		t.Fatalf("pods must attach the DRBD device, got %q", st.DevicePath)
 	}
 	if st.DiskState != diskStateUpToDate || !st.Connected {

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -300,16 +300,18 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		// Single replica: no barrier needed, but queued writes must land.
-		// The freeze upgrades the cut to filesystem-consistent here too —
-		// Sync drains the block layer, not the page cache above it.
+		// No explicit freeze here: with the filesystem directly on the
+		// backend device, lvmthin's own cut suspends that device (dm
+		// suspend), which flushes and freezes the filesystem as a KERNEL
+		// freeze holder — a userspace FIFREEZE stacked on top leaves the
+		// blockdev freeze count unbalanced and the device unmountable
+		// ("Can't mount, blockdev is frozen"). The replicated rounds
+		// freeze safely because their filesystem sits on /dev/drbdX,
+		// isolated from the backing device the backend suspends.
 		be, err := r.backendFor(vol)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if err := r.freeze(ctx, vol); err != nil {
-			return ctrl.Result{}, err
-		}
-		defer r.thaw(ctx, vol)
 		if err := be.Sync(ctx, vol.Name); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -86,6 +86,10 @@ type SnapshotReconciler struct {
 	Reader client.Reader
 	// Recorder emits the BarrierStuck warning; optional.
 	Recorder events.EventRecorder
+	// Freezer freezes the mounted filesystem before this node's barrier
+	// rises, making the cut filesystem-consistent (issue #291); optional
+	// (nil skips, crash-consistent as before).
+	Freezer *Freezer
 
 	// barrierFails counts consecutive DRBD failures on the barrier path
 	// (the status read and suspend-io) per snapshot. Past barrierFailLimit
@@ -177,6 +181,16 @@ func (r *SnapshotReconciler) resumeIO(ctx context.Context, name string) error {
 	return r.DRBD.ResumeIO(ctx, name)
 }
 
+// freeze and thaw wrap the shared helpers with this reconciler's
+// freezer and node.
+func (r *SnapshotReconciler) freeze(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) error {
+	return freezeMounted(ctx, r.Freezer, r.NodeName, vol)
+}
+
+func (r *SnapshotReconciler) thaw(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) {
+	thawMounted(ctx, r.Freezer, r.NodeName, vol)
+}
+
 // Reconcile drives one snapshot's state machine from this node's view.
 func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	snap := &miroirv1alpha1.MiroirSnapshot{}
@@ -258,6 +272,10 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, r.resumeUnlessSiblingRound(ctx, snap, vol)
 			}
 		}
+		// A freeze can outlive the barrier (a crash mid-round whose
+		// stale barrier the startup sweep resumed); thaw is a no-op
+		// when nothing is frozen.
+		r.thaw(ctx, vol)
 		return ctrl.Result{}, nil
 	}
 
@@ -282,10 +300,16 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		// Single replica: no barrier needed, but queued writes must land.
+		// The freeze upgrades the cut to filesystem-consistent here too —
+		// Sync drains the block layer, not the page cache above it.
 		be, err := r.backendFor(vol)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+		if err := r.freeze(ctx, vol); err != nil {
+			return ctrl.Result{}, err
+		}
+		defer r.thaw(ctx, vol)
 		if err := be.Sync(ctx, vol.Name); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -376,7 +400,14 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 	if _, err := r.backendFor(vol); err != nil {
 		return ctrl.Result{}, err
 	}
+	// Freeze strictly before the local suspend: FIFREEZE writes back the
+	// page cache, and those writes must reach the device (and replicate)
+	// while this leg still accepts IO.
+	if err := r.freeze(ctx, vol); err != nil {
+		return r.barrierFailed(ctx, snap, vol, err)
+	}
 	if err := r.suspendIO(ctx, vol.Name); err != nil {
+		r.thaw(ctx, vol)
 		return r.barrierFailed(ctx, snap, vol, err)
 	}
 	r.clearBarrierFails(snap.Name)
@@ -595,13 +626,20 @@ func (r *SnapshotReconciler) snapReader() client.Reader {
 }
 
 // resumeUnlessSiblingRound lifts the local barrier unless a sibling
-// snapshot's live round owns it (that round's protocol lifts it).
+// snapshot's live round owns it (that round's protocol lifts it). The
+// filesystem freeze is shared state exactly like the kernel flag, so
+// it thaws under the same rule: the round that lifts the barrier lifts
+// the freeze.
 func (r *SnapshotReconciler) resumeUnlessSiblingRound(ctx context.Context, snap *miroirv1alpha1.MiroirSnapshot, vol *miroirv1alpha1.MiroirVolume) error {
 	active, err := r.otherRoundActive(ctx, snap)
 	if err != nil || active {
 		return err
 	}
-	return r.resumeIO(ctx, vol.Name)
+	if err := r.resumeIO(ctx, vol.Name); err != nil {
+		return err
+	}
+	r.thaw(ctx, vol)
+	return nil
 }
 
 // isCoordinator: the Primary owns the barrier (suspend-io only blocks

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -1290,34 +1290,3 @@ func TestSnapshotSuspendFailureThawsFreeze(t *testing.T) {
 		t.Fatalf("a failed raise must thaw what it froze: %v", calls)
 	}
 }
-
-// The single-replica cut freezes the mounted filesystem around
-// Sync+Snapshot: Sync drains the block layer, the freeze drains the
-// page cache above it.
-func TestSnapshotUnreplicatedFreezesAroundCut(t *testing.T) {
-	s := newScheme(t)
-	fb := newFakeBackend()
-	v := vol(volPvc1, nodeA)
-	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
-		nodeA: {DeviceCreated: true, DevicePath: "/dev/lv1"},
-	}
-	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA)).
-		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
-		Build()
-
-	rec := &ioctlRecorder{}
-	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb),
-		Freezer: mountedFreezer(rec, map[string]string{"/dev/lv1": "/mnt/lv1"})}
-	reconcileSnap(t, r, snapSnap1)
-
-	if calls := rec.recorded(); len(calls) != 2 ||
-		calls[0] != "freeze /mnt/lv1" || calls[1] != "thaw /mnt/lv1" {
-		t.Fatalf("the cut must be bracketed by freeze and thaw: %v", calls)
-	}
-	got := &miroirv1alpha1.MiroirSnapshot{}
-	_ = c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got)
-	if !got.Status.ReadyToUse {
-		t.Fatalf("snapshot must be ready: %+v", got.Status)
-	}
-}

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -1201,3 +1201,123 @@ func TestSnapshotSiblingCheckReadsThroughAPIReader(t *testing.T) {
 	fe.notCalledWith(t, "resume-io")
 	fe.notCalledWith(t, "suspend-io")
 }
+
+// The filesystem freeze brackets the replicated round on the node that
+// has the volume mounted (the coordinator/Primary): frozen before the
+// barrier rises, thawed when the round resumes. The Secondary mounts
+// nothing and must never freeze.
+func TestSnapshotFreezeBracketsReplicatedRound(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate, DevicePath: devDrbd1000},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate, DevicePath: devDrbd1000},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	recK := &ioctlRecorder{}
+	feK := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	rK := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD:    &drbd.Driver{StateDir: t.TempDir(), Exec: feK.run},
+		Freezer: mountedFreezer(recK, map[string]string{devDrbd1000: mntStage1})}
+
+	recP := &ioctlRecorder{}
+	feP := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`}
+	rP := &SnapshotReconciler{Client: c, NodeName: nodeB, Pools: poolsOf(newFakeBackend()),
+		DRBD:    &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run},
+		Freezer: mountedFreezer(recP, nil)}
+
+	// Coordinator raise: freeze precedes the barrier.
+	reconcileSnap(t, rK, snapSnap1)
+	if calls := recK.recorded(); len(calls) != 1 || calls[0] != callFreeze1 {
+		t.Fatalf("coordinator must freeze its mount at the raise: %v", calls)
+	}
+	// Peer raise: nothing mounted, nothing frozen.
+	reconcileSnap(t, rP, snapSnap1)
+	// Cut on both, then the coordinator collects and thaws.
+	reconcileSnap(t, rK, snapSnap1)
+	reconcileSnap(t, rP, snapSnap1)
+	reconcileSnap(t, rK, snapSnap1)
+	feK.calledWith(t, "drbdadm resume-io pvc-1")
+	if calls := recK.recorded(); len(calls) != 2 || calls[1] != callThaw1 {
+		t.Fatalf("closing the round must thaw the freeze: %v", calls)
+	}
+	// The peer lifts its own barrier at readyToUse; it froze nothing.
+	reconcileSnap(t, rP, snapSnap1)
+	if calls := recP.recorded(); len(calls) != 0 {
+		t.Fatalf("the unmounted Secondary must never freeze or thaw: %v", calls)
+	}
+}
+
+// A freeze followed by a failed suspend must not leave the filesystem
+// frozen behind a barrier that never rose.
+func TestSnapshotSuspendFailureThawsFreeze(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate, DevicePath: devDrbd1000},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	rec := &ioctlRecorder{}
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"}]}]`,
+		errOn: map[string]error{"suspend-io": errors.New("exit status 20")}}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD:    &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run},
+		Freezer: mountedFreezer(rec, map[string]string{devDrbd1000: mntStage1})}
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}); err == nil {
+		t.Fatal("a failed suspend must surface")
+	}
+	if calls := rec.recorded(); len(calls) != 2 ||
+		calls[0] != callFreeze1 || calls[1] != callThaw1 {
+		t.Fatalf("a failed raise must thaw what it froze: %v", calls)
+	}
+}
+
+// The single-replica cut freezes the mounted filesystem around
+// Sync+Snapshot: Sync drains the block layer, the freeze drains the
+// page cache above it.
+func TestSnapshotUnreplicatedFreezesAroundCut(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := vol(volPvc1, nodeA)
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DevicePath: "/dev/lv1"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	rec := &ioctlRecorder{}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		Freezer: mountedFreezer(rec, map[string]string{"/dev/lv1": "/mnt/lv1"})}
+	reconcileSnap(t, r, snapSnap1)
+
+	if calls := rec.recorded(); len(calls) != 2 ||
+		calls[0] != "freeze /mnt/lv1" || calls[1] != "thaw /mnt/lv1" {
+		t.Fatalf("the cut must be bracketed by freeze and thaw: %v", calls)
+	}
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	_ = c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got)
+	if !got.Status.ReadyToUse {
+		t.Fatalf("snapshot must be ready: %+v", got.Status)
+	}
+}


### PR DESCRIPTION
Closes #291.

## Problem

Snapshot rounds raise the DRBD `suspend-io` barrier, which is block-level: it quiesces writes reaching the device but not the page cache above it. Data an application wrote without `fsync` in the seconds before a cut could be missing from the snapshot — upstream's group-snapshot conformance spec caught exactly that on the replicated e2e's slow VMs (a restored member came back empty), while the same spec passed on a fast host where ext4's ~5s journal commit won the race.

## Fix

Each node now freezes the filesystems of the volumes **it** has mounted (`FIFREEZE` writes back all dirty pages and quiesces the fs) immediately before raising its own barrier on that volume, and thaws them when it lifts the barrier.

The ordering argument is what makes this small: neither round's protocol changes. The mount lives on the Primary (DRBD only mounts there), `suspend-io` only blocks writes where they originate, and the freeze's writeback replicates to every leg before the Primary's own barrier rises — so every leg's cut includes the flushed data, regardless of which node drives the round or in what order peers raised. This holds for the group round too, where member volumes can have different Primaries than the driver: each node freezes its own mounts before its own raise, and that is sufficient.

- The single-replica path freezes around its `Sync`+`Snapshot` — same page-cache gap, no DRBD required to hit it.
- Raw block volumes have no filesystem to freeze and keep crash consistency; the docs now state both semantics.
- Mounts are matched to devices by device *number*, so alias paths (`/dev/drbd*`, `/dev/mapper/…`, zvols) resolve, and devtmpfs binds of raw-block volumes can never match.
- `FIFREEZE`/`FITHAW` are defined locally from `linux/fs.h` (`_IOWR('X', 119/120, int)`) — `x/sys/unix` does not export them.

## Failure discipline

A freeze is as crashable as the barrier it precedes, so it follows the same rules the barrier already has:

- **Bounded**: `FIFREEZE` blocks until writeback completes; past 30s the round fails and retries — and because the ioctl itself cannot be interrupted, an abandoned freeze self-cancels the moment it lands, so a failed `Freeze` never leaves a filesystem frozen with no owner.
- **Shared-state semantics**: already-frozen (EBUSY) is success on the way up, not-frozen (EINVAL) is success on the way down — mirroring how the kernel's one `suspend-io` flag is shared between racing sibling rounds. The round that lifts the barrier lifts the freeze.
- **Crash recovery**: every terminal observation of a round (ready, voided, deleted) re-checks and thaws; the startup sweep thaws alongside the stale barriers it resumes (fresh rounds keep their freeze — their own close lifts it). A failed raise (suspend error, status-patch race) thaws what it froze before backing off.

## Verification

- 11 new tests: Freezer units (mountinfo device-number matching, EBUSY/EINVAL mapping, the timeout self-cancel race, raw-block non-match) and round-level assertions that the freeze brackets the round on the mounted node, never runs on the Secondary, and thaws on a failed raise. `mise run test` and golangci-lint clean.
- A live verification run on the local Talos QEMU cluster (fix-built images, the exact conformance specs that failed in CI) is in flight; results land as a PR comment.

The replicated e2e currently skips the data-consistency spec (#289's skip list references this issue); removing that skip is the follow-up once this merges.