### PR TITLE
fix(csi): honor topology when shrinking restores

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -708,8 +708,9 @@ func diskfulOf(reps []miroirv1alpha1.Replica) []miroirv1alpha1.Replica {
 // a different diskful count than the source volume had (issue #305).
 // Growing appends freshly placed FullSync joiners — their content
 // arrives over the wire, so unlike the CoW legs they may land anywhere
-// the pool reaches. Shrinking keeps a subset of the source legs, seed
-// first, Done legs preferred. The source tie-breaker (if any) is
+// the pool reaches. Shrinking keeps a subset of the source legs, including
+// the scheduler-selected completed leg when topology is constrained, then
+// seed first and Done legs preferred. The source tie-breaker (if any) is
 // discarded and re-derived for the final shape, and node ids are
 // re-numbered around the preserved legs — a leg cloning DRBD metadata
 // keeps the id that metadata is keyed by, everything else takes the
@@ -720,7 +721,21 @@ func (c *Controller) reshapeRestore(ctx context.Context, nodes nodemap.Map, reqs
 	diskful := diskfulOf(base)
 	switch {
 	case len(diskful) > target:
-		diskful = keepRestoreLegs(diskful, target)
+		pin := ""
+		if !remoteAccess {
+			pin = selectedTopologyNode(reqs)
+			if reqs != nil && len(reqs.GetRequisite()) > 0 && pin == "" {
+				return nil, status.Error(codes.ResourceExhausted,
+					"no complete source snapshot leg satisfies the requested topology")
+			}
+			if pin != "" && !slices.ContainsFunc(diskful, func(rep miroirv1alpha1.Replica) bool {
+				return rep.Node == pin && !rep.FullSync
+			}) {
+				return nil, status.Errorf(codes.ResourceExhausted,
+					"no complete source snapshot leg exists on topology node %q", pin)
+			}
+		}
+		diskful = keepRestoreLegs(diskful, target, pin)
 	case len(diskful) < target:
 		excluded := map[string]bool{}
 		for _, rep := range diskful {
@@ -769,22 +784,47 @@ func (c *Controller) reshapeRestore(ctx context.Context, nodes nodemap.Map, reqs
 	return c.withTieBreaker(ctx, nodes, diskful, target, quorum)
 }
 
-// keepRestoreLegs selects target legs from the source's diskful layout:
-// the seed (first diskful — the clone's sync source, already validated
-// complete by restoreReplicas) stays first, then the remaining legs in
-// order with Done legs before FullSync ones — dropping a Done leg while
-// keeping a FullSync one would trade a free CoW clone for a full resync.
-func keepRestoreLegs(diskful []miroirv1alpha1.Replica, target int) []miroirv1alpha1.Replica {
+// keepRestoreLegs selects target legs from the source's diskful layout.
+// A pinned completed leg is guaranteed inclusion; for an unreplicated
+// target it replaces the source seed, which no longer has a DRBD generation
+// to bootstrap. Replicated targets keep the seed first, then the pin, then
+// the remaining legs in order with Done before FullSync.
+func keepRestoreLegs(diskful []miroirv1alpha1.Replica, target int, pin string) []miroirv1alpha1.Replica {
 	kept := make([]miroirv1alpha1.Replica, 0, target)
 	kept = append(kept, diskful[0])
+	if pin != "" {
+		pinned := diskful[slices.IndexFunc(diskful, func(rep miroirv1alpha1.Replica) bool {
+			return rep.Node == pin
+		})]
+		if target == 1 {
+			return []miroirv1alpha1.Replica{pinned}
+		}
+		if pin != diskful[0].Node {
+			kept = append(kept, pinned)
+		}
+	}
 	for _, fullSync := range []bool{false, true} {
 		for _, rep := range diskful[1:] {
-			if rep.FullSync == fullSync && len(kept) < target {
+			if rep.Node != pin && rep.FullSync == fullSync && len(kept) < target {
 				kept = append(kept, rep)
 			}
 		}
 	}
 	return kept
+}
+
+// selectedTopologyNode returns the scheduler-selected node from a
+// WaitForFirstConsumer request. The provisioner puts it first in preferred;
+// strict-topology requests also carry it as the sole requisite entry.
+func selectedTopologyNode(reqs *csi.TopologyRequirement) string {
+	for _, tops := range [][]*csi.Topology{reqs.GetPreferred(), reqs.GetRequisite()} {
+		for _, top := range tops {
+			if node := top.GetSegments()[constants.TopologyKey]; node != "" {
+				return node
+			}
+		}
+	}
+	return ""
 }
 
 // spreadByZone selects count nodes from ordered (already ranked by topology

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1205,6 +1205,73 @@ func TestCreateVolumeRestoreShrinksToUnreplicated(t *testing.T) {
 	}
 }
 
+func TestCreateVolumeRestoreShrinkHonorsSelectedTopology(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1, Address: staleAddrB},
+			},
+		},
+	}
+	c := reshapeController(t, srcVol)
+	req := restoreReq("1")
+	req.AccessibilityRequirements = topologyReq(nodeB)
+
+	resp, err := c.CreateVolume(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Spec.Replicas) != 1 || got.Spec.Replicas[0].Node != nodeB {
+		t.Fatalf("the selected node's snapshot leg must be retained: %+v", got.Spec.Replicas)
+	}
+	if top := resp.Volume.AccessibleTopology; len(top) != 1 || top[0].GetSegments()[constants.TopologyKey] != nodeB {
+		t.Fatalf("the restored PV must stay accessible on the selected node: %+v", top)
+	}
+}
+
+func TestCreateVolumeRestoreShrinkRefusesSelectedIncompleteLeg(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1, Address: staleAddrB},
+			},
+		},
+	}
+	c := reshapeController(t, srcVol)
+	snap := &miroirv1alpha1.MiroirSnapshot{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, snap); err != nil {
+		t.Fatal(err)
+	}
+	delete(snap.Status.PerNode, nodeB)
+	if err := c.Client.Status().Update(t.Context(), snap); err != nil {
+		t.Fatal(err)
+	}
+	req := restoreReq("1")
+	req.AccessibilityRequirements = topologyReq(nodeB)
+
+	_, err := c.CreateVolume(t.Context(), req)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("an incomplete selected leg must be ResourceExhausted, got %v", err)
+	}
+	if !strings.Contains(err.Error(), nodeB) {
+		t.Fatalf("the refusal must name the selected node: %v", err)
+	}
+}
+
 // Shrinking keeps Done legs over post-snapshot FullSync ones — dropping
 // a free CoW clone while keeping a leg that must full-resync would be
 // pure waste — and the re-derived tie-breaker takes the smallest unused

--- a/test/e2e/replicashape_test.go
+++ b/test/e2e/replicashape_test.go
@@ -93,6 +93,10 @@ var _ = Describe("restore replica reshape", Ordered, func() {
 		Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
 		Expect(v.Spec.DRBD).To(BeNil(), "shrunk restore must be unreplicated")
 		Expect(v.Spec.Replicas).To(HaveLen(1))
+		var reader corev1.Pod
+		Expect(k8s.Get(ctx, client.ObjectKey{Namespace: ns, Name: "shape-down-reader"}, &reader)).To(Succeed())
+		Expect(v.Spec.Replicas[0].Node).To(Equal(reader.Spec.NodeName),
+			"shrunk restore must retain the snapshot leg selected for its consumer")
 
 		Expect(sha(ns, "shape-down-reader", "/data/seed")).To(Equal(downSum))
 	})


### PR DESCRIPTION
## Summary

- retain the completed snapshot leg selected by WaitForFirstConsumer when shrinking a restore
- return ResourceExhausted when the selected node has no completed snapshot leg
- cover selected-node affinity in unit and hardware E2E tests

## Testing

- mise run lint
- mise run test
- mise run test-integration