### PR TITLE
fix(agent): resize a restore clone's backing after DRBD attach

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,7 +63,7 @@ jobs:
             task: e2e-replicated-conformance
             diagnostics: e2e-replicated-diagnostics
             testdriver: testdriver.yaml
-            skip: \[Disruptive\]|\[Serial\]|should not mount / map unused volumes|restoring snapshot to larger size pvc
+            skip: \[Disruptive\]|\[Serial\]|should not mount / map unused volumes
             disk: 20GiB
             timeout: 60
     permissions:

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -215,10 +215,14 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				DeviceCreated: true, DevicePath: dev, Pool: poolName,
 			}
 		}
-		if err := pool.Backend.Resize(ctx, vol.Name, vol.Spec.SizeBytes); err != nil {
-			return ctrl.Result{}, r.reportError(ctx, vol, err)
-		}
 		if vol.Spec.DRBD == nil {
+			// A restore clone is born at the snapshot's size; grow the
+			// backing to the requested size. No DRBD here, so no internal
+			// metadata to relocate; a replicated volume grows only after
+			// attach (below), or the clone's stranded metadata wedges it.
+			if err := pool.Backend.Resize(ctx, vol.Name, vol.Spec.SizeBytes); err != nil {
+				return ctrl.Result{}, r.reportError(ctx, vol, err)
+			}
 			log.V(1).Info("replica realized", "volume", vol.Name, "device", dev)
 			// resyncRatio 1 and quorum true, not the zero values: an
 			// unreplicated volume is fully in sync with itself and has no
@@ -286,13 +290,10 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.latchActivated(ctx, vol, st); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Online growth: once every peer's backing device is at the new size
-	// (the local leg was just resized above), the first diskful replica
-	// grows the DRBD device over them. It withholds the new size from its
-	// status until then — the CSI expansion wait keys on status, and the
-	// filesystem must not grow against a still-small DRBD device. A
-	// diskless tie-breaker must never be the resize coordinator.
-	reportSize, requeue, err := r.growIfCoordinator(ctx, vol, st)
+	// Grow this leg to the spec size now that DRBD has attached it: resize
+	// the backing, then (coordinator only) grow the DRBD device over the
+	// peers. growLeg documents why the resize must follow the attach.
+	reportSize, requeue, err := r.growLeg(ctx, pool.Backend, vol, st, localDiskless)
 	if err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
@@ -1177,6 +1178,29 @@ func (r *VolumeReconciler) assignMinor(vol *miroirv1alpha1.MiroirVolume) (int32,
 		return m, nil
 	}
 	return r.DRBD.AllocateMinor(vol.Name)
+}
+
+// growLeg brings this leg up to the spec size after DRBD has attached it:
+// resize the backing, then let the coordinator grow the DRBD device over the
+// peers (growIfCoordinator withholds the size until every peer's backing
+// reports grown).
+//
+// The resize must follow the attach for a restore clone. A clone is born at
+// the snapshot's size and carries the source's DRBD internal metadata at that
+// offset. Attaching first keeps the metadata findable, so the leg adopts it
+// and reaches UpToDate like a same-size restore; growIfCoordinator's drbdadm
+// resize then relocates it while growing the device. Resizing the backing
+// before attach strands the metadata, so create-md mints a fresh Inconsistent
+// generation the leg never leaves (birth generation is skipped for clones,
+// and both legs come up Inconsistent so neither can be a sync source). A
+// fresh volume is already at size, so the resize is a no-op for it.
+func (r *VolumeReconciler) growLeg(ctx context.Context, be backend.Backend, vol *miroirv1alpha1.MiroirVolume, st drbd.Status, localDiskless bool) (int64, time.Duration, error) {
+	if !localDiskless {
+		if err := be.Resize(ctx, vol.Name, vol.Spec.SizeBytes); err != nil {
+			return 0, 0, err
+		}
+	}
+	return r.growIfCoordinator(ctx, vol, st)
 }
 
 // growIfCoordinator runs drbdadm resize when this node is the resize

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -76,6 +76,10 @@ type fakeBackend struct {
 	createVol   []string
 	stats       backend.PoolStats
 	statsErr    error
+	// seq, when set, appends a marker on Resize into a log shared with the
+	// DRBD exec, so a test can assert the backing resize is ordered after
+	// the DRBD attach rather than before it.
+	seq *[]string
 }
 
 // errBoom is the generic injected failure for fake backends.
