### PR TITLE
fix(agent): recover volumes wedged by a leaked filesystem freeze

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -966,8 +966,19 @@ func resumeStaleBarriers(driver *drbd.Driver, freezer *agent.Freezer, nodeName s
 		}
 		for _, name := range stale {
 			if device := paths[name]; device != "" {
-				if err := freezer.Thaw(device); err != nil {
+				mp, err := freezer.Thaw(device)
+				switch {
+				case err != nil:
 					setupLog.Error(err, "cannot thaw stale filesystem freeze", "volume", name)
+				case mp == "":
+					// Usually a leg that never froze (only mounted legs do),
+					// but a freeze leaked before its mount went away is
+					// unreachable now — mount refuses the frozen device and
+					// FITHAW needs a mountpoint (issue #311). Not silent, so
+					// the leak never looks like success; the stage-time
+					// recovery is what clears it.
+					setupLog.Info("stale barrier volume is not mounted; nothing to thaw here",
+						"volume", name, "device", device)
 				}
 			}
 		}

--- a/internal/agent/fsfreeze.go
+++ b/internal/agent/fsfreeze.go
@@ -110,17 +110,51 @@ func (f *Freezer) Freeze(ctx context.Context, device string) (string, error) {
 	}
 }
 
-// Thaw lifts the freeze on the filesystem mounted from device. Not
-// mounted or not frozen (EINVAL) are successes: thaw is called from
-// every path that closes or abandons a barrier round, most of which
-// never froze anything.
-func (f *Freezer) Thaw(device string) error {
+// Thaw lifts the freeze on the filesystem mounted from device, returning
+// the mountpoint it thawed. Not mounted (mountpoint "") or not frozen
+// (EINVAL) are successes: thaw is called from every path that closes or
+// abandons a barrier round, most of which never froze anything. But ""
+// also means an actually-leaked freeze was NOT lifted — FITHAW needs a
+// mountpoint, and a frozen device refuses every new mount (issue #311) —
+// so callers who suspect a leak must not read "" as thawed; the
+// stage-time recovery (stage.EnsureFilesystem) is what clears those.
+func (f *Freezer) Thaw(device string) (string, error) {
 	mp, err := f.mountpointOf(device)
 	if err != nil || mp == "" {
-		return err
+		return "", err
 	}
 	if err := f.ioctl(mp, fiThaw); err != nil && !errors.Is(err, unix.EINVAL) {
-		return fmt.Errorf("thaw %s (%s): %w", mp, device, err)
+		return "", fmt.Errorf("thaw %s (%s): %w", mp, device, err)
+	}
+	return mp, nil
+}
+
+// ThawMountpoint lifts a freeze on the block-device-backed filesystem
+// mounted at target; not a mountpoint and not frozen (EINVAL) are
+// successes, as it guards every staging unmount and those almost never
+// tear down a frozen filesystem. The unmount must run after it: once the
+// last mountpoint is gone, FITHAW has nothing left to open while the
+// frozen device refuses every new mount — the catch-22 of issue #311.
+// Only block-device mounts (mountinfo major != 0) are touched: opening a
+// dead hard-NFS mountpoint for the ioctl would hang exactly where the
+// unstage path's forced unmount cannot.
+func (f *Freezer) ThawMountpoint(target string) error {
+	data, err := f.mountinfo()
+	if err != nil {
+		return err
+	}
+	for line := range strings.Lines(string(data)) {
+		fields := strings.Fields(line)
+		if len(fields) < 5 || fields[4] != target {
+			continue
+		}
+		if maj, _, ok := strings.Cut(fields[2], ":"); !ok || maj == "0" {
+			return nil
+		}
+		if err := f.ioctl(target, fiThaw); err != nil && !errors.Is(err, unix.EINVAL) {
+			return fmt.Errorf("thaw %s: %w", target, err)
+		}
+		return nil
 	}
 	return nil
 }
@@ -183,7 +217,7 @@ func thawMounted(ctx context.Context, f *Freezer, node string, vol *miroirv1alph
 	if device == "" {
 		return
 	}
-	if err := f.Thaw(device); err != nil {
+	if _, err := f.Thaw(device); err != nil {
 		ctrl.LoggerFrom(ctx).Error(err, "cannot thaw the snapshot filesystem freeze", "volume", vol.Name)
 	}
 }

--- a/internal/agent/fsfreeze_test.go
+++ b/internal/agent/fsfreeze_test.go
@@ -180,16 +180,89 @@ func TestFreezeTimeoutSelfCancels(t *testing.T) {
 func TestThawToleratesNotFrozen(t *testing.T) {
 	rec := &ioctlRecorder{errs: []error{unix.EINVAL}}
 	f := testFreezer(rec)
-	if err := f.Thaw(devDrbd1000); err != nil {
+	mp, err := f.Thaw(devDrbd1000)
+	if err != nil {
 		t.Fatalf("EINVAL (not frozen) must be a success: %v", err)
+	}
+	if !strings.HasSuffix(mp, "/globalmount") {
+		t.Fatalf("Thaw must report the mountpoint it reached, got %q", mp)
+	}
+}
+
+func TestThawReportsNoMountpoint(t *testing.T) {
+	rec := &ioctlRecorder{}
+	f := testFreezer(rec)
+	// Not mounted: a no-op, but the empty mountpoint must be visible to
+	// callers — a freeze leaked on an unmounted device was NOT lifted.
+	mp, err := f.Thaw("/dev/drbd9999")
+	if err != nil || mp != "" {
+		t.Fatalf("unmounted device must report no mountpoint, got %q, %v", mp, err)
+	}
+	if len(rec.recorded()) != 0 {
+		t.Fatalf("no ioctl may run without a mount: %v", rec.recorded())
 	}
 }
 
 func TestThawSurfacesRealErrors(t *testing.T) {
 	rec := &ioctlRecorder{errs: []error{errors.New("io error")}}
 	f := testFreezer(rec)
-	if err := f.Thaw(devDrbd1000); err == nil {
+	if _, err := f.Thaw(devDrbd1000); err == nil {
 		t.Fatal("a real thaw failure must surface (a frozen workload)")
+	}
+}
+
+func TestThawMountpointThawsTheStagingMount(t *testing.T) {
+	rec := &ioctlRecorder{}
+	f := testFreezer(rec)
+	target := "/var/lib/kubelet/plugins/kubernetes.io/csi/miroir/abc/globalmount"
+	if err := f.ThawMountpoint(target); err != nil {
+		t.Fatal(err)
+	}
+	if calls := rec.recorded(); len(calls) != 1 || calls[0] != "thaw "+target {
+		t.Fatalf("unexpected ioctls: %v", calls)
+	}
+}
+
+func TestThawMountpointSkipsNonMountpoint(t *testing.T) {
+	rec := &ioctlRecorder{}
+	f := testFreezer(rec)
+	// An unstage retry after the unmount already happened: the target is
+	// no longer in mountinfo, and an ioctl against a plain directory would
+	// reach whatever filesystem holds it.
+	if err := f.ThawMountpoint("/var/lib/kubelet/plugins/kubernetes.io/csi/miroir/gone/globalmount"); err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.recorded()) != 0 {
+		t.Fatalf("no ioctl may run against a non-mountpoint: %v", rec.recorded())
+	}
+}
+
+func TestThawMountpointSkipsNonBlockMounts(t *testing.T) {
+	rec := &ioctlRecorder{}
+	f := testFreezer(rec)
+	// A devtmpfs/NFS-style mount (major 0) can never wear a bdev freeze,
+	// and opening a dead hard-NFS mountpoint would hang — never touch it.
+	if err := f.ThawMountpoint("/var/lib/kubelet/pods/y/volumeDevices/pvc-2"); err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.recorded()) != 0 {
+		t.Fatalf("no ioctl may run against a non-block mount: %v", rec.recorded())
+	}
+}
+
+func TestThawMountpointToleratesNotFrozen(t *testing.T) {
+	rec := &ioctlRecorder{errs: []error{unix.EINVAL}}
+	f := testFreezer(rec)
+	if err := f.ThawMountpoint("/var/lib/kubelet/plugins/kubernetes.io/csi/miroir/abc/globalmount"); err != nil {
+		t.Fatalf("EINVAL (not frozen) must be a success: %v", err)
+	}
+}
+
+func TestThawMountpointSurfacesRealErrors(t *testing.T) {
+	rec := &ioctlRecorder{errs: []error{errors.New("io error")}}
+	f := testFreezer(rec)
+	if err := f.ThawMountpoint("/var/lib/kubelet/plugins/kubernetes.io/csi/miroir/abc/globalmount"); err == nil {
+		t.Fatal("a real thaw failure must surface")
 	}
 }
 

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/agent"
 	"github.com/home-operations/miroir/internal/constants"
 	"github.com/home-operations/miroir/internal/drbd"
 	"github.com/home-operations/miroir/internal/stage"
@@ -60,6 +61,16 @@ type Node struct {
 	// volume's deletion forever. RWO remote-access staging refuses
 	// instead; RWX (NFS) staging needs no DRBD leg and still works.
 	ClientOnly bool
+	// Freezer lifts a snapshot-round filesystem freeze leaked onto the
+	// staging mount before unstage tears it down (issue #311); nil skips
+	// (tests).
+	Freezer Thawer
+}
+
+// Thawer lifts a filesystem freeze from a staging mountpoint before its
+// unmount; *agent.Freezer implements it.
+type Thawer interface {
+	ThawMountpoint(target string) error
 }
 
 // NewNode wires a Node service with the host mount/format tooling.
@@ -69,6 +80,7 @@ func NewNode(c client.Client, nodeName string, d stage.DRBDStatus) *Node {
 		NodeName: nodeName,
 		Mounter:  mount.NewSafeFormatAndMount(mount.New(""), utilexec.New()),
 		DRBD:     d,
+		Freezer:  agent.NewFreezer(),
 	}
 }
 
@@ -410,6 +422,16 @@ const nfsUnmountTimeout = 30 * time.Second
 func (n *Node) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	if req.GetVolumeId() == "" || req.GetStagingTargetPath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id and staging path are required")
+	}
+	// Lift any leaked snapshot-round freeze while the staging mount still
+	// exists: once the unmount below removes the last mountpoint, FITHAW
+	// has nothing left to open while the frozen device refuses every new
+	// mount — the catch-22 of issue #311. Best-effort: a failed thaw must
+	// never block unstage (the stage-time recovery is the backstop).
+	if n.Freezer != nil {
+		if err := n.Freezer.ThawMountpoint(req.GetStagingTargetPath()); err != nil {
+			log.Error(err, "cannot thaw the staging mount before unstage", "volume", req.GetVolumeId())
+		}
 	}
 	if err := cleanupMount(req.GetStagingTargetPath(), n.Mounter); err != nil {
 		return nil, status.Errorf(codes.Internal, "unstage: %v", err)

--- a/internal/csi/node_test.go
+++ b/internal/csi/node_test.go
@@ -561,3 +561,54 @@ func TestNodeUnstageForcesWhenVolumeGone(t *testing.T) {
 		t.Fatal("unstage must take the deadline-bounded force path")
 	}
 }
+
+// fakeThawer records thaw requests; err scripts a failure.
+type fakeThawer struct {
+	targets []string
+	err     error
+}
+
+func (f *fakeThawer) ThawMountpoint(target string) error {
+	f.targets = append(f.targets, target)
+	return f.err
+}
+
+// Unstage must lift a leaked snapshot-round freeze while the staging
+// mount still exists: once the unmount removes the last mountpoint, a
+// frozen device can neither be thawed (FITHAW needs a mountpoint) nor
+// mounted again — the catch-22 of issue #311.
+func TestNodeUnstageThawsBeforeUnmount(t *testing.T) {
+	target := t.TempDir()
+	n := newNode(t, stagedVolume(), fakeDRBDStatus{})
+	n.Mounter = mount.NewSafeFormatAndMount(
+		mount.NewFakeMounter([]mount.MountPoint{{Path: target}}), utilexec.New())
+	thawer := &fakeThawer{}
+	n.Freezer = thawer
+
+	if _, err := n.NodeUnstageVolume(t.Context(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          volPvc1,
+		StagingTargetPath: target,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(thawer.targets) != 1 || thawer.targets[0] != target {
+		t.Fatalf("the staging mount must be thawed before the unmount: %v", thawer.targets)
+	}
+}
+
+// A failed thaw must never block unstage — the stage-time frozen-bdev
+// recovery is the backstop for a freeze this best-effort lift missed.
+func TestNodeUnstageProceedsWhenThawFails(t *testing.T) {
+	target := t.TempDir()
+	n := newNode(t, stagedVolume(), fakeDRBDStatus{})
+	n.Mounter = mount.NewSafeFormatAndMount(
+		mount.NewFakeMounter([]mount.MountPoint{{Path: target}}), utilexec.New())
+	n.Freezer = &fakeThawer{err: context.DeadlineExceeded}
+
+	if _, err := n.NodeUnstageVolume(t.Context(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          volPvc1,
+		StagingTargetPath: target,
+	}); err != nil {
+		t.Fatalf("a failed thaw must not fail unstage: %v", err)
+	}
+}

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -842,6 +842,29 @@ func (d *Driver) Down(ctx context.Context, name string) error {
 	return d.releaseMinor(name)
 }
 
+// Restart drops and re-registers the resource's kernel state (down + up),
+// keeping the rendered config and the minor assignment. It exists for one
+// consumer: a filesystem freeze leaked onto an unmounted device pins the
+// bdev's freeze count with no mountpoint left for FITHAW, and dropping the
+// minor's bdev inode is the only remaining way to clear it (issue #311).
+// The disconnect costs a brief bitmap-based resync on reconnect. A
+// resource wearing the teardown wedge signature is refused outright — a
+// down spawned against it can only hang (see ErrWedged); the caller's
+// retry re-evaluates.
+func (d *Driver) Restart(ctx context.Context, name string) error {
+	peerIDs, wedged := d.liveTeardownView(ctx, name)
+	if wedged {
+		return fmt.Errorf("restart %s: teardown wedge signature; refusing to spawn a down", name)
+	}
+	if err := d.downResource(ctx, name, peerIDs); err != nil {
+		return err
+	}
+	if _, err := d.adm(ctx, "up", name); err != nil {
+		return fmt.Errorf("up %s: %w", name, err)
+	}
+	return nil
+}
+
 // DiskUpToDate is the disk state of a replica holding current data.
 const DiskUpToDate = "UpToDate"
 

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1010,6 +1010,64 @@ func TestDownDetachingWithPeersStillDowns(t *testing.T) {
 	fe.calledWith(t, "drbdsetup down pvc-1")
 }
 
+// Restart drops and re-registers the kernel state — the only lever that
+// clears a filesystem freeze leaked onto an unmounted device (issue #311)
+// — while the rendered config and minor assignment stay for the up.
+func TestRestartDownsAndUps(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"` + DiskUpToDate + `"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.Restart(t.Context(), volPvc1); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
+	fe.calledWith(t, "drbdsetup down pvc-1")
+	fe.calledWith(t, "drbdadm up pvc-1")
+	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
+		t.Fatalf("rendered config must survive a restart: %v", err)
+	}
+}
+
+// A resource wearing the teardown wedge signature must be refused: a down
+// spawned against it can only hang and strand an unkillable process.
+func TestRestartRefusesWedged(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"Detaching"}],"connections":[]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.Restart(t.Context(), volPvc1); err == nil {
+		t.Fatal("a wedged resource must refuse restart")
+	}
+	fe.notCalledWith(t, "drbdsetup down")
+	fe.notCalledWith(t, "drbdadm up")
+}
+
+// A failed down must not be followed by an up: the resource is still
+// registered, and the error is the caller's retry signal.
+func TestRestartSkipsUpWhenDownFails(t *testing.T) {
+	fe := &fakeExec{
+		responses: map[string]string{
+			cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary","connections":[]}]`,
+		},
+		errOn: map[string]error{"down pvc-1": errors.New("Device is held open by someone")},
+	}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.Restart(t.Context(), volPvc1); err == nil {
+		t.Fatal("a failed down must surface")
+	}
+	fe.notCalledWith(t, "drbdadm up")
+}
+
 // A wedged orphan must be skipped from the sweep's own status parse —
 // spawning a down against it can only hang 30s and strand another
 // unkillable process per agent boot.

