### PR TITLE
feat(csi): reshape replica count on restore (grow and shrink)

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/volumesource.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/volumesource.go
@@ -25,6 +25,16 @@ package v1alpha1
 type VolumeSourceApplyConfiguration struct {
 	// SnapshotName references a MiroirSnapshot by name.
 	SnapshotName *string `json:"snapshotName,omitempty"`
+	// PadForMetadata marks every diskful backing of this volume as padded
+	// by the DRBD internal-metadata overhead. Set at creation when a
+	// restore crosses the replication boundary (an unreplicated source
+	// restored into a replicated volume, directly or transitively): the
+	// source filesystem spans its full nominal size, so internal metadata
+	// only fits if every leg's backing is grown past sizeBytes — the
+	// clone before create-md, and full-sync joiners at creation, or the
+	// device would size below the filesystem. Inherited by replicated
+	// restores of padded volumes; immutable with the rest of the source.
+	PadForMetadata *bool `json:"padForMetadata,omitempty"`
 }
 
 // VolumeSourceApplyConfiguration constructs a declarative configuration of the VolumeSource type for use with
@@ -38,5 +48,13 @@ func VolumeSource() *VolumeSourceApplyConfiguration {
 // If called multiple times, the SnapshotName field is set to the value of the last call.
 func (b *VolumeSourceApplyConfiguration) WithSnapshotName(value string) *VolumeSourceApplyConfiguration {
 	b.SnapshotName = &value
+	return b
+}
+
+// WithPadForMetadata sets the PadForMetadata field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PadForMetadata field is set to the value of the last call.
+func (b *VolumeSourceApplyConfiguration) WithPadForMetadata(value bool) *VolumeSourceApplyConfiguration {
+	b.PadForMetadata = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -504,6 +504,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.home-operations.miroir.api.v1alpha1.VolumeSource
   map:
     fields:
+    - name: padForMetadata
+      type:
+        scalar: boolean
     - name: snapshotName
       type:
         scalar: string

--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -210,7 +210,7 @@ func (s MiroirVolumeSpec) FirstDiskfulReplica() *Replica {
 // +kubebuilder:validation:XValidation:rule="self.replicas.all(r, self.replicas.exists_one(o, o.node == r.node))",message="replica nodes must be unique: a node holds at most one leg of a volume"
 // +kubebuilder:validation:XValidation:rule="!has(self.clients) || self.clients.all(c, self.clients.exists_one(o, o.node == c.node))",message="client-leg nodes must be unique"
 // +kubebuilder:validation:XValidation:rule="!has(self.drbd) || !has(oldSelf.drbd) || self.drbd.port == oldSelf.drbd.port",message="drbd.port is immutable: it was allocated cluster-wide at creation and the allocator assumes existing volumes keep their ports"
-// +kubebuilder:validation:XValidation:rule="has(self.source) == has(oldSelf.source) && (!has(self.source) || !has(oldSelf.source) || self.source.snapshotName == oldSelf.source.snapshotName)",message="source is immutable: it records the snapshot this volume was cloned from"
+// +kubebuilder:validation:XValidation:rule="has(self.source) == has(oldSelf.source) && (!has(self.source) || !has(oldSelf.source) || (self.source.snapshotName == oldSelf.source.snapshotName && (has(self.source.padForMetadata) && self.source.padForMetadata) == (has(oldSelf.source.padForMetadata) && oldSelf.source.padForMetadata)))",message="source is immutable: it records the snapshot and metadata padding this volume was cloned with"
 // +kubebuilder:validation:XValidation:rule="!has(self.export) || !has(oldSelf.export) || self.export.fsType == oldSelf.export.fsType",message="export.fsType is immutable: the gateway formatted the volume with it at first start"
 type MiroirVolumeSpec struct {
 	// SizeBytes is the provisioned (virtual, thin) size of the volume.

--- a/api/v1alpha1/miroirvolume_types.go
+++ b/api/v1alpha1/miroirvolume_types.go
@@ -110,6 +110,17 @@ type DRBDSpec struct {
 type VolumeSource struct {
 	// SnapshotName references a MiroirSnapshot by name.
 	SnapshotName string `json:"snapshotName"`
+	// PadForMetadata marks every diskful backing of this volume as padded
+	// by the DRBD internal-metadata overhead. Set at creation when a
+	// restore crosses the replication boundary (an unreplicated source
+	// restored into a replicated volume, directly or transitively): the
+	// source filesystem spans its full nominal size, so internal metadata
+	// only fits if every leg's backing is grown past sizeBytes — the
+	// clone before create-md, and full-sync joiners at creation, or the
+	// device would size below the filesystem. Inherited by replicated
+	// restores of padded volumes; immutable with the rest of the source.
+	// +optional
+	PadForMetadata bool `json:"padForMetadata,omitempty"`
 }
 
 // VolumeClient is an ephemeral diskless consumer leg: a DRBD peer with no

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -263,6 +263,18 @@ spec:
                 description: Source, if set, provisions content from a snapshot (CoW
                   clone).
                 properties:
+                  padForMetadata:
+                    description: |-
+                      PadForMetadata marks every diskful backing of this volume as padded
+                      by the DRBD internal-metadata overhead. Set at creation when a
+                      restore crosses the replication boundary (an unreplicated source
+                      restored into a replicated volume, directly or transitively): the
+                      source filesystem spans its full nominal size, so internal metadata
+                      only fits if every leg's backing is grown past sizeBytes — the
+                      clone before create-md, and full-sync joiners at creation, or the
+                      device would size below the filesystem. Inherited by replicated
+                      restores of padded volumes; immutable with the rest of the source.
+                    type: boolean
                   snapshotName:
                     description: SnapshotName references a MiroirSnapshot by name.
                     type: string

--- a/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
+++ b/charts/miroir/crds/miroir.home-operations.com_miroirvolumes.yaml
@@ -342,10 +342,12 @@ spec:
             - message: 'drbd.port is immutable: it was allocated cluster-wide at creation
                 and the allocator assumes existing volumes keep their ports'
               rule: '!has(self.drbd) || !has(oldSelf.drbd) || self.drbd.port == oldSelf.drbd.port'
-            - message: 'source is immutable: it records the snapshot this volume was
-                cloned from'
+            - message: 'source is immutable: it records the snapshot and metadata
+                padding this volume was cloned with'
               rule: has(self.source) == has(oldSelf.source) && (!has(self.source)
-                || !has(oldSelf.source) || self.source.snapshotName == oldSelf.source.snapshotName)
+                || !has(oldSelf.source) || (self.source.snapshotName == oldSelf.source.snapshotName
+                && (has(self.source.padForMetadata) && self.source.padForMetadata)
+                == (has(oldSelf.source.padForMetadata) && oldSelf.source.padForMetadata)))
             - message: 'export.fsType is immutable: the gateway formatted the volume
                 with it at first start'
               rule: '!has(self.export) || !has(oldSelf.export) || self.export.fsType

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -263,6 +263,18 @@ spec:
                 description: Source, if set, provisions content from a snapshot (CoW
                   clone).
                 properties:
+                  padForMetadata:
+                    description: |-
+                      PadForMetadata marks every diskful backing of this volume as padded
+                      by the DRBD internal-metadata overhead. Set at creation when a
+                      restore crosses the replication boundary (an unreplicated source
+                      restored into a replicated volume, directly or transitively): the
+                      source filesystem spans its full nominal size, so internal metadata
+                      only fits if every leg's backing is grown past sizeBytes — the
+                      clone before create-md, and full-sync joiners at creation, or the
+                      device would size below the filesystem. Inherited by replicated
+                      restores of padded volumes; immutable with the rest of the source.
+                    type: boolean
                   snapshotName:
                     description: SnapshotName references a MiroirSnapshot by name.
                     type: string

--- a/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
+++ b/config/crd/bases/miroir.home-operations.com_miroirvolumes.yaml
@@ -342,10 +342,12 @@ spec:
             - message: 'drbd.port is immutable: it was allocated cluster-wide at creation
                 and the allocator assumes existing volumes keep their ports'
               rule: '!has(self.drbd) || !has(oldSelf.drbd) || self.drbd.port == oldSelf.drbd.port'
-            - message: 'source is immutable: it records the snapshot this volume was
-                cloned from'
+            - message: 'source is immutable: it records the snapshot and metadata
+                padding this volume was cloned with'
               rule: has(self.source) == has(oldSelf.source) && (!has(self.source)
-                || !has(oldSelf.source) || self.source.snapshotName == oldSelf.source.snapshotName)
+                || !has(oldSelf.source) || (self.source.snapshotName == oldSelf.source.snapshotName
+                && (has(self.source.padForMetadata) && self.source.padForMetadata)
+                == (has(oldSelf.source.padForMetadata) && oldSelf.source.padForMetadata)))
             - message: 'export.fsType is immutable: the gateway formatted the volume
                 with it at first start'
               rule: '!has(self.export) || !has(oldSelf.export) || self.export.fsType

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -95,3 +95,41 @@ see [Remote consumers and auto-diskful](remote-consumers.md). For
 what happens when a disk (rather than a node) fails, and how legs are
 verified against each other, see
 [Disk failures, rebuilds, and verification](resilience.md).
+
+## Changing the replica count on restore
+
+A live volume can never cross the replication boundary: an
+unreplicated (`replicas: 1`) volume cannot gain a DRBD layer in
+place, and its PersistentVolume is pinned to its one node forever.
+What _is_ supported is requesting a different replica count when
+restoring a snapshot (or cloning a PVC): the restored volume is born
+with the class's shape, whatever the source had.
+
+This is the growth story for a cluster going from one storage node
+to two. For each PVC:
+
+1. Snapshot the PVC (any `VolumeSnapshotClass` backed by miroir).
+2. Create a new PVC from that snapshot using the replicated
+   StorageClass.
+3. Repoint the workload at the new PVC and delete the old one.
+
+The leg on the node that holds the snapshot restores as an instant
+copy-on-write clone; every additional leg is placed on another node
+carrying the class's pool and receives its content over the wire as
+a DRBD full sync (the restore reports Ready once the sync
+completes). The new PersistentVolume carries the replicated
+topology from the start, so pods can immediately follow either
+node.
+
+Shrinking works the same way in reverse: restoring a replicated
+volume's snapshot with a `replicas: 1` class keeps one
+copy-on-write leg and drops the replication layer. When the counts
+differ, the restore keeps the legs that hold the snapshot in
+preference to ones that would need a full sync.
+
+One implementation detail worth knowing: a restore that crosses
+from unreplicated to replicated grows every backing slightly past
+the requested size (`spec.source.padForMetadata`), because the
+source filesystem spans its full nominal size and DRBD's internal
+metadata must fit behind it. The padding is virtual on every miroir
+backend and invisible to the workload.

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -801,18 +801,49 @@ func (r *VolumeReconciler) mintGenerations(ctx context.Context, vol *miroirv1alp
 // metadata at UUID_JUST_CREATED, the birth flow refuses (the volume holds
 // real data, and its FullSync joiners must not be declared identical),
 // and there was no metadata to adopt — so nothing else can ever move this
-// volume past Inconsistent. SeedUUID flips the seed UpToDate with a full
-// bitmap toward every peer; the just-created joiners then elect full
-// SyncTarget on their handshakes.
+// volume past Inconsistent. ForceFullSyncSource flips the seed UpToDate
+// with a full bitmap toward every peer; the just-created joiners then
+// elect full SyncTarget on their handshakes. A crash between its promote
+// and demote leaves the role Primary with the mint already durable
+// (UpToDate), which the pending gate no longer matches — the recovery
+// branch demotes it (best-effort: a real consumer holding the device
+// refuses harmlessly, and Activated cannot have latched yet because the
+// latch runs after this mint).
 func (r *VolumeReconciler) mintRestoreSeedUUID(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, st drbd.Status, localDiskless bool) (drbd.Status, error) {
+	if r.restoreSeedStuckPrimary(vol, st, localDiskless) {
+		ctrl.LoggerFrom(ctx).Info("demoting restore seed left Primary by an interrupted mint", "volume", vol.Name)
+		if err := r.DRBD.Demote(ctx, vol.Name); err != nil {
+			ctrl.LoggerFrom(ctx).V(1).Info("seed demote refused; leaving it to the consumer lifecycle",
+				"volume", vol.Name, "error", err)
+			return st, nil
+		}
+		return r.DRBD.Status(ctx, vol.Name)
+	}
 	if !r.restoreSeedPending(vol, st, localDiskless) {
 		return st, nil
 	}
 	ctrl.LoggerFrom(ctx).Info("seeding restore data generation (forces full sync to joiners)", "volume", vol.Name)
-	if err := r.DRBD.SeedUUID(ctx, vol.Name); err != nil {
+	if err := r.DRBD.ForceFullSyncSource(ctx, vol.Name); err != nil {
 		return st, err
 	}
 	return r.DRBD.Status(ctx, vol.Name)
+}
+
+// restoreSeedStuckPrimary reports a padded-restore seed left Primary by a
+// mint whose demote never ran: same leg identity as the pending gate, but
+// the disk already UpToDate, the role still Primary, and the volume never
+// Activated (a consumer's promote latches Activated on the pass that
+// observes it, so an unactivated Primary here can only be the mint's).
+func (r *VolumeReconciler) restoreSeedStuckPrimary(vol *miroirv1alpha1.MiroirVolume, st drbd.Status, localDiskless bool) bool {
+	if localDiskless || vol.Spec.DRBD == nil ||
+		vol.Spec.Source == nil || !vol.Spec.Source.PadForMetadata {
+		return false
+	}
+	seed := vol.Spec.FirstDiskfulReplica()
+	if seed == nil || seed.Node != r.NodeName || seed.FullSync {
+		return false
+	}
+	return st.Primary && st.DiskState == drbd.DiskUpToDate && !vol.Status.Activated
 }
 
 // restoreSeedPending gates the restore seed mint on proof that this leg

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -603,6 +603,11 @@ func (r *VolumeReconciler) realizeBacking(ctx context.Context, be backend.Backen
 		}
 		return "", err
 	}
+	if vol.Spec.DRBD == nil {
+		if err := r.DRBD.InvalidateForeignMetadataWipe(vol.Name); err != nil {
+			return "", err
+		}
+	}
 	if _, err := be.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name); err != nil {
 		return "", err
 	}

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -1261,12 +1261,15 @@ func (r *VolumeReconciler) orphanHold(ctx context.Context, vol *miroirv1alpha1.M
 // reclaimOrphanHold routes a deletion around the pinned minor: the only
 // thing an orphaned hold pins is the DRBD minor itself, so force-detach
 // frees the backing and the sweep destroys it, letting the caller release
-// the finalizer through teardown's normal tail. The rendered config and
-// the minor assignment deliberately stay — the kernel minor is pinned
-// until a reboot, releasing the number would hand it to a new volume, and
-// the startup orphan sweep reaps both once the reboot clears the state.
-// On any failure the original busy outcome stands and the parked retry
-// re-evaluates (ForceDetach no-ops once detached, so a failed sweep
+// the finalizer through teardown's normal tail. The rendered config goes
+// with the volume — left behind it would hold the volume's DRBD port
+// hostage against the next volume handed the recycled number (see
+// drbd.RemoveConfig) — while the minor assignment deliberately stays:
+// the kernel minor is pinned until a reboot, releasing the number would
+// hand it to a new volume, and the startup orphan sweep reaps the
+// reservation once the reboot clears the state. On any failure the
+// original busy outcome stands and the parked retry re-evaluates
+// (ForceDetach no-ops once detached, so a failed sweep or config removal
 // converges on the next cycle).
 func (r *VolumeReconciler) reclaimOrphanHold(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, slot miroirv1alpha1.ReplicaStatus, cause error) error {
 	if err := r.DRBD.ForceDetach(ctx, vol.Name, slot.DRBDMinor); err != nil {
@@ -1275,6 +1278,9 @@ func (r *VolumeReconciler) reclaimOrphanHold(ctx context.Context, vol *miroirv1a
 		return cause
 	}
 	if err := r.Pools.SweepDelete(ctx, vol.Name); err != nil {
+		return err
+	}
+	if err := r.DRBD.RemoveConfig(vol.Name); err != nil {
 		return err
 	}
 	ctrl.LoggerFrom(ctx).Info("teardown reclaimed from an orphaned device hold; kernel minor stays pinned until reboot",

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -284,10 +284,11 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
-	// Birth generation, ordered before growIfCoordinator so resize never
-	// runs against a both-Inconsistent device; status is re-read so this
-	// same pass proceeds against UpToDate legs.
-	if st, err = r.mintBirthUUID(ctx, vol, resource, st, localDiskless); err != nil {
+	// Data generations (birth, or the padded-restore seed), ordered
+	// before growIfCoordinator so resize never runs against a
+	// both-Inconsistent device; status is re-read so this same pass
+	// proceeds against UpToDate legs.
+	if st, err = r.mintGenerations(ctx, vol, resource, st, localDiskless); err != nil {
 		return ctrl.Result{}, r.reportError(ctx, vol, err)
 	}
 	// Ordered before handleSplitBrain so the same pass cannot auto-discard
@@ -556,25 +557,44 @@ func peerBackingsGrown(vol *miroirv1alpha1.MiroirVolume, self string) bool {
 	return true
 }
 
+// backingBytes is the size a diskful backing must realize for vol: the
+// spec size, plus the internal-metadata overhead when the volume is
+// padded (a restore that crossed the replication boundary — see
+// VolumeSource.PadForMetadata). Every diskful leg must agree: DRBD sizes
+// the device to the smallest leg's usable bytes, and an unpadded joiner
+// would shrink the device below the restored filesystem.
+func backingBytes(vol *miroirv1alpha1.MiroirVolume) int64 {
+	if vol.Spec.DRBD != nil && vol.Spec.Source != nil && vol.Spec.Source.PadForMetadata {
+		return vol.Spec.SizeBytes + drbd.InternalMetaOverhead(vol.Spec.SizeBytes)
+	}
+	return vol.Spec.SizeBytes
+}
+
 // realizeBacking creates the backing device: fresh, or cloned from a
-// snapshot for restores. Clones are byte-identical on every replica and
-// carry the source's live DRBD metadata, so restored legs connect with
-// identical inherited generations and skip the resync. A wiped node's
-// recreated device gets fresh just-created metadata and full-syncs at the
-// first handshake — no special-casing needed.
+// snapshot for restores. Clones of a replicated source are byte-identical
+// on every replica and carry the source's live DRBD metadata, so restored
+// legs connect with identical inherited generations and skip the resync.
+// A wiped node's recreated device gets fresh just-created metadata and
+// full-syncs at the first handshake — no special-casing needed. A padded
+// clone (unreplicated source restored into a replicated volume) instead
+// grows by the metadata overhead here, BEFORE the DRBD apply: there is no
+// adopted metadata to strand (the #300 concern), and create-md must land
+// in the grown tail rather than over the source filesystem's last bytes.
+// The grow runs on the recovery path too — a crash between clone and
+// resize must not leave an unpadded backing for create-md to corrupt.
 func (r *VolumeReconciler) realizeBacking(ctx context.Context, be backend.Backend, vol *miroirv1alpha1.MiroirVolume, fullSync bool) (dev string, err error) {
 	if vol.Spec.Source == nil || fullSync {
 		// A FullSync joiner never clones, even on a restored volume: its
 		// node holds no source snapshot, and its content arrives over the
 		// wire as a full SyncTarget regardless of what the backing holds.
-		return be.Create(ctx, vol.Name, vol.Spec.SizeBytes)
+		return be.Create(ctx, vol.Name, backingBytes(vol))
 	}
 	// The backing is cloned once and survives reboots; the source snapshot
 	// may be gone by then, so recover an existing device without it.
 	if exists, err := be.Exists(ctx, vol.Name); err != nil {
 		return "", err
 	} else if exists {
-		return be.Create(ctx, vol.Name, vol.Spec.SizeBytes)
+		return r.padClone(ctx, be, vol)
 	}
 	snap := &miroirv1alpha1.MiroirSnapshot{}
 	if err := r.Get(ctx, types.NamespacedName{Name: vol.Spec.Source.SnapshotName}, snap); err != nil {
@@ -583,7 +603,27 @@ func (r *VolumeReconciler) realizeBacking(ctx context.Context, be backend.Backen
 		}
 		return "", err
 	}
-	return be.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name)
+	if _, err := be.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name); err != nil {
+		return "", err
+	}
+	return r.padClone(ctx, be, vol)
+}
+
+// padClone re-activates an existing clone and, on a padded volume, grows
+// it to backingBytes ahead of the DRBD apply (Resize is grow-only and
+// idempotent). Unpadded volumes keep today's contract: replicated clones
+// grow only after attach (growLeg), unreplicated ones on their own path.
+func (r *VolumeReconciler) padClone(ctx context.Context, be backend.Backend, vol *miroirv1alpha1.MiroirVolume) (string, error) {
+	dev, err := be.Create(ctx, vol.Name, vol.Spec.SizeBytes)
+	if err != nil {
+		return "", err
+	}
+	if vol.Spec.DRBD != nil && vol.Spec.Source.PadForMetadata {
+		if err := be.Resize(ctx, vol.Name, backingBytes(vol)); err != nil {
+			return "", err
+		}
+	}
+	return dev, nil
 }
 
 // drbdResource maps the CRD desired state to a render input. Entries the
@@ -741,6 +781,72 @@ func (r *VolumeReconciler) mintBirthUUID(ctx context.Context, vol *miroirv1alpha
 		return st, err
 	}
 	return r.DRBD.Status(ctx, vol.Name)
+}
+
+// mintGenerations runs the mutually exclusive one-time generation mints:
+// the birth UUID for a fresh volume, or the restore seed UUID for a
+// padded restore (its gates are disjoint from birth's — birth refuses
+// FullSync legs and the seed mint requires them).
+func (r *VolumeReconciler) mintGenerations(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, res drbd.Resource, st drbd.Status, localDiskless bool) (drbd.Status, error) {
+	st, err := r.mintBirthUUID(ctx, vol, res, st, localDiskless)
+	if err != nil {
+		return st, err
+	}
+	return r.mintRestoreSeedUUID(ctx, vol, st, localDiskless)
+}
+
+// mintRestoreSeedUUID mints the data generation for the seed leg of a
+// restore that crossed the replication boundary (an unreplicated source
+// cloned into a replicated volume): create-md left the clone's fresh
+// metadata at UUID_JUST_CREATED, the birth flow refuses (the volume holds
+// real data, and its FullSync joiners must not be declared identical),
+// and there was no metadata to adopt — so nothing else can ever move this
+// volume past Inconsistent. SeedUUID flips the seed UpToDate with a full
+// bitmap toward every peer; the just-created joiners then elect full
+// SyncTarget on their handshakes.
+func (r *VolumeReconciler) mintRestoreSeedUUID(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, st drbd.Status, localDiskless bool) (drbd.Status, error) {
+	if !r.restoreSeedPending(vol, st, localDiskless) {
+		return st, nil
+	}
+	ctrl.LoggerFrom(ctx).Info("seeding restore data generation (forces full sync to joiners)", "volume", vol.Name)
+	if err := r.DRBD.SeedUUID(ctx, vol.Name); err != nil {
+		return st, err
+	}
+	return r.DRBD.Status(ctx, vol.Name)
+}
+
+// restoreSeedPending gates the restore seed mint on proof that this leg
+// is the data-bearing clone waiting on its first generation, and nothing
+// else: only the padded-restore seed (first diskful, never FullSync — the
+// clone), only fresh self-created metadata (adopted metadata carries a
+// real generation; see Driver.MetadataAdopted), only while Inconsistent,
+// and only while no peer has ever reported UpToDate — a seed leg
+// recreated after a node wipe wears the same fresh-metadata signature,
+// but its peers hold the data now and it must join as a plain full
+// SyncTarget, not declare its blank disk the source.
+func (r *VolumeReconciler) restoreSeedPending(vol *miroirv1alpha1.MiroirVolume, st drbd.Status, localDiskless bool) bool {
+	if localDiskless || vol.Spec.DRBD == nil ||
+		vol.Spec.Source == nil || !vol.Spec.Source.PadForMetadata {
+		return false
+	}
+	seed := vol.Spec.FirstDiskfulReplica()
+	if seed == nil || seed.Node != r.NodeName || seed.FullSync {
+		return false
+	}
+	if st.DiskState != drbd.DiskInconsistent || r.DRBD.MetadataAdopted(vol.Name) {
+		return false
+	}
+	for _, ds := range st.PeerDiskState {
+		if ds == drbd.DiskUpToDate {
+			return false
+		}
+	}
+	for node, ps := range vol.Status.PerNode {
+		if node != r.NodeName && ps.DiskState == drbd.DiskUpToDate {
+			return false
+		}
+	}
+	return true
 }
 
 // handleSplitBrain detects an active split and routes it into recovery.
@@ -1310,7 +1416,10 @@ func (r *VolumeReconciler) assignMinor(vol *miroirv1alpha1.MiroirVolume) (int32,
 // fresh volume is already at size, so the resize is a no-op for it.
 func (r *VolumeReconciler) growLeg(ctx context.Context, be backend.Backend, vol *miroirv1alpha1.MiroirVolume, st drbd.Status, localDiskless bool) (int64, time.Duration, error) {
 	if !localDiskless {
-		if err := be.Resize(ctx, vol.Name, vol.Spec.SizeBytes); err != nil {
+		// backingBytes, not the spec size: a padded volume's legs all
+		// carry the metadata overhead, and growing one leg to the bare
+		// spec would cap the DRBD device below the restored filesystem.
+		if err := be.Resize(ctx, vol.Name, backingBytes(vol)); err != nil {
 			return 0, 0, err
 		}
 	}

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -594,7 +594,7 @@ func (r *VolumeReconciler) realizeBacking(ctx context.Context, be backend.Backen
 	if exists, err := be.Exists(ctx, vol.Name); err != nil {
 		return "", err
 	} else if exists {
-		return r.padClone(ctx, be, vol)
+		return r.finishClone(ctx, be, vol)
 	}
 	snap := &miroirv1alpha1.MiroirSnapshot{}
 	if err := r.Get(ctx, types.NamespacedName{Name: vol.Spec.Source.SnapshotName}, snap); err != nil {
@@ -606,19 +606,27 @@ func (r *VolumeReconciler) realizeBacking(ctx context.Context, be backend.Backen
 	if _, err := be.CreateFromSnapshot(ctx, vol.Name, snap.Spec.VolumeName, snap.Name); err != nil {
 		return "", err
 	}
-	return r.padClone(ctx, be, vol)
+	return r.finishClone(ctx, be, vol)
 }
 
-// padClone re-activates an existing clone and, on a padded volume, grows
-// it to backingBytes ahead of the DRBD apply (Resize is grow-only and
-// idempotent). Unpadded volumes keep today's contract: replicated clones
-// grow only after attach (growLeg), unreplicated ones on their own path.
-func (r *VolumeReconciler) padClone(ctx context.Context, be backend.Backend, vol *miroirv1alpha1.MiroirVolume) (string, error) {
+// finishClone re-activates an existing clone and settles the shape a
+// boundary-crossing restore left it in — both run on the recovery path
+// too, so a crash right after the clone cannot skip them. A padded
+// volume grows to backingBytes ahead of the DRBD apply (Resize is
+// grow-only and idempotent); an unreplicated target sheds any DRBD
+// metadata a replicated source's clone carried, or blkid reads the raw
+// backing as TYPE=drbd and staging refuses it (see WipeForeignMetadata).
+// Unpadded replicated volumes keep today's contract: clones grow only
+// after attach (growLeg).
+func (r *VolumeReconciler) finishClone(ctx context.Context, be backend.Backend, vol *miroirv1alpha1.MiroirVolume) (string, error) {
 	dev, err := be.Create(ctx, vol.Name, vol.Spec.SizeBytes)
 	if err != nil {
 		return "", err
 	}
-	if vol.Spec.DRBD != nil && vol.Spec.Source.PadForMetadata {
+	if vol.Spec.DRBD == nil {
+		return dev, r.DRBD.WipeForeignMetadata(ctx, vol.Name, dev)
+	}
+	if vol.Spec.Source.PadForMetadata {
 		if err := be.Resize(ctx, vol.Name, backingBytes(vol)); err != nil {
 			return "", err
 		}

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -693,7 +693,7 @@ func TestReconcilePaddedRestoreFullSyncJoinerPadsBacking(t *testing.T) {
 	}
 	// The joiner must not mint the seed generation — its content arrives
 	// over the wire.
-	fe.notCalledWith(t, "new-current-uuid")
+	fe.notCalledWith(t, "primary --force")
 }
 
 // The seed of a padded restore sits on fresh create-md metadata that
@@ -726,8 +726,9 @@ func TestReconcilePaddedRestoreSeedMintsGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fe.calledWith(t, "new-current-uuid "+volPvc1+"/0")
-	fe.notCalledWith(t, "--clear-bitmap")
+	fe.calledWith(t, "drbdadm primary --force "+volPvc1)
+	fe.calledWith(t, "drbdadm secondary "+volPvc1)
+	fe.notCalledWith(t, "new-current-uuid")
 }
 
 // A seed leg recreated after a node wipe wears the same fresh-metadata
@@ -761,7 +762,38 @@ func TestReconcilePaddedRestoreSeedMintRefusesWhenPeerHasData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fe.notCalledWith(t, "new-current-uuid")
+	fe.notCalledWith(t, "primary --force")
+}
+
+// A padded-restore seed found Primary and UpToDate without ever being
+// Activated can only be a mint whose demote never ran (the crash window
+// between promote and secondary): the next pass must demote it so a
+// consumer on the peer node can promote.
+func TestReconcilePaddedRestoreSeedDemotesInterruptedMint(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := paddedRestoreVol()
+	up := `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
+	fe := &fakeDRBDExec{statusSeq: []string{up, up, up, up}}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, "src-vol")).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		t.Fatal(err)
+	}
+
+	fe.calledWith(t, "drbdadm secondary "+volPvc1)
+	fe.notCalledWith(t, "primary --force")
 }
 
 // Every status apply must name only this node's slot and the phase — never a

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1476,6 +1476,9 @@ func orphanHoldFixture(t *testing.T, procDir string) (*VolumeReconciler, *fakeBa
 	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte("resource \"pvc-1\" {}\n"), 0o640); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(stateDir, "minor.assign"), []byte("pvc-1 1422\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
 	fe := &fakeDRBDExec{
@@ -1540,8 +1543,16 @@ func TestReconcileTeardownOrphanHoldReclaims(t *testing.T) {
 			t.Fatalf("this node's finalizer must release after the reclaim: %v", got.Finalizers)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(r.DRBD.StateDir, "pvc-1.res")); err != nil {
-		t.Fatalf("rendered config must stay for the post-reboot orphan sweep: %v", err)
+	// The rendered config goes with the volume — left behind it would
+	// hold the DRBD port hostage against the next volume handed the
+	// recycled number — while the minor reservation stays so the zombie
+	// kernel minor cannot be re-assigned before the reboot clears it.
+	if _, err := os.Stat(filepath.Join(r.DRBD.StateDir, "pvc-1.res")); !os.IsNotExist(err) {
+		t.Fatalf("rendered config must be removed by the reclaim: %v", err)
+	}
+	assign, err := os.ReadFile(filepath.Join(r.DRBD.StateDir, "minor.assign"))
+	if err != nil || !strings.Contains(string(assign), volPvc1) {
+		t.Fatalf("minor reservation must survive the reclaim, got %q / %v", assign, err)
 	}
 	if !drainEvents(rec, "TeardownReclaimed") {
 		t.Fatal("want a TeardownReclaimed event")

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -589,6 +589,181 @@ func TestReconcile_RestoreToLargerResizesBackingAfterAttach(t *testing.T) {
 	}
 }
 
+// paddedRestoreVol builds a 2-leg replicated restore that crossed the
+// replication boundary (PadForMetadata): node-a is the seed clone,
+// node-b the FullSync joiner.
+func paddedRestoreVol() *miroirv1alpha1.MiroirVolume {
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID, v.Spec.Replicas[0].Address = 0, addrA
+	v.Spec.Replicas[1].NodeID, v.Spec.Replicas[1].Address = 1, addrB
+	v.Spec.Replicas[1].FullSync = true
+	v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapSnap1, PadForMetadata: true}
+	return v
+}
+
+// A padded restore's clone must grow by the metadata overhead BEFORE the
+// DRBD apply: there is no adopted metadata to strand (the source was
+// unreplicated), and create-md must land in the grown tail, not over the
+// source filesystem's last bytes (issue #305).
+func TestReconcilePaddedRestoreGrowsCloneBeforeCreateMD(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := paddedRestoreVol()
+	stateDir := t.TempDir()
+	// Empty statusJSON: probeMetadata's kernel probe must see no attached
+	// resource, or the fresh clone reads as adopted metadata and create-md
+	// never runs. The --json status reads are served from statusSeq.
+	up := `[{"name":"` + volPvc1 + `",
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
+	fe := &fakeDRBDExec{statusSeq: []string{up, up, up, up}}
+	fb.seq = &fe.calls // interleave the backing resize into the DRBD call log
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, "src-vol")).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fb.fromSnapVol) != 1 {
+		t.Fatalf("the seed must clone the snapshot, got %v", fb.fromSnapVol)
+	}
+	createMD, resize := -1, -1
+	for i, call := range fe.calls {
+		switch {
+		case createMD < 0 && strings.Contains(call, "create-md"):
+			createMD = i
+		case resize < 0 && strings.Contains(call, "backend-resize "+volPvc1):
+			resize = i
+		}
+	}
+	if createMD < 0 || resize < 0 {
+		t.Fatalf("want both create-md and a backing resize, calls: %v", fe.calls)
+	}
+	if resize > createMD {
+		t.Fatalf("padded clone must grow before create-md (metadata would overwrite the filesystem tail): resize=%d create-md=%d, calls: %v",
+			resize, createMD, fe.calls)
+	}
+	want := 1<<30 + drbd.InternalMetaOverhead(1<<30)
+	if fb.created[volPvc1] != want {
+		t.Fatalf("clone backing must realize the padded size %d, got %d", want, fb.created[volPvc1])
+	}
+}
+
+// A padded restore's FullSync joiner must realize the padded size too:
+// DRBD sizes the device to the smallest leg, and a bare-spec joiner
+// would cap it below the restored filesystem.
+func TestReconcilePaddedRestoreFullSyncJoinerPadsBacking(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := paddedRestoreVol()
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `",
+		"devices":[{"disk-state":"` + diskStateInconsistent + `"}],
+		"connections":[{"peer-node-id":0,"connection-state":"Connected"}]}]`}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeB, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fb.fromSnapVol) != 0 {
+		t.Fatal("a FullSync joiner must never clone")
+	}
+	want := 1<<30 + drbd.InternalMetaOverhead(1<<30)
+	if fb.created[volPvc1] != want {
+		t.Fatalf("joiner backing must realize the padded size %d, got %d", want, fb.created[volPvc1])
+	}
+	// The joiner must not mint the seed generation — its content arrives
+	// over the wire.
+	fe.notCalledWith(t, "new-current-uuid")
+}
+
+// The seed of a padded restore sits on fresh create-md metadata that
+// nothing else can promote (the birth flow refuses data-bearing volumes,
+// and there was no metadata to adopt): the agent must mint its data
+// generation with a full bitmap so the joiners full-sync from it.
+func TestReconcilePaddedRestoreSeedMintsGeneration(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := paddedRestoreVol()
+	// statusSeq, not statusJSON: the metadata must read as this agent's
+	// own fresh create (see the create-md test above) — adopted metadata
+	// carries a generation and correctly refuses the mint.
+	inc := `[{"name":"` + volPvc1 + `",
+		"devices":[{"disk-state":"` + diskStateInconsistent + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
+	fe := &fakeDRBDExec{statusSeq: []string{inc, inc, inc, inc}}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, "src-vol")).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		t.Fatal(err)
+	}
+
+	fe.calledWith(t, "new-current-uuid "+volPvc1+"/0")
+	fe.notCalledWith(t, "--clear-bitmap")
+}
+
+// A seed leg recreated after a node wipe wears the same fresh-metadata
+// signature as first bring-up, but its peer holds the data now: the mint
+// must refuse and let the leg join as a plain full SyncTarget.
+func TestReconcilePaddedRestoreSeedMintRefusesWhenPeerHasData(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := paddedRestoreVol()
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeB: {DiskState: diskStateUpToDate, DeviceCreated: true},
+	}
+	// statusSeq like the mint test: with freshly created metadata the
+	// peer-data guard must be the thing refusing, not metadata adoption.
+	inc := `[{"name":"` + volPvc1 + `",
+		"devices":[{"disk-state":"` + diskStateInconsistent + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
+	fe := &fakeDRBDExec{statusSeq: []string{inc, inc, inc, inc}}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, "src-vol")).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		t.Fatal(err)
+	}
+
+	fe.notCalledWith(t, "new-current-uuid")
+}
+
 // Every status apply must name only this node's slot and the phase — never a
 // peer's slot or Formatted (a CSI-owned field). A full-status apply would
 // force-own those and revert them to this agent's stale read, hot-looping the

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -2039,6 +2039,43 @@ func TestRealizeBackingFullSyncJoinerCreatesFresh(t *testing.T) {
 	}
 }
 
