### PR TITLE
test(e2e): expand storage conformance coverage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -71,8 +71,10 @@ jobs:
       # tag, so the host:port push form would parse wrong there.
       CONTROLLER_IMAGE: registry.e2e/miroir-controller:e2e
       AGENT_IMAGE: registry.e2e/miroir-agent:e2e
+      GATEWAY_IMAGE: registry.e2e/miroir-gateway:e2e
       PUSH_CONTROLLER_IMAGE: localhost:5000/miroir-controller:e2e
       PUSH_AGENT_IMAGE: localhost:5000/miroir-agent:e2e
+      PUSH_GATEWAY_IMAGE: localhost:5000/miroir-gateway:e2e
       # test.sh packages the chart, pushes it here, and installs it back over OCI, so
       # the run exercises the distributed artifact rather than the working tree.
       CHART_REGISTRY: oci://localhost:5000/charts
@@ -172,6 +174,20 @@ jobs:
           cache-to: ${{ matrix.suite == 'replicated' && 'type=gha,mode=max,scope=e2e-agent' || '' }}
 
       - wait: [cluster, controller-image, agent-image]
+
+      # Only the RWX lane needs the gateway target. Build it after the agent so
+      # Buildx can reuse the agent stage that the gateway extends.
+      - name: Build gateway image
+        if: matrix.gateway == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          target: gateway
+          tags: ${{ env.PUSH_GATEWAY_IMAGE }}
+          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
+          cache-from: type=gha,scope=e2e-gateway
+          cache-to: type=gha,mode=max,scope=e2e-gateway
 
       - name: Cache conformance test binaries
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,6 +50,19 @@ jobs:
             testdriver: testdriver.yaml
           - suite: zfs
             testdriver: testdriver-zfs.yaml
+          # Filesystem-only multi-node access through the NFS gateway. Keeping this
+          # separate avoids advertising unsupported raw-block RWX.
+          - suite: rwx
+            testdriver: testdriver-rwx.yaml
+            gateway: "true"
+            focus: "miroir.home-operations.com.*(ROX mode|concurrently access the single volume from pods on different node)"
+          # Serial specs need exclusive use of their cluster. The focus keeps this
+          # lane on upstream [Serial] coverage instead of replaying the parallel set.
+          - suite: serial
+            testdriver: testdriver.yaml
+            procs: "1"
+            focus: 'miroir.home-operations.com.*\[Serial\]'
+            skip: '\[Disruptive\]|should not mount / map unused volumes'
     env:
       # Two names for one image in the runner-local registry. The nodes pull
       # registry.e2e, which the Talos mirror in patches/registry.yaml points at the
@@ -171,11 +184,15 @@ jobs:
         env:
           TESTDRIVER: ${{ matrix.testdriver }}
           RUN_SPECS: ${{ matrix.specs }}
+          GATEWAY_ENABLED: ${{ matrix.gateway || 'false' }}
+          STORAGE_CAPACITY_ENABLED: "true"
           CLUSTER_NAME: ${{ steps.cluster.outputs.cluster-name }}
           ENDPOINT: ${{ steps.cluster.outputs.endpoint }}
           KUBECONFIG: ${{ steps.cluster.outputs.kubeconfig }}
           TALOSCONFIG: ${{ steps.cluster.outputs.talosconfig }}
-          PROCS: "4"
+          PROCS: ${{ matrix.procs || '4' }}
+          FOCUS: ${{ matrix.focus }}
+          SKIP: ${{ matrix.skip }}
           VERBOSE: "1"
 
       - name: Diagnostics

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,8 @@ RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     nfs-ganesha \
     nfs-ganesha-vfs && \