--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"os"
 	"slices"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -203,6 +204,9 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 		// FormatAndMount formats only when the device has no filesystem —
 		// the mkfs-if-blank step.
 		if err := d.Mounter.FormatAndMount(dev, target, fsType, flags); err != nil {
+			if rerr := recoverFrozenBdev(ctx, d, vol, dev, err); rerr != nil {
+				return rerr
+			}
 			return status.Errorf(codes.Internal, "format/mount %s: %v", dev, err)
 		}
 		if format == "" {
@@ -244,6 +248,39 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 		return status.Errorf(codes.Internal, "record activated flag: %v", err)
 	}
 	return nil
+}
+
+// resourceRestarter is the optional Deps.DRBD upgrade the frozen-bdev
+// recovery needs; *drbd.Driver implements it, a status-only fake skips
+// the recovery.
+type resourceRestarter interface {
+	Restart(ctx context.Context, name string) error
+}
+
+// recoverFrozenBdev handles a mount refused because the device's freeze
+// count is pinned: a filesystem freeze leaked by a snapshot barrier round
+// whose thaw never ran — agent restart or unmount between freeze and thaw
+// (issue #311). The volume is otherwise wedged on this node forever, as
+// FITHAW needs a mountpoint and every new mount is refused; the kernel
+// prints exactly this text for the refusal (fs/super.c get_tree_bdev),
+// surfaced through mount(8)'s output inside the error. Dropping the
+// minor's bdev inode is the only way out: down/up the resource and hand
+// kubelet an Unavailable to retry the stage. Returns nil when the error
+// is not this case (the caller's generic wrap applies).
+func recoverFrozenBdev(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVolume, dev string, mountErr error) error {
+	if vol.Spec.DRBD == nil || !strings.Contains(mountErr.Error(), "blockdev is frozen") {
+		return nil
+	}
+	r, ok := d.DRBD.(resourceRestarter)
+	if !ok {
+		return nil
+	}
+	if err := r.Restart(ctx, vol.Name); err != nil {
+		return status.Errorf(codes.Internal,
+			"clear leaked filesystem freeze on %s (restart %s): %v", dev, vol.Name, err)
+	}
+	return status.Errorf(codes.Unavailable,
+		"cleared a leaked filesystem freeze on %s by restarting %s; retry the stage", dev, vol.Name)
 }
 
 // MarkFormatted flips the Formatted status flag once; shared by the