+func TestRealizeBackingRecloneInvalidatesForeignMetadataWipe(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA)
+	v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapSnap1}
+	snap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: "source"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v, snap).Build()
+	fb := newFakeBackend()
+	fe := &fakeDRBDExec{responses: map[string]string{"dump-md": "version \"v09\";"}}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
+
+	if _, err := r.realizeBacking(t.Context(), fb, v, false); err != nil {
+		t.Fatal(err)
+	}
+	delete(fb.created, volPvc1)
+	delete(fb.existing, volPvc1)
+	if _, err := r.realizeBacking(t.Context(), fb, v, false); err != nil {
+		t.Fatal(err)
+	}
+
+	var probes, wipes int
+	for _, call := range fe.calls {
+		if strings.Contains(call, "dump-md") {
+			probes++
+		}
+		if strings.Contains(call, "wipe-md") {
+			wipes++
+		}
+	}
+	if probes != 2 || wipes != 2 {
+		t.Fatalf("each clone incarnation must be probed and wiped, got %d probes and %d wipes: %v", probes, wipes, fe.calls)
+	}
+}
+
 // A backing device that vanished after this node had realized it (the
 // status slot still says DeviceCreated) is the node-wipe signature: the
 // recreated device gets fresh just-created metadata and full-syncs at the

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -358,7 +358,11 @@ func TestReconcileSourceSnapshotGoneRecoversBacking(t *testing.T) {
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
-	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
+	// A DRBD driver even though the volume is unreplicated: recovering a
+	// restore clone probes it for foreign metadata (finishClone).
+	fe := &fakeDRBDExec{}
+	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }}}
 
 	reconcile(t, r, volPvc1)
 
