### PR TITLE
test(e2e): add serial conformance leg

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,6 +50,13 @@ jobs:
             testdriver: testdriver.yaml
           - suite: zfs
             testdriver: testdriver-zfs.yaml
+          # Serial specs need exclusive use of their cluster. The focus keeps this
+          # lane on upstream [Serial] coverage instead of replaying the parallel set.
+          - suite: serial
+            testdriver: testdriver.yaml
+            procs: "1"
+            focus: 'miroir.home-operations.com.*\[Serial\]'
+            skip: '\[Disruptive\]|should not mount / map unused volumes'
     env:
       # Two names for one image in the runner-local registry. The nodes pull
       # registry.e2e, which the Talos mirror in patches/registry.yaml points at the
@@ -175,7 +182,9 @@ jobs:
           ENDPOINT: ${{ steps.cluster.outputs.endpoint }}
           KUBECONFIG: ${{ steps.cluster.outputs.kubeconfig }}
           TALOSCONFIG: ${{ steps.cluster.outputs.talosconfig }}
-          PROCS: "4"
+          PROCS: ${{ matrix.procs || '4' }}
+          FOCUS: ${{ matrix.focus }}
+          SKIP: ${{ matrix.skip }}
           VERBOSE: "1"
 
       - name: Diagnostics

--- a/test/conformance/run.sh
+++ b/test/conformance/run.sh
@@ -3,7 +3,7 @@
 # cluster kubectl currently points at, using testdriver.yaml.
 #
 #   ./test/conformance/run.sh                 # parallel-safe set
-#   SKIP='\[Disruptive\]' ./run.sh PROCS=1    # include [Serial] specs
+#   SKIP='\[Disruptive\]' PROCS=1 ./run.sh    # include [Serial] specs
 #   FOCUS='.*snapshot.*' ./run.sh             # narrow down
 #   TESTDRIVER=testdriver-local.yaml ./run.sh # miroir-local (lvmthin)
 #   TESTDRIVER=testdriver-zfs.yaml ./run.sh   # miroir-zfs (replicated zfs)
@@ -35,7 +35,7 @@ PROCS=${PROCS:-4}
 mkdir -p report
 
 exec "$bin/ginkgo" -procs="$PROCS" ${VERBOSE:+-v} \
-    -focus="$FOCUS" -skip="$SKIP" -timeout=3h \
+    -focus="$FOCUS" -skip="$SKIP" -fail-on-empty -timeout=3h \
     "$bin/e2e.test" -- \
     -storage.testdriver="$PWD/$TESTDRIVER" \
     -kubeconfig="$KUBECONFIG" \


### PR DESCRIPTION
## What

Adds a dedicated `serial` leg to the e2e conformance matrix that runs the upstream `[Serial]` external-storage specs with exclusive cluster use (`PROCS=1`).

This is the first of several PRs breaking apart the larger conformance-coverage expansion so each CI lane can be reviewed on its own.

## Details

- **`.github/workflows/e2e.yaml`**
  - New `serial` matrix entry against the existing `testdriver.yaml`, with `procs: "1"`, a `[Serial]`-only focus, and a skip for `[Disruptive]` plus the `should not mount / map unused volumes` spec.
  - The conformance-run step now sources `PROCS`/`FOCUS`/`SKIP` from the matrix (`matrix.procs || '4'`). The existing lanes leave these unset, so they resolve to empty and fall through to `run.sh`'s defaults, preserving their current parallel-safe behavior.
- **`test/conformance/run.sh`**
  - Add `-fail-on-empty` so a focus that matches zero specs fails the run instead of reporting green — important now that a lane pins a narrow focus.
  - Fix the usage comment (`PROCS=1` is an env var, so it belongs before `./run.sh`).

## Scope

CI-only. No Go changes and `testdriver.yaml` is untouched — the shared code fixes and coverage-expansion (xfs/capacity, gateway/rwx) land in follow-up PRs.

## Testing

Not run locally (requires the full QEMU e2e cluster). YAML parses via `yq`; `run.sh` passes `bash -n` and the pre-commit `shellcheck`/`zizmor`/`format-yaml` hooks.
