### PR TITLE
test(e2e): add a zfs backend leg to the QEMU e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,6 +48,8 @@ jobs:
           # group snapshots included.
           - suite: replicated
             testdriver: testdriver.yaml
+          - suite: zfs
+            testdriver: testdriver-zfs.yaml
     env:
       # Two names for one image in the runner-local registry. The nodes pull
       # registry.e2e, which the Talos mirror in patches/registry.yaml points at the

--- a/test/conformance/run.sh
+++ b/test/conformance/run.sh
@@ -6,6 +6,7 @@
 #   SKIP='\[Disruptive\]' ./run.sh PROCS=1    # include [Serial] specs
 #   FOCUS='.*snapshot.*' ./run.sh             # narrow down
 #   TESTDRIVER=testdriver-local.yaml ./run.sh # miroir-local (lvmthin)
+#   TESTDRIVER=testdriver-zfs.yaml ./run.sh   # miroir-zfs (replicated zfs)
 #   VERBOSE=1 ./run.sh                        # per-spec live output
 #
 # The e2e.test/ginkgo binaries are fetched to match the server version

--- a/test/conformance/testdriver-zfs.yaml
+++ b/test/conformance/testdriver-zfs.yaml
@@ -1,0 +1,39 @@
+# Driver definition for the upstream Kubernetes external-storage e2e
+# suite (test/e2e/storage/external). Run via ./run.sh.
+#
+# Drives the replicated zfs class (pool: zfs, replicas: 2), so DRBD pairs
+# a zvol with a zvol -- the zfs analogue of testdriver.yaml.
+StorageClass:
+  FromExistingClassName: miroir-zfs
+SnapshotClass:
+  FromExistingClassName: miroir-snap
+GroupSnapshotClass:
+  FromExistingClassName: miroir-group-snap
+DriverInfo:
+  Name: miroir.home-operations.com
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 10Gi
+  SupportedFsType:
+    ext4: {}
+  Capabilities:
+    persistence: true
+    block: true
+    exec: true
+    fsGroup: true
+    multipods: true
+    controllerExpansion: true
+    nodeExpansion: true
+    onlineExpansion: true
+    offlineExpansion: true
+    snapshotDataSource: true
+    groupSnapshot: true
+    pvcDataSource: true
+    topology: true
+    singleNodeVolume: false
+    # RWX is implemented (NFS gateway over a replicated volume) but the
+    # upstream RWX specs need real DRBD + ganesha, not kind. Flip to true
+    # once the smoke suite's RWX scenario passes on a real cluster.
+    RWX: false
+    readWriteOncePod: true
+    capacity: false

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -5,32 +5,36 @@ End-to-end tests for the miroir CSI driver against a local Talos cluster, booted
 
 ## Overview
 
-Both CI legs boot the same `cluster.yaml` -- a controller node and two storage
-workers, with the DRBD kernel module baked in by an Image Factory schematic -- and
-drive the tests against it. The action boots the shape the document describes, exports
-a kubeconfig and talosconfig, and destroys the cluster in its post step; `test.sh`
-then installs the driver from a packaged Helm chart and runs the tests.
+Every CI leg boots the same `cluster.yaml` -- a controller node and two storage
+workers, with the DRBD and ZFS kernel modules baked in by an Image Factory schematic
+-- and drives the tests against it. The action boots the shape the document
+describes, exports a kubeconfig and talosconfig, and destroys the cluster in its post
+step; `test.sh` then installs the driver from a packaged Helm chart and runs the
+tests.
 
-The two legs run the same document and differ in what `test.sh` drives against it, so
-a failure names the path that broke:
+The legs run the same document and differ in what `test.sh` drives against it, so a
+failure names the path that broke:
 
 | Leg           | Runs                                       | Class               |
 | ------------- | ------------------------------------------ | ------------------- |
 | `conformance` | miroir's Go specs, then the upstream suite | `miroir-local`      |
 | `replicated`  | the upstream suite                         | `miroir-replicated` |