@@ -122,6 +126,9 @@ func (f *fakeBackend) Create(_ context.Context, vol string, size int64) (string,
 func (f *fakeBackend) Resize(_ context.Context, vol string, size int64) error {
 	if f.created[vol] < size {
 		f.created[vol] = size
+	}
+	if f.seq != nil {
+		*f.seq = append(*f.seq, "backend-resize "+vol)
 	}
 	return nil
 }
@@ -511,6 +518,74 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 	}
 	if got.Status.Phase != miroirv1alpha1.VolumeReady {
 		t.Fatalf("phase = %s, want Ready with both legs UpToDate", got.Status.Phase)
+	}
+}
+
+// Regression (#290): a restore that grows the volume must resize the backing
+// only after DRBD has attached it. The clone is born at the snapshot's size
+// carrying the source's internal metadata at that offset; growing the backing
+// first strands the metadata and the leg never leaves Inconsistent. The
+// backend resize must therefore be ordered after the drbdadm attach, not
+// before it.
+func TestReconcile_RestoreToLargerResizesBackingAfterAttach(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend() // no existing backing: realizeBacking clones the snapshot
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrA
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = addrB
+	// Restore from a snapshot to a size larger than the source.
+	v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapSnap1}
+	v.Spec.SizeBytes = 2 << 30
+
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
+		"resource \"pvc-1\" {\n    on \"node-a\" {\n        device minor 1000;\n    }\n}\n",
+	), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`}
+	fb.seq = &fe.calls // interleave the backing resize into the DRBD call log
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, "src-vol")).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fb.fromSnapVol) != 1 || fb.fromSnapVol[0] != volPvc1 {
+		t.Fatalf("restore must clone the backing, got CreateFromSnapshot %v", fb.fromSnapVol)
+	}
+	attach, resize := -1, -1
+	for i, call := range fe.calls {
+		switch {
+		case attach < 0 && strings.Contains(call, "drbdadm adjust "+volPvc1):
+			attach = i
+		case strings.Contains(call, "backend-resize "+volPvc1):
+			resize = i
+		}
+	}
+	if attach < 0 {
+		t.Fatalf("DRBD never attached the backing, calls: %v", fe.calls)
+	}
+	if resize < 0 {
+		t.Fatalf("backing was never resized to the requested size, calls: %v", fe.calls)
+	}
+	if resize < attach {
+		t.Fatalf("backing resized before DRBD attach (strands clone metadata): attach=%d resize=%d, calls: %v",
+			attach, resize, fe.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #290. Restore-to-larger volumes came up `Inconsistent` on both legs and hung at `0/2 Creating`; `NodeStage` then refused to mount them. The root cause is an ordering bug in the agent's realize path, not the IO starvation / round fairness the issue first suspected.

## Root cause

A restore backing is a CoW clone of the source snapshot: it is born at the snapshot's size and carries the source's DRBD internal metadata at that size's offset. The realize path grew the backing to the requested (larger) size **before** layering DRBD on it:

- growing the backing first moves the device end, stranding the internal metadata;
- on attach, `ensureMetadata` cannot find it, so `create-md` mints a fresh `Inconsistent` generation;
- birth generation (skip-initial-sync) is deliberately skipped for clones, and both legs come up `Inconsistent`, so neither can be a sync source;
- the leg never reaches `UpToDate`, the volume stays `0/2 Creating`, and `NodeStage` refuses to mount (it requires `UpToDate`).

Fresh volumes are born at the requested size (the pre-attach resize was a no-op for them), and same-size restores never resize, so only **restore-to-larger** tripped this, which is exactly the failing conformance spec.

## Fix

Attach the clone at its native size first, so the leg adopts the source metadata and reaches `UpToDate` exactly like a same-size restore. Only then grow the backing, and let `growIfCoordinator`'s `drbdadm resize` relocate the metadata while it grows the DRBD device (the existing, working online-expansion path). Unreplicated restores keep resizing inline, having no DRBD metadata to strand.

## The concurrency hypothesis was a red herring

The issue suspected barrier/round contention under the parallel group-snapshot specs. I reproduced the failure **in isolation**: a single 2Gi restore from a 1Gi snapshot on an otherwise idle QEMU cluster hangs at `0/2 Creating`, both legs `Inconsistent` and connected at 2Gi, no split brain. Zero concurrency, deterministic. The ordering bug, not contention, is the cause.

## Validation

- **Live QEMU cluster** (Talos, real DRBD): with the fix, the same isolated restore reaches `2/2 Ready` in ~30s (was a 3+ minute hang), the reader pod mounts, `df` shows the grown `1.9G` filesystem, and the source data survives the clone.
- **Regression test** `TestReconcile_RestoreToLargerResizesBackingAfterAttach` asserts the backing resize is ordered after the DRBD attach. It passes on this branch and fails on `main` (resize recorded before attach).
- `go test ./internal/agent/`, `go vet`, and `gofmt` are clean.

## e2e

Re-enables the `restoring snapshot to larger size pvc` conformance spec on the replicated leg (skipped in #289 pending this fix), so CI exercises the fixed path end to end.