+    # Docker synthesizes this link at runtime, but containerd expects it in
+    # the image. The VFS FSAL cannot discover mounted exports without it.
+    rm -f /etc/mtab && \
+    ln -s /proc/mounts /etc/mtab && \
     rm -rf /var/lib/apt/lists/*

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1530,7 +1530,8 @@ func orphanHoldFixture(t *testing.T, procDir string) (*VolumeReconciler, *fakeBa
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
 	fe := &fakeDRBDExec{
 		statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
-			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],"connections":[]}]`,
+			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
 		errOn: map[string]error{cmdDownPvc1: errors.New(heldOpenWithOpeners)},
 	}
 	rec := events.NewFakeRecorder(8)
@@ -1580,6 +1581,7 @@ func TestReconcileTeardownOrphanHoldReclaims(t *testing.T) {
 		t.Fatalf("the reclaim cycle must complete teardown: %v", err)
 	}
 	fe.calledWith(t, "drbdsetup detach 1422 --force")
+	fe.calledWith(t, "drbdsetup del-peer pvc-1 1")
 	fe.notCalledWith(t, "wipe-md")
 	if fb.existing[volPvc1] {
 		t.Fatal("the backing device must be destroyed by the reclaim")

--- a/internal/csi/groupcontroller.go
+++ b/internal/csi/groupcontroller.go
@@ -47,8 +47,7 @@ func (c *Controller) GroupControllerGetCapabilities(_ context.Context, _ *csi.Gr
 
 // CreateVolumeGroupSnapshot provisions one MiroirSnapshot per source
 // volume plus the MiroirSnapshotGroup that cuts them under one shared
-// write barrier, and reports readiness as-is: the external-snapshotter
-// polls until ready_to_use. Idempotent by name.
+// write barrier. Idempotent by name.
 func (c *Controller) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.CreateVolumeGroupSnapshotRequest) (*csi.CreateVolumeGroupSnapshotResponse, error) {
 	if req.GetName() == "" || len(req.GetSourceVolumeIds()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "group snapshot name and source volumes are required")
@@ -138,7 +137,14 @@ func (c *Controller) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.Cre
 		}
 		grp = existing
 	}
-	return &csi.CreateVolumeGroupSnapshotResponse{GroupSnapshot: csiGroupSnapshot(grp, snaps, vols)}, nil
+	result := csiGroupSnapshot(grp, snaps, vols)
+	if !result.GetReadyToUse() {
+		// external-snapshotter records member readiness only from the
+		// successful Create response; keep the operation pending until it
+		// can persist a complete, usable member set.
+		return nil, status.Errorf(codes.Aborted, "group snapshot %s is not ready", grp.Name)
+	}
+	return &csi.CreateVolumeGroupSnapshotResponse{GroupSnapshot: result}, nil
 }
 
 // refuseMemberMismatch fails fast when the named group already exists

--- a/internal/csi/groupcontroller_test.go
+++ b/internal/csi/groupcontroller_test.go
@@ -63,23 +63,11 @@ func TestCreateVolumeGroupSnapshotCreatesMembersAndGroup(t *testing.T) {
 	c := &Controller{Client: cl}
 
 	// Deliberately unsorted: member order must not depend on it.
-	resp, err := c.CreateVolumeGroupSnapshot(t.Context(), &csi.CreateVolumeGroupSnapshotRequest{
+	_, err := c.CreateVolumeGroupSnapshot(t.Context(), &csi.CreateVolumeGroupSnapshotRequest{
 		Name: groupGsnap1, SourceVolumeIds: []string{volSrc, volPvc1},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	gs := resp.GetGroupSnapshot()
-	if gs.GetGroupSnapshotId() != groupGsnap1 || gs.GetReadyToUse() {
-		t.Fatalf("fresh group must report not ready under its id: %+v", gs)
-	}
-	if len(gs.GetSnapshots()) != 2 {
-		t.Fatalf("want 2 member snapshots, got %+v", gs.GetSnapshots())
-	}
-	for _, m := range gs.GetSnapshots() {
-		if m.GetGroupSnapshotId() != groupGsnap1 {
-			t.Fatalf("members must carry the group id: %+v", m)
-		}
+	if status.Code(err) != codes.Aborted {
+		t.Fatalf("fresh group must remain pending, got %v", err)
 	}
 
 	grp := &miroirv1alpha1.MiroirSnapshotGroup{}
@@ -118,14 +106,40 @@ func TestCreateVolumeGroupSnapshotIdempotent(t *testing.T) {
 		Name: groupGsnap1, SourceVolumeIds: []string{volSrc, volPvc1},
 	}
 
-	if _, err := c.CreateVolumeGroupSnapshot(t.Context(), req); err != nil {
-		t.Fatal(err)
+	if _, err := c.CreateVolumeGroupSnapshot(t.Context(), req); status.Code(err) != codes.Aborted {
+		t.Fatalf("fresh group must remain pending, got %v", err)
 	}
-	if _, err := c.CreateVolumeGroupSnapshot(t.Context(), req); err != nil {
-		t.Fatalf("identical retry must succeed: %v", err)
+	if _, err := c.CreateVolumeGroupSnapshot(t.Context(), req); status.Code(err) != codes.Aborted {
+		t.Fatalf("identical pending retry must remain pending, got %v", err)
 	}
 
-	_, err := c.CreateVolumeGroupSnapshot(t.Context(), &csi.CreateVolumeGroupSnapshotRequest{
+	grp := &miroirv1alpha1.MiroirSnapshotGroup{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: groupGsnap1}, grp); err != nil {
+		t.Fatal(err)
+	}
+	grp.Status.ReadyToUse = true
+	if err := cl.Status().Update(t.Context(), grp); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range grp.Spec.SnapshotNames {
+		snap := &miroirv1alpha1.MiroirSnapshot{}
+		if err := cl.Get(t.Context(), types.NamespacedName{Name: name}, snap); err != nil {
+			t.Fatal(err)
+		}
+		snap.Status.ReadyToUse = true
+		if err := cl.Status().Update(t.Context(), snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	resp, err := c.CreateVolumeGroupSnapshot(t.Context(), req)
+	if err != nil {
+		t.Fatalf("ready identical retry must succeed: %v", err)
+	}
+	if !resp.GetGroupSnapshot().GetReadyToUse() || len(resp.GetGroupSnapshot().GetSnapshots()) != 2 {
+		t.Fatalf("ready retry must return every usable member: %+v", resp.GetGroupSnapshot())
+	}
+
+	_, err = c.CreateVolumeGroupSnapshot(t.Context(), &csi.CreateVolumeGroupSnapshotRequest{
 		Name: groupGsnap1, SourceVolumeIds: []string{volSrc},
 	})
 	if status.Code(err) != codes.AlreadyExists {

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -1077,8 +1077,10 @@ func (d *Driver) Restart(ctx context.Context, name string) error {
 // keep the minor assignment (see RemoveConfig): the kernel minor stays
 // pinned until a reboot, releasing the number would hand it to a new
 // volume, and the startup orphan sweep reaps it once the reboot clears
-// the state. Already-detached (Diskless) and not-in-kernel are
-// no-ops so a retry after a failed backing delete converges. A resource
+// the state. Remaining peer connections are removed after the detach so
+// the zombie resource releases its replication port. Already-detached
+// resources still shed those connections, while not-in-kernel resources
+// are no-ops so a retry after a failed backing delete converges. A resource
 // wearing the teardown wedge signature is refused like everywhere else —
 // mid-detach is exactly the state a second detach would race.
 func (d *Driver) ForceDetach(ctx context.Context, name string, minor int32) error {
@@ -1093,14 +1095,19 @@ func (d *Driver) ForceDetach(ctx context.Context, name string, minor int32) erro
 		if res.wedgeSignature() {
 			return fmt.Errorf("force-detach %s: %w", name, ErrWedged)
 		}
-		if len(res.Devices) == 0 || res.Devices[0].DiskState == DiskDiskless {
-			return nil
-		}
-		if err := d.disconnectPeers(ctx, name, res.peerIDs()); err != nil {
+		peerIDs := res.peerIDs()
+		if err := d.disconnectPeers(ctx, name, peerIDs); err != nil {
 			return err
 		}
-		if _, err := d.Exec(ctx, "drbdsetup", "detach", strconv.Itoa(int(minor)), "--force"); err != nil {
-			return fmt.Errorf("force-detach %s: %w", name, err)
+		if len(res.Devices) > 0 && res.Devices[0].DiskState != DiskDiskless {
+			if _, err := d.Exec(ctx, "drbdsetup", "detach", strconv.Itoa(int(minor)), "--force"); err != nil {
+				return fmt.Errorf("force-detach %s: %w", name, err)
+			}
+		}
+		for _, id := range peerIDs {
+			if _, err := d.Exec(ctx, "drbdsetup", "del-peer", name, strconv.Itoa(int(id))); err != nil {
+				return fmt.Errorf("remove %s peer %d: %w", name, id, err)
+			}
 		}
 		return nil
 	}

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1216,10 +1216,11 @@ func TestMetadataAdoptedTracksMarker(t *testing.T) {
 	}
 }
 
-// ForceDetach disconnects the peers, then force-detaches the backing by
-// minor — the escape hatch for a deletion whose down is permanently
-// refused by an orphaned opener (issue #319). No down is spawned and the
-// rendered config survives: the caller keeps the zombie minor reserved
+// ForceDetach disconnects the peers, force-detaches the backing by minor,
+// then removes the peer definitions. It is the escape hatch for a deletion
+// whose down is permanently refused by an orphaned opener (issue #319).
+// No down is spawned and the rendered config survives: the caller keeps
+// the zombie minor reserved
 // until the post-reboot orphan sweep reaps it.
 func TestForceDetachDisconnectsAndDetaches(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{
@@ -1237,6 +1238,7 @@ func TestForceDetachDisconnectsAndDetaches(t *testing.T) {
 	}
 	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
 	fe.calledWith(t, "drbdsetup detach 1422 --force")
+	fe.calledWith(t, "drbdsetup del-peer pvc-1 1")
 	fe.notCalledWith(t, "drbdsetup down")
 	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
 		t.Fatalf("rendered config must survive a force-detach: %v", err)
@@ -1261,6 +1263,24 @@ func TestForceDetachAlreadyDisklessNoop(t *testing.T) {
 	if err := d.ForceDetach(t.Context(), volPvc1, 1422); err != nil {
 		t.Fatal(err)
 	}
+	fe.notCalledWith(t, "drbdsetup detach")
+}
+
+// A retry after the backing was detached must still remove connections
+// that reserve the deleted volume's endpoint in the kernel.
+func TestForceDetachDisklessRemovesPeers(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Primary",
+			"devices":[{"disk-state":"Diskless"}],
+			"connections":[{"peer-node-id":1,"connection-state":"StandAlone"}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.ForceDetach(t.Context(), volPvc1, 1422); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
+	fe.calledWith(t, "drbdsetup del-peer pvc-1 1")
 	fe.notCalledWith(t, "drbdsetup detach")
 }
 

--- a/internal/gateway/ganesha.go
+++ b/internal/gateway/ganesha.go
@@ -50,6 +50,7 @@ var ganeshaTemplate = template.Must(template.New("ganesha.conf").Parse(
 	NFS_Port = {{.Port}};
 	Protocols = 4;
 	Enable_UDP = false;
+	Enable_RQUOTA = false;
 }
 
 NFSv4 {

--- a/internal/gateway/ganesha.go
+++ b/internal/gateway/ganesha.go
@@ -49,6 +49,7 @@ var ganeshaTemplate = template.Must(template.New("ganesha.conf").Parse(
 	`NFS_CORE_PARAM {
 	NFS_Port = {{.Port}};
 	Protocols = 4;
+	Enable_UDP = false;
 }
 
 NFSv4 {

--- a/internal/gateway/ganesha_test.go
+++ b/internal/gateway/ganesha_test.go
@@ -36,6 +36,7 @@ func TestRenderGanesha(t *testing.T) {
 	for _, want := range []string{
 		"NFS_Port = 2049;",
 		"Protocols = 4;",
+		"Enable_UDP = false;",
 		"RecoveryBackend = fs;",
 		"RecoveryRoot = /export/pvc-abc/.ganesha-recovery;",
 		"Grace_Period = 60;",

--- a/internal/gateway/ganesha_test.go
+++ b/internal/gateway/ganesha_test.go
@@ -37,6 +37,7 @@ func TestRenderGanesha(t *testing.T) {
 		"NFS_Port = 2049;",
 		"Protocols = 4;",
 		"Enable_UDP = false;",
+		"Enable_RQUOTA = false;",
 		"RecoveryBackend = fs;",
 		"RecoveryRoot = /export/pvc-abc/.ganesha-recovery;",
 		"Grace_Period = 60;",

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -90,6 +90,7 @@ func (c *Config) withDefaults() {
 
 const (
 	ganeshaPort   = 2049
+	ganeshaPID    = "/run/ganesha.pid"
 	gracePeriod   = 60
 	leaseLifetime = 30
 )
@@ -181,7 +182,7 @@ func writeGaneshaConf(cfg Config, mountPath string) error {
 // the fs grow). It returns nil on a clean ctx-cancelled stop and an error
 // if ganesha exits on its own — a dead server must restart the pod.
 func supervise(ctx context.Context, mounter *mount.SafeFormatAndMount, cfg Config, dev, mountPath string, h *health, healthErr <-chan error, log logr.Logger) error {
-	cmd := exec.Command(ganeshaBin, "-F", "-f", cfg.GaneshaConf, "-N", "NIV_EVENT")
+	cmd := exec.Command(ganeshaBin, "-F", "-p", ganeshaPID, "-L", "STDOUT", "-f", cfg.GaneshaConf, "-N", "NIV_EVENT")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/internal/gateway/supervise_test.go
+++ b/internal/gateway/supervise_test.go
@@ -70,12 +70,14 @@ func superviseCfg() (Config, *mount.SafeFormatAndMount) {
 // A ganesha that exits on its own must surface an error: a dead server
 // restarts the pod, silence would leave every NFS client hanging.
 func TestSuperviseFailsWhenGaneshaExits(t *testing.T) {
-	stubGanesha(t, "exit 3")
+	stubGanesha(t, `test "$*" = "-F -p /run/ganesha.pid -L STDOUT -f /etc/ganesha/ganesha.conf -N NIV_EVENT" || exit 4
+exit 3`)
 	cfg, m := superviseCfg()
+	cfg.GaneshaConf = "/etc/ganesha/ganesha.conf"
 
 	err := supervise(t.Context(), m, cfg, "/dev/null", t.TempDir(), &health{},
 		make(chan error), logr.Discard())
-	if err == nil || !strings.Contains(err.Error(), "ganesha exited") {
+	if err == nil || !strings.Contains(err.Error(), "ganesha exited: exit status 3") {
 		t.Fatalf("self-exit must error, got %v", err)
 	}
 }

--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -193,9 +193,6 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 			return status.Errorf(codes.DataLoss,
 				"volume %s was formatted before but %s reads blank — refusing to reformat", vol.Name, dev)
 		}
-		if err := renewCloneXFSUUID(ctx, d, vol, dev, format); err != nil {
-			return err
-		}
 		if format != "" {
 			// Record before mounting so a clone that arrived with a
 			// filesystem is protected from then on.
@@ -206,7 +203,7 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 
 		// FormatAndMount formats only when the device has no filesystem —
 		// the mkfs-if-blank step.
-		if err := d.Mounter.FormatAndMount(dev, target, fsType, flags); err != nil {
+		if err := d.Mounter.FormatAndMount(dev, target, fsType, xfsCloneMountFlags(vol, format, flags)); err != nil {
 			if rerr := recoverFrozenBdev(ctx, d, vol, dev, err); rerr != nil {
 				return rerr
 			}
@@ -254,17 +251,13 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 }
 
 // XFS refuses to mount a snapshot-derived filesystem while its source with
-// the same UUID is mounted on the node. Renew the clone before its first
-// successful stage; retries before Activated may safely renew it again.
-func renewCloneXFSUUID(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVolume, dev, format string) error {
-	if format != "xfs" || vol.Spec.Source == nil || vol.Status.Activated {
-		return nil
+// the same on-disk UUID is mounted on the node. nouuid gives each mount an
+// in-memory identity without mutating the crash-consistent snapshot image.
+func xfsCloneMountFlags(vol *miroirv1alpha1.MiroirVolume, format string, flags []string) []string {
+	if format != "xfs" || vol.Spec.Source == nil || slices.Contains(flags, "nouuid") {
+		return flags
 	}
-	out, err := d.Mounter.Exec.CommandContext(ctx, "xfs_admin", "-U", "generate", dev).CombinedOutput()
-	if err != nil {
-		return status.Errorf(codes.Internal, "renew XFS UUID on %s: %v: %s", dev, err, strings.TrimSpace(string(out)))
-	}
-	return nil
+	return append(slices.Clone(flags), "nouuid")
 }
 
 // resourceRestarter is the optional Deps.DRBD upgrade the frozen-bdev

--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -193,6 +193,9 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 			return status.Errorf(codes.DataLoss,
 				"volume %s was formatted before but %s reads blank — refusing to reformat", vol.Name, dev)
 		}
+		if err := renewCloneXFSUUID(ctx, d, vol, dev, format); err != nil {
+			return err
+		}
 		if format != "" {
 			// Record before mounting so a clone that arrived with a
 			// filesystem is protected from then on.
@@ -246,6 +249,20 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 	// auto-recovery.
 	if err := MarkActivated(ctx, d.Client, vol); err != nil {
 		return status.Errorf(codes.Internal, "record activated flag: %v", err)
+	}
+	return nil
+}
+
+// XFS refuses to mount a snapshot-derived filesystem while its source with
+// the same UUID is mounted on the node. Renew the clone before its first
+// successful stage; retries before Activated may safely renew it again.
+func renewCloneXFSUUID(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVolume, dev, format string) error {
+	if format != "xfs" || vol.Spec.Source == nil || vol.Status.Activated {
+		return nil
+	}
+	out, err := d.Mounter.Exec.CommandContext(ctx, "xfs_admin", "-U", "generate", dev).CombinedOutput()
+	if err != nil {
+		return status.Errorf(codes.Internal, "renew XFS UUID on %s: %v: %s", dev, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/internal/stage/stage_test.go
+++ b/internal/stage/stage_test.go
@@ -24,6 +24,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	mount "k8s.io/mount-utils"
+	utilexec "k8s.io/utils/exec"
+	testingexec "k8s.io/utils/exec/testing"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 	"github.com/home-operations/miroir/internal/drbd"
@@ -111,5 +114,42 @@ func TestRecoverFrozenBdevNeedsRestarter(t *testing.T) {
 	err := recoverFrozenBdev(t.Context(), Deps{DRBD: statusOnlyDRBD{}}, replicatedVolume(), "/dev/drbd1378", errFrozenMount)
 	if err != nil {
 		t.Fatalf("a status-only DRBD dep must fall through to the generic wrap, got %v", err)
+	}
+}
+
+func TestRenewCloneXFSUUID(t *testing.T) {
+	fakeExec := &testingexec.FakeExec{
+		ExactOrder: true,
+		CommandScript: []testingexec.FakeCommandAction{func(_ string, _ ...string) utilexec.Cmd {
+			return testingexec.InitFakeCmd(&testingexec.FakeCmd{CombinedOutputScript: []testingexec.FakeAction{
+				func() ([]byte, []byte, error) { return nil, nil, nil },
+			}}, "xfs_admin", "-U", "generate", "/dev/drbd1001")
+		}},
+	}
+	vol := replicatedVolume()
+	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-1"}
+	d := Deps{Mounter: mount.NewSafeFormatAndMount(nil, fakeExec)}
+	if err := renewCloneXFSUUID(t.Context(), d, vol, "/dev/drbd1001", "xfs"); err != nil {
+		t.Fatal(err)
+	}
+	if fakeExec.CommandCalls != 1 {
+		t.Fatalf("expected one xfs_admin call, got %d", fakeExec.CommandCalls)
+	}
+}
+
+func TestRenewCloneXFSUUIDSkipsNonCloneAndActivated(t *testing.T) {
+	fakeExec := &testingexec.FakeExec{}
+	d := Deps{Mounter: mount.NewSafeFormatAndMount(nil, fakeExec)}
+	vol := replicatedVolume()
+	if err := renewCloneXFSUUID(t.Context(), d, vol, "/dev/drbd1001", "xfs"); err != nil {
+		t.Fatal(err)
+	}
+	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-1"}
+	vol.Status.Activated = true
+	if err := renewCloneXFSUUID(t.Context(), d, vol, "/dev/drbd1001", "xfs"); err != nil {
+		t.Fatal(err)
+	}
+	if fakeExec.CommandCalls != 0 {
+		t.Fatalf("xfs_admin must not run, got %d calls", fakeExec.CommandCalls)
 	}
 }

--- a/internal/stage/stage_test.go
+++ b/internal/stage/stage_test.go
@@ -19,14 +19,12 @@ package stage
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	mount "k8s.io/mount-utils"
-	utilexec "k8s.io/utils/exec"
-	testingexec "k8s.io/utils/exec/testing"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 	"github.com/home-operations/miroir/internal/drbd"
@@ -117,39 +115,32 @@ func TestRecoverFrozenBdevNeedsRestarter(t *testing.T) {
 	}
 }
 
-func TestRenewCloneXFSUUID(t *testing.T) {
-	fakeExec := &testingexec.FakeExec{
-		ExactOrder: true,
-		CommandScript: []testingexec.FakeCommandAction{func(_ string, _ ...string) utilexec.Cmd {
-			return testingexec.InitFakeCmd(&testingexec.FakeCmd{CombinedOutputScript: []testingexec.FakeAction{
-				func() ([]byte, []byte, error) { return nil, nil, nil },
-			}}, "xfs_admin", "-U", "generate", "/dev/drbd1001")
-		}},
-	}
+func TestXFSCloneMountFlags(t *testing.T) {
+	const noatime = "noatime"
 	vol := replicatedVolume()
 	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-1"}
-	d := Deps{Mounter: mount.NewSafeFormatAndMount(nil, fakeExec)}
-	if err := renewCloneXFSUUID(t.Context(), d, vol, "/dev/drbd1001", "xfs"); err != nil {
-		t.Fatal(err)
+	original := []string{noatime}
+	got := xfsCloneMountFlags(vol, "xfs", original)
+	if !slices.Equal(got, []string{noatime, "nouuid"}) {
+		t.Fatalf("flags = %v, want noatime,nouuid", got)
 	}
-	if fakeExec.CommandCalls != 1 {
-		t.Fatalf("expected one xfs_admin call, got %d", fakeExec.CommandCalls)
+	if !slices.Equal(original, []string{noatime}) {
+		t.Fatalf("input flags were mutated: %v", original)
 	}
 }
 
-func TestRenewCloneXFSUUIDSkipsNonCloneAndActivated(t *testing.T) {
-	fakeExec := &testingexec.FakeExec{}
-	d := Deps{Mounter: mount.NewSafeFormatAndMount(nil, fakeExec)}
+func TestXFSCloneMountFlagsSkipsOtherFilesystemsAndSources(t *testing.T) {
 	vol := replicatedVolume()
-	if err := renewCloneXFSUUID(t.Context(), d, vol, "/dev/drbd1001", "xfs"); err != nil {
-		t.Fatal(err)
+	flags := []string{"relatime"}
+	if got := xfsCloneMountFlags(vol, "xfs", flags); !slices.Equal(got, flags) {
+		t.Fatalf("non-clone flags = %v, want %v", got, flags)
 	}
 	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-1"}
-	vol.Status.Activated = true
-	if err := renewCloneXFSUUID(t.Context(), d, vol, "/dev/drbd1001", "xfs"); err != nil {
-		t.Fatal(err)
+	if got := xfsCloneMountFlags(vol, "ext4", flags); !slices.Equal(got, flags) {
+		t.Fatalf("ext4 clone flags = %v, want %v", got, flags)
 	}
-	if fakeExec.CommandCalls != 0 {
-		t.Fatalf("xfs_admin must not run, got %d calls", fakeExec.CommandCalls)
+	withNoUUID := []string{"nouuid"}
+	if got := xfsCloneMountFlags(vol, "xfs", withNoUUID); !slices.Equal(got, withNoUUID) {
+		t.Fatalf("existing nouuid flags = %v, want %v", got, withNoUUID)
 	}
 }

--- a/test/conformance/run.sh
+++ b/test/conformance/run.sh
@@ -3,10 +3,11 @@
 # cluster kubectl currently points at, using testdriver.yaml.
 #
 #   ./test/conformance/run.sh                 # parallel-safe set
-#   SKIP='\[Disruptive\]' ./run.sh PROCS=1    # include [Serial] specs
+#   SKIP='\[Disruptive\]' PROCS=1 ./run.sh    # include [Serial] specs
 #   FOCUS='.*snapshot.*' ./run.sh             # narrow down
 #   TESTDRIVER=testdriver-local.yaml ./run.sh # miroir-local (lvmthin)
 #   TESTDRIVER=testdriver-zfs.yaml ./run.sh   # miroir-zfs (replicated zfs)
+#   TESTDRIVER=testdriver-rwx.yaml ./run.sh   # filesystem-only RWX/ROX
 #   VERBOSE=1 ./run.sh                        # per-spec live output
 #
 # The e2e.test/ginkgo binaries are fetched to match the server version
@@ -35,7 +36,7 @@ PROCS=${PROCS:-4}
 mkdir -p report
 
 exec "$bin/ginkgo" -procs="$PROCS" ${VERBOSE:+-v} \
-    -focus="$FOCUS" -skip="$SKIP" -timeout=3h \
+    -focus="$FOCUS" -skip="$SKIP" -fail-on-empty -timeout=3h \
     "$bin/e2e.test" -- \
     -storage.testdriver="$PWD/$TESTDRIVER" \
     -kubeconfig="$KUBECONFIG" \

--- a/test/conformance/testdriver-local.yaml
+++ b/test/conformance/testdriver-local.yaml
@@ -11,6 +11,11 @@ DriverInfo:
     Max: 10Gi
   SupportedFsType:
     ext4: {}
+    xfs: {}
+  SupportedMountOption:
+    noatime: {}
+  TopologyKeys:
+    - miroir.home-operations.com/node
   Capabilities:
     persistence: true
     block: true
@@ -27,5 +32,6 @@ DriverInfo:
     singleNodeVolume: true
     # RWX needs the replicated (DRBD) path; the local driver can't exercise it.
     RWX: false
+    multiplePVsSameID: true
     readWriteOncePod: true
-    capacity: false
+    capacity: true

--- a/test/conformance/testdriver-rwx.yaml
+++ b/test/conformance/testdriver-rwx.yaml
@@ -1,10 +1,8 @@
-# Driver definition for the upstream Kubernetes external-storage e2e
-# suite (test/e2e/storage/external). Run via ./run.sh.
-#
-# Drives the replicated zfs class (pool: zfs, replicas: 2), so DRBD pairs
-# a zvol with a zvol -- the zfs analogue of testdriver.yaml.
+# Driver definition for the upstream Kubernetes external-storage e2e suite's
+# filesystem-only multi-node tests. The replicated LVM-thin class is exported
+# through Miroir's NFS gateway; raw-block RWX is intentionally not advertised.
 StorageClass:
-  FromExistingClassName: miroir-zfs
+  FromExistingClassName: miroir-replicated
 SnapshotClass:
   FromExistingClassName: miroir-snap
 GroupSnapshotClass:
@@ -23,7 +21,7 @@ DriverInfo:
     - miroir.home-operations.com/node
   Capabilities:
     persistence: true
-    block: true
+    block: false
     exec: true
     fsGroup: true
     multipods: true
@@ -36,9 +34,8 @@ DriverInfo:
     pvcDataSource: true
     topology: true
     singleNodeVolume: false
-    # The filesystem-only testdriver-rwx.yaml covers multi-node access without
-    # also enabling unsupported raw-block RWX patterns in this block-capable run.
-    RWX: false
+    RWX: true
+    capReadOnlyMany: true
     multiplePVsSameID: true
     readWriteOncePod: true
     capacity: true

--- a/test/conformance/testdriver-rwx.yaml
+++ b/test/conformance/testdriver-rwx.yaml
@@ -17,8 +17,6 @@ DriverInfo:
     xfs: {}
   SupportedMountOption:
     noatime: {}
-  TopologyKeys:
-    - miroir.home-operations.com/node
   Capabilities:
     persistence: true
     block: false

--- a/test/conformance/testdriver-zfs.yaml
+++ b/test/conformance/testdriver-zfs.yaml
@@ -19,8 +19,6 @@ DriverInfo:
     xfs: {}
   SupportedMountOption:
     noatime: {}
-  TopologyKeys:
-    - miroir.home-operations.com/node
   Capabilities:
     persistence: true
     block: true

--- a/test/conformance/testdriver.yaml
+++ b/test/conformance/testdriver.yaml
@@ -16,6 +16,11 @@ DriverInfo:
     Max: 10Gi
   SupportedFsType:
     ext4: {}
+    xfs: {}
+  SupportedMountOption:
+    noatime: {}
+  TopologyKeys:
+    - miroir.home-operations.com/node
   Capabilities:
     persistence: true
     block: true
@@ -31,9 +36,9 @@ DriverInfo:
     pvcDataSource: true
     topology: true
     singleNodeVolume: false
-    # RWX is implemented (NFS gateway over a replicated volume) but the
-    # upstream RWX specs need real DRBD + ganesha, not kind. Flip to true
-    # once the smoke suite's RWX scenario passes on a real cluster.
+    # The filesystem-only testdriver-rwx.yaml covers multi-node access without
+    # also enabling unsupported raw-block RWX patterns in this block-capable run.
     RWX: false
+    multiplePVsSameID: true
     readWriteOncePod: true
-    capacity: false
+    capacity: true

--- a/test/conformance/testdriver.yaml
+++ b/test/conformance/testdriver.yaml
@@ -19,8 +19,6 @@ DriverInfo:
     xfs: {}
   SupportedMountOption:
     noatime: {}
-  TopologyKeys:
-    - miroir.home-operations.com/node
   Capabilities:
     persistence: true
     block: true

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -15,11 +15,13 @@ tests.
 The legs run the same document and differ in what `test.sh` drives against it, so a
 failure names the path that broke:
 
-| Leg           | Runs                                       | Class               |
-| ------------- | ------------------------------------------ | ------------------- |
-| `conformance` | miroir's Go specs, then the upstream suite | `miroir-local`      |
-| `replicated`  | the upstream suite                         | `miroir-replicated` |
-| `zfs`         | the upstream suite                         | `miroir-zfs`        |
+| Leg           | Runs                                                | Class               |
+| ------------- | --------------------------------------------------- | ------------------- |
+| `conformance` | miroir's Go specs, then the parallel upstream suite | `miroir-local`      |
+| `replicated`  | the parallel upstream block/filesystem suite        | `miroir-replicated` |
+| `zfs`         | the parallel upstream block/filesystem suite        | `miroir-zfs`        |
+| `rwx`         | the parallel upstream filesystem-only RWX/ROX suite | `miroir-replicated` |
+| `serial`      | upstream `[Serial]` specs, one process              | `miroir-replicated` |
 
 miroir's Go specs (`test/e2e`) assert the local lifecycle, snapshot/restore, block and
 placement behaviour the upstream suite does not; the conformance leg runs them
@@ -27,9 +29,12 @@ placement behaviour the upstream suite does not; the conformance leg runs them
 external-storage run. The replicated leg drives that upstream suite against the DRBD
 (replicas: 2) class, group snapshots included; the zfs leg drives it against the same
 DRBD shape backed by the zfs pool instead, so replication pairs zvol with zvol and
-the zfs snapshot/restore path runs under the suite. Real per-node kernels and real
-block devices are the point: the DRBD path needs the DRBD 9 module, which only a real
-Talos node has.
+the zfs snapshot/restore path runs under the suite. The rwx leg enables the NFS
+gateway and advertises only filesystem volume modes, while the serial leg gives
+exclusive-cluster specs a single Ginkgo process. Every leg enables CSI storage
+capacity publication; the upstream definitions exercise ext4, xfs, topology and
+mount options. Real per-node kernels and real block devices are the point: the DRBD
+path needs the DRBD 9 module, which only a real Talos node has.
 
 ```text
 cluster.yaml              the one cluster shape every leg boots
@@ -78,8 +83,11 @@ talosctl kubeconfig /tmp/miroir-e2e/kubeconfig --nodes 10.5.0.2 --force
 set -gx CLUSTER_NAME miroir-e2e
 set -gx KUBECONFIG /tmp/miroir-e2e/kubeconfig
 set -gx TALOSCONFIG /tmp/miroir-e2e/talosconfig
-set -gx TESTDRIVER testdriver.yaml # or testdriver-local.yaml / testdriver-zfs.yaml
-set -gx RUN_SPECS 1                 # also run the Go specs (the conformance leg does)
+set -gx TESTDRIVER testdriver.yaml # or testdriver-local.yaml / testdriver-zfs.yaml / testdriver-rwx.yaml
+set -gx RUN_SPECS 1                # also run the Go specs (the conformance leg does)
+set -gx STORAGE_CAPACITY_ENABLED true
+# Required with testdriver-rwx.yaml:
+set -gx GATEWAY_ENABLED true
 ./test.sh
 
 sudo -E (mise which talosctl) cluster destroy --name miroir-e2e -f

--- a/test/e2e-qemu/diagnostics.sh
+++ b/test/e2e-qemu/diagnostics.sh
@@ -21,6 +21,9 @@ echo "---- controller logs ----"
 kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=controller --tail=200 --all-containers
 echo "---- agent logs ----"
 kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=agent --tail=200 --all-containers
+echo "---- gateway logs ----"
+kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=gateway --tail=200 --all-containers --prefix
+kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=gateway --tail=200 --all-containers --prefix --previous
 echo "---- drbd state ----"
 for n in $workers; do
     echo "== $n =="

--- a/test/e2e-qemu/image.sh
+++ b/test/e2e-qemu/image.sh
@@ -13,7 +13,7 @@ cd "$REPO_ROOT"
 
 GO_VERSION="${GO_VERSION:-$(mise config get tools.go)}"
 
-# Both images are stages of the one Dockerfile; --target selects which.
+# The images are stages of the one Dockerfile; --target selects which.
 build_push() {
     local target=$1 image=$2
     log "Building $target image $image..."
@@ -24,5 +24,10 @@ build_push() {
 
 build_push controller "$CONTROLLER_IMAGE"
 build_push agent "$AGENT_IMAGE"
-
-log "Images ready: $CONTROLLER_IMAGE, $AGENT_IMAGE"
+if [[ "${GATEWAY_ENABLED:-false}" == "true" ]]; then
+    : "${GATEWAY_IMAGE:?must be set when GATEWAY_ENABLED=true}"
+    build_push gateway "$GATEWAY_IMAGE"
+    log "Images ready: $CONTROLLER_IMAGE, $AGENT_IMAGE, $GATEWAY_IMAGE"
+else
+    log "Images ready: $CONTROLLER_IMAGE, $AGENT_IMAGE"
+fi

--- a/test/e2e-qemu/test.sh
+++ b/test/e2e-qemu/test.sh
@@ -217,6 +217,8 @@ install_chart() {
         --set agent.image.tag="$agent_tag" \
         --set agent.image.pullPolicy=Always \
         --set groupSnapshots.enabled=true \
+        --set gateway.enabled="${GATEWAY_ENABLED:-false}" \
+        --set storageCapacity.enabled="${STORAGE_CAPACITY_ENABLED:-false}" \
         --wait --timeout 10m
 }
 

--- a/test/e2e-qemu/test.sh
+++ b/test/e2e-qemu/test.sh
@@ -24,19 +24,24 @@ guard_cluster() {
         die "node '$node' does not start with '$CLUSTER_NAME'; refusing to proceed"
 }
 
-# CI sets CONTROLLER_IMAGE and AGENT_IMAGE and builds them concurrently with the
-# cluster, so by the time we get here they are already in the registry. A local run
-# leaves them unset; build both to ttl.sh so it needs no registry of its own.
+# CI builds the requested images concurrently with the cluster, so by the time we
+# get here they are already in the registry. A local run builds them to ttl.sh so it
+# needs no registry of its own.
 build_images_if_needed() {
-    if [[ -n "${CONTROLLER_IMAGE:-}" && -n "${AGENT_IMAGE:-}" ]]; then
-        log "Using pre-built images: $CONTROLLER_IMAGE, $AGENT_IMAGE"
+    local gateway_enabled=${GATEWAY_ENABLED:-false}
+    if [[ -n "${CONTROLLER_IMAGE:-}" && -n "${AGENT_IMAGE:-}" ]] &&
+        [[ "$gateway_enabled" != "true" || -n "${GATEWAY_IMAGE:-}" ]]; then
+        log "Using pre-built controller and agent images"
         return
     fi
     local stamp
     stamp=$(date +%s)
     CONTROLLER_IMAGE="ttl.sh/miroir-controller-e2e-${stamp}:2h"
     AGENT_IMAGE="ttl.sh/miroir-agent-e2e-${stamp}:2h"
-    export CONTROLLER_IMAGE AGENT_IMAGE
+    if [[ "$gateway_enabled" == "true" ]]; then
+        GATEWAY_IMAGE="ttl.sh/miroir-gateway-e2e-${stamp}:2h"
+    fi
+    export CONTROLLER_IMAGE AGENT_IMAGE GATEWAY_IMAGE
     "${SCRIPT_DIR}/image.sh"
 }
 
@@ -182,6 +187,18 @@ install_chart() {
     IFS=':' read -r controller_repo controller_tag <<<"$CONTROLLER_IMAGE"
     IFS=':' read -r agent_repo agent_tag <<<"$AGENT_IMAGE"
 
+    local gateway_args=()
+    if [[ "${GATEWAY_ENABLED:-false}" == "true" ]]; then
+        : "${GATEWAY_IMAGE:?must be set when GATEWAY_ENABLED=true}"
+        local gateway_repo gateway_tag
+        IFS=':' read -r gateway_repo gateway_tag <<<"$GATEWAY_IMAGE"
+        gateway_args=(
+            --set gateway.image.repository="$gateway_repo"
+            --set gateway.image.tag="$gateway_tag"
+            --set gateway.image.pullPolicy=Always
+        )
+    fi
+
     log "Packaging the chart..."
     local chart_dir chart_ref
     chart_dir=$(mktemp -d)
@@ -216,6 +233,7 @@ install_chart() {
         --set agent.image.repository="$agent_repo" \
         --set agent.image.tag="$agent_tag" \
         --set agent.image.pullPolicy=Always \
+        "${gateway_args[@]}" \
         --set groupSnapshots.enabled=true \
         --set gateway.enabled="${GATEWAY_ENABLED:-false}" \
         --set storageCapacity.enabled="${STORAGE_CAPACITY_ENABLED:-false}" \


### PR DESCRIPTION
## Summary

- add dedicated QEMU lanes for filesystem-only RWX/ROX gateway coverage and upstream serial specs
- exercise XFS, mount options, topology keys, multiple PVs sharing one handle, and CSI capacity in the existing driver definitions
- enable gateway and storage-capacity chart features per lane, fail focused runs when no specs match, and document the matrix

## Validation

- mise run lint
- mise run test
- mise run test-integration
- mise run test-sanity
- mise run helm-lint
- mise run helm-docs-check
- shellcheck, oxfmt, yq, and zizmor
- Kubernetes v1.36.2 upstream dry-run: 13 RWX/ROX specs and 16 serial specs selected

Not run locally: mise run helm-test, because the Helm unittest plugin is not installed in this environment. CI provides that check.

Closes #327