+| `zfs`         | the upstream suite                         | `miroir-zfs`        |
 
 miroir's Go specs (`test/e2e`) assert the local lifecycle, snapshot/restore, block and
 placement behaviour the upstream suite does not; the conformance leg runs them
 (`RUN_SPECS=1`) against the miroir-local (lvmthin, replicas: 1) class before the long
 external-storage run. The replicated leg drives that upstream suite against the DRBD
-(replicas: 2) class, group snapshots included. Real per-node kernels and real block
-devices are the point: the DRBD path needs the DRBD 9 module, which only a real Talos
-node has.
+(replicas: 2) class, group snapshots included; the zfs leg drives it against the same
+DRBD shape backed by the zfs pool instead, so replication pairs zvol with zvol and
+the zfs snapshot/restore path runs under the suite. Real per-node kernels and real
+block devices are the point: the DRBD path needs the DRBD 9 module, which only a real
+Talos node has.
 
 ```text
-cluster.yaml              the one cluster shape both legs boot
-schematic.yaml            the drbd system extension (referenced by cluster.yaml)
-patches/modules.yaml      shared: the DRBD / dm-thin kernel modules
+cluster.yaml              the one cluster shape every leg boots
+schematic.yaml            the drbd + zfs system extensions (referenced by cluster.yaml)
+patches/modules.yaml      shared: the DRBD / dm-thin / zfs kernel modules
 patches/registry.yaml     shared: where the nodes pull the miroir images
 classes.yaml              the StorageClasses / snapshot classes under test
 common.sh                 shared configuration for the scripts
@@ -63,7 +67,7 @@ sudo -E (mise which talosctl) cluster create qemu \
     --cidr 10.5.0.0/24 \
     --schematic-id "$SCHEMATIC_ID" \
     --controlplanes 1 --workers 2 --memory-workers 5GiB \
-    --disks virtio:8GiB,virtio:20GiB \
+    --disks virtio:8GiB,virtio:20GiB,virtio:20GiB \
     --config-patch @patches/modules.yaml \
     --config-patch @patches/registry.yaml \
     --talosconfig-destination /tmp/miroir-e2e/talosconfig
@@ -74,7 +78,7 @@ talosctl kubeconfig /tmp/miroir-e2e/kubeconfig --nodes 10.5.0.2 --force
 set -gx CLUSTER_NAME miroir-e2e
 set -gx KUBECONFIG /tmp/miroir-e2e/kubeconfig
 set -gx TALOSCONFIG /tmp/miroir-e2e/talosconfig
-set -gx TESTDRIVER testdriver.yaml # replicated leg; or testdriver-local.yaml
+set -gx TESTDRIVER testdriver.yaml # or testdriver-local.yaml / testdriver-zfs.yaml
 set -gx RUN_SPECS 1                 # also run the Go specs (the conformance leg does)
 ./test.sh
 
@@ -124,10 +128,14 @@ The image overrides (`image.*`, `agent.image.*`) and `groupSnapshots.enabled` ar
 passed as `--set` either way, so they win over the chart's defaults.
 
 The install is CR-first: the CRDs, the StorageClasses, and a labelled MiroirNodeGroup
-pointing the lvmthin pool at the workers' `/dev/vdb` all land before the driver, so
-the agent boots straight into storage mode. The namespace is labelled
-`pod-security.kubernetes.io/enforce=privileged` first, because Talos enforces the
-baseline standard and would otherwise reject the privileged agent DaemonSet.
+pointing the lvmthin pool at the workers' `/dev/vdb` and the zfs pool at a dataset on
+the `tank` zpool all land before the driver, so the agent boots straight into storage
+mode. The zpool itself is the one piece of node state the agent deliberately leaves
+to the operator, so `test.sh` creates it first: one privileged pod per worker,
+running the agent image's own `zpool create` against `/dev/vdc`. The namespace is
+labelled `pod-security.kubernetes.io/enforce=privileged` before any of this, because
+Talos enforces the baseline standard and would otherwise reject the privileged zpool
+pods and agent DaemonSet.
 
 ## What the action's profile supplies
 
@@ -144,9 +152,9 @@ matching Factory installer, so the drbd extension would survive a `talosctl upgr
 The e2e never upgrades, so this is inert here, but it is the correct default and costs
 nothing.
 