@@ -694,6 +698,49 @@ func TestReconcilePaddedRestoreFullSyncJoinerPadsBacking(t *testing.T) {
 	// The joiner must not mint the seed generation — its content arrives
 	// over the wire.
 	fe.notCalledWith(t, "primary --force")
+}
+
+// A restore that shrank out of replication clones the replicated
+// source's DRBD metadata into a raw backing pods stage directly: realize
+// must wipe it (blkid otherwise reads the device as TYPE=drbd and
+// staging refuses), while a clone of an unreplicated source — no
+// metadata — stays untouched.
+func TestReconcileUnreplicatedRestoreWipesForeignMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		dumpMD   map[string]string
+		wantWipe bool
+	}{
+		{name: "replicated source clone", dumpMD: map[string]string{"dump-md": `version "v09";`}, wantWipe: true},
+		{name: "unreplicated source clone", wantWipe: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newScheme(t)
+			fb := newFakeBackend()
+			v := vol(volPvc1, nodeA)
+			v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapSnap1}
+			fe := &fakeDRBDExec{responses: tc.dumpMD}
+			c := fake.NewClientBuilder().WithScheme(s).
+				WithObjects(v, snapObj(snapSnap1, "src-vol")).
+				WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+				Build()
+			r := &VolumeReconciler{
+				Client: c, NodeName: nodeA, Pools: poolsOf(fb),
+				DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+			}
+
+			reconcile(t, r, volPvc1)
+
+			if len(fb.fromSnapVol) != 1 {
+				t.Fatalf("restore must clone, got %v", fb.fromSnapVol)
+			}
+			if tc.wantWipe {
+				fe.calledWith(t, "wipe-md")
+			} else {
+				fe.notCalledWith(t, "wipe-md")
+			}
+		})
+	}
 }
 
 // The seed of a padded restore sits on fresh create-md metadata that

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -557,18 +557,9 @@ func (c *Controller) place(ctx context.Context, nodes nodemap.Map, reqs *csi.Top
 	// overcommit guard, so a topology-pinned volume refuses rather than
 	// silently landing on a node the pod can't reach.
 	ordered := make([]string, 0, len(candidates))
-	topologyMatched := false
-	for _, t := range append(reqs.GetPreferred(), reqs.GetRequisite()...) {
-		n, ok := t.GetSegments()[constants.TopologyKey]
-		if !ok {
-			continue
-		}
-		if _, ok := candidates[n]; !ok {
-			continue
-		}
-		topologyMatched = true
-		ordered = append(ordered, n)
-		break
+	pin, topologyMatched := topologyPick(reqs, candidates, excluded)
+	if pin != "" {
+		ordered = append(ordered, pin)
 	}
 	if reqs != nil && len(reqs.GetRequisite()) > 0 && !topologyMatched && !remoteAccess {
 		// On a remote-access volume the scheduler may pick a non-storage
@@ -664,6 +655,28 @@ func (c *Controller) withTieBreaker(ctx context.Context, nodes nodemap.Map, plac
 		Address:  addr,
 		Diskless: true,
 	}), nil
+}
+
+// topologyPick resolves the scheduler's topology selection against the
+// placeable candidates: the first candidate named by the requirement is
+// pinned. A named node that instead already holds a kept leg (a reshaped
+// restore placing joiners passes those as excluded) satisfies the
+// topology without a pin — scanning on would pin a rotation artifact,
+// the exact #258 bug — and must not trip the topology refusal.
+func topologyPick(reqs *csi.TopologyRequirement, candidates map[string]nodemap.Pool, excluded map[string]bool) (pin string, matched bool) {
+	for _, t := range append(reqs.GetPreferred(), reqs.GetRequisite()...) {
+		n, ok := t.GetSegments()[constants.TopologyKey]
+		if !ok {
+			continue
+		}
+		if excluded[n] {
+			return "", true
+		}
+		if _, ok := candidates[n]; ok {
+			return n, true
+		}
+	}
+	return "", false
 }
 
 // nextFreeNodeID returns the smallest DRBD node id no replica uses.

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -171,7 +171,7 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 
-	snapID, cloneSrc, err := c.resolveContentSource(ctx, req, sizeBytes, replicas, params.pool)
+	snapID, cloneSrc, err := c.resolveContentSource(ctx, req, sizeBytes, params.pool)
 	if err != nil {
 		return nil, err
 	}
@@ -195,26 +195,10 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		c.allocMu.Unlock()
 		return nil, err
 	}