--- a/internal/stage/stage_test.go
+++ b/internal/stage/stage_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/drbd"
+)
+
+type statusOnlyDRBD struct{}
+
+func (statusOnlyDRBD) Status(context.Context, string) (drbd.Status, error) {
+	return drbd.Status{}, nil
+}
+
+// restartingDRBD is the resourceRestarter upgrade the recovery needs.
+type restartingDRBD struct {
+	statusOnlyDRBD
+	restarted []string
+	err       error
+}
+
+func (r *restartingDRBD) Restart(_ context.Context, name string) error {
+	r.restarted = append(r.restarted, name)
+	return r.err
+}
+
+func replicatedVolume() *miroirv1alpha1.MiroirVolume {
+	return &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1"},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			DRBD: &miroirv1alpha1.DRBDSpec{Port: 7000},
+		},
+	}
+}
+
+// errFrozenMount mirrors what FormatAndMount surfaces when the kernel
+// refuses the mount over a pinned bdev freeze count (fs/super.c via
+// mount(8)'s output).
+var errFrozenMount = errors.New(`mount failed: exit status 32
+Output: mount: /stage/globalmount: /dev/drbd1378 already mounted or mount point busy.
+mount warning:
+      * drbd1378: Can't mount, blockdev is frozen`)
+
+func TestRecoverFrozenBdevRestartsAndRetries(t *testing.T) {
+	r := &restartingDRBD{}
+	err := recoverFrozenBdev(t.Context(), Deps{DRBD: r}, replicatedVolume(), "/dev/drbd1378", errFrozenMount)
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("recovery must hand kubelet an Unavailable retry, got %v", err)
+	}
+	if len(r.restarted) != 1 || r.restarted[0] != "pvc-1" {
+		t.Fatalf("the volume's resource must be restarted: %v", r.restarted)
+	}
+}
+
+func TestRecoverFrozenBdevSurfacesRestartFailure(t *testing.T) {
+	r := &restartingDRBD{err: errors.New("resource wedged")}
+	err := recoverFrozenBdev(t.Context(), Deps{DRBD: r}, replicatedVolume(), "/dev/drbd1378", errFrozenMount)
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("a failed restart must surface, got %v", err)
+	}
+}
+
+func TestRecoverFrozenBdevIgnoresOtherMountErrors(t *testing.T) {
+	r := &restartingDRBD{}
+	err := recoverFrozenBdev(t.Context(), Deps{DRBD: r}, replicatedVolume(), "/dev/drbd1378",
+		errors.New("mount failed: wrong fs type"))
+	if err != nil {
+		t.Fatalf("an ordinary mount failure is not the recovery's, got %v", err)
+	}
+	if len(r.restarted) != 0 {
+		t.Fatalf("no restart may run for an ordinary mount failure: %v", r.restarted)
+	}
+}
+
+func TestRecoverFrozenBdevSkipsLocalVolumes(t *testing.T) {
+	r := &restartingDRBD{}
+	vol := replicatedVolume()
+	vol.Spec.DRBD = nil
+	if err := recoverFrozenBdev(t.Context(), Deps{DRBD: r}, vol, "/dev/vg-miroir/pvc-1", errFrozenMount); err != nil {
+		t.Fatalf("a local volume's device is no DRBD resource to restart, got %v", err)
+	}
+	if len(r.restarted) != 0 {
+		t.Fatalf("no restart may run for a local volume: %v", r.restarted)
+	}
+}
+
+func TestRecoverFrozenBdevNeedsRestarter(t *testing.T) {
+	err := recoverFrozenBdev(t.Context(), Deps{DRBD: statusOnlyDRBD{}}, replicatedVolume(), "/dev/drbd1378", errFrozenMount)
+	if err != nil {
+		t.Fatalf("a status-only DRBD dep must fall through to the generic wrap, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #311.

A snapshot barrier round's FIFREEZE leaks whenever nothing runs the paired thaw: the agent restarting between freeze and thaw, or the staging mount being torn down mid-round. `Thaw` silently no-ops without a mountpoint, and the pinned bdev freeze count refuses every new mount of the device, so the volume is permanently unmountable on that node with no in-tree recovery: the catch-22 from the issue.

This breaks the catch-22 on all three legs rather than picking one:

### 1. Prevention: unstage thaws before it unmounts (`internal/csi/node.go`, `Freezer.ThawMountpoint`)

`NodeUnstageVolume` now lifts any freeze from the staging mountpoint before `cleanupMount` removes it, so a leaked freeze can no longer outlive its last mountpoint on the graceful path. Details that matter:

- Best-effort: a failed thaw logs and never blocks unstage (the stage-time recovery below is the backstop).
- `ThawMountpoint` only touches **block-device-backed** mounts (mountinfo `major != 0`). Opening a dead hard-NFS staging mountpoint for the ioctl would hang exactly where the forced-unmount path (`nfsUnmountTimeout`) is designed not to — and a major-0 filesystem can't wear a bdev freeze anyway.
- Not-a-mountpoint and not-frozen (`EINVAL`) are successes, same contract as `Thaw`.

### 2. Recovery: staging clears the wedge itself (`stage.recoverFrozenBdev`, `drbd.Driver.Restart`)

When `FormatAndMount` fails with the kernel's `Can't mount, blockdev is frozen` refusal (fs/super.c `get_tree_bdev`, surfaced through mount(8)'s output — same string-matching precedent as `isMissingMetadata`), staging restarts the DRBD resource and returns `Unavailable` so kubelet retries; the next stage mounts cleanly.

- `Driver.Restart` is down + up, keeping the rendered config and the minor assignment — dropping the minor's bdev inode is the only remaining lever once the mount is gone (the issue's documented operator workaround, now automatic and logged in the CSI error). It reuses `downResource`'s disconnect-first ordering and refuses a resource wearing the teardown wedge signature (no down spawned against LINBIT/drbd#137).
- Wired as an optional interface upgrade on `Deps.DRBD`, so the NFS gateway's stage loop gets the same recovery and status-only fakes are untouched.
- Because detection is at the failure point rather than marker state, this also heals volumes **already wedged before this fix ships** (the reporter's `pvc-80106b80-…` case, where no snapshot objects remain).
- Gated on `vol.Spec.DRBD != nil`: local volumes never get a miroir FIFREEZE and have no resource to restart.

### 3. Observability: the silent no-op is gone

`Thaw` now returns the mountpoint it reached (mirroring `Freeze`), and the startup barrier sweep logs when a stale volume's device had no mountpoint to thaw — usually a leg that never froze, but never again a leak masquerading as success.

### Why no persisted freeze markers (issue option 2)

With unstage thawing before unmount and the agent being the only path that can unmount (mounts survive an agent restart, and the reconcilers' existing close/ReadyToUse paths re-thaw mounted leftovers), a freeze can only strand on an *unmounted* device — where a marker's only use would be triggering the same down/up the stage-time recovery already performs, just earlier than anyone needs it. A leaked freeze on an unmounted device is inert until someone stages (DRBD replication is unaffected, per the issue), so recovery at stage time converges exactly when it matters, without new hostPath state to keep truthful.

### Testing

- `go test ./...` green on linux (golang 1.26.3 container); `test/integration` needs envtest binaries not present locally and was not run — CI covers it.
- New tests: `ThawMountpoint` (staging mount, non-mountpoint, non-block mount, EINVAL, real error), `Driver.Restart` (sequence, wedge refusal, down-failure short-circuit), `recoverFrozenBdev` (recovery + retry, restart failure, ordinary mount errors, local volumes, status-only deps), unstage thaw-before-unmount + thaw-failure tolerance.
- `golangci-lint run` (v2.12.2): 0 issues.
- Not verified on hardware: the actual kernel-level clear of `bd_fsfreeze_count` by down/up rests on the issue's diagnosis and documented workaround.