-What is left in `patches/` is only what the profile has no opinion about: the DRBD and
-dm-thin kernel modules the agent needs, and the `registry.e2e` mirror that feeds the
-nodes their images.
+What is left in `patches/` is only what the profile has no opinion about: the DRBD,
+dm-thin, and zfs kernel modules the agent needs, and the `registry.e2e` mirror that
+feeds the nodes their images.
 
 ## Configuration
 

--- a/test/e2e-qemu/classes.yaml
+++ b/test/e2e-qemu/classes.yaml
@@ -1,7 +1,7 @@
 # Storage classes for the QEMU e2e: plain manifests, exactly what the docs tell users
 # to author. The topology (a MiroirNodeGroup) is applied by test.sh, which knows the
-# worker data disk. The class names match test/conformance/testdriver.yaml and
-# testdriver-local.yaml (FromExistingClassName).
+# worker data disks. The class names match test/conformance/testdriver.yaml,
+# testdriver-local.yaml, and testdriver-zfs.yaml (FromExistingClassName).
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -24,6 +24,19 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 parameters:
   miroir.home-operations.com/replicas: "2"
+  csi.storage.k8s.io/fstype: ext4
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: miroir-zfs
+provisioner: miroir.home-operations.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+parameters:
+  miroir.home-operations.com/replicas: "2"
+  miroir.home-operations.com/pool: zfs
   csi.storage.k8s.io/fstype: ext4
 ---
 apiVersion: snapshot.storage.k8s.io/v1

--- a/test/e2e-qemu/cluster.yaml
+++ b/test/e2e-qemu/cluster.yaml
@@ -29,13 +29,15 @@ spec:
     cidr: 10.5.0.0/24
   qemu:
     schematic: "@schematic.yaml"
-    # The first disk goes to every node (the system disk); the second is attached to
-    # workers only -- it is /dev/vdb, which the MiroirNodeGroup points the lvmthin
-    # pool at. Parallel conformance provisions many volumes and the controller's
-    # overcommit guard counts virtual size at capacity times two, so it is sized well
-    # above the sum of the live volumes.
+    # The first disk goes to every node (the system disk); the rest are attached to
+    # workers only -- /dev/vdb, which the MiroirNodeGroup points the lvmthin pool
+    # at, and /dev/vdc, which test.sh turns into the zpool backing the zfs pool.
+    # Parallel conformance provisions many volumes and the controller's overcommit
+    # guard counts virtual size at capacity times two, so both are sized well above
+    # the sum of the live volumes.
     disks:
       - virtio:8GiB
+      - virtio:20GiB
       - virtio:20GiB
   config-patches:
     cluster:

--- a/test/e2e-qemu/diagnostics.sh
+++ b/test/e2e-qemu/diagnostics.sh
@@ -26,6 +26,13 @@ for n in $workers; do
     echo "== $n =="
     talosctl -n "$n" read /proc/drbd
 done
+echo "---- zfs state ----"
+for pod in $(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=agent \
+    -o jsonpath='{.items[*].metadata.name}'); do
+    echo "== $pod =="
+    kubectl exec -n "$NAMESPACE" "$pod" -c agent -- zpool status 2>&1
+    kubectl exec -n "$NAMESPACE" "$pod" -c agent -- zfs list -t all 2>&1
+done
 echo "---- worker dmesg (tail) ----"
 talosctl -n "${workers// /,}" dmesg | tail -100
 true

