### PR TITLE
test(e2e): trim guest overhead on the replicated QEMU cluster

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -298,6 +298,7 @@ sudo -E "$(mise which talosctl)" cluster create qemu \
   --memory-workers 5GiB \
   --disks "virtio:8GiB,virtio:${MIROIR_E2E_DISK_SIZE:-20GiB}" \
   --config-patch @{{config_root}}/deploy/e2e/talos-patch.yaml \
+  --config-patch-controlplanes @{{config_root}}/deploy/e2e/talos-patch-controlplane.yaml \
   --talosconfig-destination "$TALOSCONFIG"
 sudo chown -R "$(id -u):$(id -g)" "$bindir"
 

--- a/deploy/e2e/schematic.yaml
+++ b/deploy/e2e/schematic.yaml
@@ -4,6 +4,8 @@
 customization:
   extraKernelArgs:
     - talos.dashboard.disabled=1
+    - talos.auditd.disabled=1
+    - mitigations=off
   systemExtensions:
     officialExtensions:
       - siderolabs/drbd

--- a/deploy/e2e/talos-patch-controlplane.yaml
+++ b/deploy/e2e/talos-patch-controlplane.yaml
@@ -1,0 +1,14 @@
+# Control-plane-only machine config for the replicated (QEMU) e2e
+# cluster. Kept separate from talos-patch.yaml because Talos rejects an
+# etcd section on a worker config ("etcd config is only allowed on
+# control plane machines"), so these cannot ride the all-node patch.
+cluster:
+  etcd:
+    extraArgs:
+      unsafe-no-fsync: "true"
+  apiServer:
+    auditPolicy:
+      apiVersion: audit.k8s.io/v1
+      kind: Policy
+      rules:
+        - level: None

--- a/deploy/e2e/talos-patch.yaml
+++ b/deploy/e2e/talos-patch.yaml
@@ -18,3 +18,15 @@ machine:
       registry.e2e:
         endpoints:
           - http://10.5.0.1:5000
+  kubelet:
+    # Borrowed from kind. A node's single 10GiB disk ends up holding two full
+    # sets of Kubernetes images plus the Talos installer, and if kubelet's
+    # default thresholds trip partway through a run it garbage-collects images
+    # and evicts pods, which surfaces as a flaky failure rather than a disk
+    # problem. Nothing here is reclaimed at the end anyway; the VM is deleted.
+    extraConfig:
+      imageGCHighThresholdPercent: 100
+      evictionHard:
+        nodefs.available: "0%"
+        nodefs.inodesFree: "0%"
+        imagefs.available: "0%"


### PR DESCRIPTION
Ports the guest-side perf work from [home-operations/tuppr#390](https://github.com/home-operations/tuppr/pull/390) back to the cluster it was originally modelled on.

## Measured result: no demonstrable speedup

The motivating idea was that the replicated leg spends most of its time inside the conformance suite, so trimming steady-state guest cost should pay off there. Measured against five recent `main` runs, it does not show up:

| | suite phase |
| --- | --- |
| `main` (5 runs) | 1075s, 1127s, 1240s, 1246s, 1286s |
| this PR (1 run) | 1308s |

One sample, sitting just above a baseline that already spreads 211s run to run. That is not a regression I can demonstrate either, but it is definitely not a win. The ~20% natural variance suggests the suite phase is dominated by waiting (pod scheduling, PVC binding, DRBD sync, poll intervals) rather than by guest CPU or etcd fsync, which is exactly the kind of workload these settings cannot help.

**So the case for this PR is not speed.** It is that it stops the cluster doing work nothing consumes, each item verified to take effect. Judge it on that. If that is not worth the added `--config-patch-controlplanes` wiring, it should be closed.

## What each setting does

| | |
| --- | --- |
| `mitigations=off` | Three VMs take the `talosctl` default of 2.0 CPUs each on a 4-vCPU runner, so guest cycles spent on side-channel mitigations are contended. The VMs are destroyed at the end of the run. |
| `talos.auditd.disabled=1` | Kernel audit events nothing consumes. |
| etcd `unsafe-no-fsync` | etcd shares the runner SSD with the lvmthin pool and the DRBD replication under test. `run.sh` skips `[Disruptive]` and `[Serial]`, so no spec kills a node and the durability traded away is never exercised. |
| `auditPolicy: level: None` | Talos defaults to a single `level: Metadata` rule with **no** `omitStages` (`APIServerDefaultAuditPolicy`), so every API request writes two records to `/var/log/audit/kube`. |

`selinux=0` is deliberately not included: Talos 1.13 already defaults it off, and #198 put a 1.13 floor in place.

## Why a second patch file

The etcd and apiServer settings cannot ride `talos-patch.yaml`. Talos rejects an etcd section on a worker:

```
$ talosctl validate -c worker.yaml -m metal
	* etcd config is only allowed on control plane machines
```

So they go behind `--config-patch-controlplanes`, which is the same split tuppr made.

## Verified on a live 1cp/2w QEMU cluster

Booted with these patches, not just config-validated:

- all three kernel args on both the control plane and a worker: `talos.dashboard.disabled=1 talos.auditd.disabled=1 mitigations=off`
- `auditd` gone from the service list (0 entries); kernel agrees mitigations are off (`spectre_v2: Vulnerable; IBPB: disabled; STIBP: disabled`)
- etcd `Running` / `HEALTH OK` with `unsafe-no-fsync=true` in its startup flags
- the policy the apiserver actually loads (`/system/config/kubernetes/kube-apiserver/auditpolicy.yaml`) is `rules: [- level: None]`, and `kube-apiserver.log` is **0 bytes** after a full bootstrap
- no regression from the split: workers keep the `registry.e2e` mirror and the drbd/dm_thin_pool modules, and carry no etcd or apiServer section

## Note

Adding kernel args changed the schematic id, so the `talos-boot` cache key rolled once. The measured run above was on a cache hit, so that cost is not in its number.

## The follow-up that probably matters more

tuppr's other half was measurement-driven VM right-sizing. miroir's `--memory-workers 5GiB` was set reactively off an OOM, never measured, and 2 + 5 + 5 GiB on a 16GB runner with a 12G swapfile means we do not know whether the workers swap during the phase that dominates the job. Given the variance above, that is a better lead than anything in this PR.