### PR TITLE
ci(e2e): give the storage workers more of the runner's RAM

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,7 +63,7 @@ jobs:
             task: e2e-replicated-conformance
             diagnostics: e2e-replicated-diagnostics
             testdriver: testdriver.yaml
-            skip: \[Disruptive\]|\[Serial\]|should not mount / map unused volumes|restoring snapshot to larger size pvc
+            skip: \[Disruptive\]|\[Serial\]|should not mount / map unused volumes
             disk: 20GiB
             timeout: 60
     permissions:
@@ -109,7 +109,7 @@ jobs:
       - name: Enable swap
         if: matrix.suite != 'local'
         run: |
-          sudo fallocate -l 8G /mnt/swapfile
+          sudo fallocate -l 12G /mnt/swapfile
           sudo chmod 600 /mnt/swapfile
           sudo mkswap /mnt/swapfile
           sudo swapon /mnt/swapfile

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,7 +63,7 @@ jobs:
             task: e2e-replicated-conformance
             diagnostics: e2e-replicated-diagnostics
             testdriver: testdriver.yaml
-            skip: \[Disruptive\]|\[Serial\]|should not mount / map unused volumes
+            skip: \[Disruptive\]|\[Serial\]|should not mount / map unused volumes|restoring snapshot to larger size pvc
             disk: 20GiB
             timeout: 60
     permissions:

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -282,7 +282,7 @@ cd "$bindir"
 # provision many volumes and the controller's overcommit guard counts
 # virtual (spec) size at capacity times two. Workers also take most of
 # the 16 GB runner's RAM (5 GiB each): they run DRBD, dm-thin, kubelet
-# and every test pod, and starving them stalls snapshot rounds (#290).
+# and every test pod, and 3 GiB left them tight enough to OOM.
 # virtio-balloon (talosctl default) returns the unused pages during the
 # image-build window, and the host swapfile backstops the test phase.
 sudo -E "$(mise which talosctl)" cluster create qemu \

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -280,14 +280,18 @@ cd "$bindir"
 # nodes, the control plane node runs the controller Deployment only.
 # The data disk sizes the lvmthin pool: parallel conformance specs
 # provision many volumes and the controller's overcommit guard counts
-# virtual (spec) size at capacity times two.
+# virtual (spec) size at capacity times two. Workers also take most of
+# the 16 GB runner's RAM (5 GiB each): they run DRBD, dm-thin, kubelet
+# and every test pod, and starving them stalls snapshot rounds (#290).
+# virtio-balloon (talosctl default) returns the unused pages during the
+# image-build window, and the host swapfile backstops the test phase.
 sudo -E "$(mise which talosctl)" cluster create qemu \
   --name "$cluster" \
   --cidr 10.5.0.0/24 \
   --schematic-id "$schematic" \
   --controlplanes 1 \
   --workers 2 \
-  --memory-workers 3GiB \
+  --memory-workers 5GiB \
   --disks "virtio:8GiB,virtio:${MIROIR_E2E_DISK_SIZE:-20GiB}" \
   --config-patch @{{config_root}}/deploy/e2e/talos-patch.yaml \
   --talosconfig-destination "$TALOSCONFIG"


### PR DESCRIPTION
Answers the resource question on the merged Talos e2e matrix (#289): are we using the free GitHub runner well? No, on the memory axis.

## The runner vs. what we allocated

Standard hosted runners are **4 vCPU / 16 GB / 14 GB SSD**, free on public repos ([docs](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)). The Talos legs allocated only **8 GiB across three VMs** (control plane 2 GiB + two workers at **3 GiB** each), leaving 4-6 GiB idle through the test phase. The workers carry DRBD, dm-thin, kubelet, and every conformance pod, and 3 GiB left them tight enough to OOM once (which is why the swapfile exists).

## Change

- `--memory-workers` 3 GiB → **5 GiB** (12 GiB guest RAM; control plane stays 2 GiB).
- swapfile 8 GiB → **12 GiB** cushion.

Verified operationally clean on CI: cluster create 2m22s (no boot pressure), no OOM, no disk issue.

## What this is NOT

This started as an experiment to test whether #290 (single-volume snapshot cuts stalling past the 5-minute readiness budget) was worker-memory starvation. **It isn't.** With 5 GiB workers, un-skipping #290's spec still timed out, *and* a second snapshot+restore spec that had been passing timed out too once the extra concurrent snapshot load joined the PROCS=4 pool. Both are timeouts, not data errors, on a healthy cluster — so #290 is a snapshot-path serialization issue under concurrent rounds, a code problem, not RAM. Its spec stays skipped (details on #290).

CPU is left oversubscribed (dropping the control-plane share would bottleneck the apiserver); disk relocation to `/mnt` is a separate follow-up.

## Merge call

This is now just a resource-utilization improvement (better-fed workers, bigger swap), decoupled from #290. Merge if you want the workers off the 3 GiB edge; there's no correctness change and #290 is unaffected either way.