--- a/test/e2e-qemu/patches/modules.yaml
+++ b/test/e2e-qemu/patches/modules.yaml
@@ -1,7 +1,8 @@
-# DRBD 9 needs its kernel modules loaded and the agent drives dm-thin:
+# DRBD 9 needs its kernel modules loaded and the agent drives dm-thin and zfs:
 # usermode_helper=disabled stops DRBD from calling out to /sbin/drbdadm on the host,
-# which Talos does not ship, and dm_thin_pool is =m in the Talos kernel with nothing
-# on the host to autoload it. Mirrors docs/requirements.md. Applied to every node.
+# which Talos does not ship; dm_thin_pool is =m in the Talos kernel with nothing on
+# the host to autoload it; zfs comes from the schematic's extension and nothing
+# autoloads it either. Mirrors docs/requirements.md. Applied to every node.
 machine:
   kernel:
     modules:
@@ -10,3 +11,4 @@ machine:
           - usermode_helper=disabled
       - name: drbd_transport_tcp
       - name: dm_thin_pool
+      - name: zfs

--- a/test/e2e-qemu/schematic.yaml
+++ b/test/e2e-qemu/schematic.yaml
@@ -1,9 +1,11 @@
 # Image Factory schematic for the QEMU e2e cluster. The siderolabs/drbd extension
 # ships the DRBD 9 kernel module the agent requires; the in-tree drbd.ko is the 8.4
-# API and is not built anyway. The ephemeral profile's kernel args
-# (talos.dashboard.disabled, talos.auditd.disabled, mitigations=off) are merged into
-# this schematic by the action, so they are not repeated here.
+# API and is not built anyway. siderolabs/zfs ships the ZFS module for the zfs
+# backend leg. The ephemeral profile's kernel args (talos.dashboard.disabled,
+# talos.auditd.disabled, mitigations=off) are merged into this schematic by the
+# action, so they are not repeated here.
 customization:
   systemExtensions:
     officialExtensions:
       - siderolabs/drbd
+      - siderolabs/zfs

--- a/test/e2e-qemu/test.sh
+++ b/test/e2e-qemu/test.sh
@@ -56,12 +56,80 @@ install_snapshot_stack() {
     kubectl -n kube-system rollout status deploy/snapshot-controller --timeout=150s
 }
 
+# Talos enforces the baseline Pod Security Standard, which rejects privileged pods;
+# the namespace must carry the privileged label before the zpool pods or helm create
+# any.
+prepare_namespace() {
+    log "Preparing the $NAMESPACE namespace..."
+    kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    kubectl label namespace "$NAMESPACE" pod-security.kubernetes.io/enforce=privileged --overwrite
+}
+
+# The agent creates the parent dataset itself but a zpool is deliberately the
+# operator's (docs/quickstart.md), so the harness plays operator: one privileged pod
+# per worker runs zpool create on /dev/vdc, the third virtio disk cluster.yaml
+# attaches to workers. The agent image ships the zfs userland and the host carries
+# the module, exactly like the agent's own execution environment, and the mounts
+# mirror the agent's: /run/udev because zpool create partitions a whole disk and
+# then waits on udev for the partition nodes.
+#
+# The same pod pins the ARC to 512MiB, which would otherwise grow toward most of a
+# worker's 5GiB the parallel suite needs for pods. Through sysfs at runtime because
+# nothing earlier can deliver the parameter: a zfs.zfs_arc_max kernel arg needs
+# modprobe (Talos loads modules through kmod directly), and a machine-config module
+# parameter races the zfs extension's own service for who loads the module.
+create_zpools() {
+    log "Creating the zfs pool on each worker..."
+    for node in $(kubectl get nodes -l '!node-role.kubernetes.io/control-plane' \
+        -o jsonpath='{.items[*].metadata.name}'); do
+        kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: zpool-create-${node}
+  namespace: ${NAMESPACE}
+  labels:
+    app: zpool-create
+spec:
+  nodeName: ${node}
+  restartPolicy: Never
+  containers:
+    - name: zpool-create
+      image: ${AGENT_IMAGE}
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          echo 536870912 > /sys/module/zfs/parameters/zfs_arc_max
+          zpool list tank >/dev/null 2>&1 || zpool create -f tank /dev/vdc
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: dev
+          mountPath: /dev
+        - name: run-udev
+          mountPath: /run/udev
+  volumes:
+    - name: dev
+      hostPath:
+        path: /dev
+    - name: run-udev
+      hostPath:
+        path: /run/udev
+EOF
+    done
+    kubectl -n "$NAMESPACE" wait --for=jsonpath='{.status.phase}'=Succeeded \
+        pod -l app=zpool-create --timeout=5m
+    kubectl -n "$NAMESPACE" delete pod -l app=zpool-create --wait=false
+}
+
 # Config is CR-first, the same order the upgrade guide mandates: CRDs, then the
 # classes and the topology, then the driver -- so the agent boots straight into
 # storage mode instead of client-only plus a self-restart. Both workers carry the