-	placed := srcReplicas
-	if snapID == "" {
-		// One topology snapshot serves both placement and the tie-breaker
-		// pick; separate resolves could observe different topologies
-		// mid-RPC.
-		nodes, err := c.nodes(ctx)
-		if err != nil {
-			c.allocMu.Unlock()
-			return nil, err
-		}
-		p, err := c.place(ctx, nodes, req.GetAccessibilityRequirements(), replicas, sizeBytes, req.GetName(), vols, remoteAccess, params.pool)
-		if err != nil {
-			c.allocMu.Unlock()
-			return nil, err
-		}
-		placed, err = c.withTieBreaker(ctx, nodes, p, replicas, quorum)
-		if err != nil {
-			c.allocMu.Unlock()
-			return nil, err
-		}
+	placed, err := c.placeVolume(ctx, req, snapID, srcReplicas, replicas, sizeBytes, vols, remoteAccess, params.pool, quorum)
+	if err != nil {
+		c.allocMu.Unlock()
+		return nil, err
 	}
 	vol := &miroirv1alpha1.MiroirVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -395,8 +379,10 @@ func (c *Controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 
 // resolveSource resolves a restore's source: on a clone (snapID set) it
 // validates the snapshot, size, and pool, and returns the placement
-// replicas (following the source, FullSyncing post-snapshot legs). Returns
-// zero values for a fresh volume (no content source).
+// replicas (following the source, FullSyncing post-snapshot legs; a class
+// requesting a different diskful count is reshaped later, see
+// reshapeRestore) plus the padding verdict for a boundary-crossing
+// restore. Returns zero values for a fresh volume (no content source).
 func (c *Controller) resolveSource(ctx context.Context, snapID string, sizeBytes int64, replicas int, pool string) (*miroirv1alpha1.VolumeSource, []miroirv1alpha1.Replica, bool, error) {
 	if snapID == "" {
 		return nil, nil, false, nil
@@ -411,11 +397,6 @@ func (c *Controller) resolveSource(ctx context.Context, snapID string, sizeBytes
 		return nil, nil, false, status.Errorf(codes.InvalidArgument,
 			"requested %d below snapshot size %d", sizeBytes, snap.Status.SizeBytes)
 	}
-	if len(srcVol.Spec.DiskfulReplicas()) != replicas {
-		return nil, nil, false, status.Errorf(codes.InvalidArgument,
-			"restore replica count %d must match source diskful replicas %d",
-			replicas, len(srcVol.Spec.DiskfulReplicas()))
-	}
 	// CoW clones cannot cross pools: each leg clones its node-local
 	// snapshot inside the pool that holds it.
 	for _, rep := range srcVol.Spec.DiskfulReplicas() {
@@ -429,7 +410,44 @@ func (c *Controller) resolveSource(ctx context.Context, snapID string, sizeBytes
 	if err != nil {
 		return nil, nil, false, err
 	}
-	return &miroirv1alpha1.VolumeSource{SnapshotName: snapID}, srcReplicas, snap.Status.SourceFormatted, nil
+	source := &miroirv1alpha1.VolumeSource{
+		SnapshotName: snapID,
+		// A replicated target restored across the replication boundary —
+		// from an unreplicated source, directly or through a chain of
+		// padded restores — pads every backing by the internal-metadata
+		// overhead (see the field's doc). Sticky through replicated
+		// restore chains: a padded source's clone is physically padded
+		// and its filesystem sized past the bare spec, so its joiners
+		// must pad too.
+		PadForMetadata: replicas > 1 && (srcVol.Spec.DRBD == nil ||
+			(srcVol.Spec.Source != nil && srcVol.Spec.Source.PadForMetadata)),
+	}
+	return source, srcReplicas, snap.Status.SourceFormatted, nil
+}
+
+// placeVolume decides the volume's replica layout inside the allocMu
+// critical section: fresh volumes are placed (plus tie-breaker), a
+// restore follows its source, and a restore whose class requests a
+// different diskful count than the source had is reshaped (issue #305).
+// One topology snapshot serves placement and the tie-breaker pick;
+// separate resolves could observe different topologies mid-RPC.
+func (c *Controller) placeVolume(ctx context.Context, req *csi.CreateVolumeRequest, snapID string, srcReplicas []miroirv1alpha1.Replica, replicas int, sizeBytes int64, vols []miroirv1alpha1.MiroirVolume, remoteAccess bool, pool string, quorum miroirv1alpha1.QuorumPolicy) ([]miroirv1alpha1.Replica, error) {
+	if snapID != "" && len(diskfulOf(srcReplicas)) == replicas {
+		return srcReplicas, nil
+	}
+	nodes, err := c.nodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if snapID != "" {
+		return c.reshapeRestore(ctx, nodes, req.GetAccessibilityRequirements(),
+			srcReplicas, replicas, sizeBytes, req.GetName(), vols, remoteAccess, pool, quorum)
+	}
+	p, err := c.place(ctx, nodes, req.GetAccessibilityRequirements(), replicas, sizeBytes, req.GetName(), vols, remoteAccess, pool, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.withTieBreaker(ctx, nodes, p, replicas, quorum)
 }
 
 // allocVolumes lists every volume once for the allocMu critical section
@@ -456,15 +474,19 @@ func (c *Controller) allocVolumes(ctx context.Context, needed bool) ([]miroirv1a
 // so a cold cluster still provisions. For replicated volumes it resolves
 // each node's InternalIP and assigns DRBD node ids by slice position —
 // replicas[0] is the GI-seed winner (internal/drbd).
-func (c *Controller) place(ctx context.Context, nodes nodemap.Map, reqs *csi.TopologyRequirement, count int, sizeBytes int64, name string, vols []miroirv1alpha1.MiroirVolume, remoteAccess bool, pool string) ([]miroirv1alpha1.Replica, error) {
+func (c *Controller) place(ctx context.Context, nodes nodemap.Map, reqs *csi.TopologyRequirement, count int, sizeBytes int64, name string, vols []miroirv1alpha1.MiroirVolume, remoteAccess bool, pool string, excluded map[string]bool) ([]miroirv1alpha1.Replica, error) {
 	// Every diskful leg needs the pool on its own node; a class naming a
 	// pool too few nodes carry must say so instead of a generic refusal.
 	// Unplaceable nodes (address conflict) are excluded outright — but
 	// counted, so the refusal names the real cause instead of blaming the
-	// pool declarations.
+	// pool declarations. Callers placing joiners for a reshaped restore
+	// pass the nodes already holding a leg as excluded.
 	candidates := map[string]nodemap.Pool{}
 	conflicted := 0
 	for n := range nodes {
+		if excluded[n] {
+			continue
+		}
 		p, ok := nodes.Pool(n, pool)
 		if !ok {
 			continue
@@ -633,11 +655,123 @@ func (c *Controller) withTieBreaker(ctx context.Context, nodes nodemap.Map, plac
 		return nil, err
 	}
 	return append(placed, miroirv1alpha1.Replica{
-		Node:     tb,
-		NodeID:   int32(len(placed)), //nolint:gosec // ≤3 replicas
+		Node: tb,
+		// Smallest unused, not positional: a reshaped restore preserves
+		// the source legs' ids (clone metadata is keyed by them), so the
+		// kept set can be sparse. Identical to len(placed) for a freshly
+		// placed contiguous layout.
+		NodeID:   nextFreeNodeID(placed),
 		Address:  addr,
 		Diskless: true,
 	}), nil
+}
+
+// nextFreeNodeID returns the smallest DRBD node id no replica uses.
+func nextFreeNodeID(reps []miroirv1alpha1.Replica) int32 {
+	used := map[int32]bool{}
+	for _, r := range reps {
+		used[r.NodeID] = true
+	}
+	for id := int32(0); ; id++ {
+		if !used[id] {
+			return id
+		}
+	}
+}
+
+// diskfulOf filters a replica layout down to its diskful legs, order
+// preserved.
+func diskfulOf(reps []miroirv1alpha1.Replica) []miroirv1alpha1.Replica {
+	diskful := make([]miroirv1alpha1.Replica, 0, len(reps))
+	for _, rep := range reps {
+		if !rep.Diskless {
+			diskful = append(diskful, rep)
+		}
+	}
+	return diskful
+}
+
+// reshapeRestore adapts a restore's replica layout to a class requesting
+// a different diskful count than the source volume had (issue #305).
+// Growing appends freshly placed FullSync joiners — their content
+// arrives over the wire, so unlike the CoW legs they may land anywhere
+// the pool reaches. Shrinking keeps a subset of the source legs, seed
+// first, Done legs preferred. The source tie-breaker (if any) is
+// discarded and re-derived for the final shape, and node ids are
+// re-numbered around the preserved legs — a leg cloning DRBD metadata
+// keeps the id that metadata is keyed by, everything else takes the
+// smallest unused id. A 1-replica target ends unreplicated: the sole
+// kept leg sheds the replication-only fields (the clone's embedded
+// metadata becomes inert tail bytes past the filesystem).
+func (c *Controller) reshapeRestore(ctx context.Context, nodes nodemap.Map, reqs *csi.TopologyRequirement, base []miroirv1alpha1.Replica, target int, sizeBytes int64, name string, vols []miroirv1alpha1.MiroirVolume, remoteAccess bool, pool string, quorum miroirv1alpha1.QuorumPolicy) ([]miroirv1alpha1.Replica, error) {
+	diskful := diskfulOf(base)
+	switch {
+	case len(diskful) > target:
+		diskful = keepRestoreLegs(diskful, target)
+	case len(diskful) < target:
+		excluded := map[string]bool{}
+		for _, rep := range diskful {
+			excluded[rep.Node] = true
+		}
+		extra, err := c.place(ctx, nodes, reqs, target-len(diskful), sizeBytes, name, vols, remoteAccess, pool, excluded)
+		if err != nil {
+			return nil, err
+		}
+		for i := range extra {
+			extra[i].FullSync = true
+		}
+		diskful = append(diskful, extra...)
+	}
+	if target == 1 {
+		diskful[0].NodeID, diskful[0].Address, diskful[0].FullSync = 0, "", false
+		return diskful[:1], nil
+	}
+	// Preserved clone legs (recognizable by their replicated-source
+	// address) keep their ids; everything else — an unreplicated source's
+	// seed, placement's positional ids — is re-numbered and addressed.
+	used := map[int32]bool{}
+	assign := make([]int, 0, len(diskful))
+	for i := range diskful {
+		if diskful[i].Address != "" && !diskful[i].FullSync {
+			used[diskful[i].NodeID] = true
+			continue
+		}
+		assign = append(assign, i)
+	}
+	for _, i := range assign {
+		id := int32(0)
+		for used[id] {
+			id++
+		}
+		used[id] = true
+		diskful[i].NodeID = id
+		if diskful[i].Address == "" {
+			addr, err := c.replicationAddress(ctx, nodes, diskful[i].Node)
+			if err != nil {
+				return nil, err
+			}
+			diskful[i].Address = addr
+		}
+	}
+	return c.withTieBreaker(ctx, nodes, diskful, target, quorum)
+}
+
+// keepRestoreLegs selects target legs from the source's diskful layout:
+// the seed (first diskful — the clone's sync source, already validated
+// complete by restoreReplicas) stays first, then the remaining legs in
+// order with Done legs before FullSync ones — dropping a Done leg while
+// keeping a FullSync one would trade a free CoW clone for a full resync.
+func keepRestoreLegs(diskful []miroirv1alpha1.Replica, target int) []miroirv1alpha1.Replica {
+	kept := make([]miroirv1alpha1.Replica, 0, target)
+	kept = append(kept, diskful[0])
+	for _, fullSync := range []bool{false, true} {
+		for _, rep := range diskful[1:] {
+			if rep.FullSync == fullSync && len(kept) < target {
+				kept = append(kept, rep)
+			}
+		}
+	}
+	return kept
 }
 
 // spreadByZone selects count nodes from ordered (already ranked by topology
@@ -858,12 +992,12 @@ func (c *Controller) handleCreateErr(ctx context.Context, err error, vol *miroir
 // volume clone the internal snapshot this call cuts on the source
 // volume (waiting until every leg holds it). cloneSrc is the clone's
 // source volume id, "" for snapshot and blank sources.
-func (c *Controller) resolveContentSource(ctx context.Context, req *csi.CreateVolumeRequest, sizeBytes int64, replicas int, pool string) (snapID, cloneSrc string, err error) {
+func (c *Controller) resolveContentSource(ctx context.Context, req *csi.CreateVolumeRequest, sizeBytes int64, pool string) (snapID, cloneSrc string, err error) {
 	snapID, cloneSrc, err = contentSourceIDs(req)
 	if err != nil || cloneSrc == "" {
 		return snapID, cloneSrc, err
 	}
-	snapID, err = c.ensureCloneSnapshot(ctx, cloneSrc, req.GetName(), sizeBytes, replicas, pool)
+	snapID, err = c.ensureCloneSnapshot(ctx, cloneSrc, req.GetName(), sizeBytes, pool)
 	return snapID, cloneSrc, err
 }
 
@@ -899,7 +1033,7 @@ func contentSourceIDs(req *csi.CreateVolumeRequest) (snapID, cloneVolID string, 
 // The shape checks run before the cut — a clone whose class can never
 // match the source must fail without freezing the source volume for a
 // snapshot round it would then leak.
-func (c *Controller) ensureCloneSnapshot(ctx context.Context, srcVolID, cloneVolID string, sizeBytes int64, replicas int, pool string) (string, error) {
+func (c *Controller) ensureCloneSnapshot(ctx context.Context, srcVolID, cloneVolID string, sizeBytes int64, pool string) (string, error) {
 	snapName := constants.CloneSnapshotPrefix + cloneVolID
 	// A taken volume name that is not this clone can only end in
 	// handleCreateErr's AlreadyExists — refuse it BEFORE the cut, or the
@@ -934,10 +1068,10 @@ func (c *Controller) ensureCloneSnapshot(ctx context.Context, srcVolID, cloneVol
 		return "", status.Errorf(codes.InvalidArgument,
 			"requested %d below clone source volume size %d", sizeBytes, srcVol.Spec.SizeBytes)
 	}
-	if got := len(srcVol.Spec.DiskfulReplicas()); got != replicas {
-		return "", status.Errorf(codes.InvalidArgument,
-			"clone replica count %d must match source diskful replicas %d", replicas, got)
-	}
+	// No replica-count gate: a clone is an internal snapshot plus a
+	// restore, and a count differing from the source's is reshaped on the
+	// restore leg of that path (reshapeRestore), same as an explicit
+	// snapshot restore.
 	for _, rep := range srcVol.Spec.DiskfulReplicas() {
 		if src := nodemap.PoolOrDefault(rep.Pool); src != pool {
 			return "", status.Errorf(codes.InvalidArgument,

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -980,6 +980,278 @@ func TestCreateVolumeFromSnapshotFullSyncsPostSnapshotReplica(t *testing.T) {
 	}
 }
 
+// reshapeController is a 3-node tie-breaker-enabled controller seeded
+// with a restore source volume and its ready snapshot (Done on every
+// diskful source leg).
+func reshapeController(t *testing.T, srcVol *miroirv1alpha1.MiroirVolume) *Controller {
+	t.Helper()
+	done := map[string]miroirv1alpha1.SnapshotNodeState{}
+	for _, rep := range srcVol.Spec.DiskfulReplicas() {
+		done[rep.Node] = miroirv1alpha1.SnapshotDone
+	}
+	srcSnap := &miroirv1alpha1.MiroirSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
+		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: srcVol.Name},
+		Status: miroirv1alpha1.MiroirSnapshotStatus{
+			ReadyToUse: true, SizeBytes: srcVol.Spec.SizeBytes, PerNode: done,
+		},
+	}
+	cl := readyOnGet(newScheme(t),
+		nodeObj(nodeA, addrA), nodeObj(nodeB, addrB), nodeObj(nodeC, addrC))
+	for _, obj := range []client.Object{srcVol, srcSnap} {
+		if err := cl.Create(t.Context(), obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := cl.Status().Update(t.Context(), srcSnap); err != nil {
+		t.Fatal(err)
+	}
+	return &Controller{
+		Client: cl,
+		Nodes: nodemap.Map{
+			nodeA: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin}),
+			nodeB: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin}),
+			nodeC: storageNode(nodemap.Pool{Backend: miroirv1alpha1.BackendLVMThin}),
+		},
+		ProvisionTimeout: 2 * time.Second,
+		AutoTieBreaker:   true,
+	}
+}
+
+// restoreReq is a snapshot-restore CreateVolume request for snapSnap1
+// with the given replica count.
+func restoreReq(replicas string) *csi.CreateVolumeRequest {
+	return &csi.CreateVolumeRequest{
+		Name:               volNew,
+		VolumeCapabilities: volCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 5 << 30},
+		Parameters:         map[string]string{constants.ParamReplicas: replicas},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapSnap1},
+			},
+		},
+	}
+}
+
+// Restoring an unreplicated source into a 2-replica class (issue #305):
+// the source leg seeds (CoW clone, address resolved, id 0), the extra
+// leg is placed elsewhere as a FullSync joiner, a tie-breaker completes
+// quorum, and the volume is marked padded — the clone gains internal
+// metadata only because every backing grows past the spec size.
+func TestCreateVolumeRestoreExpandsUnreplicatedSource(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
+		},
+	}
+	c := reshapeController(t, srcVol)
+
+	if _, err := c.CreateVolume(t.Context(), restoreReq("2")); err != nil {
+		t.Fatal(err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.DRBD == nil {
+		t.Fatal("the expanded restore must be born replicated")
+	}
+	if got.Spec.Source == nil || !got.Spec.Source.PadForMetadata {
+		t.Fatalf("a boundary-crossing restore must be padded: %+v", got.Spec.Source)
+	}
+	diskful := got.Spec.DiskfulReplicas()
+	if len(diskful) != 2 || len(got.Spec.Replicas) != 3 {
+		t.Fatalf("want 2 diskful + tie-breaker, got %+v", got.Spec.Replicas)
+	}
+	seed := diskful[0]
+	if seed.Node != nodeA || seed.FullSync || seed.NodeID != 0 || seed.Address != addrA {
+		t.Fatalf("the source leg must seed with id 0 and a resolved address: %+v", seed)
+	}
+	joiner := diskful[1]
+	if !joiner.FullSync || joiner.Node == nodeA || joiner.NodeID != 1 || joiner.Address == "" {
+		t.Fatalf("the extra leg must full-sync elsewhere with id 1: %+v", joiner)
+	}
+	tb := got.Spec.Replicas[2]
+	if !tb.Diskless || tb.NodeID != 2 || tb.Node == seed.Node || tb.Node == joiner.Node {
+		t.Fatalf("unexpected tie-breaker %+v", tb)
+	}
+}
+
+// Restoring a replicated source into a 3-replica class: the source legs
+// keep the ids their clone metadata is keyed by, the extra leg full-syncs
+// under the next free id, and no padding applies (the source backings
+// already carry internal metadata).
+func TestCreateVolumeRestoreExpandsReplicatedSource(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1, Address: staleAddrB},
+			},
+		},
+	}
+	c := reshapeController(t, srcVol)
+
+	if _, err := c.CreateVolume(t.Context(), restoreReq("3")); err != nil {
+		t.Fatal(err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.Source.PadForMetadata {
+		t.Fatal("a replicated-source restore must not pad")
+	}
+	diskful := got.Spec.DiskfulReplicas()
+	if len(diskful) != 3 || len(got.Spec.Replicas) != 3 {
+		t.Fatalf("want exactly 3 diskful legs, got %+v", got.Spec.Replicas)
+	}
+	if diskful[0].NodeID != 0 || diskful[0].FullSync || diskful[0].Address != addrA ||
+		diskful[1].NodeID != 1 || diskful[1].FullSync {
+		t.Fatalf("source legs must keep their ids, not full-sync, and re-resolve addresses: %+v", diskful[:2])
+	}
+	if diskful[2].Node != nodeC || !diskful[2].FullSync || diskful[2].NodeID != 2 {
+		t.Fatalf("the extra leg must full-sync on the spare node under id 2: %+v", diskful[2])
+	}
+}
+
+// Restoring a replicated source into a 1-replica class ends unreplicated:
+// only the seed leg survives, shed of the replication-only fields — the
+// clone's embedded DRBD metadata becomes inert tail bytes.
+func TestCreateVolumeRestoreShrinksToUnreplicated(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1, Address: staleAddrB},
+				{Node: nodeC, NodeID: 2, Address: addrC, Diskless: true},
+			},
+		},
+	}
+	c := reshapeController(t, srcVol)
+
+	resp, err := c.CreateVolume(t.Context(), restoreReq("1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.DRBD != nil || got.Spec.QuorumPolicy != "" {
+		t.Fatalf("a 1-replica restore must be unreplicated: %+v", got.Spec)
+	}
+	if got.Spec.Source.PadForMetadata {
+		t.Fatal("an unreplicated target never pads")
+	}
+	if len(got.Spec.Replicas) != 1 {
+		t.Fatalf("want the seed leg only, got %+v", got.Spec.Replicas)
+	}
+	kept := got.Spec.Replicas[0]
+	if kept.Node != nodeA || kept.NodeID != 0 || kept.Address != "" || kept.FullSync || kept.Diskless {
+		t.Fatalf("the kept leg must shed replication fields: %+v", kept)
+	}
+	if len(resp.Volume.AccessibleTopology) != 1 {
+		t.Fatalf("an unreplicated restore pins to its node: %+v", resp.Volume.AccessibleTopology)
+	}
+}
+
+// Shrinking keeps Done legs over post-snapshot FullSync ones — dropping
+// a free CoW clone while keeping a leg that must full-resync would be
+// pure waste — and the re-derived tie-breaker takes the smallest unused
+// id, not a positional one that would collide with the sparse kept set.
+func TestCreateVolumeRestoreShrinkPrefersDoneLegs(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1, Address: staleAddrB},
+				{Node: nodeC, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 2, Address: addrC},
+			},
+		},
+	}
+	c := reshapeController(t, srcVol)
+	// node-b was added after the snapshot: no local snapshot state there.
+	srcSnap := &miroirv1alpha1.MiroirSnapshot{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, srcSnap); err != nil {
+		t.Fatal(err)
+	}
+	delete(srcSnap.Status.PerNode, nodeB)
+	if err := c.Client.Status().Update(t.Context(), srcSnap); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.CreateVolume(t.Context(), restoreReq("2")); err != nil {
+		t.Fatal(err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	diskful := got.Spec.DiskfulReplicas()
+	if len(diskful) != 2 || diskful[0].Node != nodeA || diskful[1].Node != nodeC {
+		t.Fatalf("want the Done legs (a, c) kept, got %+v", diskful)
+	}
+	if diskful[0].FullSync || diskful[1].FullSync {
+		t.Fatalf("kept Done legs must clone, not full-sync: %+v", diskful)
+	}
+	if diskful[0].NodeID != 0 || diskful[1].NodeID != 2 {
+		t.Fatalf("kept legs must keep their metadata-keyed ids: %+v", diskful)
+	}
+	if len(got.Spec.Replicas) != 3 {
+		t.Fatalf("want a re-derived tie-breaker, got %+v", got.Spec.Replicas)
+	}
+	if tb := got.Spec.Replicas[2]; !tb.Diskless || tb.Node != nodeB || tb.NodeID != 1 {
+		t.Fatalf("tie-breaker must take the spare node under the smallest unused id: %+v", tb)
+	}
+}
+
+// PadForMetadata is sticky through replicated restore chains: a padded
+// source's clone is physically padded and its filesystem sized past the
+// bare spec, so its joiners must pad too.
+func TestCreateVolumeRestoreInheritsPadding(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Source:       &miroirv1alpha1.VolumeSource{SnapshotName: "older-snap", PadForMetadata: true},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1, Address: staleAddrB},
+			},
+		},
+	}
+	c := reshapeController(t, srcVol)
+
+	if _, err := c.CreateVolume(t.Context(), restoreReq("2")); err != nil {
+		t.Fatal(err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Spec.Source.PadForMetadata {
+		t.Fatal("a replicated restore of a padded source must stay padded")
+	}
+}
+
 // A lagging informer after AlreadyExists must surface as Unavailable
 // (retryable) — not Internal, which the provisioner treats as final and
 // would record "volume not created" for a volume that exists.
@@ -1750,8 +2022,6 @@ func TestCreateVolumeCloneShapeChecksRunBeforeCut(t *testing.T) {
 		params map[string]string
 		want   codes.Code
 	}{
-		{name: "replica count mismatch", source: volSrc, size: 5 << 30,
-			params: map[string]string{constants.ParamReplicas: "2"}, want: codes.InvalidArgument},
 		{name: "smaller than source", source: volSrc, size: 1 << 30, want: codes.InvalidArgument},
 		{name: "cross pool", source: volSrc, size: 5 << 30,
 			params: map[string]string{constants.ParamPool: poolFast}, want: codes.InvalidArgument},

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1080,6 +1080,44 @@ func TestCreateVolumeRestoreExpandsUnreplicatedSource(t *testing.T) {
 	}
 }
 
+// Under WaitForFirstConsumer the scheduler usually selects the node the
+// pod runs on — for a restore that is typically the seed's node, which
+// joiner placement excludes. The kept leg satisfies that topology, so
+// the restore must succeed with the joiner placed elsewhere instead of
+// refusing (or pinning a rotation artifact, #258).
+func TestCreateVolumeRestoreExpandTopologyOnSeedNode(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
+		},
+	}
+	c := reshapeController(t, srcVol)
+	req := restoreReq("2")
+	req.AccessibilityRequirements = &csi.TopologyRequirement{
+		Preferred: []*csi.Topology{
+			{Segments: map[string]string{constants.TopologyKey: nodeA}},
+			{Segments: map[string]string{constants.TopologyKey: nodeB}},
+		},
+		Requisite: []*csi.Topology{
+			{Segments: map[string]string{constants.TopologyKey: nodeA}},
+		},
+	}
+
+	if _, err := c.CreateVolume(t.Context(), req); err != nil {
+		t.Fatalf("topology on the seed node must be satisfied by the kept leg: %v", err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	diskful := got.Spec.DiskfulReplicas()
+	if len(diskful) != 2 || diskful[0].Node != nodeA || diskful[1].Node == nodeA {
+		t.Fatalf("want the seed kept and the joiner elsewhere, got %+v", diskful)
+	}
+}
+
 // Restoring a replicated source into a 3-replica class: the source legs
 // keep the ids their clone metadata is keyed by, the extra leg full-syncs
 // under the next free id, and no padding applies (the source backings

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -105,7 +105,7 @@ func TestPlaceWeightsByFreeSpace(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestPlaceRefusesOvercommit(t *testing.T) {
 	}
 
 	// Default 2× ratio: 15 + 10 = 25 GiB provisioned > 20 GiB cap on both.
-	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 10*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 10*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("overcommit must be ResourceExhausted, got %v", err)
 	}
@@ -144,7 +144,7 @@ func TestPlaceTopologyPinnedRefusedWhenOvercommitted(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	_, err := c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, 10*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, 10*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("pinned overcommitted node must be ResourceExhausted, got %v", err)
 	}
@@ -154,7 +154,7 @@ func TestPlaceFallsBackWithoutStats(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: placementClient(s), Nodes: testNodes}
 
-	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestPlaceHonoursConfiguredRatio(t *testing.T) {
 	}
 
 	// 11 GiB on a 10 GiB pool breaches a 1× ratio on every node.
-	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 11*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 11*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("1x ratio must refuse an over-capacity volume, got %v", err)
 	}
