### PR TITLE
ci(e2e): run the QEMU e2e legs on the home-operations runner

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -109,14 +109,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils ovmf
 
-      - name: Enable swap
-        if: matrix.suite != 'local'
-        run: |
-          sudo fallocate -l 12G /mnt/swapfile
-          sudo chmod 600 /mnt/swapfile
-          sudo mkswap /mnt/swapfile
-          sudo swapon /mnt/swapfile
-
       - name: Cache Talos boot images
         if: matrix.suite != 'local'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,7 @@ jobs:
           # Upstream Kubernetes external-storage suite on miroir-local,
           # on the Talos QEMU cluster (real per-node kernels, PSA).
           - suite: conformance
-            runner: home-operations
+            runner: home-operations-onedr0p
             cluster: e2e-replicated-cluster
             provision: e2e-replicated-provision
             task: e2e-replicated-conformance
@@ -60,7 +60,7 @@ jobs:
           # Upstream suite on miroir-replicated (real DRBD), group
           # snapshots included, on its own Talos QEMU cluster.
           - suite: replicated
-            runner: home-operations
+            runner: home-operations-onedr0p
             cluster: e2e-replicated-cluster
             provision: e2e-replicated-provision
             task: e2e-replicated-conformance

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,7 @@ jobs:
           # Upstream Kubernetes external-storage suite on miroir-local,
           # on the Talos QEMU cluster (real per-node kernels, PSA).
           - suite: conformance
-            runner: home-operations-onedr0p
+            runner: home-operations
             cluster: e2e-replicated-cluster
             provision: e2e-replicated-provision
             task: e2e-replicated-conformance
@@ -60,7 +60,7 @@ jobs:
           # Upstream suite on miroir-replicated (real DRBD), group
           # snapshots included, on its own Talos QEMU cluster.
           - suite: replicated
-            runner: home-operations-onedr0p
+            runner: home-operations
             cluster: e2e-replicated-cluster
             provision: e2e-replicated-provision
             task: e2e-replicated-conformance

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   e2e:
     name: E2E (${{ matrix.suite }})
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
@@ -39,6 +39,7 @@ jobs:
           # on kind: the fast leg, and the only one contributors can run
           # with nothing but docker.
           - suite: local
+            runner: ubuntu-24.04
             cluster: e2e-cluster
             provision: e2e-provision
             task: e2e-run
@@ -48,6 +49,7 @@ jobs:
           # Upstream Kubernetes external-storage suite on miroir-local,
           # on the Talos QEMU cluster (real per-node kernels, PSA).
           - suite: conformance
+            runner: home-operations-onedr0p
             cluster: e2e-replicated-cluster
             provision: e2e-replicated-provision
             task: e2e-replicated-conformance
@@ -58,6 +60,7 @@ jobs:
           # Upstream suite on miroir-replicated (real DRBD), group
           # snapshots included, on its own Talos QEMU cluster.
           - suite: replicated
+            runner: home-operations-onedr0p
             cluster: e2e-replicated-cluster
             provision: e2e-replicated-provision
             task: e2e-replicated-conformance

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -107,7 +107,7 @@ jobs:
         if: matrix.suite != 'local'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils ovmf
+          sudo apt-get install -y --no-install-recommends iptables qemu-system-x86 qemu-utils ovmf
 
       - name: Cache Talos boot images
         if: matrix.suite != 'local'


### PR DESCRIPTION
## What

Runs the two **Talos QEMU** e2e legs - `conformance` and `replicated` - on the self-hosted **`home-operations-onedr0p`** runner (the on-cluster ARC scale set with hardware `/dev/kvm`) instead of GitHub-hosted `ubuntu-24.04`. The `local` kind leg stays on `ubuntu-24.04` - it needs no KVM and is the fork/contributor-friendly leg.

Implemented with a matrix `runner` field driving `runs-on: ${{ matrix.runner }}`:

| suite | runner |
|---|---|
| `local` | `ubuntu-24.04` |
| `conformance` | `home-operations-onedr0p` |
| `replicated` | `home-operations-onedr0p` |

`runs-on` targets the scale set by **name**. On github.com, runner scale sets can only be targeted by name (custom scale-set labels are a GitHub Enterprise Server-only feature), so there's no shared-label pool - if another org admin adds a runner, it gets its own scale-set name and workflows fan out via a matrix (Option C).

Companion to onedr0p/home-ops#11326 (the runner + KVM device plugin).

## Prerequisites / validation

This PR self-validates: it triggers `e2e` on `pull_request`, so the QEMU legs schedule on the runner. Watch for:

1. **Runner-group access** - the `home-operations` runner group must grant **this repo** access (org → Settings → Actions → Runner groups). Otherwise the QEMU legs sit queued ("waiting for a runner").
2. **Runner capabilities** - the legs do `sudo apt-get install qemu-*`, create swap, and use Docker (`docker run registry:3`, buildx). The runner is ARC **kubernetes container mode** (`ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=false`); if the runner image lacks a Docker daemon or `apt`, those steps fail and the runner image needs adjusting. The `local` leg is unaffected (still hosted), so a runner gap only reddens the two QEMU legs.