-# storage class label; /dev/vdb is the extra virtio disk cluster.yaml attaches to
-# workers, and the labelled MiroirNodeGroup is the group controller's coverage:
-# label -> group -> materialized MiroirNode -> agent.
+# storage class label; /dev/vdb is the second virtio disk cluster.yaml attaches to
+# workers, tank the zpool create_zpools made on the third, and the labelled
+# MiroirNodeGroup is the group controller's coverage: label -> group ->
+# materialized MiroirNode -> agent.
 apply_storage_config() {
     log "Applying CRDs, classes, and the node topology..."
     kubectl apply -f "${REPO_ROOT}/charts/miroir/crds/"
@@ -88,19 +156,15 @@ spec:
       - name: default
         lvmthin:
           device: /dev/vdb
+      - name: zfs
+        zfs:
+          dataset: tank/miroir
 EOF
 }
 
 # Install the chart the way it is actually distributed: packaged, and -- in CI --
 # pushed to an OCI registry and pulled back, rather than from the working tree.
 install_chart() {
-    # Talos enforces the baseline Pod Security Standard, which rejects the privileged
-    # agent DaemonSet; the namespace must carry the privileged label before helm
-    # creates any pods.
-    log "Preparing the $NAMESPACE namespace..."
-    kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-    kubectl label namespace "$NAMESPACE" pod-security.kubernetes.io/enforce=privileged --overwrite
-
     local controller_repo controller_tag agent_repo agent_tag
     IFS=':' read -r controller_repo controller_tag <<<"$CONTROLLER_IMAGE"
     IFS=':' read -r agent_repo agent_tag <<<"$AGENT_IMAGE"
@@ -151,8 +215,9 @@ main() {
     : "${CLUSTER_NAME:?must be metadata.name from cluster.yaml}"
 
     # Which storage class the upstream suite drives. testdriver.yaml is the replicated
-    # (DRBD) class; testdriver-local.yaml is the single-node lvmthin one. run.sh reads
-    # SKIP / PROCS / VERBOSE / FOCUS from the environment, so the workflow sets those.
+    # (DRBD over lvmthin) class; testdriver-local.yaml the single-node lvmthin one;
+    # testdriver-zfs.yaml the replicated zfs one. run.sh reads SKIP / PROCS / VERBOSE
+    # / FOCUS from the environment, so the workflow sets those.
     export TESTDRIVER="${TESTDRIVER:-testdriver.yaml}"
 
     # Where the Talos API calls go. CI passes the action's endpoint output; otherwise
@@ -172,6 +237,8 @@ main() {
     kubectl wait --for=condition=Ready node --all --timeout=5m
 
     install_snapshot_stack
+    prepare_namespace
+    create_zpools
     apply_storage_config
     install_chart
 

--- a/test/e2e-qemu/test.sh
+++ b/test/e2e-qemu/test.sh
@@ -118,8 +118,21 @@ spec:
         path: /run/udev
 EOF
     done
-    kubectl -n "$NAMESPACE" wait --for=jsonpath='{.status.phase}'=Succeeded \
-        pod -l app=zpool-create --timeout=5m
+    # Poll rather than kubectl wait: wait --for can watch one phase only, and a
+    # Failed pod should fail the run now (with its logs), not after the full
+    # timeout.
+    local end=$((SECONDS + 300)) phases
+    while :; do
+        phases=$(kubectl -n "$NAMESPACE" get pods -l app=zpool-create \
+            -o jsonpath='{.items[*].status.phase}')
+        if [[ "$phases" == *Failed* ]]; then
+            kubectl -n "$NAMESPACE" logs -l app=zpool-create --prefix --tail=5 || true
+            die "zpool creation failed"
+        fi
+        [[ -n "$phases" && "$phases" != *Pending* && "$phases" != *Running* ]] && break
+        ((SECONDS < end)) || die "timed out waiting for the zpool pods"
+        sleep 2
+    done
     kubectl -n "$NAMESPACE" delete pod -l app=zpool-create --wait=false
 }
 


### PR DESCRIPTION
Closes #294.

The Talos legs run lvmthin only; the zfs backend had no CI coverage on real kernels — the manual smoke gate was its only exercise. This adds a third matrix leg driving the upstream external-storage suite against a new `miroir-zfs` class (`pool: zfs`, replicas: 2), so DRBD pairs zvol with zvol and the zfs snapshot/restore path (#263/#264) and zvol readiness (#232) run under the suite.

### What's in the leg

- `schematic.yaml` gains `siderolabs/zfs` (schematic id changes; the boot-image cache key already hashes the file). Module 2.4.3 vs the agent's 2.3 userland is the supported direction.
- Workers get a third virtio disk (`/dev/vdc`), and `patches/modules.yaml` loads `zfs` — nothing on Talos autoloads it.
- The MiroirNodeGroup template gains a `zfs` pool at `tank/miroir`. Every leg boots the identical shape, so all legs now run multi-pool topologies.
- `test/conformance/testdriver-zfs.yaml`, capabilities identical to `testdriver.yaml`.
- `diagnostics.sh` dumps `zpool status` / `zfs list` through the agent pods on failure.

### The zpool

The agent creates the parent dataset itself but a zpool is deliberately operator-owned, so `test.sh` plays operator: one privileged pod per worker runs `zpool create` on `/dev/vdc` using the agent image's own zfs userland (namespace prep moved ahead of it, since the pods need the privileged PSA label). Two things the local run caught:

- `zpool create` on a whole disk GPT-partitions it and then waits on udev for the partition nodes, so the pod mounts `/run/udev` alongside `/dev`, mirroring the agent DaemonSet. Without it: `cannot label 'vdc': failed to detect device partitions on '/dev/vdc1': 19`.
- The ARC pin lives in the same pod as a runtime sysfs write (512MiB), because nothing earlier can deliver the parameter: a `zfs.zfs_arc_max` kernel arg needs modprobe semantics (Talos loads modules through kmod directly; verified present on the cmdline and inert), and a machine-config module parameter races the zfs extension's own import service for who loads the module.

### Verification

Full leg run locally against a QEMU cluster booted with the new shape: **91 passed / 0 failed** in ~17 minutes wall-clock (suite 15m at PROCS=4), snapshots, group snapshots, expansion, and clones included. Both workers published both pools in MiroirNode status (`default` lvmthin 19.3GB, `zfs` 20.9GB, no errors) and `arcstats c_max` confirmed pinned at 512MiB on both.

Not covered here: the mixed zfs↔lvmthin pairing named in #294's payoff — that needs asymmetric per-node pools (hand-authored MiroirNodes) and a fourth disk, and is a natural follow-up.