### PR TITLE
test(e2e): add rwx conformance leg

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,6 +50,13 @@ jobs:
             testdriver: testdriver.yaml
           - suite: zfs
             testdriver: testdriver-zfs.yaml
+          # Filesystem-only multi-node access through the NFS gateway. Keeping this
+          # separate avoids advertising unsupported raw-block RWX.
+          - suite: rwx
+            testdriver: testdriver-rwx.yaml
+            gateway: "true"
+            capacity: "true"
+            focus: "miroir.home-operations.com.*(ROX mode|concurrently access the single volume from pods on different node)"
           # Serial specs need exclusive use of their cluster. The focus keeps this
           # lane on upstream [Serial] coverage instead of replaying the parallel set.
           - suite: serial
@@ -65,8 +72,10 @@ jobs:
       # tag, so the host:port push form would parse wrong there.
       CONTROLLER_IMAGE: registry.e2e/miroir-controller:e2e
       AGENT_IMAGE: registry.e2e/miroir-agent:e2e
+      GATEWAY_IMAGE: registry.e2e/miroir-gateway:e2e
       PUSH_CONTROLLER_IMAGE: localhost:5000/miroir-controller:e2e
       PUSH_AGENT_IMAGE: localhost:5000/miroir-agent:e2e
+      PUSH_GATEWAY_IMAGE: localhost:5000/miroir-gateway:e2e
       # test.sh packages the chart, pushes it here, and installs it back over OCI, so
       # the run exercises the distributed artifact rather than the working tree.
       CHART_REGISTRY: oci://localhost:5000/charts
@@ -165,7 +174,22 @@ jobs:
           cache-from: type=gha,scope=e2e-agent
           cache-to: ${{ matrix.suite == 'replicated' && 'type=gha,mode=max,scope=e2e-agent' || '' }}
 
-      - wait: [cluster, controller-image, agent-image]
+      # Gateway extends the agent stage, so buildx reuses it and only layers on
+      # the ganesha packages.
+      - name: Build gateway image
+        id: gateway-image
+        background: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          target: gateway
+          tags: ${{ env.PUSH_GATEWAY_IMAGE }}
+          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
+          cache-from: type=gha,scope=e2e-gateway
+          cache-to: ${{ matrix.suite == 'replicated' && 'type=gha,mode=max,scope=e2e-gateway' || '' }}
+
+      - wait: [cluster, controller-image, agent-image, gateway-image]
 
       - name: Cache conformance test binaries
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -178,6 +202,8 @@ jobs:
         env:
           TESTDRIVER: ${{ matrix.testdriver }}
           RUN_SPECS: ${{ matrix.specs }}
