### PR TITLE
docs: fix stale and self-contradictory claims from a documentation review

### DIFF
--- a/charts/miroir/values.schema.json
+++ b/charts/miroir/values.schema.json
@@ -461,7 +461,7 @@
       "type": "object"
     },
     "groupSnapshots": {
-      "description": "Volume group snapshots: crash-consistent snapshots cut across several\nPVCs at once under one shared write barrier (VolumeGroupSnapshot API).\nOff by default because it needs cluster-side pieces the chart does not\nship: the groupsnapshot.storage.k8s.io v1beta2 CRDs and a\nsnapshot-controller running with --feature-gates=CSIVolumeGroupSnapshot=true\n(the same gate this flag passes to the csi-snapshotter sidecar).\nOnly replicated volumes (replicas \u003e 1) can join a group — the DRBD\nwrite barrier is what makes the cut atomic across volumes.",
+      "description": "Volume group snapshots: crash-consistent snapshots cut across several\nPVCs at once under one shared write barrier (VolumeGroupSnapshot API).\nOff by default because it needs cluster-side pieces the chart does not\nship: the groupsnapshot.storage.k8s.io v1 CRDs and a\nsnapshot-controller running with --feature-gates=CSIVolumeGroupSnapshot=true\n(the same gate this flag passes to the csi-snapshotter sidecar).\nOnly replicated volumes (replicas \u003e 1) can join a group — the DRBD\nwrite barrier is what makes the cut atomic across volumes.",
       "properties": {
         "enabled": {
           "default": false,

--- a/charts/miroir/values.yaml
+++ b/charts/miroir/values.yaml
@@ -101,7 +101,7 @@ storageCapacity:
 # Volume group snapshots: crash-consistent snapshots cut across several
 # PVCs at once under one shared write barrier (VolumeGroupSnapshot API).
 # Off by default because it needs cluster-side pieces the chart does not
-# ship: the groupsnapshot.storage.k8s.io v1beta2 CRDs and a
+# ship: the groupsnapshot.storage.k8s.io v1 CRDs and a
 # snapshot-controller running with --feature-gates=CSIVolumeGroupSnapshot=true
 # (the same gate this flag passes to the csi-snapshotter sidecar).
 # Only replicated volumes (replicas > 1) can join a group — the DRBD

--- a/docs/coexistence.md
+++ b/docs/coexistence.md
@@ -1,8 +1,8 @@
 # Coexistence with other provisioners
 
 - **OpenEBS LocalPV-ZFS**: keep your pool and let `openebs-zfs` stay
-  the default StorageClass. miroir scopes itself to the dataset you
-  configure in Helm values.
+  the default StorageClass. miroir scopes itself to the dataset the
+  MiroirNode's `spec.pools[].zfs.dataset` names.
 - **Other LVM tenants**: bound the thin pool with
   the MiroirNode's `spec.pools[].lvmthin.poolSize` (e.g. `400g`) and let the
   co-tenant allocate from the VG's remainder.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,8 +4,8 @@ The **miroir** chart installs only the driver; its values are documented
 value-by-value in the generated
 [chart README](https://github.com/home-operations/miroir/blob/main/charts/miroir/README.md)
 (kept in sync with `values.yaml` by helm-docs; CI fails if it goes
-stale). The storage configuration — MiroirNode/MiroirNodeGroup custom
-resources, StorageClasses, and VolumeSnapshotClasses — is plain
+stale). The storage configuration (MiroirNode/MiroirNodeGroup custom
+resources, StorageClasses, and VolumeSnapshotClasses) is plain
 manifests ([Quickstart](quickstart.md) shows the layouts;
 `kubectl explain miroirnode.spec` is the topology reference). This page
 is the orientation layer: which groups of chart values exist, where
@@ -29,7 +29,7 @@ their behavior is explained, and every StorageClass parameter.
   ([Monitoring](monitoring.md)).
 - **`agent` / `sidecars`** (and the root's image/resources): workload
   knobs for images, resources, `agent.kubeletDir`,
-  `agent.loopfileBaseDirs` (hostPath mounts for loopfile pools — pod
+  `agent.loopfileBaseDirs` (hostPath mounts for loopfile pools: pod
   spec the chart cannot derive from your CRs),
   `sidecars.healthMonitor`.
 - **`logging`**: level and encoder for both components.
@@ -38,7 +38,7 @@ their behavior is explained, and every StorageClass parameter.
 
 A miroir class is a standard StorageClass with
 `provisioner: miroir.home-operations.com` and these `parameters` (all
-values are strings — quote the numbers and booleans):
+values are strings; quote the numbers and booleans):
 
 | Parameter                                          | Default            | Meaning                                                                                                                                                                                                                                                                                                       |
 | -------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -46,10 +46,10 @@ values are strings — quote the numbers and booleans):
 | `miroir.home-operations.com/pool`                  | `default`          | The named storage pool the class provisions from. Every replica of a volume lands in this pool on its node, so the pool must exist (in the MiroirNode specs) on at least `replicas` nodes.                                                                                                                     |
 | `miroir.home-operations.com/quorum`                | `freeze`           | Replicated only: `freeze` never diverges but halts writes without a peer majority; `last-man-standing` keeps the survivor writable at the risk of split-brain. See [Replication and quorum](replication.md).                                                                                                   |
 | `miroir.home-operations.com/allowRemoteVolumeAccess` | `"true"`           | Replicated only: pods on nodes without a replica consume the volume through an ephemeral diskless DRBD leg at replication-network speed. `"false"` pins pods to replica nodes for local reads. See [Remote consumers](remote-consumers.md).                                                                     |
-| `miroir.home-operations.com/bitmapGranularity`     | absent (DRBD 4096) | Replicated only: DRBD bitmap block size in bytes, a power of two 4096–1048576. Coarser cuts bitmap RAM proportionally but resyncs more per dirty bit — worth considering for classes holding large volumes. Fixed when a replica's metadata is created: changing the class affects new volumes only.             |
+| `miroir.home-operations.com/bitmapGranularity`     | absent (DRBD 4096) | Replicated only: DRBD bitmap block size in bytes, a power of two 4096–1048576. Coarser cuts bitmap RAM proportionally but resyncs more per dirty bit; worth considering for classes holding large volumes. Fixed when a replica's metadata is created: changing the class affects new volumes only.             |
 | `csi.storage.k8s.io/fstype`                        | `ext4`             | `ext4` or `xfs`.                                                                                                                                                                                                                                                                                               |
 
-The standard StorageClass fields behave as usual — with two worth
+The standard StorageClass fields behave as usual, with two worth
 writing explicitly, because the Kubernetes defaults are rarely what you
 want: `volumeBindingMode: WaitForFirstConsumer` (delays provisioning
 until a pod schedules, so placement can prefer that pod's node; the
@@ -65,13 +65,13 @@ and a `deletionPolicy`
 ([Quickstart](quickstart.md#4-snapshot-and-restore) has the manifest;
 the snapshot-controller and its CRDs deploy separately). PVC clones
 (`dataSource: {kind: PersistentVolumeClaim}`) need no class of their
-own — the clone's StorageClass just has to match the source volume's
+own; the clone's StorageClass just has to match the source volume's
 `replicas` and `pool` ([Quickstart → Clone a
 PVC](quickstart.md#clone-a-pvc)).
 VolumeGroupSnapshotClasses take exactly the same two fields as a
 VolumeSnapshotClass, but the feature is off by default: it needs
 `groupSnapshots.enabled: true` in the chart plus the cluster-side
-group snapshot CRDs and feature gate —
+group snapshot CRDs and feature gate;
 [Quickstart → Group snapshots](quickstart.md#group-snapshots) lists
 all three switches.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,6 +9,7 @@ tasks:
 ```bash
 mise run test              # unit tests (regenerates manifests first)
 mise run test-integration  # envtest apiserver: CRD schema + CEL rules
+mise run test-sanity       # upstream csi-test sanity suite, in-process
 mise run lint          # golangci-lint
 mise run build         # bin/miroir
 mise run manifests     # CRD + RBAC generation

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,25 @@ byte-identical copy on a second node by completing every write on
 both. If a node dies, pods restart on the surviving node with
 current data.
 
+A 2-replica volume on a 3-node cluster looks like this (the
+[terminology](#terminology) below defines the words):
+
+```mermaid
+flowchart LR
+    subgraph node-a
+        POD[pod] --> A[("leg A (Primary)")]
+    end
+    subgraph node-b
+        B[("leg B (Secondary)")]
+    end
+    subgraph node-c
+        T["tie-breaker (diskless)"]
+    end
+    A <==>|synchronous replication| B
+    A -. quorum vote .- T
+    B -. quorum vote .- T
+```
+
 ## When to use it
 
 - You want replicated block storage without running Ceph.
@@ -87,8 +106,13 @@ require DRBD experience:
 - **[Remote consumers and auto-diskful](remote-consumers.md)**:
   mounting volumes from nodes without a replica, and converting
   settled consumers to local replicas.
+- **[Disk failures, rebuilds, and verification](resilience.md)**:
+  what a failing disk does, auto-evict for dead nodes, and the
+  scheduled online verify.
 - **[ReadWriteMany (RWX)](rwx.md)**: shared filesystems over NFS on
   top of replicated volumes.
+- **[Upgrading](upgrading.md)**: keeping the CRDs in step, and the
+  version-to-version migration steps.
 - **[Node maintenance and upgrades](maintenance.md)**: the safe
   per-node loop for reboots and upgrades.
 - **[Monitoring](monitoring.md)**: metrics, starter alerts, and the

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,23 +7,25 @@ node shutdown), then:
 
 Storage configuration is plain manifests, applied and versioned like
 any other Kubernetes object: the node topology (MiroirNode custom
-resources — or a MiroirNodeGroup that materializes them from a label
+resources, or a MiroirNodeGroup that materializes them from a label
 selector), the StorageClasses (`replicas: "1"` is node-local,
 `replicas: "2"` is DRBD-replicated), and the VolumeSnapshotClasses.
 The chart installs only the driver. The CRDs validate the topology
 (`kubectl explain miroirnode.spec` is the reference), `kubectl apply`
 rejects unknown fields outright, and pool names and the classes that
 select them sit side by side in whatever file you keep them in. Pods
-can mount miroir volumes from any node with a MiroirNode — data lives
-only on nodes whose pools hold replicas; the rest consume remotely
+can mount miroir volumes from any node with a MiroirNode; data lives
+only on nodes whose pools hold replicas, and the rest consume remotely
 ([Remote consumers](remote-consumers.md)). Keep every schedulable node
 in the map, or set the `allowRemoteVolumeAccess: "false"` parameter on
 the class so pods stay on replica nodes.
 
-**A fleet with a path convention.** The common case: every storage node
-carries the same partition label, so the whole fleet is ONE node group —
-a MiroirNode is materialized per label-matched node, and **adding a
-storage node is labeling it** (`kubectl label node node-c
+/// tab | One node group (the common case)
+
+Every storage node carries the same partition label, so the whole
+fleet is ONE node group: a MiroirNode is materialized per
+label-matched node, and **adding a storage node is labeling it**
+(`kubectl label node node-c
 storage.miroir.home-operations.com/class=std`). Existing replicated
 volumes pick a third node up as a quorum tie-breaker automatically.
 
@@ -73,26 +75,25 @@ driver: miroir.home-operations.com
 deletionPolicy: Delete
 ```
 
-Write `volumeBindingMode` and `allowVolumeExpansion` explicitly as
-above — the Kubernetes defaults (`Immediate`, no expansion) are rarely
-what you want. Every class parameter is documented in
-[Helm chart values → StorageClass parameters](configuration.md#storageclass-parameters).
-
 Group members inherit per-node facts from the Node object: an empty
 template `zone` takes the node's `topology.kubernetes.io/zone` label,
 and a dedicated replication NIC comes from a
 `miroir.home-operations.com/address` annotation on the Node. A node
 leaving the selector orphans its MiroirNode in place (never deleted
-under live volumes); hand-authored MiroirNodes always win over groups —
-use them for odd-one-out boxes.
+under live volumes); hand-authored MiroirNodes always win over
+groups, so use them for odd-one-out boxes.
 
-**Mixed backends and failure domains.** Heterogeneous nodes are
-per-node MiroirNodes (or label-partitioned groups per disk class).
-DRBD replicates whatever device each backend provides, so one volume
-can pair a ZFS zvol with an LVM thin LV. `zone` (optional) spreads replicas and the
-tie-breaker across failure domains; `address` (optional) pins
-replication to a dedicated storage NIC/VLAN, IPv4 or IPv6 (default:
-the node's `InternalIP`; applies to volumes created afterwards).
+///
+
+/// tab | Mixed backends and zones
+
+Heterogeneous nodes are per-node MiroirNodes (or label-partitioned
+groups per disk class). DRBD replicates whatever device each backend
+provides, so one volume can pair a ZFS zvol with an LVM thin LV.
+`zone` (optional) spreads replicas and the tie-breaker across failure
+domains; `address` (optional) pins replication to a dedicated storage
+NIC/VLAN, IPv4 or IPv6 (default: the node's `InternalIP`; applies to
+volumes created afterwards).
 
 ```yaml
 apiVersion: miroir.home-operations.com/v1alpha1
@@ -130,10 +131,14 @@ spec:
               baseDir: /var/lib/miroir
 ```
 
-**Two tiers per node.** A pool name identifies the same tier across
-nodes, and a StorageClass selects one with the `pool` parameter
-(classes that name none use `default`). Volumes never span pools:
-every replica of a volume lands in the class's pool on its node.
+///
+
+/// tab | Two storage tiers per node
+
+A pool name identifies the same tier across nodes, and a StorageClass
+selects one with the `pool` parameter (classes that name none use
+`default`). Volumes never span pools: every replica of a volume lands
+in the class's pool on its node.
 
 ```yaml
 apiVersion: miroir.home-operations.com/v1alpha1
@@ -162,10 +167,14 @@ parameters:
     csi.storage.k8s.io/fstype: ext4
 ```
 
-**One node, no dedicated disk.** Dev clusters: loopfile backs volumes
-with sparse files on an existing filesystem. Loopfile base
-directories must also be listed in the **driver** chart's
-`agent.loopfileBaseDirs` so the agent pod mounts them.
+///
+
+/// tab | Single node, no dedicated disk
+
+Dev clusters: loopfile backs volumes with sparse files on an existing
+filesystem. Loopfile base directories must also be listed in the
+**driver** chart's `agent.loopfileBaseDirs` so the agent pod mounts
+them.
 
 ```yaml
 apiVersion: miroir.home-operations.com/v1alpha1
@@ -192,7 +201,9 @@ parameters:
     csi.storage.k8s.io/fstype: ext4
 ```
 
-A pool's backend is the configuration block it carries — exactly one
+///
+
+A pool's backend is the configuration block it carries: exactly one
 of `lvmthin`, `zfs`, or `loopfile` (write `lvmthin: {}` when the VG
 already exists).
 
@@ -201,6 +212,15 @@ already exists).
 | `lvmthin`  | A partition or disk for the thin pool  | `dm_thin_pool` kernel module                             |
 | `zfs`      | A ZFS pool, you specify the dataset    | ZFS module on the node ([Requirements](requirements.md)) |
 | `loopfile` | A path on a reflink-capable filesystem | `loop` module; XFS `reflink=1` / btrfs                   |
+
+/// tip | Write the StorageClass fields explicitly
+
+Write `volumeBindingMode: WaitForFirstConsumer` and
+`allowVolumeExpansion: true` as in the manifests above: the
+Kubernetes defaults (`Immediate`, no expansion) are rarely what you
+want.
+
+///
 
 [Configuration](configuration.md) documents the driver chart's values
 (DRBD tuning, behavior knobs, workloads) and every
@@ -211,17 +231,24 @@ is always current.
 
 ## 2. Install
 
+/// tab | Helm
+
 ```bash
 helm install miroir oci://ghcr.io/home-operations/charts/miroir \
   -n miroir-system --create-namespace
 kubectl apply -f topology.yaml
 ```
 
-On Talos, create and label the namespace first instead of using
+///
+
+/// tab | Talos
+
+Create and label the namespace first instead of using
 `--create-namespace`. Talos enforces the `baseline` [Pod Security
-Standard][pss] by default, which silently rejects the agent DaemonSet's
-pods (the agent runs privileged: DRBD, LVM, and mounting need host
-access) - the install then times out with the agents stuck at `0/N`:
+Standard][pss] by default, which silently rejects the agent
+DaemonSet's pods (the agent runs privileged: DRBD, LVM, and mounting
+need host access) - the install then times out with the agents stuck
+at `0/N`:
 
 ```bash
 kubectl create namespace miroir-system
@@ -234,18 +261,21 @@ kubectl apply -f topology.yaml
 
 [pss]: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 
+///
+
 The driver chart deploys one `miroir-controller` Deployment and a
-`miroir-agent` DaemonSet on every schedulable node, plus the CRDs — so
-the topology manifests apply after it. Each agent provisions its node's
-pools with idempotent setup the moment its MiroirNode exists (existing
-pools are reused) — agents on nodes without one serve client-only and
-switch over by themselves — and restarts itself to re-run setup when
-the pool spec changes. Your manifests are the source of truth: nothing
-deletes a MiroirNode but you, and decommissioning a node stays an
-explicit `kubectl delete miroirnode <name>` — for a group member, first
-take the node out of the selector (remove its class label), or the
-group recreates the MiroirNode within seconds. Inspect the topology
-with `kubectl get miroirnodes`.
+`miroir-agent` DaemonSet on every schedulable node, plus the CRDs, so
+the topology manifests apply after it. Each agent provisions its
+node's pools with idempotent setup the moment its MiroirNode exists
+(existing pools are reused) and restarts itself to re-run setup when
+the pool spec changes; agents on nodes without a MiroirNode serve
+client-only and switch over by themselves. Your manifests are the
+source of truth: nothing deletes a MiroirNode but you, and
+decommissioning a node stays an explicit
+`kubectl delete miroirnode <name>`. For a group member, first take
+the node out of the selector (remove its class label), or the group
+recreates the MiroirNode within seconds. Inspect the topology with
+`kubectl get miroirnodes`.
 
 ## 3. Claim a volume
 
@@ -270,13 +300,24 @@ tie-breaker fits in.
 
 Requires the cluster-wide `snapshot-controller` and `volumesnapshot`
 CRDs (see the [CSI snapshot docs](https://kubernetes-csi.github.io/docs/snapshots.html)),
-plus a VolumeSnapshotClass (the `miroir-snap` manifest above).
+plus a VolumeSnapshotClass (the `miroir-snap` manifest above). Any
+distribution of the upstream snapshot-controller works; the
+[home-operations chart][snap-chart] ships it with the CRDs exactly as
+upstream publishes them:
+
+```bash
+helm install snapshot-controller \
+  oci://ghcr.io/home-operations/charts/snapshot-controller \
+  -n kube-system
+```
+
+[snap-chart]: https://github.com/home-operations/helm-charts/tree/main/charts/snapshot-controller
 
 Snapshots of a mounted filesystem are filesystem-consistent: for
 replicated volumes the agent freezes the filesystem (flushing every
 cached write) on the node where it is mounted just before the cut and
 thaws it right after, and for `replicas: 1` lvmthin volumes the cut
-itself suspends the device with the same flush-and-freeze effect — so
+itself suspends the device with the same flush-and-freeze effect, so
 even data an application wrote without `fsync` is in the snapshot.
 Unreplicated `zfs` and `loopfile` snapshots, all raw block volumes,
 and [RWX volumes](rwx.md) (mounted inside the NFS gateway pod, where
@@ -364,19 +405,27 @@ default: the `groupsnapshot.storage.k8s.io` CRDs installed
 cluster-wide, the cluster's snapshot-controller running with
 `--feature-gates=CSIVolumeGroupSnapshot=true`, and
 `groupSnapshots.enabled: true` in the chart (which passes the same
-feature gate to the csi-snapshotter sidecar). Only replicated
+feature gate to the csi-snapshotter sidecar). The
+[home-operations snapshot-controller chart][snap-chart] covers the
+first two: it ships the group CRDs and enables the feature gate by
+default (`controller.volumeGroupSnapshots`). Only replicated
 volumes (`replicas` ≥ 2) can join a group: the DRBD write barrier is
 what makes the cut atomic across volumes.
 
 With external-snapshotter v8.6 and later the group API is served at
 `v1` (older releases serve `v1beta2`), and upstream ships the group
 CRDs with `conversion.strategy: None`; the schemas are identical
-across versions, so no conversion webhook is involved. If another
-chart has stamped a webhook conversion onto these CRDs (some
-snapshot-controller charts do), group snapshots fail with confusing
-`service not found` or `unexpected conversion version` errors while
-regular snapshots keep working; patch the CRDs back to
+across versions, so no conversion webhook is involved.
+
+/// warning | A stamped conversion webhook breaks group snapshots
+
+If another chart has stamped a webhook conversion onto these CRDs
+(some snapshot-controller charts do), group snapshots fail with
+confusing `service not found` or `unexpected conversion version`
+errors while regular snapshots keep working; patch the CRDs back to
 `strategy: None`.
+
+///
 
 ```yaml
 apiVersion: groupsnapshot.storage.k8s.io/v1
@@ -402,6 +451,17 @@ Each member is an ordinary VolumeSnapshot and restores individually
 through `dataSource` exactly like the single-volume restore above.
 Members delete as a set: deleting the VolumeGroupSnapshot removes
 them all, and a member cannot be deleted on its own.
+
+/// note | Snapshots are not backups
+
+A miroir snapshot is a copy-on-write copy on the same nodes and pool
+as its volume, so it dies with them. For backups exported to durable
+storage, pair miroir with [kopiur](https://kopiur.home-operations.com/),
+the home-operations backup operator: it makes a
+[kopia](https://kopia.io/) repository a first-class Kubernetes
+resource and schedules backups into it.
+
+///
 
 ## 5. Expand online
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -278,8 +278,10 @@ cached write) on the node where it is mounted just before the cut and
 thaws it right after, and for `replicas: 1` lvmthin volumes the cut
 itself suspends the device with the same flush-and-freeze effect — so
 even data an application wrote without `fsync` is in the snapshot.
-Unreplicated `zfs` and `loopfile` snapshots and all raw block volumes
-are crash-consistent; quiesce writes yourself if you need more there.
+Unreplicated `zfs` and `loopfile` snapshots, all raw block volumes,
+and [RWX volumes](rwx.md) (mounted inside the NFS gateway pod, where
+the agent's freeze cannot reach) are crash-consistent; quiesce writes
+yourself if you need more there.
 
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1
@@ -292,7 +294,11 @@ spec:
         persistentVolumeClaimName: my-data
 ```
 
-Restore by pointing a new PVC at the snapshot:
+Restore by pointing a new PVC at the snapshot. A restore is a
+copy-on-write clone on the nodes holding the snapshot, so it cannot
+change shape: the new PVC's StorageClass must request the source
+volume's replica count and pool, and its size must be at least the
+snapshot's.
 
 ```yaml
 apiVersion: v1
@@ -300,7 +306,7 @@ kind: PersistentVolumeClaim
 metadata:
     name: my-data-restored
 spec:
-    storageClassName: miroir-local
+    storageClassName: miroir-replicated # must match the source's replicas and pool
     dataSource:
         name: my-data-snap
         kind: VolumeSnapshot
@@ -327,7 +333,7 @@ kind: PersistentVolumeClaim
 metadata:
     name: my-data-copy
 spec:
-    storageClassName: miroir-local
+    storageClassName: miroir-replicated # must match the source's replicas and pool
     dataSource:
         name: my-data
         kind: PersistentVolumeClaim

--- a/docs/remote-consumers.md
+++ b/docs/remote-consumers.md
@@ -13,9 +13,9 @@ unmount, filling in the connection details (node id, address) exactly
 as for an operator-added replica. A pod landing on the tie-breaker's
 node needs no client leg; it uses the tie-breaker leg directly.
 
-Set `allowRemoteVolumeAccess: false` on a `storageClasses` entry to
-opt that class out: its PVs then pin pods to the diskful replica
-nodes, guaranteeing local reads.
+Set the `miroir.home-operations.com/allowRemoteVolumeAccess: "false"`
+parameter on a StorageClass to opt that class out: its PVs then pin
+pods to the diskful replica nodes, guaranteeing local reads.
 
 Trade-offs to understand:
 

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -45,7 +45,7 @@ Behavior and knobs:
   node name.
 - **Existing volumes are retrofitted.** Adding a third node to
   the topology (applying its MiroirNode) appends a tie-breaker to every 2-replica `freeze` volume
-  that lacks one — the controller follows MiroirNode changes live, no
+  that lacks one; the controller follows MiroirNode changes live, no
   restart involved.
   Editing a volume's `spec.quorumPolicy` from `last-man-standing` to
   `freeze` triggers the same reconciler.

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -10,9 +10,9 @@ both keep accepting writes, the copies diverge
 ([split-brain](index.md#terminology)) and one side's writes must
 eventually be thrown away. The **quorum policy** is the per-class
 answer to that situation, a trade between never diverging and
-staying writable. It is set per StorageClass via the `quorum` field
-on a `storageClasses` entry with `replicas > 1` (the
-`miroir.home-operations.com/quorum` parameter).
+staying writable. It is set per StorageClass via the
+`miroir.home-operations.com/quorum` parameter on classes whose
+`replicas` is above 1.
 
 ## `freeze` (default)
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -30,7 +30,9 @@ ships inside the agent image; nodes only provide kernel modules.
 
 [gns]: https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown
 
-## Talos
+## Node setup by OS
+
+/// tab | Talos
 
 Talos is the primary target. For replication use **≥ 1.13.0** (its
 `siderolabs/drbd` extension ships the DRBD 9.3.1 module the agent
@@ -65,7 +67,9 @@ machine:
 
 [factory]: https://factory.talos.dev
 
-## Debian/Ubuntu
+///
+
+/// tab | Debian/Ubuntu
 
 Stock kernels ship `dm_thin_pool` and `loop`, so `lvmthin` and
 `loopfile` need nothing extra. For the rest:
@@ -86,5 +90,7 @@ Stock kernels ship `dm_thin_pool` and `loop`, so `lvmthin` and
   critical-pod window ≥ the agent's grace period (default 60s).
 
 [ppa]: https://launchpad.net/~linbit/+archive/ubuntu/linbit-drbd9-stack
+
+///
 
 Nothing in the controller or agent is otherwise OS-specific.

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -1,7 +1,9 @@
 # Disk failures, node rebuilds, and verification
 
-A failing **disk** is not a failing node. Since v0.3 the global DRBD
-config defaults to `on-io-error detach` (`drbd.onIoError`). A leg
+## A failing disk is not a failing node
+
+Since v0.3 the global DRBD config defaults to `on-io-error detach`
+(`drbd.onIoError`). A leg
 whose backing device errors drops to Diskless, and the volume keeps
 serving through the peer rather than surfacing I/O errors into the pod.
 The detached leg shows as `DiskState: Diskless` in
@@ -9,8 +11,10 @@ The detached leg shows as `DiskState: Diskless` in
 1 for that node. To recover: replace the disk, then remove and re-add
 the replica.
 
-**Rebuilding a node is safe.** A reinstall (e.g. a Talos wipe) destroys
-the backing devices and miroir's node-local state together. When the
+## Rebuilding a node is safe
+
+A reinstall (e.g. a Talos wipe) destroys the backing devices and
+miroir's node-local state together. When the
 node rejoins, the agent detects the wipe and makes each recreated leg
 a full sync target rather than trusting its empty disk.
 
@@ -24,8 +28,10 @@ are skipped, because loop devices mishandle discards;
 `drbd.resync.discardGranularity` remains as a manual cluster-wide
 fallback.)
 
-**Dead nodes: auto-evict.** A node that dies permanently leaves every
-volume it carried degraded until someone re-places its replicas.
+## Auto-evict for dead nodes
+
+A node that dies permanently leaves every volume it carried degraded
+until someone re-places its replicas.
 Setting `autoEvictAfter` (a Helm value, e.g. `"60m"`, off by default)
 automates that. Each node's heartbeat is the `MiroirNode` status its
 agent refreshes about every minute. Once a node's heartbeat has been
@@ -52,7 +58,7 @@ Auto-evict is deliberately timid. It stands down in any of these cases:
   replicating in the kernel and evicting anything would sever live
   storage.
 - More than one node's heartbeat is stale (opted-out nodes don't
-  count — theirs are expected to go dark). That pattern points at the
+  count; theirs are expected to go dark). That pattern points at the
   network or API server, not at two simultaneous dead nodes.
 - A surviving replica still sees the "dead" node's DRBD connections up.
   The node is then alive, and only its Kubernetes connection is broken.
@@ -66,7 +72,9 @@ A node with known long outages can opt out with
 longest planned reboot or upgrade window, since eviction discards the
 dead node's copy of the data.
 
-One scheduling limitation to know about: a PersistentVolume's node
+/// note | PV node affinity cannot follow an eviction
+
+A PersistentVolume's node
 affinity is fixed by Kubernetes at creation and cannot be updated, so
 on volumes without `allowRemoteVolumeAccess` the pod can only ever
 schedule onto the volume's _original_ replica nodes. After an eviction
@@ -75,7 +83,11 @@ replica protects the data, but the scheduler cannot place the pod on
 the replacement node. Remote-access volumes (the default for
 replicated classes) carry no such pin and are unaffected.
 
-**Verification** is the only cross-leg integrity check (a ZFS scrub
+///
+
+## Verification
+
+Online verify is the only cross-leg integrity check (a ZFS scrub
 validates one leg against itself). `drbd.verify.algorithm` (default
 `crc32c`) arms it. `drbd.verify.schedule` (a 5-field cron, e.g.
 `"0 4 * * 0"`) then runs an online verify of every replicated volume on

--- a/docs/rwx.md
+++ b/docs/rwx.md
@@ -59,12 +59,13 @@ Things worth knowing:
 - **`freeze` quorum is required** (the default). Under
   `last-man-standing` a partition could leave the old and rescheduled
   gateways both writable; the controller rejects that combination.
-- **Snapshots** work exactly as for RWO volumes: device-level and
-  crash-consistent (the snapshot captures the filesystem as if the
-  node had lost power at that instant; journaling filesystems
-  recover this cleanly), with the gateway as the sole writer during
-  the barrier,
-  and the volume gets the same split-brain protections: the gateway
+- **Snapshots are crash-consistent**, not filesystem-consistent:
+  the filesystem is mounted inside the gateway pod, out of reach of
+  the freeze the agent applies to locally mounted volumes, so the
+  snapshot captures it as if the node had lost power at that instant
+  (journaling filesystems recover this cleanly). The write barrier
+  works as for RWO volumes, with the gateway as the sole writer, and
+  the volume gets the same split-brain protections: the gateway
   stages through the same pipeline that latches "this volume holds
   data", so auto-recovery never discards a diverged leg out from
   under it.

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -13,6 +13,14 @@ everything as it was.
 
 ## Destroying the data
 
+/// danger | There is no undo
+
+The armed hook deletes every MiroirVolume and MiroirSnapshot, and the
+agents then erase the DRBD resources and backing devices on the
+nodes. It includes volumes whose PV reclaimPolicy is `Retain`.
+
+///
+
 To delete every volume as part of the uninstall, arm the pre-delete hook
 first. Helm bakes hooks into the release at install/upgrade time, so the
 confirmation must be set **before** running `helm uninstall`:
@@ -31,8 +39,8 @@ the release to a newer chart on its way out.
 
 The hook Job deletes every MiroirVolume and MiroirSnapshot and waits while
 each node's agent tears down its DRBD resources and backing devices through
-the finalizers — including volumes whose PV reclaimPolicy is `Retain`. If a
-teardown cannot finish (a node is down), the job blocks:
+the finalizers. If a teardown cannot finish (a node is down), the job
+blocks:
 `kubectl get miroirvolumes` shows what is stuck, and the agent log on the
 affected node
 (`kubectl logs -n miroir-system -l app.kubernetes.io/component=agent`)

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -32,10 +32,10 @@ starts with the CRDs.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 spec:
-  install:
-    crds: Create
-  upgrade:
-    crds: CreateReplace # default is Skip; required
+    install:
+        crds: Create
+    upgrade:
+        crds: CreateReplace # default is Skip; required
 ```
 
 **Plain Helm** has no automatic path; apply the new chart's CRDs before
@@ -52,7 +52,7 @@ The storage configuration moves out of the miroir chart entirely: the
 node topology becomes `MiroirNode` custom resources (or a
 `MiroirNodeGroup` materializing them from a label selector) and,
 together with the StorageClasses and VolumeSnapshotClasses, is now
-plain manifests you apply and version yourself — the miroir chart
+plain manifests you apply and version yourself; the miroir chart
 installs only the driver. The CRD schema is what validates the
 topology, and `kubectl apply` rejects unknown fields outright.
 Alongside the move:
@@ -110,7 +110,7 @@ under its backend's block:
 
 There is no `backend` field any more: the block that is present IS the
 backend, so exactly one of `lvmthin`/`zfs`/`loopfile` is required even
-when it has nothing to say — an lvmthin pool whose VG already exists
+when it has nothing to say: an lvmthin pool whose VG already exists
 still writes `lvmthin: {}`. A homogeneous fleet can become one
 `MiroirNodeGroup` instead of per-node objects
 ([Quickstart](quickstart.md) shows the layout).
@@ -118,7 +118,7 @@ still writes `lvmthin: {}`. A homogeneous fleet can become one
 Each `storageClasses` entry becomes a standard StorageClass manifest:
 the chart's knobs map to `parameters`
 ([the full table](configuration.md#storageclass-parameters)), and what
-the chart used to default now needs writing —
+the chart used to default now needs writing:
 `volumeBindingMode: WaitForFirstConsumer`, `allowVolumeExpansion: true`,
 and the `storageclass.kubernetes.io/is-default-class` annotation where
 `isDefault` was used. `volumeSnapshotClasses` entries become
@@ -128,16 +128,16 @@ Before (0.10 miroir values):
 
 ```yaml
 nodes:
-  k8s-0:
-    zone: rack-1
-    pools:
-      default:
-        backend: lvmthin
-        device: /dev/disk/by-partlabel/r-miroir
-        thinPoolSize: 400g
+    k8s-0:
+        zone: rack-1
+        pools:
+            default:
+                backend: lvmthin
+                device: /dev/disk/by-partlabel/r-miroir
+                thinPoolSize: 400g
 storageClasses:
-  - name: miroir-replicated
-    replicas: 2
+    - name: miroir-replicated
+      replicas: 2
 ```
 
 After (plain manifests):
@@ -146,35 +146,35 @@ After (plain manifests):
 apiVersion: miroir.home-operations.com/v1alpha1
 kind: MiroirNode
 metadata:
-  name: k8s-0
+    name: k8s-0
 spec:
-  zone: rack-1
-  pools:
-    - name: default
-      lvmthin:
-        device: /dev/disk/by-partlabel/r-miroir
-        poolSize: 400g
+    zone: rack-1
+    pools:
+        - name: default
+          lvmthin:
+              device: /dev/disk/by-partlabel/r-miroir
+              poolSize: 400g
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: miroir-replicated
+    name: miroir-replicated
 provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
-  miroir.home-operations.com/replicas: "2"
-  csi.storage.k8s.io/fstype: ext4
+    miroir.home-operations.com/replicas: "2"
+    csi.storage.k8s.io/fstype: ext4
 ```
 
 Apply the MiroirNode manifests **before** upgrading the driver chart,
 so the rolled agents boot straight into storage mode. Your cluster
 already has one `MiroirNode` per storage node (the 0.10 agents created
-them to publish pool capacity); `kubectl apply` over them just works —
+them to publish pool capacity); `kubectl apply` over them just works:
 the spec becomes yours, the status stays the agents'. Declaring the
 fleet as a MiroirNodeGroup instead? The existing MiroirNodes carry no
 group label, so the group reports them as Conflict and touches nothing
-(a direct MiroirNode always wins). Hand them over explicitly — the
+(a direct MiroirNode always wins). Hand them over explicitly, and the
 group then converges each spec to its template:
 
 ```bash
@@ -194,17 +194,17 @@ $(kubectl get volumesnapshotclasses -o jsonpath='{range .items[?(@.driver=="miro
 kubectl annotate $classes helm.sh/resource-policy=keep --overwrite
 ```
 
-After step 3 they are plain, unowned objects — the manifests you
+After step 3 they are plain, unowned objects: the manifests you
 authored above are their source of truth from then on (apply them over
 the live objects, and drop the keep annotation if you like:
 `kubectl annotate $classes helm.sh/resource-policy-`). MiroirNodes need
 no shielding: the 0.10 chart never rendered them. Clusters tracking
-unreleased main are the one exception — a development-window chart
-briefly rendered MiroirNodes — so there, extend the annotate command
+unreleased main are the one exception (a development-window chart
+briefly rendered MiroirNodes); there, extend the annotate command
 with `$(kubectl get miroirnodes -o name)`.
 
 Loopfile users: also set the driver chart's `agent.loopfileBaseDirs`
-to every `loopfile.baseDir` in use — the agent pod's hostPath mounts
+to every `loopfile.baseDir` in use: the agent pod's hostPath mounts
 are pod spec, which the driver chart cannot derive from objects it
 does not render.
 
@@ -235,7 +235,8 @@ your configuration (`lvmthin.device`, `zfs.dataset`, ...). If a block is
 missing, the CRD update in step 1 was skipped and the old schema pruned it:
 apply the CRDs and then your manifests again.
 
-### Also breaking, but unlikely to affect you
+/// details | Also breaking, but unlikely to affect you
+    type: note
 
 - The `--nodes-config` flag and `--mode=setup` are gone, along with the
   per-node setup Jobs and their ServiceAccount. Only custom `agent.extraArgs`
@@ -250,7 +251,7 @@ apply the CRDs and then your manifests again.
   from new placement until it is resolved.
 - `helm uninstall` no longer destroys volume data by default. The pre-delete
   hook that deletes every MiroirVolume/MiroirSnapshot is now rendered only
-  when `uninstall.confirmation` is set to `yes-really-destroy-data` — see
+  when `uninstall.confirmation` is set to `yes-really-destroy-data`; see
   [Uninstall](uninstall.md). If your teardown automation relied on the old
   behavior, set the confirmation.
 - The controller pod now tolerates `node.kubernetes.io/unreachable` for 5
@@ -262,7 +263,9 @@ apply the CRDs and then your manifests again.
   the schema, along with the controller's fold of them into the default
   pool. They existed for the 0.9→0.10 rollout skew; 0.10 agents already
   publish (and read) only `status.pools`. Anything scraping the flat paths
-  directly has been broken since 0.10 — use `status.pools[*]`.
+  directly has been broken since 0.10; use `status.pools[*]`.
+
+///
 
 ## 0.9.x → 0.10.0: named storage pools
 
@@ -281,22 +284,22 @@ Before:
 
 ```yaml
 nodes:
-  k8s-0:
-    zone: rack-1
-    backend: lvmthin
-    device: /dev/disk/by-partlabel/r-miroir
+    k8s-0:
+        zone: rack-1
+        backend: lvmthin
+        device: /dev/disk/by-partlabel/r-miroir
 ```
 
 After:
 
 ```yaml
 nodes:
-  k8s-0:
-    zone: rack-1
-    pools:
-      default:
-        backend: lvmthin
-        device: /dev/disk/by-partlabel/r-miroir
+    k8s-0:
+        zone: rack-1
+        pools:
+            default:
+                backend: lvmthin
+                device: /dev/disk/by-partlabel/r-miroir
 ```
 
 The chart fails fast on the flat shape, so a missed node is a template error
@@ -319,28 +322,29 @@ unknown (the same as a cold cluster) until the DaemonSet finishes rolling.
 
 ```yaml
 nodes:
-  k8s-0:
-    pools:
-      default:
-        backend: lvmthin
-        device: /dev/disk/by-partlabel/r-miroir
-      fast:
-        backend: lvmthin
-        device: /dev/disk/by-id/nvme-Micron_7450_MTFDKBA800TFS_XXXX
-  # k8s-1, k8s-2 identical
+    k8s-0:
+        pools:
+            default:
+                backend: lvmthin
+                device: /dev/disk/by-partlabel/r-miroir
+            fast:
+                backend: lvmthin
+                device: /dev/disk/by-id/nvme-Micron_7450_MTFDKBA800TFS_XXXX
+    # k8s-1, k8s-2 identical
 storageClasses:
-  - name: miroir-replicated
-    replicas: 2
-  - name: miroir-replicated-fast
-    replicas: 3
-    pool: fast
+    - name: miroir-replicated
+      replicas: 2
+    - name: miroir-replicated-fast
+      replicas: 3
+      pool: fast
 ```
 
 Each agent creates the new pool's VG and thin-pool at startup. New pools get
 `vg-miroir-<pool>`; the default pool keeps `vg-miroir`, which is why step 2
 needs no data migration.
 
-### Also breaking, but unlikely to affect you
+/// details | Also breaking, but unlikely to affect you
+    type: note
 
 - The agent/setup `--lvm-vg` and `--lvm-thinpool` flags are gone; VG naming
   derives from the pool name. The chart never set them; only custom
@@ -356,6 +360,8 @@ needs no data migration.
   reconciles and deletions fail loudly (`storage pool "x" is not configured on
   this node`) until the pool returns or the volumes are gone.
 
+///
+
 ## 0.8.x → 0.9.0: RWX is opt-in
 
 Serving ReadWriteMany is now an explicit operator decision. Gateway pods run
@@ -369,7 +375,7 @@ values before you upgrade.**
 
 ```yaml
 gateway:
-  enabled: true
+    enabled: true
 ```
 
 Without it, running gateway pods keep serving until their next restart, but


### PR DESCRIPTION
Two passes over the docs site: an accuracy review against the current code, and a standards/organization pass adopting the MkDocs Material features the site already enables.

## Commit 1: accuracy fixes

**Quickstart restore/clone examples could not work as written.** \`CreateVolume\` rejects a restore or clone whose class does not match the source's replica count and pool (\`resolveSource\`), but the §3 claim example uses \`miroir-replicated\` while the §4 restore and clone examples used \`miroir-local\` — copy-pasting them failed with \`InvalidArgument\`. The restore section now states the rule, and both examples use the matching class.

**RWX snapshots are still crash-consistent post-freeze (#292).** The gateway mounts the device inside its own container mount namespace (only \`/dev\` is hostPath-mounted), so the agent's \`freezeMounted\` no-ops for RWX volumes. The quickstart freeze paragraph now carves them out, and the RWX snapshot bullet no longer claims parity with RWO.

**Group-snapshot CRD version contradiction.** \`values.yaml\` still said \`v1beta2\`; the chart ships csi-snapshotter v8.6, which serves the group API at \`v1\` — and configuration.md embeds values.yaml verbatim, so the site disagreed with its own quickstart (#287). Comment fixed, schema regenerated.

**Leftover pre-0.11 configuration phrasing.** Quorum and \`allowRemoteVolumeAccess\` "on a \`storageClasses\` entry" and the ZFS dataset "in Helm values" now name the StorageClass parameter or MiroirNode field that replaced them (#237/#255).

## Commit 2: Material features, organization, ecosystem pointers

- **quickstart**: the four storage layouts and the Helm/Talos install variants become content tabs; the explicit-StorageClass-fields advice becomes a tip; the group-CRD webhook-conversion gotcha becomes a warning.
- **quickstart**: the snapshot stack now points at the [home-operations snapshot-controller chart](https://github.com/home-operations/helm-charts/tree/main/charts/snapshot-controller) (ships the CRDs webhook-free — exactly the failure mode the new warning describes — and enables the group feature gate by default via \`controller.volumeGroupSnapshots\`), and a "snapshots are not backups" note points at [kopiur](https://kopiur.home-operations.com/) for backups exported to durable storage.
- **requirements**: per-OS node setup becomes content tabs.
- **resilience**: bold-paragraph pseudo-headings become real H2s (toc + deep links); the PV-affinity limitation becomes a note.
- **uninstall**: danger admonition on the data-destruction hook.
- **upgrading**: the two "Also breaking, but unlikely to affect you" lists collapse into details blocks; YAML examples move to the 4-space indent the rest of the site uses.
- **index**: mermaid topology diagram (2 replicas + tie-breaker) and the two pages missing from "Where to next".
- **all pages**: the 33 em dashes that crept back in since #238 are gone.

Verified with \`mise run docs\` (strict) and \`mise run helm-test\`; rendered HTML checked for tab sets, details blocks, admonitions, the mermaid block, and resolved reference links.