### PR TITLE
ci(e2e): run the Talos legs on Blacksmith 8-vCPU runners

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   e2e:
     name: E2E (${{ matrix.suite }})
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
@@ -39,6 +39,7 @@ jobs:
           # on kind: the fast leg, and the only one contributors can run
           # with nothing but docker.
           - suite: local
+            runner: ubuntu-24.04
             cluster: e2e-cluster
             provision: e2e-provision
             task: e2e-run
@@ -48,16 +49,21 @@ jobs:
           # Upstream Kubernetes external-storage suite on miroir-local,
           # on the Talos QEMU cluster (real per-node kernels, PSA).
           - suite: conformance
+            runner: blacksmith-8vcpu-ubuntu-2404
             cluster: e2e-replicated-cluster
             provision: e2e-replicated-provision
             task: e2e-replicated-conformance
             diagnostics: e2e-replicated-diagnostics
             testdriver: testdriver-local.yaml
             disk: 20GiB
+            worker-mem: 8GiB
+            worker-cpus: "3.0"
+            procs: "6"
             timeout: 60
           # Upstream suite on miroir-replicated (real DRBD), group
           # snapshots included, on its own Talos QEMU cluster.
           - suite: replicated
+            runner: blacksmith-8vcpu-ubuntu-2404
             cluster: e2e-replicated-cluster
             provision: e2e-replicated-provision
             task: e2e-replicated-conformance
@@ -65,6 +71,9 @@ jobs:
             testdriver: testdriver.yaml
             skip: \[Disruptive\]|\[Serial\]|should not mount / map unused volumes|restoring snapshot to larger size pvc
             disk: 20GiB
+            worker-mem: 8GiB
+            worker-cpus: "3.0"
+            procs: "6"
             timeout: 60
     permissions:
       contents: read
@@ -106,17 +115,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils ovmf
 
-      - name: Enable swap
-        if: matrix.suite != 'local'
-        run: |
-          sudo fallocate -l 12G /mnt/swapfile
-          sudo chmod 600 /mnt/swapfile
-          sudo mkswap /mnt/swapfile
-          sudo swapon /mnt/swapfile
-
       - name: Cache Talos boot images
         if: matrix.suite != 'local'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.0.2
         with:
           path: ~/.talos/cache
           key: talos-boot-${{ steps.tools.outputs.talos }}-${{ hashFiles('deploy/e2e/schematic.yaml') }}
@@ -133,6 +134,8 @@ jobs:
         env:
           CLUSTER: ${{ matrix.cluster }}
           MIROIR_E2E_DISK_SIZE: ${{ matrix.disk }}
+          MIROIR_E2E_WORKER_MEM: ${{ matrix.worker-mem }}
+          MIROIR_E2E_WORKER_CPUS: ${{ matrix.worker-cpus }}
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -188,7 +191,7 @@ jobs:
 
       - name: Cache conformance test binaries
         if: matrix.suite != 'local'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.0.2
         with:
           path: test/conformance/.bin
           key: conformance-bin-${{ steps.tools.outputs.talos }}
@@ -199,7 +202,7 @@ jobs:
           TASK: ${{ matrix.task }}
           TESTDRIVER: ${{ matrix.testdriver }}
           SKIP: ${{ matrix.skip }}
-          PROCS: ${{ matrix.suite != 'local' && '4' || '' }}
+          PROCS: ${{ matrix.procs }}
           VERBOSE: ${{ matrix.suite != 'local' && '1' || '' }}
 
       - name: Diagnostics

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -73,7 +73,7 @@ jobs:
             disk: 20GiB
             worker-mem: 8GiB
             worker-cpus: "3.0"
-            procs: "6"
+            procs: "4"
             timeout: 60
     permissions:
       contents: read

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -284,18 +284,21 @@ cd "$bindir"
 # nodes, the control plane node runs the controller Deployment only.
 # The data disk sizes the lvmthin pool: parallel conformance specs
 # provision many volumes and the controller's overcommit guard counts
