### PR TITLE
fix(agent): reclaim volume deletions blocked by an orphaned device hold

### DIFF
--- a/internal/agent/orphanhold.go
+++ b/internal/agent/orphanhold.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// drbdMajor is DRBD's registered block major (LANANA, drivers/block/drbd).
+// Mountinfo rows are matched against it by number so no device node needs
+// to be stat'ed.
+const drbdMajor = 147
+
+// openerPidRE pulls the pids out of the opener list drbdsetup prints when
+// a state change fails with "Device is held open by someone" (-12), e.g.
+// "drbd1422 opened by mount (pid 149800) at 2026-07-20 22:48:32". The
+// format is the kernel's drbd_report_openers line, relayed on stderr by
+// drbd-utils; the same lines appear in the issue #319 field report.
+var openerPidRE = regexp.MustCompile(`\bopened by .* \(pid (\d+)\)`)
+
+// openerPids parses the opener pids out of a held-open failure. Empty
+// when the tooling did not report openers — callers must then assume a
+// live consumer.
+func openerPids(msg string) []int {
+	var pids []int
+	for _, m := range openerPidRE.FindAllStringSubmatch(msg, -1) {
+		if pid, err := strconv.Atoi(m[1]); err == nil {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+// pidAlive reports whether pid still exists under procDir. A recycled pid
+// reads as alive — the safe direction: the caller keeps waiting instead
+// of reclaiming.
+func pidAlive(procDir string, pid int) bool {
+	_, err := os.Stat(filepath.Join(procDir, strconv.Itoa(pid)))
+	return err == nil
+}
+
+// deviceMountedAnywhere reports whether /dev/drbd<minor> backs a
+// filesystem mount or appears as a raw-block bind in any mount namespace
+// visible under procDir. The agent runs with hostPID, so walking every
+// process's mountinfo covers container namespaces too — a force-deleted
+// pod's container can keep the staged filesystem mounted in its own
+// namespace after the host paths are gone, and that is a live consumer,
+// not an orphan (#195: never destroy a backing under a consumer).
+// Namespaces are deduped via ns/mnt so each table is read once; a process
+// that exits mid-scan is skipped. Errors reading procDir itself surface —
+// "could not check" must never read as "not mounted".
+func deviceMountedAnywhere(procDir string, minor int32) (bool, error) {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return false, err
+	}
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if _, err := strconv.Atoi(e.Name()); err != nil {
+			continue
+		}
+		if ns, err := os.Readlink(filepath.Join(procDir, e.Name(), "ns", "mnt")); err == nil {
+			if seen[ns] {
+				continue
+			}
+			seen[ns] = true
+		}
+		data, err := os.ReadFile(filepath.Join(procDir, e.Name(), "mountinfo"))
+		if err != nil {
+			continue
+		}
+		if mountinfoListsDevice(data, minor) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// mountinfoListsDevice reports whether one mountinfo table references
+// /dev/drbd<minor>: a filesystem mount carries the device's major:minor
+// in field 3 (the mounted fs's st_dev), and a raw-block publish is a
+// devtmpfs bind whose root (field 4) is the device node's path.
+func mountinfoListsDevice(data []byte, minor int32) bool {
+	fsDev := fmt.Sprintf("%d:%d", drbdMajor, minor)
+	bindRoot := fmt.Sprintf("/drbd%d", minor)
+	for line := range strings.Lines(string(data)) {
+		f := strings.Fields(line)
+		if len(f) < 5 {
+			continue
+		}
+		if f[2] == fsDev || f[3] == bindRoot {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/orphanhold.go
+++ b/internal/agent/orphanhold.go
@@ -17,12 +17,15 @@ limitations under the License.
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 // drbdMajor is DRBD's registered block major (LANANA, drivers/block/drbd).
@@ -65,9 +68,11 @@ func pidAlive(procDir string, pid int) bool {
 // pod's container can keep the staged filesystem mounted in its own
 // namespace after the host paths are gone, and that is a live consumer,
 // not an orphan (#195: never destroy a backing under a consumer).
-// Namespaces are deduped via ns/mnt so each table is read once; a process
-// that exits mid-scan is skipped. Errors reading procDir itself surface —
-// "could not check" must never read as "not mounted".
+// Namespaces are deduped via ns/mnt so each table is read once. Every
+// error fails closed — "could not check" must never read as "not
+// mounted" — except a process gone mid-scan: reaped reads ENOENT, a
+// zombie EINVAL (its mount namespace is already released), and neither
+// can hold a mount.
 func deviceMountedAnywhere(procDir string, minor int32) (bool, error) {
 	entries, err := os.ReadDir(procDir)
 	if err != nil {
@@ -86,7 +91,10 @@ func deviceMountedAnywhere(procDir string, minor int32) (bool, error) {
 		}
 		data, err := os.ReadFile(filepath.Join(procDir, e.Name(), "mountinfo"))
 		if err != nil {
-			continue
+			if os.IsNotExist(err) || errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ESRCH) {
+				continue
+			}
+			return false, err
 		}
 		if mountinfoListsDevice(data, minor) {
 			return true, nil

--- a/internal/agent/orphanhold.go
+++ b/internal/agent/orphanhold.go
@@ -83,11 +83,9 @@ func deviceMountedAnywhere(procDir string, minor int32) (bool, error) {
 		if _, err := strconv.Atoi(e.Name()); err != nil {
 			continue
 		}
-		if ns, err := os.Readlink(filepath.Join(procDir, e.Name(), "ns", "mnt")); err == nil {
-			if seen[ns] {
-				continue
-			}
-			seen[ns] = true
+		ns, nsErr := os.Readlink(filepath.Join(procDir, e.Name(), "ns", "mnt"))
+		if nsErr == nil && seen[ns] {
+			continue
 		}
 		data, err := os.ReadFile(filepath.Join(procDir, e.Name(), "mountinfo"))
 		if err != nil {
@@ -95,6 +93,13 @@ func deviceMountedAnywhere(procDir string, minor int32) (bool, error) {
 				continue
 			}
 			return false, err
+		}
+		// Mark the namespace covered only now: a process that exited
+		// between the readlink and the read must not retire its shared
+		// namespace unread, or a surviving sibling's table — possibly the
+		// one listing the device — would be skipped as a duplicate.
+		if nsErr == nil {
+			seen[ns] = true
 		}
 		if mountinfoListsDevice(data, minor) {
 			return true, nil

--- a/internal/agent/orphanhold_test.go
+++ b/internal/agent/orphanhold_test.go
@@ -30,8 +30,12 @@ const heldOpenWithOpeners = `pvc-1: State change failed: (-12) Device is held op
 /dev/drbd1422 open_cnt:1, writable:1; list of openers follows
 drbd1422 opened by mount (pid 4242424) at 2026-07-20 22:48:32.925`
 
-// unrelatedMountinfo is a mountinfo table that references no DRBD device.
-const unrelatedMountinfo = "36 25 0:35 / /run rw - tmpfs tmpfs rw\n"
+// unrelatedMountinfo is a mountinfo table that references no DRBD device;
+// drbd1422Mountinfo one whose filesystem is backed by /dev/drbd1422.
+const (
+	unrelatedMountinfo = "36 25 0:35 / /run rw - tmpfs tmpfs rw\n"
+	drbd1422Mountinfo  = "824 25 147:1422 / /data rw - ext4 /dev/drbd1422 rw\n"
+)
 
 func TestOpenerPidsParsesReportedOpeners(t *testing.T) {
 	got := openerPids(heldOpenWithOpeners + "\ndrbd1422 opened by qemu-system (pid 555) at 2026-07-20 23:00:00.000")
@@ -78,12 +82,47 @@ func procFixture(t *testing.T, mountinfoByPid map[int]string) string {
 	return dir
 }
 
+// mntNS stamps a pid dir in a procFixture with an ns/mnt symlink so two
+// pids can share (or claim) a mount namespace identity.
+func mntNS(t *testing.T, procDir string, pid int, ns string) {
+	t.Helper()
+	nsDir := filepath.Join(procDir, strconv.Itoa(pid), "ns")
+	if err := os.MkdirAll(nsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(ns, filepath.Join(nsDir, "mnt")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A process that exits between the ns readlink and the mountinfo read
+// must not retire its shared namespace unread: the surviving sibling's
+// table — here the one listing the device — would otherwise be skipped
+// as a duplicate and the device would read as orphaned.
+func TestDeviceMountedAnywhereGoneProcessDoesNotRetireNamespace(t *testing.T) {
+	dir := procFixture(t, map[int]string{
+		200: drbd1422Mountinfo,
+	})
+	// Pid 100: ns link present, mountinfo already gone (exited mid-scan).
+	// Scanned first (ReadDir is name-sorted).
+	if err := os.MkdirAll(filepath.Join(dir, "100"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mntNS(t, dir, 100, "mnt:[4026531840]")
+	mntNS(t, dir, 200, "mnt:[4026531840]")
+
+	mounted, err := deviceMountedAnywhere(dir, 1422)
+	if err != nil || !mounted {
+		t.Fatalf("the sibling's table must still be read, got %v / %v", mounted, err)
+	}
+}
+
 // The scan must see a mount held only inside a container's namespace —
 // the force-deleted-pod hazard (#195): the host table is clean while the
 // container still runs with the staged filesystem mounted.
 func TestDeviceMountedAnywhereSeesContainerNamespaces(t *testing.T) {
 	host := unrelatedMountinfo
-	container := "824 25 147:1422 / /data rw - ext4 /dev/drbd1422 rw\n"
+	container := drbd1422Mountinfo
 	dir := procFixture(t, map[int]string{1: host, 4321: container})
 
 	mounted, err := deviceMountedAnywhere(dir, 1422)

--- a/internal/agent/orphanhold_test.go
+++ b/internal/agent/orphanhold_test.go
@@ -104,6 +104,33 @@ func TestDeviceMountedAnywhereSurfacesUnreadableProc(t *testing.T) {
 	}
 }
 
+// A live process whose mountinfo cannot be read must fail the scan
+// closed: skipping it could hide the one table listing the device and
+// authorize destroying the backing under a consumer. Only a process gone
+// mid-scan (reaped: ENOENT; zombie: EINVAL, verified on Linux 7.x) may
+// be skipped — a mountinfo that is a directory stands in for any other
+// read error here.
+func TestDeviceMountedAnywhereFailsClosedOnUnreadableTable(t *testing.T) {
+	dir := procFixture(t, map[int]string{1: unrelatedMountinfo})
+	if err := os.MkdirAll(filepath.Join(dir, "4321", "mountinfo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deviceMountedAnywhere(dir, 1422); err == nil {
+		t.Fatal("an unreadable live table must surface as an error, not read as unmounted")
+	}
+
+	// A vanished process is the one tolerated gap: a pid dir with no
+	// mountinfo (the ENOENT shape) must not fail the scan.
+	gone := procFixture(t, map[int]string{1: unrelatedMountinfo})
+	if err := os.MkdirAll(filepath.Join(gone, "9876"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mounted, err := deviceMountedAnywhere(gone, 1422)
+	if err != nil || mounted {
+		t.Fatalf("a reaped process must be skipped, got %v / %v", mounted, err)
+	}
+}
+
 func TestPidAlive(t *testing.T) {
 	dir := procFixture(t, map[int]string{4321: ""})
 	if !pidAlive(dir, 4321) {

--- a/internal/agent/orphanhold_test.go
+++ b/internal/agent/orphanhold_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026.
+
+Licensed under the GNU Affero General Public License, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// heldOpenWithOpeners is the drbdsetup down failure shape from the issue
+// #319 field report: the -12 state-change error plus the kernel's opener
+// list relayed on stderr.
+const heldOpenWithOpeners = `pvc-1: State change failed: (-12) Device is held open by someone
+/dev/drbd1422 open_cnt:1, writable:1; list of openers follows
+drbd1422 opened by mount (pid 4242424) at 2026-07-20 22:48:32.925`
+
+// unrelatedMountinfo is a mountinfo table that references no DRBD device.
+const unrelatedMountinfo = "36 25 0:35 / /run rw - tmpfs tmpfs rw\n"
+
+func TestOpenerPidsParsesReportedOpeners(t *testing.T) {
+	got := openerPids(heldOpenWithOpeners + "\ndrbd1422 opened by qemu-system (pid 555) at 2026-07-20 23:00:00.000")
+	if len(got) != 2 || got[0] != 4242424 || got[1] != 555 {
+		t.Fatalf("want [4242424 555], got %v", got)
+	}
+	// No opener list (older drbd-utils, or a non-DRBD busy cause) must
+	// parse to nothing — the caller then assumes a live consumer.
+	if got := openerPids("pvc-1: State change failed: Device is held open by someone"); len(got) != 0 {
+		t.Fatalf("want no pids without an opener list, got %v", got)
+	}
+}
+
+func TestMountinfoListsDevice(t *testing.T) {
+	fsMount := []byte("824 25 147:1422 / /var/lib/kubelet/plugins/kubernetes.io/csi/x/globalmount rw - ext4 /dev/drbd1422 rw\n")
+	if !mountinfoListsDevice(fsMount, 1422) {
+		t.Fatal("a filesystem mount backed by the device must match")
+	}
+	// A raw-block publish is a devtmpfs bind whose root is the device node.
+	bind := []byte("910 25 0:6 /drbd1422 /var/lib/kubelet/pods/u/volumeDevices/x rw - devtmpfs devtmpfs rw\n")
+	if !mountinfoListsDevice(bind, 1422) {
+		t.Fatal("a raw-block bind of the device node must match")
+	}
+	other := []byte("36 25 0:35 / /run rw - tmpfs tmpfs rw\n824 25 147:1423 / /mnt rw - ext4 /dev/drbd1423 rw\n")
+	if mountinfoListsDevice(other, 1422) {
+		t.Fatal("unrelated mounts must not match")
+	}
+}
+
+// procFixture builds a fake /proc: one numbered dir per pid, each with
+// the given mountinfo table.
+func procFixture(t *testing.T, mountinfoByPid map[int]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for pid, mi := range mountinfoByPid {
+		pidDir := filepath.Join(dir, strconv.Itoa(pid))
+		if err := os.MkdirAll(pidDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pidDir, "mountinfo"), []byte(mi), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// The scan must see a mount held only inside a container's namespace —
+// the force-deleted-pod hazard (#195): the host table is clean while the
+// container still runs with the staged filesystem mounted.
+func TestDeviceMountedAnywhereSeesContainerNamespaces(t *testing.T) {
+	host := unrelatedMountinfo
+	container := "824 25 147:1422 / /data rw - ext4 /dev/drbd1422 rw\n"
+	dir := procFixture(t, map[int]string{1: host, 4321: container})
+
+	mounted, err := deviceMountedAnywhere(dir, 1422)
+	if err != nil || !mounted {
+		t.Fatalf("want mounted=true from the container table, got %v / %v", mounted, err)
+	}
+
+	clean := procFixture(t, map[int]string{1: host, 4321: host})
+	mounted, err = deviceMountedAnywhere(clean, 1422)
+	if err != nil || mounted {
+		t.Fatalf("want mounted=false with no table listing the device, got %v / %v", mounted, err)
+	}
+}
+
+func TestDeviceMountedAnywhereSurfacesUnreadableProc(t *testing.T) {
+	if _, err := deviceMountedAnywhere(filepath.Join(t.TempDir(), "missing"), 1422); err == nil {
+		t.Fatal("an unreadable proc dir must surface as an error, not read as unmounted")
+	}
+}
+
+func TestPidAlive(t *testing.T) {
+	dir := procFixture(t, map[int]string{4321: ""})
+	if !pidAlive(dir, 4321) {
+		t.Fatal("existing pid dir must read alive")
+	}
+	if pidAlive(dir, 9999) {
+		t.Fatal("missing pid dir must read dead")
+	}
+}

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -69,6 +70,10 @@ type VolumeReconciler struct {
 	// KmsgPath overrides /dev/kmsg for the split-brain kernel-log capture
 	// (tests point it at a plain file).
 	KmsgPath string
+	// ProcDir overrides /proc for the orphaned-hold checks — opener pid
+	// liveness and the all-namespaces mount scan (tests point it at a
+	// fixture directory).
+	ProcDir string
 	// Recorder emits the TeardownWedged warning; optional.
 	Recorder events.EventRecorder
 
@@ -877,8 +882,14 @@ func (r *VolumeReconciler) teardown(ctx context.Context, vol *miroirv1alpha1.Mir
 			}
 			// A still-staged device answers "held open"; classify it as
 			// ErrBusy so teardown takes the 10s retry, not the workqueue's
-			// minutes-long backoff (NodeUnstage releases it shortly).
-			return backend.Busy(err)
+			// minutes-long backoff (NodeUnstage releases it shortly). An
+			// orphaned hold no retry can release routes around the down
+			// instead of parking on it forever (issue #319).
+			busy := backend.Busy(err)
+			if r.orphanHold(ctx, vol, slot, busy) {
+				return r.reclaimOrphanHold(ctx, vol, slot, busy)
+			}
+			return busy
 		}
 		// With the resource down, wipe the DRBD metadata before the sweep
 		// removes the device, so freed blocks cannot carry a stale generation
@@ -936,16 +947,26 @@ const wedgedRequeue = 5 * time.Minute
 // reportWedged surfaces a teardown the kernel can no longer finish
 // (drbd.ErrWedged) — Warning Event, status message, and the wedged gauge
 // the shipped alerts page on — then parks the retry at wedgedRequeue.
-// The gauge clears on any non-wedged teardown outcome, on teardown
-// success (dropVolumeMetrics), and when the CR vanishes (volumeGone).
+// The escalation latches on the transition cycle: the park can outlive
+// the wedge only through a reboot, and re-emitting an identical Event,
+// Error log, and no-op status write every cycle is pure churn (issue
+// #319: a wedged volume streamed 123 of them). The gauge is re-raised
+// every cycle regardless — it is process state and must survive an agent
+// restart into an already-stamped Message. It clears on any non-wedged
+// teardown outcome, on teardown success (dropVolumeMetrics), and when
+// the CR vanishes (volumeGone).
 func (r *VolumeReconciler) reportWedged(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
+	recordWedged(vol)
+	if vol.Status.PerNode[r.NodeName].Message == cause.Error() {
+		ctrl.LoggerFrom(ctx).V(1).Info("teardown still wedged in kernel; retry stays parked", "volume", vol.Name)
+		return ctrl.Result{RequeueAfter: wedgedRequeue}, nil
+	}
 	ctrl.LoggerFrom(ctx).Error(cause, "teardown wedged in kernel", "volume", vol.Name)
 	if r.Recorder != nil {
 		r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "TeardownWedged", "Teardown",
 			"DRBD cannot tear down %s: device stuck Detaching with connections gone (LINBIT/drbd#137); reboot node %s to clear it",
 			vol.Name, r.NodeName)
 	}
-	recordWedged(vol)
 	return r.parkWithMessage(ctx, vol, cause, wedgedRequeue)
 }
 
@@ -988,9 +1009,11 @@ func (r *VolumeReconciler) handleTeardownError(ctx context.Context, vol *miroirv
 // busyFailLimit is how many consecutive ErrBusy teardown outcomes ride the
 // fast 10s retry — NodeUnstage normally releases the device within a few
 // cycles — before the loop escalates; busyRetryAfter is the parked cadence.
-// The finalizer is never released on busy: the hold may be a live mount,
-// and force-releasing would leak the backing device or destroy it under a
-// consumer (issue #195).
+// The finalizer is never released on a busy outcome itself: the hold may
+// be a live mount, and force-releasing would leak the backing device or
+// destroy it under a consumer (issue #195). The one exit is the orphaned-
+// hold reclaim (orphanHold), which completes a real teardown of the
+// backing first and only fires past this same threshold.
 const (
 	busyFailLimit  = 30 // ~5 minutes at the 10s cadence
 	busyRetryAfter = time.Minute
@@ -998,8 +1021,9 @@ const (
 
 // reportBusy paces one ErrBusy teardown outcome: the fast 10s retry below
 // busyFailLimit, then a Warning Event, a status Message naming the cause,
-// and the parked cadence. The cause is always logged — an ErrBusy from the
-// backend sweep looks identical to a held-open device without it.
+// and the parked cadence. The cause is logged on every fast cycle and on
+// the escalation — an ErrBusy from the backend sweep looks identical to a
+// held-open device without it — and demotes to V(1) once parked.
 func (r *VolumeReconciler) reportBusy(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, cause error) (ctrl.Result, error) {
 	r.busyMu.Lock()
 	if r.busyFails == nil {
@@ -1013,15 +1037,21 @@ func (r *VolumeReconciler) reportBusy(ctx context.Context, vol *miroirv1alpha1.M
 			"volume", vol.Name, "attempts", fails, "error", cause)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
-	ctrl.LoggerFrom(ctx).Error(cause, "teardown still busy; parking the retry",
-		"volume", vol.Name, "attempts", fails)
 	// Latch the escalation on the crossing cycle: the parked retry can
-	// outlive the hold by hours, and re-emitting an identical Event plus a
-	// no-op status write every cycle is pure API churn.
-	if fails == busyFailLimit && r.Recorder != nil {
-		r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "TeardownBusy", "Teardown",
-			"cannot tear down %s on node %s after %d attempts: %v; something still holds the device (or its backing) open",
-			vol.Name, r.NodeName, fails, cause)
+	// outlive the hold by hours, and re-emitting an identical Event, Error
+	// log, and no-op status write every cycle is pure churn (issue #319:
+	// one parked volume streamed 648 Error lines).
+	if fails > busyFailLimit {
+		ctrl.LoggerFrom(ctx).V(1).Info("teardown still busy; retry stays parked",
+			"volume", vol.Name, "attempts", fails)
+	} else {
+		ctrl.LoggerFrom(ctx).Error(cause, "teardown still busy; parking the retry",
+			"volume", vol.Name, "attempts", fails)
+		if r.Recorder != nil {
+			r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "TeardownBusy", "Teardown",
+				"cannot tear down %s on node %s after %d attempts: %v; something still holds the device (or its backing) open",
+				vol.Name, r.NodeName, fails, cause)
+		}
 	}
 	if vol.Status.PerNode[r.NodeName].Message == cause.Error() {
 		return ctrl.Result{RequeueAfter: busyRetryAfter}, nil
@@ -1034,6 +1064,90 @@ func (r *VolumeReconciler) clearBusyFails(name string) {
 	r.busyMu.Lock()
 	delete(r.busyFails, name)
 	r.busyMu.Unlock()
+}
+
+// busyFailCount reads the volume's consecutive busy-teardown count.
+func (r *VolumeReconciler) busyFailCount(name string) int {
+	r.busyMu.Lock()
+	defer r.busyMu.Unlock()
+	return r.busyFails[name]
+}
+
+// procDir resolves the /proc override for the orphaned-hold checks.
+func (r *VolumeReconciler) procDir() string {
+	if r.ProcDir != "" {
+		return r.ProcDir
+	}
+	return "/proc"
+}
+
+// orphanHold reports whether a busy teardown outcome is the unwinnable
+// held-open state of issue #319 — the device pinned by a leaked freeze's
+// dead superblock, which no retry, restart, or unstage can ever release —
+// as opposed to a still-staged device NodeUnstage frees shortly. It
+// requires all of: a deletion-targeted volume (a removed replica's volume
+// lives on and keeps the parked retry), a known minor, a busy streak past
+// the escalation threshold (an in-flight unstage never lasts that long),
+// a held-open failure whose reported openers have all exited (a live
+// consumer's opener pid is alive; a plain fs mount's dead mount(8) pid is
+// disambiguated by the mount scan below), and the device mounted in no
+// mount namespace on the node. Any doubt — no opener list, an unreadable
+// /proc, a surviving mount — reads as "live consumer" and the park stands.
+func (r *VolumeReconciler) orphanHold(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, slot miroirv1alpha1.ReplicaStatus, cause error) bool {
+	if vol.DeletionTimestamp.IsZero() || slot.DRBDMinor <= 0 {
+		return false
+	}
+	if r.busyFailCount(vol.Name) < busyFailLimit {
+		return false
+	}
+	if !strings.Contains(cause.Error(), "held open") {
+		return false
+	}
+	pids := openerPids(cause.Error())
+	if len(pids) == 0 {
+		return false
+	}
+	for _, pid := range pids {
+		if pidAlive(r.procDir(), pid) {
+			return false
+		}
+	}
+	mounted, err := deviceMountedAnywhere(r.procDir(), slot.DRBDMinor)
+	if err != nil {
+		ctrl.LoggerFrom(ctx).V(1).Info("cannot scan mount namespaces for the orphaned-hold check; teardown stays parked",
+			"volume", vol.Name, "error", err)
+		return false
+	}
+	return !mounted
+}
+
+// reclaimOrphanHold routes a deletion around the pinned minor: the only
+// thing an orphaned hold pins is the DRBD minor itself, so force-detach
+// frees the backing and the sweep destroys it, letting the caller release
+// the finalizer through teardown's normal tail. The rendered config and
+// the minor assignment deliberately stay — the kernel minor is pinned
+// until a reboot, releasing the number would hand it to a new volume, and
+// the startup orphan sweep reaps both once the reboot clears the state.
+// On any failure the original busy outcome stands and the parked retry
+// re-evaluates (ForceDetach no-ops once detached, so a failed sweep
+// converges on the next cycle).
+func (r *VolumeReconciler) reclaimOrphanHold(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, slot miroirv1alpha1.ReplicaStatus, cause error) error {
+	if err := r.DRBD.ForceDetach(ctx, vol.Name, slot.DRBDMinor); err != nil {
+		ctrl.LoggerFrom(ctx).Info("orphaned-hold reclaim could not detach; teardown stays parked",
+			"volume", vol.Name, "error", err)
+		return cause
+	}
+	if err := r.Pools.SweepDelete(ctx, vol.Name); err != nil {
+		return err
+	}
+	ctrl.LoggerFrom(ctx).Info("teardown reclaimed from an orphaned device hold; kernel minor stays pinned until reboot",
+		"volume", vol.Name, "minor", slot.DRBDMinor, "cause", cause.Error())
+	if r.Recorder != nil {
+		r.Recorder.Eventf(vol, nil, corev1.EventTypeNormal, "TeardownReclaimed", "Teardown",
+			"backing of %s reclaimed on node %s: the DRBD device was held open only by exited processes (leaked freeze, issue #311); orphaned minor %d frees itself on the next reboot",
+			vol.Name, r.NodeName, slot.DRBDMinor)
+	}
+	return nil
 }
 
 // reportRealizeError routes a realizeBacking failure: an impossible

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1370,7 +1370,7 @@ func TestReconcileTeardownOrphanHoldLiveOpenerStaysParked(t *testing.T) {
 func TestReconcileTeardownOrphanHoldMountedStaysParked(t *testing.T) {
 	procDir := procFixture(t, map[int]string{
 		1:    unrelatedMountinfo,
-		4321: "824 25 147:1422 / /data rw - ext4 /dev/drbd1422 rw\n",
+		4321: drbd1422Mountinfo,
 	})
 	r, fb, fe, _ := orphanHoldFixture(t, procDir)
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1249,6 +1249,147 @@ func TestReconcileBusyStreakResetsOutsideTeardown(t *testing.T) {
 	}
 }
 
+// orphanHoldFixture assembles a deletion whose down is refused by the
+// issue #319 signature: held open, all reported openers exited, device
+// mounted in no namespace. Callers tweak the proc dir to flip individual
+// legs of the orphan proof.
+func orphanHoldFixture(t *testing.T, procDir string) (*VolumeReconciler, *fakeBackend, *fakeDRBDExec, *events.FakeRecorder) {
+	t.Helper()
+	s := newScheme(t)
+	fb := newFakeBackend()
+	fb.existing[volPvc1] = true
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	now := metav1.NewTime(time.Now())
+	v.DeletionTimestamp = &now
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DRBDMinor: 1422},
+	}
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte("resource \"pvc-1\" {}\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
+	fe := &fakeDRBDExec{
+		statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],"connections":[]}]`,
+		errOn: map[string]error{cmdDownPvc1: errors.New(heldOpenWithOpeners)},
+	}
+	rec := events.NewFakeRecorder(8)
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(fb), Recorder: rec, ProcDir: procDir,
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+	return r, fb, fe, rec
+}
+
+// drainEvents empties the recorder and reports whether any drained event
+// contains substr.
+func drainEvents(rec *events.FakeRecorder, substr string) bool {
+	for {
+		select {
+		case e := <-rec.Events:
+			if strings.Contains(e, substr) {
+				return true
+			}
+		default:
+			return false
+		}
+	}
+}
+
+// An orphaned hold — held open only by exited openers, mounted nowhere,
+// past the busy escalation — must not park forever: teardown routes
+// around the pinned minor with a force-detach, destroys the backing, and
+// releases the finalizer, leaving the rendered config for the post-reboot
+// orphan sweep (issue #319).
+func TestReconcileTeardownOrphanHoldReclaims(t *testing.T) {
+	procDir := procFixture(t, map[int]string{1: unrelatedMountinfo})
+	r, fb, fe, rec := orphanHoldFixture(t, procDir)
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+
+	// Ride the whole busy escalation first: the orphan proof must not
+	// pre-empt a hold NodeUnstage could still release.
+	for range busyFailLimit {
+		if _, err := r.Reconcile(t.Context(), req); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fe.notCalledWith(t, "drbdsetup detach")
+
+	// The next cycle reclaims instead of parking.
+	if _, err := r.Reconcile(t.Context(), req); err != nil {
+		t.Fatalf("the reclaim cycle must complete teardown: %v", err)
+	}
+	fe.calledWith(t, "drbdsetup detach 1422 --force")
+	fe.notCalledWith(t, "wipe-md")
+	if fb.existing[volPvc1] {
+		t.Fatal("the backing device must be destroyed by the reclaim")
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, got); err == nil {
+		if slices.Contains(got.Finalizers, constants.FinalizerPrefix+nodeA) {
+			t.Fatalf("this node's finalizer must release after the reclaim: %v", got.Finalizers)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(r.DRBD.StateDir, "pvc-1.res")); err != nil {
+		t.Fatalf("rendered config must stay for the post-reboot orphan sweep: %v", err)
+	}
+	if !drainEvents(rec, "TeardownReclaimed") {
+		t.Fatal("want a TeardownReclaimed event")
+	}
+}
+
+// A live opener pid is a consumer, not an orphan: the reclaim must not
+// fire and the parked busy retry stands (#195: never destroy a backing
+// under a consumer).
+func TestReconcileTeardownOrphanHoldLiveOpenerStaysParked(t *testing.T) {
+	procDir := procFixture(t, map[int]string{4242424: unrelatedMountinfo})
+	r, fb, fe, _ := orphanHoldFixture(t, procDir)
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+
+	for range busyFailLimit + 1 {
+		if _, err := r.Reconcile(t.Context(), req); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := r.Reconcile(t.Context(), req)
+	if err != nil || res.RequeueAfter != busyRetryAfter {
+		t.Fatalf("a live opener must stay parked, got %v / %v", res.RequeueAfter, err)
+	}
+	fe.notCalledWith(t, "drbdsetup detach")
+	if !fb.existing[volPvc1] {
+		t.Fatal("the backing must survive while an opener lives")
+	}
+}
+
+// A device still mounted in any namespace — even one no host path shows,
+// like a force-deleted pod's container — is a live consumer: the reclaim
+// must not fire even though every reported opener pid is dead.
+func TestReconcileTeardownOrphanHoldMountedStaysParked(t *testing.T) {
+	procDir := procFixture(t, map[int]string{
+		1:    unrelatedMountinfo,
+		4321: "824 25 147:1422 / /data rw - ext4 /dev/drbd1422 rw\n",
+	})
+	r, fb, fe, _ := orphanHoldFixture(t, procDir)
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+
+	for range busyFailLimit + 1 {
+		if _, err := r.Reconcile(t.Context(), req); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := r.Reconcile(t.Context(), req)
+	if err != nil || res.RequeueAfter != busyRetryAfter {
+		t.Fatalf("a mounted device must stay parked, got %v / %v", res.RequeueAfter, err)
+	}
+	fe.notCalledWith(t, "drbdsetup detach")
+	if !fb.existing[volPvc1] {
+		t.Fatal("the backing must survive while the device is mounted somewhere")
+	}
+}
+
 // A kernel-wedged resource (stuck Detaching with the connections gone,
 // LINBIT/drbd#137) must leave the fast busy-retry without ever spawning
 // another down: the first sighting defers on the busy cadence, the second
@@ -1308,6 +1449,22 @@ func TestReconcileTeardownWedgedParksRetry(t *testing.T) {
 	}
 	if msg := got.Status.PerNode[nodeA].Message; !strings.Contains(msg, "reboot") {
 		t.Fatalf("Message must say a reboot is required, got %q", msg)
+	}
+
+	// The escalation latches: parked cycles must not re-emit the Warning
+	// (issue #319: a wedged volume re-emitted it every cycle for hours)
+	// while the gauge stays raised.
+	res, err = r.Reconcile(t.Context(), req)
+	if err != nil || res.RequeueAfter != wedgedRequeue {
+		t.Fatalf("post-escalation cycle must stay parked, got %v / %v", res.RequeueAfter, err)
+	}
+	select {
+	case e := <-rec.Events:
+		t.Fatalf("parked wedge cycles must not re-emit events, got %q", e)
+	default:
+	}
+	if got := testutil.ToFloat64(metricWedged.WithLabelValues(volPvc1, volPvc1, "")); got != 1 {
+		t.Fatalf("wedged gauge must stay raised on parked cycles, got %v", got)
 	}
 
 	// The wedge clears (reboot happened) but the device is now merely held

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -736,19 +736,16 @@ const disconnectTimeout = 10 * time.Second
 // detach still draining gets one retry cycle to finish first.
 var ErrWedged = errors.New("resource wedged in kernel (LINBIT/drbd#137): node reboot required")
 
-// downResource disconnects each peer connection, then downs the resource.
-// Disconnecting first avoids a kernel deadlock: drbdsetup down on a
-// resource with an active resync connection can enter uninterruptible
-// sleep negotiating teardown with the peer. Disconnects are best-effort
-// (a StandAlone or unconfigured connection errors harmlessly) — except
-// when one is killed at its deadline: then the connection may be half-torn
-// and running down would race exactly that teardown, so the down is
-// deferred to the caller's retry (which disconnects again). drbdsetup
-// needs no config, takes peers by node id, and down exits 0 for unknown
-// names, keeping teardown idempotent. drbdsetup, not drbdadm: drbdadm
-// refuses conflicting .res files, and teardown is how a conflict gets
-// removed.
-func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32) error {
+// disconnectPeers disconnects each peer connection ahead of a down or a
+// force-detach. Disconnecting first avoids a kernel deadlock: drbdsetup
+// down on a resource with an active resync connection can enter
+// uninterruptible sleep negotiating teardown with the peer. Disconnects
+// are best-effort (a StandAlone or unconfigured connection errors
+// harmlessly) — except when one is killed at its deadline: then the
+// connection may be half-torn and acting on the device would race exactly
+// that teardown, so the caller's retry (which disconnects again) takes
+// over. drbdsetup needs no config and takes peers by node id.
+func (d *Driver) disconnectPeers(ctx context.Context, name string, peerIDs []int32) error {
 	for _, id := range peerIDs {
 		dcCtx, cancel := context.WithTimeout(ctx, disconnectTimeout)
 		_, _ = d.Exec(dcCtx, "drbdsetup", "disconnect", name, strconv.Itoa(int(id)))
@@ -757,9 +754,20 @@ func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32)
 		if expired {
 			// ErrBusy: the caller's short retry re-disconnects; the state
 			// clears on its own once the kernel finishes the teardown.
-			return fmt.Errorf("disconnect %s peer %d killed after %s; deferring down: %w",
+			return fmt.Errorf("disconnect %s peer %d killed after %s; deferring teardown: %w",
 				name, id, disconnectTimeout, backend.ErrBusy)
 		}
+	}
+	return nil
+}
+
+// downResource disconnects each peer connection, then downs the resource.
+// drbdsetup down exits 0 for unknown names, keeping teardown idempotent.
+// drbdsetup, not drbdadm: drbdadm refuses conflicting .res files, and
+// teardown is how a conflict gets removed.
+func (d *Driver) downResource(ctx context.Context, name string, peerIDs []int32) error {
+	if err := d.disconnectPeers(ctx, name, peerIDs); err != nil {
+		return err
 	}
 	downCtx, cancel := context.WithTimeout(ctx, downTimeout)
 	defer cancel()
@@ -861,6 +869,45 @@ func (d *Driver) Restart(ctx context.Context, name string) error {
 	}
 	if _, err := d.adm(ctx, "up", name); err != nil {
 		return fmt.Errorf("up %s: %w", name, err)
+	}
+	return nil
+}
+
+// ForceDetach releases the backing device from a resource whose down is
+// permanently refused by an orphaned opener — a leaked freeze's dead
+// superblock pinning open_cnt with no mountpoint left to thaw (issue
+// #319). Down can never win that state, but force-detach is legal on an
+// open device (dropping a failing disk under live I/O is its purpose),
+// and the backing is all a deletion still needs back. The caller must
+// keep the rendered config and the minor assignment: the kernel minor
+// stays pinned until a reboot, releasing the number would hand it to a
+// new volume, and the startup orphan sweep reaps both once the reboot
+// clears the state. Already-detached (Diskless) and not-in-kernel are
+// no-ops so a retry after a failed backing delete converges. A resource
+// wearing the teardown wedge signature is refused like everywhere else —
+// mid-detach is exactly the state a second detach would race.
+func (d *Driver) ForceDetach(ctx context.Context, name string, minor int32) error {
+	parsed, err := d.listStatus(ctx, name)
+	if err != nil {
+		return err
+	}
+	for _, res := range parsed {
+		if res.Name != name {
+			continue
+		}
+		if res.wedgeSignature() {
+			return fmt.Errorf("force-detach %s: %w", name, ErrWedged)
+		}
+		if len(res.Devices) == 0 || res.Devices[0].DiskState == DiskDiskless {
+			return nil
+		}
+		if err := d.disconnectPeers(ctx, name, res.peerIDs()); err != nil {
+			return err
+		}
+		if _, err := d.Exec(ctx, "drbdsetup", "detach", strconv.Itoa(int(minor)), "--force"); err != nil {
+			return fmt.Errorf("force-detach %s: %w", name, err)
+		}
+		return nil
 	}
 	return nil
 }

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1051,6 +1051,70 @@ func TestRestartRefusesWedged(t *testing.T) {
 	fe.notCalledWith(t, "drbdadm up")
 }
 
+// ForceDetach disconnects the peers, then force-detaches the backing by
+// minor — the escape hatch for a deletion whose down is permanently
+// refused by an orphaned opener (issue #319). No down is spawned and the
+// rendered config survives: the caller keeps the zombie minor reserved
+// until the post-reboot orphan sweep reaps it.
+func TestForceDetachDisconnectsAndDetaches(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Primary",
+			"devices":[{"disk-state":"` + DiskUpToDate + `"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path(volPvc1+".res"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.ForceDetach(t.Context(), volPvc1, 1422); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
+	fe.calledWith(t, "drbdsetup detach 1422 --force")
+	fe.notCalledWith(t, "drbdsetup down")
+	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
+		t.Fatalf("rendered config must survive a force-detach: %v", err)
+	}
+}
+
+// An already-detached (or vanished) resource is a no-op, so a retry after
+// a failed backing delete converges instead of erroring on the re-detach.
+func TestForceDetachAlreadyDisklessNoop(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Primary",
+			"devices":[{"disk-state":"Diskless"}],"connections":[]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.ForceDetach(t.Context(), volPvc1, 1422); err != nil {
+		t.Fatal(err)
+	}
+	fe.notCalledWith(t, "drbdsetup detach")
+
+	fe.responses[cmdDrbdsetupStatus] = `[]`
+	if err := d.ForceDetach(t.Context(), volPvc1, 1422); err != nil {
+		t.Fatal(err)
+	}
+	fe.notCalledWith(t, "drbdsetup detach")
+}
+
+// A resource wearing the teardown wedge signature must be refused: a
+// detach is already in flight in the kernel and racing it is exactly what
+// the wedge containment exists to prevent.
+func TestForceDetachRefusesWedged(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"Detaching"}],"connections":[]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.ForceDetach(t.Context(), volPvc1, 1422); !errors.Is(err, ErrWedged) {
+		t.Fatalf("want ErrWedged, got %v", err)
+	}
+	fe.notCalledWith(t, "drbdsetup detach")
+}
+
 // A failed down must not be followed by an up: the resource is still
 // registered, and the error is the caller's retry signal.
 func TestRestartSkipsUpWhenDownFails(t *testing.T) {

--- a/test/e2e-qemu/test.sh
+++ b/test/e2e-qemu/test.sh
@@ -256,12 +256,14 @@ main() {
     install_chart
 
     # miroir's own Go specs assert the local (lvmthin, replicas:1) lifecycle,
-    # snapshot/restore, block and placement behaviour the upstream suite does not.
-    # The conformance leg sets RUN_SPECS to run them against miroir-local before the
-    # long external-storage run, so a miroir-specific break fails fast.
+    # snapshot/restore, block, placement, and orphaned-hold teardown behaviour
+    # the upstream suite does not. The conformance leg sets RUN_SPECS to run
+    # them before the long external-storage run, so a miroir-specific break
+    # fails fast. 35m: the orphaned-hold spec alone rides the full ~6-minute
+    # busy escalation before its reclaim can fire.
     if [[ "${RUN_SPECS:-}" == "1" ]]; then
-        log "Running miroir's Go e2e specs (miroir-local)..."
-        (cd "$REPO_ROOT" && go test -tags e2e ./test/e2e/ -v -ginkgo.v -timeout 20m)
+        log "Running miroir's Go e2e specs..."
+        (cd "$REPO_ROOT" && go test -tags e2e ./test/e2e/ -v -ginkgo.v -timeout 35m)
     fi
 
     log "Running the external-storage conformance suite ($TESTDRIVER)..."

--- a/test/e2e/orphanhold_test.go
+++ b/test/e2e/orphanhold_test.go
@@ -1,0 +1,168 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+const (
+	replicatedClass = "miroir-replicated"
+	agentNamespace  = "miroir-system"
+
+	// The reclaim only fires after the full busy escalation (30 attempts
+	// at 10s) plus at least one parked 60s cycle, so the deletion needs a
+	// far longer wait than the suite default.
+	reclaimTimeout = 12 * time.Minute
+)
+
+// agentPodOn returns the miroir agent pod running on node.
+func agentPodOn(ctx context.Context, node string) string {
+	GinkgoHelper()
+	var pods corev1.PodList
+	Expect(k8s.List(ctx, &pods, client.InNamespace(agentNamespace),
+		client.MatchingLabels{"app.kubernetes.io/component": "agent"})).To(Succeed())
+	for _, p := range pods.Items {
+		if p.Spec.NodeName == node {
+			return p.Name
+		}
+	}
+	Fail("no agent pod on node " + node)
+	return ""
+}
+
+// agentExec runs sh -c inside the privileged agent container on node —
+// the harness's stand-in for node-level storage commands (same pattern as
+// smoke.sh). The agent shares the host mount namespaces via bidirectional
+// propagation, so mounts and unmounts issued here land on the host.
+func agentExec(ctx context.Context, node, sh string) string {
+	GinkgoHelper()
+	out, err := exec.Command("kubectl", "exec", "-n", agentNamespace, agentPodOn(ctx, node),
+		"-c", "agent", "--", "sh", "-c", sh).CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "agent exec on %s: %s", node, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+// Reproduces issue #319 on real DRBD and asserts the orphaned-hold
+// reclaim: a filesystem freeze leaked onto the staged volume (the #311
+// state, with the staging mountpoint removed so NodeUnstage's thaw cannot
+// fire) leaves the DRBD device held open by a dead superblock after every
+// mount is gone. drbdsetup down is then refused forever — the reclaim
+// must force-detach the backing, finish the deletion, and leave only the
+// pinned kernel minor for the post-reboot orphan sweep.
+var _ = Describe("orphaned-hold teardown reclaim", Ordered, func() {
+	const ns = "miroir-e2e-orphan"
+	ctx := context.Background()
+
+	var pv, node string
+	var minor int32
+	var failed bool
+
+	BeforeAll(func() {
+		Expect(client.IgnoreAlreadyExists(k8s.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}))).To(Succeed())
+	})
+	AfterEach(func() { failed = failed || CurrentSpecReport().Failed() })
+	AfterAll(func() {
+		if failed {
+			GinkgoWriter.Printf("specs failed — leaving namespace %q for diagnostics\n", ns)
+			return
+		}
+		_ = k8s.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	It("provisions a replicated volume and mounts it", func() {
+		Expect(k8s.Create(ctx, pvc(ns, "holddata", replicatedClass, "1Gi", nil))).To(Succeed())
+		Expect(k8s.Create(ctx, pod(ns, "holder", "holddata"))).To(Succeed())
+		eventuallyPodReady(ctx, ns, "holder")
+		pv = boundPV(ctx, ns, "holddata")
+		eventuallyMiroirVolumeReady(ctx, pv)
+		writeSeed(ns, "holder", "/data/seed")
+
+		var p corev1.Pod
+		Expect(k8s.Get(ctx, client.ObjectKey{Namespace: ns, Name: "holder"}, &p)).To(Succeed())
+		node = p.Spec.NodeName
+		var v miroirv1alpha1.MiroirVolume
+		Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
+		minor = v.Status.PerNode[node].DRBDMinor
+		Expect(minor).To(BeNumerically(">", 0), "staged leg must report its DRBD minor")
+	})
+
+	It("leaks a freeze and strips every mountpoint, leaving a dead-opener hold", func() {
+		dev := fmt.Sprintf("/dev/drbd%d", minor)
+		staging := agentExec(ctx, node,
+			fmt.Sprintf("findmnt -rn -S %s -o TARGET | grep globalmount | head -1", dev))
+		Expect(staging).NotTo(BeEmpty(), "staged device must have a globalmount")
+
+		// Freeze through the staging mountpoint, then remove that
+		// mountpoint out from under the thaw-before-unmount guard — the
+		// pre-#312 leak. Deleting the pod afterwards removes the publish
+		// bind (kubelet unmounts a frozen bind fine); the frozen
+		// superblock then holds the device open with no mountpoint left
+		// to thaw, and its recorded opener (mount) is long exited.
+		agentExec(ctx, node, fmt.Sprintf("fsfreeze -f %s && umount -l %s", staging, staging))
+
+		Expect(k8s.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "holder"}})).To(Succeed())
+		eventuallyGone(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "holder"}})
+
+		// The leak must actually pin the device: no mounts left, yet the
+		// kernel still counts an opener. Without this the repro proves
+		// nothing (a kernel that releases the superblock on unmount would
+		// let teardown succeed normally).
+		Eventually(func(g Gomega) {
+			g.Expect(agentExec(ctx, node, fmt.Sprintf("findmnt -rn -S %s -o TARGET || true", dev))).To(BeEmpty())
+			g.Expect(agentExec(ctx, node, "drbdsetup status "+pv+" --verbose")).To(ContainSubstring("open:yes"))
+		}).Should(Succeed())
+	})
+
+	It("reclaims the deletion past the pinned minor", func() {
+		Expect(k8s.Delete(ctx, &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "holddata"},
+		})).To(Succeed())
+
+		Eventually(func() bool {
+			return apierrorNotFound(k8s.Get(ctx, client.ObjectKey{Name: pv}, &miroirv1alpha1.MiroirVolume{}))
+		}).WithTimeout(reclaimTimeout).Should(BeTrue(), "MiroirVolume %s must finish deleting despite the hold", pv)
+		Eventually(func() bool {
+			return apierrorNotFound(k8s.Get(ctx, client.ObjectKey{Name: pv}, &corev1.PersistentVolume{}))
+		}).Should(BeTrue(), "PV %s must be released", pv)
+	})
+
+	It("frees the backing and leaves only the zombie minor with a reclaim event", func() {
+		// The backing LV is gone — the space came back without a reboot.
+		lvs := agentExec(ctx, node, "lvs --noheadings -o lv_name || true")
+		Expect(lvs).NotTo(ContainSubstring(pv), "backing LV must be destroyed by the reclaim")
+
+		// The kernel minor is the expected residue: still registered,
+		// diskless, pinned by the dead superblock until the node reboots
+		// (the startup orphan sweep then reaps the rendered config).
+		status := agentExec(ctx, node, "drbdsetup status "+pv+" --verbose || true")
+		Expect(status).To(ContainSubstring(pv), "zombie minor must remain until reboot")
+		Expect(status).To(ContainSubstring("Diskless"), "zombie minor must have no backing attached")
+
+		var evs eventsv1.EventList
+		Expect(k8s.List(ctx, &evs, client.InNamespace("default"))).To(Succeed())
+		found := false
+		for _, e := range evs.Items {
+			if e.Reason == "TeardownReclaimed" && e.Regarding.Name == pv {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "want a TeardownReclaimed event for %s", pv)
+	})
+})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -4,8 +4,9 @@
 // the Talos QEMU cluster $KUBECONFIG points at (test/e2e-qemu runs it as part of
 // the conformance leg). It is build-tagged so `mise run test` never compiles it.
 //
-// Scope: the local backend (miroir-local / lvmthin / replicas:1). The DRBD path is
-// left to the replicated conformance leg and smoke.sh.
+// Scope: the local backend (miroir-local / lvmthin / replicas:1), plus the
+// orphaned-hold teardown spec, which needs a replicated (DRBD) volume. The rest
+// of the DRBD path is left to the replicated conformance leg and smoke.sh.
 package e2e
 
 import (


### PR DESCRIPTION
Fixes #319.

An orphaned device hold — a leaked filesystem freeze's dead superblock pinning `open_cnt` on the DRBD device with every mountpoint gone (the #311 aftermath) — makes `drbdsetup down` fail with `(-12) Device is held open by someone` forever. Teardown parked on that error indefinitely (648 attempts / 12h in the field report), paging noise for deletion-targeted volumes with zero workload impact.

The issue proposed escalating to an event + terminal condition, and optionally attempting `Driver.Restart` as recovery. Neither survives contact with the mechanics:

- `Restart` cannot work here: its `downResource` runs the same `drbdsetup down` that is refused while `open_cnt > 0`. (The #311 workaround succeeded because that state had `open:no`.)
- A terminal give-up is wrong too: the finalizer must survive (#195), and the slow retry is what notices a reboot.

### The fix: complete the teardown instead of reporting it better

The only thing an orphaned hold pins is the DRBD minor itself. The backing device, the space, and the CR are all reclaimable — they were only blocked because teardown was serialized behind `down` succeeding first. When the hold is provably orphaned, teardown now routes around the pinned minor:

1. **`drbd.Driver.ForceDetach`** (new): disconnect peers, then `drbdsetup detach <minor> --force`. Force-detach is legal on a held-open device — dropping a failing disk under live I/O is its purpose — and it releases the backing. Refuses the wedge signature; no-ops when already Diskless or not in the kernel, so retries converge.
2. **`Pools.SweepDelete`** destroys the freed backing; the finalizer releases through teardown's normal tail. A Normal `TeardownReclaimed` event names what happened.
3. The rendered config and minor assignment deliberately **stay**: the kernel minor is pinned until a reboot, and releasing the number would hand it to a new volume. After the eventual reboot, the existing `SweepOrphans` startup pass sees an unowned `.res` with no kernel resource and reaps both — the residue is self-cleaning through machinery that already exists.

### The orphan proof (`agent.orphanHold`)

All of, before the reclaim may fire:

- deletion-targeted volume (a removed replica's volume lives on and keeps the parked retry), known minor;
- the busy streak already crossed `busyFailLimit` (~5 min) — an in-flight NodeUnstage never lasts that long;
- the held-open failure lists openers (the kernel's opener report relayed by drbdsetup) and **every opener pid has exited**;
- the device is mounted in **no mount namespace on the node**. The agent runs `hostPID`, so the scan walks every process's mountinfo (deduped by `ns/mnt`) — this is what distinguishes a dead superblock from a force-deleted pod whose container still runs with the volume mounted in its own namespace while the host table is clean (#195: never destroy a backing under a consumer). Raw-block publishes are matched by the devtmpfs bind root, filesystem mounts by the device's major:minor.

Any doubt — no opener list, an unreadable /proc, a surviving mount, a live pid — reads as "live consumer" and the parked retry stands, exactly as before.

### The wedge stays parked, quietly

A kernel-wedged teardown (LINBIT/drbd#137) has no equivalent: DRBD still pins the backing mid-detach, and releasing the finalizer would leak it forever. That path keeps park-and-page, but now latches — `reportWedged` re-emitted its Warning Event, Error log, and a status write every 5-minute cycle (123 of them in the field report); it now emits once on the transition and stays at V(1) while parked, with the paging gauge still re-raised every cycle. `reportBusy`'s parked-cycle Error log (the 648-line stream) demotes the same way; its Event and status Message were already latched.

### Testing

- Unit: `ForceDetach` (sequence, wedge refusal, Diskless/absent no-ops), the orphan-proof helpers (opener parsing, cross-namespace mount scan incl. the container-namespace hazard, unreadable-/proc fail-closed), reconciler paths (reclaim after the full escalation, live-opener and mounted-device stay parked, wedge latch).
- Integration (envtest): green.
- `golangci-lint`: 0 issues.
- **E2E (new spec, `test/e2e/orphanhold_test.go`)**: reproduces #319 on the real QEMU cluster — freeze the staged filesystem through the staging mountpoint, lazily unmount it out from under the #312 thaw-at-unstage guard, delete the pod, verify the kernel still counts an opener with no mounts left (`open:yes`), then delete the PVC and assert the MiroirVolume completes deletion through the reclaim, the backing LV is destroyed, the zombie minor remains, and the `TeardownReclaimed` event fired. Runs on the conformance leg (`RUN_SPECS=1`); the spec timeout accounts for riding the full busy escalation (`test.sh` go-test timeout raised to 35m).