@@ -196,7 +196,7 @@ func TestPlaceRefusesPhysicallyFullPool(t *testing.T) {
 	}
 
 	// Default 20× free-space ratio: 1 GiB free admits at most 20 GiB.
-	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 25*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 25*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("a physically full pool must be ResourceExhausted, got %v", err)
 	}
@@ -215,7 +215,7 @@ func TestPlaceHonoursConfiguredFreeSpaceRatio(t *testing.T) {
 
 	// The default 20× would admit this out of the same 10 GiB of free space,
 	// as would the untouched 2× virtual bound.
-	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 50*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 50*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("1x free-space ratio must refuse a volume past the physical headroom, got %v", err)
 	}
@@ -293,7 +293,7 @@ func TestPlaceSpreadsAcrossZones(t *testing.T) {
 		},
 	}
 
-	got, err := c.place(t.Context(), placeNodes(t, c), nil, 2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +350,7 @@ func TestPlaceFiltersAndRanksByPool(t *testing.T) {
 
 	// node-c has the roomiest default pool but no fast pool at all; node-b's
 	// fast pool has more headroom than node-a's.
-	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolFast, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -368,7 +368,7 @@ func TestPlaceRefusesPoolOnTooFewNodes(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: placementClient(s), Nodes: multiPoolNodes()}
 
-	_, err := c.place(t.Context(), placeNodes(t, c), nil, 3, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
+	_, err := c.place(t.Context(), placeNodes(t, c), nil, 3, 5*gib, volNew, placementVols(t, c.Client), false, poolFast, nil)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("want ResourceExhausted, got %v", err)
 	}
@@ -400,10 +400,10 @@ func TestPlaceOvercommitIsPoolScoped(t *testing.T) {
 	// Each pool holds 15 GiB provisioned of its 2×10 GiB budget: another
 	// 10 GiB breaches either pool alone (25 > 20), so per-pool accounting
 	// refuses — but 5 GiB still fits (20 > 15+5 is false; 20 >= 20 passes).
-	if _, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 10*gib, volNew, placementVols(t, c.Client), false, poolFast); status.Code(err) != codes.ResourceExhausted {
+	if _, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 10*gib, volNew, placementVols(t, c.Client), false, poolFast, nil); status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("fast pool at 15/20 GiB must refuse 10 GiB more, got %v", err)
 	}
-	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolFast)
+	got, err := c.place(t.Context(), placeNodes(t, c), nil, 1, 5*gib, volNew, placementVols(t, c.Client), false, poolFast, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -518,7 +518,7 @@ func TestPlaceRemoteAccessIgnoresNonStorageTopology(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	got, err := c.place(t.Context(), placeNodes(t, c), topologyReq("edge-node"), 2, 5*gib, volNew, placementVols(t, c.Client), true, poolDefault)
+	got, err := c.place(t.Context(), placeNodes(t, c), topologyReq("edge-node"), 2, 5*gib, volNew, placementVols(t, c.Client), true, poolDefault, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -544,7 +544,7 @@ func TestPlaceStrictRefusesNonStorageTopology(t *testing.T) {
 		Nodes: testNodes,
 	}
 
-	if _, err := c.place(t.Context(), placeNodes(t, c), topologyReq("edge-node"), 2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault); status.Code(err) != codes.ResourceExhausted {
+	if _, err := c.place(t.Context(), placeNodes(t, c), topologyReq("edge-node"), 2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil); status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("non-storage topology without remote access must refuse, got %v", err)
 	}
 }
@@ -640,10 +640,10 @@ func TestGetCapacityAgreesWithPlacement(t *testing.T) {
 	room := resp.GetAvailableCapacity()
 
 	vols := placementVols(t, c.Client)
-	if _, err := c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, room, volNew, vols, false, poolDefault); err != nil {
+	if _, err := c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, room, volNew, vols, false, poolDefault, nil); err != nil {
 		t.Fatalf("place must admit exactly the reported capacity (%d): %v", room, err)
 	}
-	_, err = c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, room+1, volNew, vols, false, poolDefault)
+	_, err = c.place(t.Context(), placeNodes(t, c), topologyPref(nodeA), 1, room+1, volNew, vols, false, poolDefault, nil)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("place must refuse one byte over the reported capacity, got %v", err)
 	}