-# virtual (spec) size at capacity times two. Workers also take most of
-# the 16 GB runner's RAM (5 GiB each): they run DRBD, dm-thin, kubelet
-# and every test pod, and 3 GiB left them tight enough to OOM.
-# virtio-balloon (talosctl default) returns the unused pages during the
-# image-build window, and the host swapfile backstops the test phase.
+# virtual (spec) size at capacity times two. Workers run DRBD, dm-thin,
+# kubelet and every test pod, so they take the bulk of the runner's RAM
+# and CPU; MIROIR_E2E_WORKER_MEM / _CPUS size them to the runner (the CI
+# legs set 8 GiB / 3 vCPU for the 8-vCPU / 32 GB Blacksmith box; the
+# defaults fit a 4-vCPU / 16 GB runner). virtio-balloon (a talosctl
+# default) returns the workers' unused pages during the image-build
+# window.
 sudo -E "$(mise which talosctl)" cluster create qemu \
   --name "$cluster" \
   --cidr 10.5.0.0/24 \
   --schematic-id "$schematic" \
   --controlplanes 1 \
   --workers 2 \
-  --memory-workers 5GiB \
+  --cpus-workers "${MIROIR_E2E_WORKER_CPUS:-2.0}" \
+  --memory-workers "${MIROIR_E2E_WORKER_MEM:-5GiB}" \
   --disks "virtio:8GiB,virtio:${MIROIR_E2E_DISK_SIZE:-20GiB}" \
   --config-patch @{{config_root}}/deploy/e2e/talos-patch.yaml \
   --talosconfig-destination "$TALOSCONFIG"


### PR DESCRIPTION
The org has Blacksmith integrated, so this moves the two resource-heavy Talos QEMU e2e legs onto `blacksmith-8vcpu-ubuntu-2404` (8 vCPU / 32 GB / 160 GB) and re-tunes the VM allocation to exploit the bigger box. Blacksmith supports nested KVM on x64, so the QEMU clusters keep `accel=kvm`.

## What moves, what doesn't

| leg | runner | why |
|---|---|---|
| `local` (kind Go specs) | `ubuntu-24.04` (free) | light and fast (~6 min); no reason to spend Blacksmith on it |
| `conformance` (Talos) | `blacksmith-8vcpu-ubuntu-2404` | the slow, KVM-heavy legs benefit from 2x cores + RAM |
| `replicated` (Talos) | `blacksmith-8vcpu-ubuntu-2404` | same |

`runs-on` is now `${{ matrix.runner }}`, so this stays per-leg.

## Getting the most out of 8 vCPU / 32 GB

- **Worker VMs 5 → 8 GiB, 2 → 3 vCPU each** (`MIROIR_E2E_WORKER_MEM`/`_CPUS`, defaulting to the old 16 GB values so a local run is unchanged). With the 2 GiB control plane that's 18 GiB of 32 and exactly 8 of 8 physical cores, no oversubscription. This directly relieves the worker memory starvation that the #290 investigation traced (the workers run DRBD, dm-thin, kubelet and every test pod).
- **Swap dropped** — it only existed to survive 16 GB; 32 GB has ~10 GB of headroom at the test-phase peak.
- **PROCS 4 → 6**, matching the 6 worker vCPU now available.
- **Talos ISO + conformance-binary caches → `useblacksmith/cache`** (v5.0.2, pinned), the co-located 400 MB/s drop-in that moves the ~900 MB of cached artifacts far faster than the GitHub cache backend a Blacksmith runner would otherwise reach.

Verified the re-tuned cluster (`--cpus-workers 3.0 --memory-workers 8GiB`) boots locally on real KVM before pushing.

## Deliberately deferred

- **`useblacksmith/build-push-action`** (sticky-disk Docker layer cache) is the biggest remaining build-time lever, but the build step is shared with the local leg (which stays on GitHub and uses `docker/build-push-action`), so wiring it needs conditional steps. Worth a follow-up once this proves out.
- Moving the `local` leg to Blacksmith too, if uniformity is preferred over the free-runner saving.

This is the first Blacksmith run for the repo; the point is to measure the speedup and confirm nested KVM behaves. Comparison against the last GitHub-runner numbers (conformance ~14 min, replicated ~24 min) will show in the checks.