### PR TITLE
test(csi): run the upstream csi-test sanity suite in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,6 +68,9 @@ jobs:
       - name: Running Integration Tests
         run: mise run test-integration
 
+      - name: Running CSI Sanity Tests
+        run: mise run test-sanity
+
   helm-unittest:
     name: Helm Unit Tests
     runs-on: ubuntu-24.04

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -88,7 +88,7 @@ cp config/crd/bases/*.yaml charts/miroir/crds/
 [tasks.test]
 description = "Run unit tests"
 depends = ["manifests", "generate", "fmt", "vet"]
-run = "go test $(go list ./... | grep -v /e2e | grep -v /integration) -coverprofile cover.out"
+run = "go test $(go list ./... | grep -v /e2e | grep -v /integration | grep -v /sanity) -coverprofile cover.out"
 
 [tasks.test-integration]
 description = "Run integration tests with envtest"
@@ -100,6 +100,10 @@ mkdir -p "$bin_dir"
 export KUBEBUILDER_ASSETS="$(setup-envtest use "$envtest_k8s" --bin-dir "$bin_dir" -p path)"
 go test ./test/integration/ -v -ginkgo.v
 '''
+
+[tasks.test-sanity]
+description = "Run the upstream csi-test sanity suite against the in-process Identity + Controller services"
+run = "go test ./test/sanity/ -count=1"
 
 [tasks.e2e-cluster]
 description = "Create (or reuse) the ephemeral miroir-test-e2e kind cluster (isolated KUBECONFIG under bin/e2e)"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/go-logr/logr v1.4.3
+	github.com/kubernetes-csi/csi-test/v5 v5.5.0
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/prometheus/client_golang v1.23.2
@@ -53,6 +54,7 @@ require (
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.uber.org/mock v0.5.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
@@ -69,6 +71,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kubernetes-csi/csi-test/v5 v5.5.0 h1:21NYP33XXfzsAGwFuFHJUIf60hY08B4ANLj819++f98=
+github.com/kubernetes-csi/csi-test/v5 v5.5.0/go.mod h1:5ZyneETi47SniZuPA9e8fIL6TTkkKv8/+jkaF0IHqKY=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -149,6 +151,8 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
+go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
@@ -192,6 +196,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -365,6 +365,9 @@ func (c *Controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	if req.GetVolumeId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id is required")
 	}
+	if len(req.GetVolumeCapabilities()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "volume capabilities are required")
+	}
 	vol := &miroirv1alpha1.MiroirVolume{}
 	if err := c.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sanity runs the upstream kubernetes-csi/csi-test sanity suite
+// (the CSI spec's gRPC contract conformance) against miroir's Identity
+// and Controller services in-process. It needs no cluster and no
+// privileges: the driver runs against a fake API client whose
+// interceptors stand in for the agents (marking volumes Ready and
+// snapshots ReadyToUse), so CreateVolume/CreateSnapshot's realization
+// waits resolve. The Node service is not exercised here because its
+// stage/publish RPCs perform real mounts and formats that need a
+// privileged host with real devices (the e2e suites cover that path).
+package sanity_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	csiapi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-test/v5/pkg/sanity"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/constants"
+	"github.com/home-operations/miroir/internal/csi"
+	"github.com/home-operations/miroir/internal/nodemap"
+)
+
+// storageNodeNames is the fake topology. The simulator stamps snapshot
+// legs across all of them so a restore finds a complete leg on whichever
+// node the source volume lives on.
+var storageNodeNames = []string{"node-a", "node-b"}
+
+// readyStatus stamps the terminal status the agents would write, so the
+// controller's realization waits (CreateVolume, ControllerExpandVolume,
+// snapshot restore) resolve against a cluster with no agents.
+func readyStatus(obj client.Object) {
+	switch o := obj.(type) {
+	case *miroirv1alpha1.MiroirVolume:
+		o.Status.Phase = miroirv1alpha1.VolumeReady
+		// Report each replica's device realized at the current spec size,
+		// so both CreateVolume's readiness wait and ExpandVolume's
+		// grown-size wait (per-node SizeBytes >= new size) resolve.
+		if o.Status.PerNode == nil {
+			o.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{}
+		}
+		for _, rep := range o.Spec.Replicas {
+			st := o.Status.PerNode[rep.Node]
+			st.DeviceCreated = true
+			st.SizeBytes = o.Spec.SizeBytes
+			o.Status.PerNode[rep.Node] = st
+		}
+	case *miroirv1alpha1.MiroirSnapshot:
+		// A real ReadyToUse snapshot has every diskful leg Done; mirror
+		// that (SizeBytes falls back to the source volume in CreateSnapshot)
+		// so the restore's seed-node check finds a complete leg.
+		o.Status.ReadyToUse = true
+		if o.Status.PerNode == nil {
+			o.Status.PerNode = map[string]miroirv1alpha1.SnapshotNodeState{}
+		}
+		for _, n := range storageNodeNames {
+			o.Status.PerNode[n] = miroirv1alpha1.SnapshotDone
+		}
+	case *miroirv1alpha1.MiroirSnapshotGroup:
+		o.Status.ReadyToUse = true
+	}
+}
+
+// agentSim is a fake client whose reads report volumes and snapshots as
+// already realized.
+func agentSim(scheme *runtime.Scheme) client.WithWatch {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(
+			&miroirv1alpha1.MiroirVolume{},
+			&miroirv1alpha1.MiroirSnapshot{},
+			&miroirv1alpha1.MiroirSnapshotGroup{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(
+				ctx context.Context, c client.WithWatch, key client.ObjectKey,
+				obj client.Object, opts ...client.GetOption,
+			) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				readyStatus(obj)
+				return nil
+			},
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				// Simulate the agents finishing teardown: strip finalizers so
+				// the fake client actually removes the object instead of
+				// parking it with a deletionTimestamp (miroir passes a
+				// name-only stub, so load the stored object to see them).
+				cur := obj.DeepCopyObject().(client.Object)
+				if err := c.Get(ctx, client.ObjectKeyFromObject(obj), cur); err == nil && len(cur.GetFinalizers()) > 0 {
+					cur.SetFinalizers(nil)
+					if err := c.Update(ctx, cur); err != nil {
+						return err
+					}
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if err := c.List(ctx, list, opts...); err != nil {
+					return err
+				}
+				switch l := list.(type) {
+				case *miroirv1alpha1.MiroirVolumeList:
+					for i := range l.Items {
+						readyStatus(&l.Items[i])
+					}
+				case *miroirv1alpha1.MiroirSnapshotList:
+					for i := range l.Items {
+						readyStatus(&l.Items[i])
+					}
+				case *miroirv1alpha1.MiroirSnapshotGroupList:
+					for i := range l.Items {
+						readyStatus(&l.Items[i])
+					}
+				}
+				return nil
+			},
+		}).
+		Build()
+}
+
+// cleanupNode is scaffolding, not a service under test: csi-test's shared
+// resource teardown calls NodeUnpublishVolume and (when STAGE_UNSTAGE is
+// advertised) NodeUnstageVolume on every controller-created volume before
+// deleting it. The real Node service performs privileged mounts, which is
+// out of scope here (the e2e suites cover it and the whole "Node Service"
+// describe is skipped), so this stub advertises no capabilities (teardown
+// then skips NodeUnstage) and answers the unpublish call benignly.
+type cleanupNode struct {
+	csiapi.UnimplementedNodeServer
+}
+
+func (cleanupNode) NodeGetCapabilities(
+	context.Context, *csiapi.NodeGetCapabilitiesRequest,
+) (*csiapi.NodeGetCapabilitiesResponse, error) {
+	return &csiapi.NodeGetCapabilitiesResponse{}, nil
+}
+
+func (cleanupNode) NodeUnpublishVolume(
+	context.Context, *csiapi.NodeUnpublishVolumeRequest,
+) (*csiapi.NodeUnpublishVolumeResponse, error) {
+	return &csiapi.NodeUnpublishVolumeResponse{}, nil
+}
+
+func storageNode() nodemap.Node {
+	return nodemap.Node{Pools: map[string]nodemap.Pool{
+		"default": {Backend: miroirv1alpha1.BackendLVMThin, Device: "/dev/vdb"},
+	}}
+}
+
+func TestCSISanity(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := miroirv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	cl := agentSim(scheme)
+	nodes := nodemap.Map{}
+	for _, n := range storageNodeNames {
+		nodes[n] = storageNode()
+	}
+
+	controller := &csi.Controller{
+		Client:           cl,
+		APIReader:        cl,
+		Nodes:            nodes,
+		ProvisionTimeout: 30 * time.Second,
+		DRBDPortBase:     7000,
+	}
+	identity := &csi.Identity{Version: "sanity", WithController: true}
+
+	// A short socket path: the scratchpad/GOTMPDIR paths overflow the
+	// 108-byte AF_UNIX limit.
+	sockDir, err := os.MkdirTemp("/tmp", "miroir-sanity-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sock := filepath.Join(sockDir, "csi.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	served := make(chan error, 1)
+	go func() { served <- csi.Serve(ctx, sock, identity, controller, cleanupNode{}) }()
+
+	// Wait for the socket to appear before handing the address to csi-test.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(sock); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("CSI socket never came up")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	config := sanity.NewTestConfig()
+	config.Address = "unix://" + sock
+	config.TestVolumeSize = 1 << 30 // 1 GiB
+	config.TestVolumeParameters = map[string]string{constants.ParamReplicas: "1"}
+	config.TestSnapshotParameters = map[string]string{}
+	config.IdempotentCount = 3
+
+	sanity.GinkgoTest(&config)
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	suiteCfg, reporterCfg := ginkgo.GinkgoConfiguration()
+	suiteCfg.SkipStrings = append(suiteCfg.SkipStrings,
+		// The Node service is not registered (stage/publish need a
+		// privileged host with real devices); its whole describe is
+		// skipped, and the e2e suites cover that path.
+		"Node Service",
+		// ListSnapshots deliberately does not paginate (it returns every
+		// snapshot; see its "no pagination: home scale" comment), so the
+		// starting-token continuation this spec asserts cannot hold.
+		// Pagination is optional in the CSI spec.
+		"should return next token when a limited number of entries are requested",
+	)
+	ginkgo.RunSpecs(t, "miroir csi-sanity (identity + controller)", suiteCfg, reporterCfg)
+}


### PR DESCRIPTION
Closes #296.

The external-storage conformance suites only reach the driver's RPCs through the CSI sidecars' happy paths. This adds [kubernetes-csi/csi-test](https://github.com/kubernetes-csi/csi-test)'s **sanity** suite, which drives the gRPC contract directly (request validation, idempotency, error codes, capability consistency) against miroir's Identity and Controller services. It's the ecosystem-standard check that TopoLVM, PMEM-CSI, and the kubernetes-csi drivers all run, and miroir wasn't running it.

## Shape

It's a plain `go test` (`mise run test-sanity`, a step in the existing Tests job): **no cluster, no privileges.** The driver serves its real gRPC on a unix socket, backed by a fake API client whose interceptors stand in for the agents:
- reads report volumes `Ready` and snapshots `ReadyToUse` (with a complete leg per node), so the controller's realization waits resolve;
- deletes clear finalizers first, simulating the agents finishing teardown, so the fake store actually removes the object instead of parking it with a deletionTimestamp.

**49 controller / identity / snapshot / group-snapshot specs pass, deterministic across ginkgo seeds.**

## What's out of scope (and why)

- **Node service** — its `NodeStage`/`NodePublish` RPCs perform real privileged mounts and formats on a host with real devices. That's what the e2e suites exist for. The whole `Node Service` describe is skipped; a tiny cleanup-only Node stub only exists to service csi-test's shared resource teardown (which calls `NodeUnpublish`/`NodeGetCapabilities` on every controller-created volume).
- **ListSnapshots pagination** — miroir deliberately does not paginate `ListSnapshots` (its `// no pagination: home scale` comment), and pagination is optional in the CSI spec, so that one spec is skipped with a comment.

## Driver fix the suite caught

`ValidateVolumeCapabilities` returned a success response for an **empty** `volume_capabilities` list; the CSI spec requires `InvalidArgument`. Fixed with a guard mirroring the other request-argument checks. This is exactly the class of spec-level gap (wrong/missing error codes) the external-storage suite tolerates but sanity does not, which is the point of adding it.

## Not changed

I left `ListSnapshots` non-paginating rather than implementing pagination in this PR: it's a deliberate design choice, not a bug, and adding an optional feature is out of scope here. Flagging it so it's a conscious call.