@@ -803,7 +803,7 @@ func TestPlaceSecondReplicaByCapacityNotRotation(t *testing.T) {
 
 	// Consumer on node-b: the provisioner sends [b, c, a].
 	got, err := c.place(t.Context(), placeNodes(t, c), rotatedTopology(nodeB, nodeA, nodeB, nodeC),
-		2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault)
+		2, 5*gib, volNew, placementVols(t, c.Client), false, poolDefault, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -836,7 +836,7 @@ func TestPlaceBurstSpreadsSecondReplicas(t *testing.T) {
 	for i := range 4 {
 		name := fmt.Sprintf("pvc-burst-%d", i)
 		got, err := c.place(t.Context(), placeNodes(t, c), rotation,
-			2, 5*gib, name, placementVols(t, cl), false, poolDefault)
+			2, 5*gib, name, placementVols(t, cl), false, poolDefault, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -114,6 +114,45 @@ func TestPlaceWeightsByFreeSpace(t *testing.T) {
 	}
 }
 
+// A reshaped restore places joiners with the kept-leg nodes excluded.
+// The scheduler's selected node being one of them satisfies the
+// requested topology — the kept leg lives there — so placement must
+// neither refuse (the strict-topology shape: requisite names only that
+// node) nor pin the next rotation entry (the #258 artifact bug): the
+// joiner falls back to capacity ranking.
+func TestPlaceExcludedTopologyNodeSatisfiesWithoutPinning(t *testing.T) {
+	s := newScheme(t)
+	c := &Controller{
+		Client: placementClient(s,
+			miroirNodeObj(nodeA, 100*gib, 90*gib), // 10 GiB free — the rotation's next entry
+			miroirNodeObj(nodeB, 100*gib, 10*gib), // 90 GiB free — capacity's pick
+		),
+		Nodes: testNodes,
+	}
+	// Selected node seedNode leads the preferred rotation; node-a follows
+	// as rotation artifact. Requisite names only the selected node (the
+	// external-provisioner --strict-topology shape).
+	const seedNode = "seed-node"
+	reqs := &csi.TopologyRequirement{
+		Preferred: []*csi.Topology{
+			{Segments: map[string]string{constants.TopologyKey: seedNode}},
+			{Segments: map[string]string{constants.TopologyKey: nodeA}},
+		},
+		Requisite: []*csi.Topology{
+			{Segments: map[string]string{constants.TopologyKey: seedNode}},
+		},
+	}
+
+	got, err := c.place(t.Context(), placeNodes(t, c), reqs, 1, 5*gib, volNew,
+		placementVols(t, c.Client), false, poolDefault, map[string]bool{seedNode: true})
+	if err != nil {
+		t.Fatalf("a kept leg on the selected node must satisfy the topology: %v", err)
+	}
+	if len(got) != 1 || got[0].Node != nodeB {
+		t.Fatalf("joiner must fall back to capacity ranking, not pin the rotation artifact: %+v", got)
+	}
+}
+
 func TestPlaceRefusesOvercommit(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -339,6 +339,31 @@ func virginMetadata(dump, name string) bool {
 // removes — keep in sync with everything Apply and ensureMetadata write.
 var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted"}
 
+// removeStateFiles deletes the resource's rendered config and markers.
+func (d *Driver) removeStateFiles(name string) error {
+	for _, suffix := range stateSuffixes {
+		if err := os.Remove(d.path(name + suffix)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveConfig removes the resource's rendered config and markers while
+// leaving its minor.assign reservation in place. It exists for the
+// orphaned-hold reclaim: the zombie kernel minor outlives its volume
+// until a reboot, and a rendered config left behind holds the volume's
+// DRBD port hostage — the controller re-allocates ports from CRs alone,
+// and drbdadm refuses to parse a config directory whose resources share
+// an endpoint, wedging the next replicated volume handed the recycled
+// port on this node (caught by the e2e). The minor reservation must
+// outlive the config (a fresh volume handed the zombie's minor could
+// never register it); the startup orphan sweep releases it once a reboot
+// clears the kernel state.
+func (d *Driver) RemoveConfig(name string) error {
+	return d.removeStateFiles(name)
+}
+
 // listStatus runs `drbdsetup status --json [name]` and parses the result —
 // the one fetch every kernel-view consumer shares.
 func (d *Driver) listStatus(ctx context.Context, name ...string) ([]jsonStatus, error) {
@@ -402,10 +427,8 @@ func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool)
 		if !found || owned(name) || stuck[name] {
 			continue
 		}
-		for _, suffix := range stateSuffixes {
-			if err := os.Remove(d.path(name + suffix)); err != nil && !os.IsNotExist(err) {
-				errs = append(errs, err)
-			}
+		if err := d.removeStateFiles(name); err != nil {
+			errs = append(errs, err)
 		}
 		// The orphaned volume never comes back to Down on this node, so
 		// its minor.assign entry would leak — and permanently burn a
@@ -414,7 +437,48 @@ func (d *Driver) SweepOrphans(ctx context.Context, owned func(name string) bool)
 			errs = append(errs, fmt.Errorf("release minor of orphan %s: %w", name, err))
 		}
 	}
+	// Assignment entries with no CR, no kernel resource, and no rendered
+	// config are reclaim leftovers: RemoveConfig keeps the reservation
+	// while the zombie minor lives, and after the reboot that cleared the
+	// kernel they are pure leaks. Ordered after the file loop so a plain
+	// config orphan is handled (and released) exactly once, above.
+	inKernel := map[string]bool{}
+	for _, res := range parsed {
+		inKernel[res.Name] = true
+	}
+	if err := d.releaseOrphanedAssignments(owned, inKernel); err != nil {
+		errs = append(errs, err)
+	}
 	return errors.Join(errs...)
+}
+
+// releaseOrphanedAssignments drops minor.assign entries whose volume has
+// vanished entirely — not owned, not in the kernel, no rendered config.
+func (d *Driver) releaseOrphanedAssignments(owned func(name string) bool, inKernel map[string]bool) error {
+	unlock, err := d.lockMinors()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	assigned, err := d.readAssignments()
+	if err != nil {
+		return err
+	}
+	changed := false
+	for name := range assigned {
+		if owned(name) || inKernel[name] {
+			continue
+		}
+		if _, err := os.Stat(d.path(name + ".res")); err == nil {
+			continue
+		}
+		delete(assigned, name)
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	return d.writeAssignments(assigned)
 }
 
 // DownSecondaries brings down every resource this node holds Secondary,
@@ -915,10 +979,8 @@ func (d *Driver) Down(ctx context.Context, name string) error {
 	if err := d.downResource(ctx, name, peerIDs); err != nil {
 		return err
 	}
-	for _, suffix := range stateSuffixes {
-		if err := os.Remove(d.path(name + suffix)); err != nil && !os.IsNotExist(err) {
-			return err
-		}
+	if err := d.removeStateFiles(name); err != nil {
+		return err
 	}
 	// Free the minor for reuse — the .res is gone, so scanUsedMinors no
 	// longer covers it, and the assignment would otherwise leak forever.
@@ -954,10 +1016,10 @@ func (d *Driver) Restart(ctx context.Context, name string) error {
 // #319). Down can never win that state, but force-detach is legal on an
 // open device (dropping a failing disk under live I/O is its purpose),
 // and the backing is all a deletion still needs back. The caller must
-// keep the rendered config and the minor assignment: the kernel minor
-// stays pinned until a reboot, releasing the number would hand it to a
-// new volume, and the startup orphan sweep reaps both once the reboot
-// clears the state. Already-detached (Diskless) and not-in-kernel are
+// keep the minor assignment (see RemoveConfig): the kernel minor stays
+// pinned until a reboot, releasing the number would hand it to a new
+// volume, and the startup orphan sweep reaps it once the reboot clears
+// the state. Already-detached (Diskless) and not-in-kernel are
 // no-ops so a retry after a failed backing delete converges. A resource
 // wearing the teardown wedge signature is refused like everywhere else —
 // mid-detach is exactly the state a second detach would race.

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -336,8 +336,9 @@ func virginMetadata(dump, name string) bool {
 }
 
 // stateSuffixes are the per-resource files in StateDir that teardown
-// removes — keep in sync with everything Apply and ensureMetadata write.
-var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted"}
+// removes — keep in sync with everything Apply, ensureMetadata, and
+// WipeForeignMetadata write.
+var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted", ".md-wiped"}
 
 // removeStateFiles deletes the resource's rendered config and markers.
 func (d *Driver) removeStateFiles(name string) error {
@@ -347,6 +348,43 @@ func (d *Driver) removeStateFiles(name string) error {
 		}
 	}
 	return nil
+}
+
+// WipeForeignMetadata probes an unreplicated volume's backing for DRBD
+// internal metadata and wipes it when present — the state a restore that
+// shrank out of replication clones in: the replicated source's metadata
+// rides the tail of the byte-identical clone, and with pods staging the
+// raw backing (no DRBD layer above it), blkid identifies the device as
+// TYPE=drbd and staging's filesystem checks refuse it (found by the
+// e2e). Probing first keeps a metadata-less clone (an unreplicated
+// source's) untouched — wipe-md against a bare device would zero the
+// filesystem tail instead. The .md-wiped marker makes it one-shot: the
+// probe must never run against the device once a consumer can have it
+// mounted, and the crash window between clone and wipe is covered by the
+// caller re-running until the marker lands. drbdmeta is addressed with
+// minor 0 as the DEVICE handle, like WipeMetadata: unreplicated volumes
+// have no minor, 0 is below minorBase so it never names a live resource,
+// and it probes as unconfigured.
+func (d *Driver) WipeForeignMetadata(ctx context.Context, name, disk string) error {
+	marker := d.path(name + ".md-wiped")
+	if _, err := os.Stat(marker); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	// "unclean" is metadata too: a snapshot cut on an attached source
+	// captures its activity log mid-flight and dump-md refuses to read
+	// it, but wipe-md --force does not care.
+	_, err := d.Exec(ctx, "drbdmeta", "0", "v09", disk, "internal", "dump-md")
+	switch {
+	case err == nil || strings.Contains(err.Error(), "unclean"):
+		if err := d.WipeMetadata(ctx, name, disk, 0); err != nil {
+			return err
+		}
+	case !isMissingMetadata(err):
+		return fmt.Errorf("probe foreign metadata on %s: %w", name, err)
+	}
+	return os.WriteFile(marker, nil, 0o640)
 }
 
 // RemoveConfig removes the resource's rendered config and markers while

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -199,7 +199,7 @@ func (d *Driver) ensureMetadata(ctx context.Context, r Resource) error {
 		// --max-peers reserves metadata slots up-front: it cannot
 		// be raised later without recreating metadata, so leave
 		// headroom beyond the current 2-node shape.
-		args := []string{"create-md", "--force", "--max-peers", "7"}
+		args := []string{"create-md", "--force", "--max-peers", strconv.Itoa(maxPeers)}
 		if r.BitmapGranularityBytes > 0 {
 			// Like max-peers, fixed for this leg's lifetime: adjust
 			// never revisits it, only a metadata recreate could.
@@ -211,6 +211,36 @@ func (d *Driver) ensureMetadata(ctx context.Context, r Resource) error {
 		}
 	}
 	return nil
+}
+
+// maxPeers is the metadata peer-slot count create-md reserves up-front
+// (it cannot be raised later without recreating metadata) and the input
+// InternalMetaOverhead sizes bitmaps for.
+const maxPeers = 7
+
+// InternalMetaOverhead returns how many extra bytes a backing device
+// needs beyond its nominal size so DRBD internal metadata (meta-disk
+// internal, created with --max-peers) fits without the usable device
+// sizing below nominal. Consumed by restores that cross the replication
+// boundary (VolumeSource.PadForMetadata): an unreplicated source's
+// filesystem spans the full nominal size, so the clone must grow by at
+// least the metadata size before create-md, and every full-sync joiner
+// must match or the DRBD device sizes to the smallest leg.
+//
+// Deliberately a generous upper bound rather than drbdmeta's exact
+// arithmetic: one bitmap bit covers 4KiB per peer slot (the finest
+// granularity DRBD accepts; a coarser BitmapGranularityBytes only
+// shrinks it), rounded up per slot, plus slack for the superblock and
+// activity log, rounded to 4MiB for backend extent alignment. The pad
+// is virtual on every miroir backend (thin/sparse), so over-reserving
+// costs nothing; the e2e restore spec verifies the bound against a real
+// create-md.
+func InternalMetaOverhead(sizeBytes int64) int64 {
+	const block = 4096
+	perPeer := (sizeBytes/32768 + block) &^ (block - 1) // 1 bit / 4KiB, per peer, rounded up
+	overhead := perPeer*(maxPeers+1) + (8 << 20)
+	const extent = 4 << 20
+	return (overhead + extent - 1) &^ (extent - 1)
 }
 
 // probeMetadata reports the backing device's DRBD metadata state.
@@ -261,6 +291,16 @@ func (d *Driver) probeMetadata(ctx context.Context, name string) (hasMD, attache
 // normal first sync during triage.
 func (d *Driver) markAdopted(name string) error {
 	return os.WriteFile(d.path(name+".md-adopted"), nil, 0o640)
+}
+
+// MetadataAdopted reports whether this leg's metadata was adopted from a
+// previous life (an attached resource, or a dump proving live data)
+// rather than created fresh by this agent. The restore seed mint keys on
+// it: adopted metadata carries a real generation and must never be
+// re-seeded.
+func (d *Driver) MetadataAdopted(name string) bool {
+	_, err := os.Stat(d.path(name + ".md-adopted"))
+	return err == nil
 }
 
 // justCreatedUUID is drbdmeta's constant current-uuid for metadata that
@@ -658,6 +698,26 @@ func IsWinner(r Resource) bool {
 // generations (issue #139).
 func (d *Driver) InitialUUID(ctx context.Context, name string) error {
 	if _, err := d.adm(ctx, "new-current-uuid", "--clear-bitmap", name+"/0"); err != nil {
+		return fmt.Errorf("new-current-uuid %s: %w", name, err)
+	}
+	return nil
+}
+
+// SeedUUID declares this leg's just-created metadata the volume's data
+// generation with a full bitmap toward every peer — DRBD's documented
+// "force the full initial sync from this node": new-current-uuid WITHOUT
+// --clear-bitmap flips the leg UpToDate as sync source and every
+// just-created peer elects full SyncTarget on its handshake. It exists
+// for one consumer: the seed leg of a restore that crossed the
+// replication boundary (an unreplicated source's clone) holds real data
+// under freshly minted metadata, so neither the birth flow (data must
+// not be declared identical to blank peers) nor metadata adoption (there
+// was none to adopt) can produce its generation. The caller gates on the
+// metadata being this agent's own fresh create (see agent
+// restoreSeedPending) — running this on a leg with a live generation
+// would fork history.
+func (d *Driver) SeedUUID(ctx context.Context, name string) error {
+	if _, err := d.adm(ctx, "new-current-uuid", name+"/0"); err != nil {
 		return fmt.Errorf("new-current-uuid %s: %w", name, err)
 	}
 	return nil

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -361,30 +361,50 @@ func (d *Driver) removeStateFiles(name string) error {
 // filesystem tail instead. The .md-wiped marker makes it one-shot: the
 // probe must never run against the device once a consumer can have it
 // mounted, and the crash window between clone and wipe is covered by the
-// caller re-running until the marker lands. drbdmeta is addressed with
-// minor 0 as the DEVICE handle, like WipeMetadata: unreplicated volumes
-// have no minor, 0 is below minorBase so it never names a live resource,
-// and it probes as unconfigured.
-func (d *Driver) WipeForeignMetadata(ctx context.Context, name, disk string) error {
+// caller re-running until the marker lands. A temporary minor assignment
+// keeps drbdmeta's DEVICE handle clear of both system resources below
+// minorBase and concurrently realized miroir resources.
+func (d *Driver) WipeForeignMetadata(ctx context.Context, name, disk string) (retErr error) {
 	marker := d.path(name + ".md-wiped")
 	if _, err := os.Stat(marker); err == nil {
 		return nil
 	} else if !os.IsNotExist(err) {
 		return err
 	}
+	probeName := "@foreign-metadata-probe/" + name
+	minor, err := d.AllocateMinor(probeName)
+	if err != nil {
+		return fmt.Errorf("reserve foreign metadata probe minor for %s: %w", name, err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, d.releaseMinor(probeName))
+	}()
+
 	// "unclean" is metadata too: a snapshot cut on an attached source
 	// captures its activity log mid-flight and dump-md refuses to read
 	// it, but wipe-md --force does not care.
-	_, err := d.Exec(ctx, "drbdmeta", "0", "v09", disk, "internal", "dump-md")
+	_, err = d.Exec(ctx, "drbdmeta", strconv.Itoa(int(minor)), "v09", disk, "internal", "dump-md")
 	switch {
 	case err == nil || strings.Contains(err.Error(), "unclean"):
-		if err := d.WipeMetadata(ctx, name, disk, 0); err != nil {
+		if err := d.WipeMetadata(ctx, name, disk, minor); err != nil {
 			return err
 		}
 	case !isMissingMetadata(err):
 		return fmt.Errorf("probe foreign metadata on %s: %w", name, err)
 	}
 	return os.WriteFile(marker, nil, 0o640)
+}
+
+// InvalidateForeignMetadataWipe forgets the one-shot result before a
+// backing is recreated from its source snapshot. The replacement clone
+// carries the source's metadata again even when its device path and volume
+// name are unchanged.
+func (d *Driver) InvalidateForeignMetadataWipe(name string) error {
+	err := os.Remove(d.path(name + ".md-wiped"))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 // RemoveConfig removes the resource's rendered config and markers while

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -703,22 +703,37 @@ func (d *Driver) InitialUUID(ctx context.Context, name string) error {
 	return nil
 }
 
-// SeedUUID declares this leg's just-created metadata the volume's data
-// generation with a full bitmap toward every peer — DRBD's documented
-// "force the full initial sync from this node": new-current-uuid WITHOUT
-// --clear-bitmap flips the leg UpToDate as sync source and every
-// just-created peer elects full SyncTarget on its handshake. It exists
-// for one consumer: the seed leg of a restore that crossed the
-// replication boundary (an unreplicated source's clone) holds real data
-// under freshly minted metadata, so neither the birth flow (data must
-// not be declared identical to blank peers) nor metadata adoption (there
-// was none to adopt) can produce its generation. The caller gates on the
-// metadata being this agent's own fresh create (see agent
-// restoreSeedPending) — running this on a leg with a live generation
-// would fork history.
-func (d *Driver) SeedUUID(ctx context.Context, name string) error {
-	if _, err := d.adm(ctx, "new-current-uuid", name+"/0"); err != nil {
-		return fmt.Errorf("new-current-uuid %s: %w", name, err)
+// ForceFullSyncSource declares this leg's data the volume's generation —
+// DRBD's documented bootstrap for a node that has the data while its
+// peers do not: primary --force flips the Inconsistent disk UpToDate and
+// mints a current UUID with full bitmaps, every just-created peer elects
+// full SyncTarget, and the immediate demote hands the device back to
+// auto-promote. Not new-current-uuid: without --clear-bitmap (and with
+// --force-resync alike) drbdsetup refuses it on a connected resource
+// ("(151) Need to be StandAlone"), and even minted StandAlone it leaves
+// the disk Inconsistent with the resync parked on the source's own state
+// (PausedSyncS, resync-suspended:dependency) — verified against DRBD 9.3
+// on the QEMU e2e. It exists for one consumer: the seed leg of a restore
+// that crossed the replication boundary (an unreplicated source's clone)
+// holds real data under freshly created metadata, so neither the birth
+// flow (data must not be declared identical to blank peers) nor metadata
+// adoption (there was none to adopt) can produce its generation. The
+// caller gates on the metadata being this agent's own fresh create (see
+// agent restoreSeedPending) — forcing a leg with a live generation would
+// fork history.
+func (d *Driver) ForceFullSyncSource(ctx context.Context, name string) error {
+	if _, err := d.adm(ctx, "primary", "--force", name); err != nil {
+		return fmt.Errorf("primary --force %s: %w", name, err)
+	}
+	return d.Demote(ctx, name)
+}
+
+// Demote releases an explicitly held Primary role back to auto-promote.
+// Used by ForceFullSyncSource and by its crash recovery (a mint whose
+// demote never ran); a device a consumer holds open refuses harmlessly.
+func (d *Driver) Demote(ctx context.Context, name string) error {
+	if _, err := d.adm(ctx, "secondary", name); err != nil {
+		return fmt.Errorf("secondary %s: %w", name, err)
 	}
 	return nil
 }

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1051,6 +1051,51 @@ func TestRestartRefusesWedged(t *testing.T) {
 	fe.notCalledWith(t, "drbdadm up")
 }
 
+// The foreign-metadata wipe must fire only on proof: metadata present
+// (or unclean — still metadata) wipes and marks; a bare device marks
+// without wiping (wipe-md there would zero the filesystem tail); the
+// marker short-circuits every later call so the probe can never run
+// against a device a consumer may have mounted.
+func TestWipeForeignMetadataProbesThenWipesOnce(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{"dump-md": "version \"v09\";"}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.WipeForeignMetadata(t.Context(), volPvc1, "/dev/x"); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "wipe-md")
+	fe.calls = nil
+	if err := d.WipeForeignMetadata(t.Context(), volPvc1, "/dev/x"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fe.calls) != 0 {
+		t.Fatalf("marker must short-circuit later calls, got %v", fe.calls)
+	}
+}
+
+func TestWipeForeignMetadataSkipsBareDevice(t *testing.T) {
+	fe := &fakeExec{} // default dump-md answer: no valid meta data
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.WipeForeignMetadata(t.Context(), volPvc1, "/dev/x"); err != nil {
+		t.Fatal(err)
+	}
+	fe.notCalledWith(t, "wipe-md")
+	if _, err := os.Stat(d.path(volPvc1 + ".md-wiped")); err != nil {
+		t.Fatalf("a bare device must still mark as settled: %v", err)
+	}
+}
+
+func TestWipeForeignMetadataWipesUncleanMetadata(t *testing.T) {
+	fe := &fakeExec{errOn: map[string]error{"dump-md": errors.New("unclean meta data; apply-al first")}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.WipeForeignMetadata(t.Context(), volPvc1, "/dev/x"); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "wipe-md")
+}
+
 // A reclaim leftover — an assignment with no CR, no kernel resource, no
 // rendered config — must be released by the startup sweep after the
 // reboot cleared the zombie; while the zombie still lives in the kernel

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1059,11 +1059,22 @@ func TestRestartRefusesWedged(t *testing.T) {
 func TestWipeForeignMetadataProbesThenWipesOnce(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{"dump-md": "version \"v09\";"}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := os.WriteFile(d.path("used.res"), []byte("device minor 1000;\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := d.WipeForeignMetadata(t.Context(), volPvc1, "/dev/x"); err != nil {
 		t.Fatal(err)
 	}
-	fe.calledWith(t, "wipe-md")
+	fe.calledWith(t, "drbdmeta 1001 v09 /dev/x internal dump-md")
+	fe.calledWith(t, "drbdmeta --force 1001 v09 /dev/x internal wipe-md")
+	assigned, err := d.readAssignments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := assigned["@foreign-metadata-probe/"+volPvc1]; ok {
+		t.Fatalf("temporary probe minor must be released: %v", assigned)
+	}
 	fe.calls = nil
 	if err := d.WipeForeignMetadata(t.Context(), volPvc1, "/dev/x"); err != nil {
 		t.Fatal(err)

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1071,19 +1071,33 @@ func TestInternalMetaOverheadBounds(t *testing.T) {
 	}
 }
 
-// SeedUUID must not pass --clear-bitmap: the whole point is a full
-// bitmap toward every peer so just-created joiners elect full
-// SyncTarget, where --clear-bitmap would declare them identical to data
-// they do not hold.
-func TestSeedUUIDKeepsBitmap(t *testing.T) {
+// The seed bootstrap is force-promote then demote — never
+// new-current-uuid, which a connected resource refuses ("Need to be
+// StandAlone") and which leaves the disk Inconsistent even when minted,
+// and never --clear-bitmap, which would declare blank joiners identical
+// to data they do not hold.
+func TestForceFullSyncSourcePromotesAndDemotes(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 
-	if err := d.SeedUUID(t.Context(), volPvc1); err != nil {
+	if err := d.ForceFullSyncSource(t.Context(), volPvc1); err != nil {
 		t.Fatal(err)
 	}
-	fe.calledWith(t, "new-current-uuid pvc-1/0")
-	fe.notCalledWith(t, "--clear-bitmap")
+	fe.calledWith(t, "drbdadm primary --force pvc-1")
+	fe.calledWith(t, "drbdadm secondary pvc-1")
+	fe.notCalledWith(t, "new-current-uuid")
+}
+
+// A failed promote must not be followed by the demote; the error is the
+// caller's retry signal.
+func TestForceFullSyncSourceSkipsDemoteOnPromoteFailure(t *testing.T) {
+	fe := &fakeExec{errOn: map[string]error{"primary --force": errors.New("boom")}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.ForceFullSyncSource(t.Context(), volPvc1); err == nil {
+		t.Fatal("a failed promote must surface")
+	}
+	fe.notCalledWith(t, "drbdadm secondary")
 }
 
 // MetadataAdopted reflects the adoption marker ensureMetadata writes for

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1051,6 +1051,50 @@ func TestRestartRefusesWedged(t *testing.T) {
 	fe.notCalledWith(t, "drbdadm up")
 }
 
+// A reclaim leftover — an assignment with no CR, no kernel resource, no
+// rendered config — must be released by the startup sweep after the
+// reboot cleared the zombie; while the zombie still lives in the kernel
+// the reservation must survive, or a new volume could be handed a minor
+// it can never register.
+func TestSweepOrphansReleasesReclaimLeftoverAssignments(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{cmdDrbdsetupStatus: `[]`}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if _, err := d.AllocateMinor("pvc-zombie"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.SweepOrphans(t.Context(), func(string) bool { return false }); err != nil {
+		t.Fatal(err)
+	}
+	assigned, err := d.readAssignments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := assigned["pvc-zombie"]; ok {
+		t.Fatalf("post-reboot sweep must release the leftover reservation: %v", assigned)
+	}
+}
+
+func TestSweepOrphansKeepsAssignmentWhileZombieLives(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{cmdDrbdsetupStatus: `[
+		{"name":"pvc-zombie","role":"Secondary","devices":[{"disk-state":"Diskless"}],"connections":[]}]`}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if _, err := d.AllocateMinor("pvc-zombie"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The sweep tries (and here fails to matter) to down the unowned
+	// kernel zombie; the reservation must survive regardless.
+	_ = d.SweepOrphans(t.Context(), func(string) bool { return false })
+	assigned, err := d.readAssignments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := assigned["pvc-zombie"]; !ok {
+		t.Fatalf("reservation must survive while the kernel holds the zombie: %v", assigned)
+	}
+}
+
 // The overhead bound must dominate the bitmap arithmetic it stands in
 // for (1 bit per 4KiB per peer slot) with real slack for the superblock
 // and activity log, stay extent-aligned, and grow monotonically.

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1051,6 +1051,57 @@ func TestRestartRefusesWedged(t *testing.T) {
 	fe.notCalledWith(t, "drbdadm up")
 }
 
+// The overhead bound must dominate the bitmap arithmetic it stands in
+// for (1 bit per 4KiB per peer slot) with real slack for the superblock
+// and activity log, stay extent-aligned, and grow monotonically.
+func TestInternalMetaOverheadBounds(t *testing.T) {
+	prev := int64(0)
+	for _, size := range []int64{1 << 30, 5 << 30, 100 << 30, 1 << 40} {
+		got := InternalMetaOverhead(size)
+		if bitmaps := size / 32768 * maxPeers; got <= bitmaps {
+			t.Fatalf("overhead %d for %d must exceed the raw bitmap bytes %d", got, size, bitmaps)
+		}
+		if got%(4<<20) != 0 {
+			t.Fatalf("overhead %d for %d must be 4MiB-aligned", got, size)
+		}
+		if got < prev {
+			t.Fatalf("overhead must grow with size: %d then %d", prev, got)
+		}
+		prev = got
+	}
+}
+
+// SeedUUID must not pass --clear-bitmap: the whole point is a full
+// bitmap toward every peer so just-created joiners elect full
+// SyncTarget, where --clear-bitmap would declare them identical to data
+// they do not hold.
+func TestSeedUUIDKeepsBitmap(t *testing.T) {
+	fe := &fakeExec{}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.SeedUUID(t.Context(), volPvc1); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "new-current-uuid pvc-1/0")
+	fe.notCalledWith(t, "--clear-bitmap")
+}
+
+// MetadataAdopted reflects the adoption marker ensureMetadata writes for
+// metadata inherited from a previous life — the restore seed mint must
+// never fire on such a leg.
+func TestMetadataAdoptedTracksMarker(t *testing.T) {
+	d := &Driver{StateDir: t.TempDir(), Exec: (&fakeExec{}).run, Mknod: fakeMknod}
+	if d.MetadataAdopted(volPvc1) {
+		t.Fatal("no marker must read as not adopted")
+	}
+	if err := d.markAdopted(volPvc1); err != nil {
+		t.Fatal(err)
+	}
+	if !d.MetadataAdopted(volPvc1) {
+		t.Fatal("marker must read as adopted")
+	}
+}
+
 // ForceDetach disconnects the peers, then force-detaches the backing by
 // minor — the escape hatch for a deletion whose down is permanently
 // refused by an orphaned opener (issue #319). No down is spawned and the

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -93,10 +93,16 @@ var _ = Describe("miroir-local volume lifecycle", Ordered, func() {
 		// Finalizers run backend.Delete() before the cluster-scoped objects go.
 		eventuallyGone(ctx, &miroirv1alpha1.MiroirVolume{ObjectMeta: metav1.ObjectMeta{Name: appPV}})
 		eventuallyGone(ctx, &miroirv1alpha1.MiroirVolume{ObjectMeta: metav1.ObjectMeta{Name: restoredPV}})
+		// Scoped to this suite's volumes: containers run in random order,
+		// and a failed sibling deliberately leaves its namespace (and thus
+		// snapshots) behind for diagnostics.
 		Eventually(func(g Gomega) {
 			var snaps miroirv1alpha1.MiroirSnapshotList
 			g.Expect(k8s.List(ctx, &snaps)).To(Succeed())
-			g.Expect(snaps.Items).To(BeEmpty(), "MiroirSnapshots not cleaned up")
+			for _, s := range snaps.Items {
+				g.Expect(s.Spec.VolumeName).NotTo(BeElementOf(appPV, restoredPV),
+					"MiroirSnapshot %s not cleaned up", s.Name)
+			}
 		}).Should(Succeed())
 	})
 })

--- a/test/e2e/orphanhold_test.go
+++ b/test/e2e/orphanhold_test.go
@@ -148,8 +148,8 @@ var _ = Describe("orphaned-hold teardown reclaim", Ordered, func() {
 		Expect(lvs).NotTo(ContainSubstring(pv), "backing LV must be destroyed by the reclaim")
 
 		// The kernel minor is the expected residue: still registered,
-		// diskless, pinned by the dead superblock until the node reboots
-		// (the startup orphan sweep then reaps the rendered config).
+		// diskless, pinned by the dead-opener hold until the node reboots
+		// (the startup orphan sweep then releases its minor reservation).
 		status := agentExec(ctx, node, "drbdsetup status "+pv+" --verbose || true")
 		Expect(status).To(ContainSubstring(pv), "zombie minor must remain until reboot")
 		Expect(status).To(ContainSubstring("Diskless"), "zombie minor must have no backing attached")

--- a/test/e2e/orphanhold_test.go
+++ b/test/e2e/orphanhold_test.go
@@ -56,13 +56,13 @@ func agentExec(ctx context.Context, node, sh string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// Reproduces issue #319 on real DRBD and asserts the orphaned-hold
-// reclaim: a filesystem freeze leaked onto the staged volume (the #311
-// state, with the staging mountpoint removed so NodeUnstage's thaw cannot
-// fire) leaves the DRBD device held open by a dead superblock after every
-// mount is gone. drbdsetup down is then refused forever — the reclaim
-// must force-detach the backing, finish the deletion, and leave only the
-// pinned kernel minor for the post-reboot orphan sweep.
+// Reproduces issue #319's shape on real DRBD and asserts the
+// orphaned-hold reclaim: a kernel object with no living process behind it
+// (in the field, a leaked freeze's dead superblock; here, a loop device —
+// see the planting step for why) holds the unmounted DRBD device open, so
+// drbdsetup down is refused forever. The reclaim must force-detach the
+// backing, finish the deletion, and leave only the pinned kernel minor
+// for the post-reboot orphan sweep.
 var _ = Describe("orphaned-hold teardown reclaim", Ordered, func() {
 	const ns = "miroir-e2e-orphan"
 	ctx := context.Background()
@@ -102,27 +102,27 @@ var _ = Describe("orphaned-hold teardown reclaim", Ordered, func() {
 		Expect(minor).To(BeNumerically(">", 0), "staged leg must report its DRBD minor")
 	})
 
-	It("leaks a freeze and strips every mountpoint, leaving a dead-opener hold", func() {
-		dev := fmt.Sprintf("/dev/drbd%d", minor)
-		staging := agentExec(ctx, node,
-			fmt.Sprintf("findmnt -rn -S %s -o TARGET | grep globalmount | head -1", dev))
-		Expect(staging).NotTo(BeEmpty(), "staged device must have a globalmount")
-
-		// Freeze through the staging mountpoint, then remove that
-		// mountpoint out from under the thaw-before-unmount guard — the
-		// pre-#312 leak. Deleting the pod afterwards removes the publish
-		// bind (kubelet unmounts a frozen bind fine); the frozen
-		// superblock then holds the device open with no mountpoint left
-		// to thaw, and its recorded opener (mount) is long exited.
-		agentExec(ctx, node, fmt.Sprintf("fsfreeze -f %s && umount -l %s", staging, staging))
-
+	It("plants a dead-opener hold on the unmounted device", func() {
+		// Clean unstage first: the pod goes, kubelet unmounts, and the
+		// #312 thaw guard runs — no mount survives in any namespace.
 		Expect(k8s.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "holder"}})).To(Succeed())
 		eventuallyGone(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "holder"}})
 
-		// The leak must actually pin the device: no mounts left, yet the
-		// kernel still counts an opener. Without this the repro proves
-		// nothing (a kernel that releases the superblock on unmount would
-		// let teardown succeed normally).
+		// Then pin the device with a kernel object whose opener is dead: a
+		// loop device holds the DRBD device open (auto-promoted, writable)
+		// after losetup itself has exited — the same shape as #319's field
+		// state, where a leaked freeze's dead superblock held open_cnt with
+		// every recorded opener long gone. Deliberately NOT reproduced via
+		// fsfreeze here: on Talos, machined's device prober race-opens a
+		// frozen bdev and wedges in the open, becoming a live opener the
+		// reclaim gates then (correctly) refuse — the freeze repro is
+		// nondeterministic, the loop hold is not.
+		dev := fmt.Sprintf("/dev/drbd%d", minor)
+		agentExec(ctx, node, "losetup -f "+dev)
+
+		// The hold must actually pin the device: no mounts anywhere, yet
+		// the kernel counts a writable opener — exactly what drbdsetup
+		// down is about to be refused over.
 		Eventually(func(g Gomega) {
 			g.Expect(agentExec(ctx, node, fmt.Sprintf("findmnt -rn -S %s -o TARGET || true", dev))).To(BeEmpty())
 			g.Expect(agentExec(ctx, node, "drbdsetup status "+pv+" --verbose")).To(ContainSubstring("open:yes"))

--- a/test/e2e/replicashape_test.go
+++ b/test/e2e/replicashape_test.go
@@ -1,0 +1,99 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+// Issue #305: a restore may request a different replica count than its
+// source. Growing crosses the replication boundary (miroir-local →
+// miroir-replicated): the clone gains fresh DRBD metadata on a padded
+// backing, mints its data generation, and full-syncs the joiner — this
+// spec is the real-hardware proof of that whole chain, including that
+// the metadata-overhead bound leaves the restored filesystem intact and
+// writable. Shrinking (miroir-replicated → miroir-local) drops the DRBD
+// layer, leaving the clone's embedded metadata as inert tail bytes.
+var _ = Describe("restore replica reshape", Ordered, func() {
+	const ns = "miroir-e2e-shape"
+	ctx := context.Background()
+
+	var upSum, downSum string
+	var failed bool
+
+	BeforeAll(func() {
+		Expect(client.IgnoreAlreadyExists(k8s.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}))).To(Succeed())
+	})
+	AfterEach(func() { failed = failed || CurrentSpecReport().Failed() })
+	AfterAll(func() {
+		if failed {
+			GinkgoWriter.Printf("specs failed — leaving namespace %q for diagnostics\n", ns)
+			return
+		}
+		_ = k8s.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	It("expands an unreplicated volume into a replicated restore (1→2)", func() {
+		Expect(k8s.Create(ctx, pvc(ns, "shape-src", storageClass, "1Gi", nil))).To(Succeed())
+		Expect(k8s.Create(ctx, pod(ns, "shape-src-writer", "shape-src"))).To(Succeed())
+		eventuallyPodReady(ctx, ns, "shape-src-writer")
+		eventuallyMiroirVolumeReady(ctx, boundPV(ctx, ns, "shape-src"))
+		upSum = writeSeed(ns, "shape-src-writer", "/data/seed")
+
+		Expect(k8s.Create(ctx, volumeSnapshot(ns, "shape-src-snap", "shape-src"))).To(Succeed())
+		eventuallySnapshotReady(ctx, ns, "shape-src-snap")
+
+		Expect(k8s.Create(ctx, pvc(ns, "shape-up", replicatedClass, "1Gi", ptr("shape-src-snap")))).To(Succeed())
+		Expect(k8s.Create(ctx, pod(ns, "shape-up-reader", "shape-up"))).To(Succeed())
+		eventuallyPodReady(ctx, ns, "shape-up-reader")
+
+		pv := boundPV(ctx, ns, "shape-up")
+		eventuallyMiroirVolumeReady(ctx, pv)
+		var v miroirv1alpha1.MiroirVolume
+		Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
+		Expect(v.Spec.DRBD).NotTo(BeNil(), "expanded restore must be replicated")
+		Expect(v.Spec.DiskfulReplicas()).To(HaveLen(2))
+		Expect(v.Spec.Source.PadForMetadata).To(BeTrue(), "boundary-crossing restore must pad its backings")
+
+		// Point-in-time content survived the boundary crossing, and the
+		// padded device still accepts writes past the source's fill line —
+		// the on-hardware proof that create-md landed in the pad, not over
+		// the filesystem tail.
+		Expect(sha(ns, "shape-up-reader", "/data/seed")).To(Equal(upSum))
+		kubectlExec(ns, "shape-up-reader", "dd if=/dev/zero of=/data/extra bs=1M count=64 2>/dev/null && sync")
+	})
+
+	It("shrinks a replicated volume into an unreplicated restore (2→1)", func() {
+		Expect(k8s.Create(ctx, pvc(ns, "shape-rep", replicatedClass, "1Gi", nil))).To(Succeed())
+		Expect(k8s.Create(ctx, pod(ns, "shape-rep-writer", "shape-rep"))).To(Succeed())
+		eventuallyPodReady(ctx, ns, "shape-rep-writer")
+		eventuallyMiroirVolumeReady(ctx, boundPV(ctx, ns, "shape-rep"))
+		downSum = writeSeed(ns, "shape-rep-writer", "/data/seed")
+
+		Expect(k8s.Create(ctx, volumeSnapshot(ns, "shape-rep-snap", "shape-rep"))).To(Succeed())
+		eventuallySnapshotReady(ctx, ns, "shape-rep-snap")
+
+		Expect(k8s.Create(ctx, pvc(ns, "shape-down", storageClass, "1Gi", ptr("shape-rep-snap")))).To(Succeed())
+		Expect(k8s.Create(ctx, pod(ns, "shape-down-reader", "shape-down"))).To(Succeed())
+		eventuallyPodReady(ctx, ns, "shape-down-reader")
+
+		pv := boundPV(ctx, ns, "shape-down")
+		eventuallyMiroirVolumeReady(ctx, pv)
+		var v miroirv1alpha1.MiroirVolume
+		Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
+		Expect(v.Spec.DRBD).To(BeNil(), "shrunk restore must be unreplicated")
+		Expect(v.Spec.Replicas).To(HaveLen(1))
+
+		Expect(sha(ns, "shape-down-reader", "/data/seed")).To(Equal(downSum))
+	})
+})

--- a/test/integration/crd_validation_test.go
+++ b/test/integration/crd_validation_test.go
@@ -135,6 +135,18 @@ var _ = Describe("MiroirVolume CEL validation", func() {
 		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "adding a source after creation must be rejected, got: %v", err)
 	})
 
+	It("rejects changing a clone source's metadata padding", func() {
+		vol := replicatedVolume("pvc-source-padding-pin")
+		vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-a", PadForMetadata: true}
+		Expect(k8sClient.Create(ctx, vol)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, vol)).To(Succeed()) })
+
+		vol.Spec.Source.PadForMetadata = false
+		err := k8sClient.Update(ctx, vol)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "metadata padding change must be rejected, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("source is immutable"))
+	})
+
 	It("rejects changing the export filesystem after formatting", func() {
 		vol := replicatedVolume("pvc-fstype-pin")
 		vol.Spec.Export = &miroirv1alpha1.ExportSpec{FSType: "ext4"}

--- a/test/integration/crd_validation_test.go
+++ b/test/integration/crd_validation_test.go
@@ -39,6 +39,7 @@ const (
 	poolDefault = "default"
 	datasetTank = "tank/miroir"
 	deviceSDB   = "/dev/sdb"
+	snapshotA   = "snap-a"
 )
 
 // unreplicatedVolume is the minimal valid single-replica volume.
@@ -117,7 +118,7 @@ var _ = Describe("MiroirVolume CEL validation", func() {
 
 	It("rejects retargeting or adding a clone source", func() {
 		vol := unreplicatedVolume("pvc-source-pin")
-		vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-a"}
+		vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapshotA}
 		Expect(k8sClient.Create(ctx, vol)).To(Succeed())
 		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, vol)).To(Succeed()) })
 
@@ -130,14 +131,14 @@ var _ = Describe("MiroirVolume CEL validation", func() {
 		Expect(k8sClient.Create(ctx, unsourced)).To(Succeed())
 		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, unsourced)).To(Succeed()) })
 
-		unsourced.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-a"}
+		unsourced.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapshotA}
 		err = k8sClient.Update(ctx, unsourced)
 		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "adding a source after creation must be rejected, got: %v", err)
 	})
 
 	It("rejects changing a clone source's metadata padding", func() {
 		vol := replicatedVolume("pvc-source-padding-pin")
-		vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-a", PadForMetadata: true}
+		vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapshotA, PadForMetadata: true}
 		Expect(k8sClient.Create(ctx, vol)).To(Succeed())
 		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, vol)).To(Succeed()) })
 


### PR DESCRIPTION
Fixes #305.

A restore (or PVC clone) may now request a different diskful replica count than its source: `1→2`/`2→3` grows a volume across or within the replication boundary, and `3→2`/`2→1` shrinks it. The restore path is the right boundary to cross — the CEL rule forbidding an in-place `drbd` toggle stands untouched; a reshaped restore is simply *born* with the class's shape.

### Controller (`internal/csi/controller.go`)

- `resolveSource` no longer requires count equality; `reshapeRestore` adapts the layout when counts differ:
  - **Grow**: extra legs are placed (`place` gains an exclusion set for nodes already holding a leg) and marked `FullSync` — their content arrives over the wire, so unlike the CoW legs they may land anywhere the class pool reaches.
  - **Shrink**: keeps a subset of the source legs, seed first, Done legs preferred over post-snapshot `FullSync` ones (dropping a free CoW clone while keeping a leg that needs a full resync would be pure waste). A `replicas: 1` target ends unreplicated, its sole leg shed of the replication-only fields.
  - Node ids: legs cloning DRBD metadata keep the ids that metadata is keyed by; everything else (an unreplicated source's seed, placed joiners, the re-derived tie-breaker) takes the smallest unused id. `withTieBreaker` switched from positional to smallest-unused ids — identical for fresh contiguous layouts, correct for sparse kept sets.
- The clone path's own count gate is gone too: a PVC clone is an internal snapshot plus a restore, so the same reshape covers it.

### The hard part: crossing from unreplicated to replicated (`PadForMetadata`)

An unreplicated source's filesystem spans its full nominal size and its backing carries no DRBD metadata. Three consequences, all handled in the agent:

1. **Metadata space.** `create-md` writes internal metadata at the device tail — on the raw clone it would land on the filesystem's last bytes, and the resulting device (`size − md`) couldn't hold the filesystem anyway. And because DRBD sizes the device to the *smallest* leg, the fix must cover every leg: the new `spec.source.padForMetadata` (set by the controller for boundary-crossing restores, sticky through replicated restore chains of padded volumes) makes each diskful backing realize `sizeBytes + drbd.InternalMetaOverhead(sizeBytes)`. The clone grows **before** the DRBD apply — the inverse of #300's attach-before-resize, which protects *adopted* metadata; here there is none to strand, and create-md must land in the grown tail. `InternalMetaOverhead` is a deliberately generous, extent-aligned upper bound on drbdmeta's arithmetic (virtual on every thin/sparse backend; the e2e verifies it against a real `create-md --max-peers 7`).
2. **Generation seeding.** The clone's fresh metadata sits at `UUID_JUST_CREATED`, and nothing existing can promote it: the birth flow (`new-current-uuid --clear-bitmap`) correctly refuses data-bearing volumes, and there was no metadata to adopt — seed and joiner would sit Inconsistent forever (the exact deadlock the `growLeg` comment describes for stranded clones). New `Driver.SeedUUID` runs `new-current-uuid` *without* `--clear-bitmap` — DRBD's documented "force the full initial sync from this node" — flipping the seed UpToDate with a full bitmap so just-created joiners elect full SyncTarget.
3. **Not re-seeding a rebuilt leg.** A seed recreated after a node wipe wears the same fresh-metadata signature while its peers now hold the data. `restoreSeedPending` therefore requires all of: the padded-restore seed leg, metadata this agent created itself (`Driver.MetadataAdopted` is the existing adoption marker), disk Inconsistent, and no peer ever having reported UpToDate (live status and CR status both) — refusal means joining as a plain full SyncTarget, the safe direction.

Shrinking to `replicas: 1` needs no agent work: the clone's embedded metadata becomes inert tail bytes past the filesystem, and the padding rules guarantee any later re-expansion grows the device past it (fresh create-md lands in the pad; the stale metadata is never at the probed tail, so it can't be adopted).

### Tests

- **Controller**: expand from unreplicated (seed keeps id 0 + gets a resolved address, joiner FullSync under the next id, tie-breaker, `padForMetadata`), expand from replicated (ids preserved, no padding), shrink to unreplicated (fields shed, topology pinned), shrink preferring Done legs with a smallest-unused-id tie-breaker, padding inheritance.
- **Agent**: padded clone grows before `create-md` (ordering asserted through the interleaved call log), FullSync joiner realizes the padded size and never mints, seed mints exactly `new-current-uuid <res>/0` (no `--clear-bitmap`), mint refused when a peer holds data.
- **drbd**: overhead bounds (dominates raw bitmap bytes, extent-aligned, monotonic), `SeedUUID` flag discipline, adoption-marker probe.
- **E2E** (`test/e2e/replicashape_test.go`, conformance leg): grow `miroir-local → miroir-replicated` — asserts point-in-time sha256, 2 diskful legs Ready (full sync completed on real DRBD), `padForMetadata`, and 64MiB of *new* writes on the restored volume (the on-hardware proof that create-md landed in the pad, not over the filesystem tail); shrink `miroir-replicated → miroir-local` — asserts sha256, single leg, no DRBD layer.
- Removed: the clone count-mismatch rejection case (that shape is now legal); csi-sanity, envtest integration, and lint all green.

### Docs

`docs/replication.md` gains "Changing the replica count on restore": the snapshot → restore → repoint workflow for going from one storage node to two, shrink symmetry, and a note on the padding detail.
