### PR TITLE
ci(e2e): run the QEMU legs on Blacksmith 8-vCPU runners

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,11 @@ permissions:
 jobs:
   e2e:
     name: E2E (${{ matrix.suite }})
-    runs-on: ubuntu-24.04
+    # 8 vCPU / 32 GB / 160 GB with nested KVM (jobs run in Firecracker microVMs),
+    # measured against GitHub's 4 vCPU / 16 GB in the first Blacksmith trial (#299):
+    # the CPU-bound conformance leg gained ~30%; cluster.yaml sizes the VMs to the
+    # bigger box (3 vCPU / 8 GiB workers).
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 60
     permissions:
       contents: read
@@ -40,16 +44,23 @@ jobs:
       matrix:
         include:
           # miroir's own Go specs, then the upstream external-storage suite, both
-          # against the local (lvmthin, replicas:1) class.
+          # against the local (lvmthin, replicas:1) class. procs 6 exploits the 6
+          # worker vCPUs: this leg is CPU-bound (no DRBD coordination) and was the
+          # big winner in the #299 measurements.
           - suite: conformance
             testdriver: testdriver-local.yaml
             specs: "1"
+            procs: "6"
           # The upstream suite against the replicated (DRBD, replicas:2) class,
-          # group snapshots included.
+          # group snapshots included. procs stays 4: the replicated legs are bounded
+          # by DRBD bring-up throughput, not CPU, and procs 6 flaked a
+          # snapshot-restore spec in the #299 trial.
           - suite: replicated
             testdriver: testdriver.yaml
+            procs: "4"
           - suite: zfs
             testdriver: testdriver-zfs.yaml
+            procs: "4"
     env:
       # Two names for one image in the runner-local registry. The nodes pull
       # registry.e2e, which the Talos mirror in patches/registry.yaml points at the
@@ -91,17 +102,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils ovmf
 
-      - name: Enable swap
-        run: |
-          sudo fallocate -l 12G /mnt/e2e-swapfile
-          sudo chmod 600 /mnt/e2e-swapfile
-          sudo mkswap /mnt/e2e-swapfile
-          sudo swapon /mnt/e2e-swapfile
+      # No swap step: it only existed to survive the 16 GB GitHub runners; the
+      # 21 GiB VM allocation leaves ~10 GB of headroom on this box.
 
       # The conformance leg compiles and runs miroir's Go specs; both legs read the
-      # module cache, only the conformance one uses it.
+      # module cache, only the conformance one uses it. useblacksmith/cache is the
+      # co-located drop-in for actions/cache — same inputs, much faster restore
+      # than reaching GitHub's cache backend from a Blacksmith runner.
       - name: Cache Go modules and build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.0.2
         with:
           path: |
             ~/.cache/go-build
@@ -161,7 +170,7 @@ jobs:
       - wait: [cluster, controller-image, agent-image]
 
       - name: Cache conformance test binaries
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.0.2
         with:
           path: test/conformance/.bin
           key: conformance-bin-${{ steps.tools.outputs.talos }}
@@ -175,7 +184,7 @@ jobs:
           ENDPOINT: ${{ steps.cluster.outputs.endpoint }}
           KUBECONFIG: ${{ steps.cluster.outputs.kubeconfig }}
           TALOSCONFIG: ${{ steps.cluster.outputs.talosconfig }}
-          PROCS: "4"
+          PROCS: ${{ matrix.procs }}
           VERBOSE: "1"
 
       - name: Diagnostics

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -66,7 +66,7 @@ sudo -E (mise which talosctl) cluster create qemu \
     --name miroir-e2e \
     --cidr 10.5.0.0/24 \
     --schematic-id "$SCHEMATIC_ID" \
-    --controlplanes 1 --workers 2 --memory-workers 5GiB \
+    --controlplanes 1 --workers 2 --memory-workers 8GiB --cpus-workers 3.0 \
     --disks virtio:8GiB,virtio:20GiB,virtio:20GiB \
     --config-patch @patches/modules.yaml \
     --config-patch @patches/registry.yaml \

--- a/test/e2e-qemu/cluster.yaml
+++ b/test/e2e-qemu/cluster.yaml
@@ -21,8 +21,12 @@ spec:
   workers:
     count: 2
     # A worker runs DRBD, dm-thin, kubelet and every test pod; 3GiB left them tight
-    # enough to OOM under the parallel conformance suite.
-    memory: 5GiB
+    # enough to OOM under the parallel conformance suite, and 5GiB was the ceiling
+    # the 16 GB GitHub runners allowed. Sized for the Blacksmith 8 vCPU / 32 GB
+    # runners: 2 workers x 3 vCPU / 8GiB plus the default control plane is 8 of 8
+    # cores and 18GiB of 32, no oversubscription (#299 measurements).
+    cpus: 3
+    memory: 8GiB
   network:
     # Explicit because patches/registry.yaml hardcodes the gateway, the first address
     # of this range. It is also talosctl's default.


### PR DESCRIPTION
Reopens #299 against the current all-QEMU matrix. Since that trial the harness was reworked (#313/#317): the kind leg is gone, every leg boots its own Talos QEMU cluster, and a zfs leg joined — so this time the whole matrix moves to `blacksmith-8vcpu-ubuntu-2404` (8 vCPU / 32 GB / 160 GB, nested KVM confirmed working in #299).

## What changes

| knob | before (GitHub 4 vCPU / 16 GB) | now (Blacksmith 8 vCPU / 32 GB) |
|---|---|---|
| worker VMs | 2 vCPU / 5 GiB | 3 vCPU / 8 GiB (`cluster.yaml`; 8 of 8 cores + 18 GiB of 32, no oversubscription) |
| swap | 12 G swapfile step | dropped — ~10 GB headroom at peak |
| `PROCS` | 4 everywhere | per-leg: 6 on conformance, 4 on replicated/zfs |
| artifact caches | `actions/cache` | `useblacksmith/cache` v5.0.2 (co-located drop-in) |

The per-leg `PROCS` split encodes what #299 measured: the conformance leg is CPU-bound and gained ~30% from the bigger box at PROCS 6, while the replicated legs are bounded by DRBD bring-up throughput — flat on wall time, and PROCS 6 flaked a snapshot-restore spec there, so they stay at 4.

`test/e2e-qemu/README.md`'s local-run flags mirror the new shape (`--memory-workers 8GiB --cpus-workers 3.0`); an 18 GiB allocation still fits a 32 GB dev host.

## Expectations to verify on this PR's runs

Against the current GitHub-runner baselines (conformance 19-20 min, replicated ~25 min, zfs 23-26 min): conformance should land well under 15 min (bigger box + PROCS 6 + faster caches); replicated/zfs should improve modestly at best — if they don't move, that reconfirms the DRBD-throughput ceiling, not a Blacksmith problem.

## Deferred, again

`useblacksmith/build-push-action` (sticky-disk Docker layer cache) is now unblocked — no leg remains on GitHub runners — and stays the biggest remaining build-time lever. Left out so this PR changes one variable at a time; worth a follow-up once the runner move proves out.