+          GATEWAY_ENABLED: ${{ matrix.gateway || 'false' }}
+          STORAGE_CAPACITY_ENABLED: ${{ matrix.capacity || 'false' }}
           CLUSTER_NAME: ${{ steps.cluster.outputs.cluster-name }}
           ENDPOINT: ${{ steps.cluster.outputs.endpoint }}
           KUBECONFIG: ${{ steps.cluster.outputs.kubeconfig }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,7 @@ RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     nfs-ganesha \
     nfs-ganesha-vfs && \
+    # Docker synthesizes this link at runtime, but containerd expects it in
+    # the image. The VFS FSAL cannot discover mounted exports without it.
+    ln -sf /proc/mounts /etc/mtab && \
     rm -rf /var/lib/apt/lists/*

--- a/internal/gateway/ganesha.go
+++ b/internal/gateway/ganesha.go
@@ -49,6 +49,8 @@ var ganeshaTemplate = template.Must(template.New("ganesha.conf").Parse(
 	`NFS_CORE_PARAM {
 	NFS_Port = {{.Port}};
 	Protocols = 4;
+	Enable_UDP = false;
+	Enable_RQUOTA = false;
 }
 
 NFSv4 {

--- a/internal/gateway/ganesha_test.go
+++ b/internal/gateway/ganesha_test.go
@@ -36,6 +36,8 @@ func TestRenderGanesha(t *testing.T) {
 	for _, want := range []string{
 		"NFS_Port = 2049;",
 		"Protocols = 4;",
+		"Enable_UDP = false;",
+		"Enable_RQUOTA = false;",
 		"RecoveryBackend = fs;",
 		"RecoveryRoot = /export/pvc-abc/.ganesha-recovery;",
 		"Grace_Period = 60;",

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -90,6 +90,7 @@ func (c *Config) withDefaults() {
 
 const (
 	ganeshaPort   = 2049
+	ganeshaPID    = "/run/ganesha.pid"
 	gracePeriod   = 60
 	leaseLifetime = 30
 )
@@ -181,7 +182,7 @@ func writeGaneshaConf(cfg Config, mountPath string) error {
 // the fs grow). It returns nil on a clean ctx-cancelled stop and an error
 // if ganesha exits on its own — a dead server must restart the pod.
 func supervise(ctx context.Context, mounter *mount.SafeFormatAndMount, cfg Config, dev, mountPath string, h *health, healthErr <-chan error, log logr.Logger) error {
-	cmd := exec.Command(ganeshaBin, "-F", "-f", cfg.GaneshaConf, "-N", "NIV_EVENT")
+	cmd := exec.Command(ganeshaBin, "-F", "-p", ganeshaPID, "-L", "STDOUT", "-f", cfg.GaneshaConf, "-N", "NIV_EVENT")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/internal/gateway/supervise_test.go
+++ b/internal/gateway/supervise_test.go
@@ -70,12 +70,14 @@ func superviseCfg() (Config, *mount.SafeFormatAndMount) {
 // A ganesha that exits on its own must surface an error: a dead server
 // restarts the pod, silence would leave every NFS client hanging.
 func TestSuperviseFailsWhenGaneshaExits(t *testing.T) {
-	stubGanesha(t, "exit 3")
+	stubGanesha(t, `test "$*" = "-F -p /run/ganesha.pid -L STDOUT -f /etc/ganesha/ganesha.conf -N NIV_EVENT" || exit 4
+exit 3`)
 	cfg, m := superviseCfg()
+	cfg.GaneshaConf = "/etc/ganesha/ganesha.conf"
 
 	err := supervise(t.Context(), m, cfg, "/dev/null", t.TempDir(), &health{},
 		make(chan error), logr.Discard())
-	if err == nil || !strings.Contains(err.Error(), "ganesha exited") {
+	if err == nil || !strings.Contains(err.Error(), "ganesha exited: exit status 3") {
 		t.Fatalf("self-exit must error, got %v", err)
 	}
 }

--- a/test/conformance/run.sh
+++ b/test/conformance/run.sh
@@ -7,6 +7,7 @@
 #   FOCUS='.*snapshot.*' ./run.sh             # narrow down
 #   TESTDRIVER=testdriver-local.yaml ./run.sh # miroir-local (lvmthin)
 #   TESTDRIVER=testdriver-zfs.yaml ./run.sh   # miroir-zfs (replicated zfs)
+#   TESTDRIVER=testdriver-rwx.yaml ./run.sh   # filesystem-only RWX/ROX
 #   VERBOSE=1 ./run.sh                        # per-spec live output
 #
 # The e2e.test/ginkgo binaries are fetched to match the server version

--- a/test/conformance/testdriver-rwx.yaml
+++ b/test/conformance/testdriver-rwx.yaml
@@ -1,0 +1,39 @@
+# Driver definition for the upstream Kubernetes external-storage e2e suite's
+# filesystem-only multi-node tests. The replicated LVM-thin class is exported
+# through Miroir's NFS gateway; raw-block RWX is intentionally not advertised.
+StorageClass:
+  FromExistingClassName: miroir-replicated
+SnapshotClass:
+  FromExistingClassName: miroir-snap
+GroupSnapshotClass:
+  FromExistingClassName: miroir-group-snap
+DriverInfo:
+  Name: miroir.home-operations.com
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 10Gi
+  SupportedFsType:
+    ext4: {}
+    xfs: {}
+  SupportedMountOption:
+    noatime: {}
+  Capabilities:
+    persistence: true
+    block: false
+    exec: true
+    fsGroup: true
+    multipods: true
+    controllerExpansion: true
+    nodeExpansion: true
+    onlineExpansion: true
+    offlineExpansion: true
+    snapshotDataSource: true
+    groupSnapshot: true
+    pvcDataSource: true
+    topology: true
+    singleNodeVolume: false
+    RWX: true
+    capReadOnlyMany: true
+    multiplePVsSameID: true
+    readWriteOncePod: true
+    capacity: true

--- a/test/e2e-qemu/image.sh
+++ b/test/e2e-qemu/image.sh
@@ -13,7 +13,7 @@ cd "$REPO_ROOT"
 
 GO_VERSION="${GO_VERSION:-$(mise config get tools.go)}"
 
-# Both images are stages of the one Dockerfile; --target selects which.
+# The images are stages of the one Dockerfile; --target selects which.
 build_push() {
     local target=$1 image=$2
     log "Building $target image $image..."
@@ -24,5 +24,10 @@ build_push() {
 
 build_push controller "$CONTROLLER_IMAGE"
 build_push agent "$AGENT_IMAGE"
-
-log "Images ready: $CONTROLLER_IMAGE, $AGENT_IMAGE"
+if [[ "${GATEWAY_ENABLED:-false}" == "true" ]]; then
+    : "${GATEWAY_IMAGE:?must be set when GATEWAY_ENABLED=true}"
+    build_push gateway "$GATEWAY_IMAGE"
+    log "Images ready: $CONTROLLER_IMAGE, $AGENT_IMAGE, $GATEWAY_IMAGE"
+else
+    log "Images ready: $CONTROLLER_IMAGE, $AGENT_IMAGE"
+fi

--- a/test/e2e-qemu/test.sh
+++ b/test/e2e-qemu/test.sh
@@ -24,19 +24,24 @@ guard_cluster() {
         die "node '$node' does not start with '$CLUSTER_NAME'; refusing to proceed"
 }
 
-# CI sets CONTROLLER_IMAGE and AGENT_IMAGE and builds them concurrently with the
-# cluster, so by the time we get here they are already in the registry. A local run
-# leaves them unset; build both to ttl.sh so it needs no registry of its own.
+# CI builds the requested images concurrently with the cluster, so by the time we
+# get here they are already in the registry. A local run builds them to ttl.sh so it
+# needs no registry of its own.
 build_images_if_needed() {
-    if [[ -n "${CONTROLLER_IMAGE:-}" && -n "${AGENT_IMAGE:-}" ]]; then
-        log "Using pre-built images: $CONTROLLER_IMAGE, $AGENT_IMAGE"
+    local gateway_enabled=${GATEWAY_ENABLED:-false}
+    if [[ -n "${CONTROLLER_IMAGE:-}" && -n "${AGENT_IMAGE:-}" ]] &&
+        [[ "$gateway_enabled" != "true" || -n "${GATEWAY_IMAGE:-}" ]]; then
+        log "Using pre-built controller and agent images"
         return
     fi
     local stamp
     stamp=$(date +%s)
     CONTROLLER_IMAGE="ttl.sh/miroir-controller-e2e-${stamp}:2h"
     AGENT_IMAGE="ttl.sh/miroir-agent-e2e-${stamp}:2h"
-    export CONTROLLER_IMAGE AGENT_IMAGE
+    if [[ "$gateway_enabled" == "true" ]]; then
+        GATEWAY_IMAGE="ttl.sh/miroir-gateway-e2e-${stamp}:2h"
+    fi
+    export CONTROLLER_IMAGE AGENT_IMAGE GATEWAY_IMAGE
     "${SCRIPT_DIR}/image.sh"
 }
 
@@ -182,6 +187,18 @@ install_chart() {
     IFS=':' read -r controller_repo controller_tag <<<"$CONTROLLER_IMAGE"
     IFS=':' read -r agent_repo agent_tag <<<"$AGENT_IMAGE"
 
+    local gateway_args=()
+    if [[ "${GATEWAY_ENABLED:-false}" == "true" ]]; then
+        : "${GATEWAY_IMAGE:?must be set when GATEWAY_ENABLED=true}"
+        local gateway_repo gateway_tag
+        IFS=':' read -r gateway_repo gateway_tag <<<"$GATEWAY_IMAGE"
+        gateway_args=(
+            --set gateway.image.repository="$gateway_repo"
+            --set gateway.image.tag="$gateway_tag"
+            --set gateway.image.pullPolicy=Always
+        )
+    fi
+
     log "Packaging the chart..."
     local chart_dir chart_ref
     chart_dir=$(mktemp -d)
@@ -216,7 +233,10 @@ install_chart() {
         --set agent.image.repository="$agent_repo" \
         --set agent.image.tag="$agent_tag" \
         --set agent.image.pullPolicy=Always \
+        "${gateway_args[@]}" \
         --set groupSnapshots.enabled=true \
+        --set gateway.enabled="${GATEWAY_ENABLED:-false}" \
+        --set storageCapacity.enabled="${STORAGE_CAPACITY_ENABLED:-false}" \
         --wait --timeout 10m
 }
 


### PR DESCRIPTION
## What

Adds an `rwx` leg to the e2e conformance matrix that exercises filesystem-only multi-node access (RWX/ROX) through Miroir's NFS gateway. It focuses the upstream ROX-mode and cross-node concurrent-access specs against a new `testdriver-rwx.yaml`; raw-block RWX is intentionally not advertised.

Second in the series breaking apart the conformance-coverage expansion (after the [serial leg](https://github.com/home-operations/miroir/pull/331)).

## CI

- **New `rwx` matrix entry** against `testdriver-rwx.yaml` with a focus of `ROX mode` + `concurrently access the single volume from pods on different node`.
- **Gateway image** is now built like the controller and agent images — an unconditional `background: true` build step (`target: gateway`, which just layers ganesha onto the already-built agent stage) added to the `wait:` gate. Enablement is per-lane: only the rwx lane sets `GATEWAY_ENABLED`/`STORAGE_CAPACITY_ENABLED` (via `matrix.gateway`/`matrix.capacity`), so other lanes build the image but leave the gateway Deployment and storage-capacity off.
- `test.sh`/`image.sh` gain the gateway + storage-capacity plumbing; the chart already supports `gateway.enabled` and `storageCapacity.enabled`, so no chart changes.

## Gateway fixes (so ganesha runs under containerd)

- Disable UDP and RQUOTA listeners in the ganesha config (unused; RQUOTA needs a service we don't run).
- Run ganesha with a writable pid path (`/run/ganesha.pid`) and log to stdout.
- Link `/etc/mtab -> /proc/mounts` in the gateway image — containerd doesn't synthesize it, and the VFS FSAL can't discover mounted exports without it.

## Scope

rwx lane + its required gateway fixes only. The drbd/csi stabilization fixes and the base coverage expansion (xfs/capacity on the other testdrivers) are left for the follow-up PR. `testdriver-rwx.yaml` keeps `capacity: true`/`multiplePVsSameID: true` as validated; storage capacity is enabled only for this lane.

## Testing

`go test ./internal/gateway/` passes; `gofmt`/`go vet` clean; workflow parses via `yq`; shell scripts pass `bash -n` and the pre-commit `shellcheck`/`zizmor`/`format-yaml` hooks. The e2e itself needs the full QEMU cluster and was not run locally.
