### PR TITLE
fix: conformance stabilization (drbd, csi, stage)

### DIFF
--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1530,7 +1530,8 @@ func orphanHoldFixture(t *testing.T, procDir string) (*VolumeReconciler, *fakeBa
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build()
 	fe := &fakeDRBDExec{
 		statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
-			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],"connections":[]}]`,
+			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`,
 		errOn: map[string]error{cmdDownPvc1: errors.New(heldOpenWithOpeners)},
 	}
 	rec := events.NewFakeRecorder(8)
@@ -1580,6 +1581,7 @@ func TestReconcileTeardownOrphanHoldReclaims(t *testing.T) {
 		t.Fatalf("the reclaim cycle must complete teardown: %v", err)
 	}
 	fe.calledWith(t, "drbdsetup detach 1422 --force")
+	fe.calledWith(t, "drbdsetup del-peer pvc-1 1")
 	fe.notCalledWith(t, "wipe-md")
 	if fb.existing[volPvc1] {
 		t.Fatal("the backing device must be destroyed by the reclaim")

--- a/internal/csi/groupcontroller.go
+++ b/internal/csi/groupcontroller.go
@@ -47,8 +47,7 @@ func (c *Controller) GroupControllerGetCapabilities(_ context.Context, _ *csi.Gr
 
 // CreateVolumeGroupSnapshot provisions one MiroirSnapshot per source
 // volume plus the MiroirSnapshotGroup that cuts them under one shared
-// write barrier, and reports readiness as-is: the external-snapshotter
-// polls until ready_to_use. Idempotent by name.
+// write barrier. Idempotent by name.
 func (c *Controller) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.CreateVolumeGroupSnapshotRequest) (*csi.CreateVolumeGroupSnapshotResponse, error) {
 	if req.GetName() == "" || len(req.GetSourceVolumeIds()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "group snapshot name and source volumes are required")
@@ -138,7 +137,14 @@ func (c *Controller) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.Cre
 		}
 		grp = existing
 	}
-	return &csi.CreateVolumeGroupSnapshotResponse{GroupSnapshot: csiGroupSnapshot(grp, snaps, vols)}, nil
+	result := csiGroupSnapshot(grp, snaps, vols)
+	if !result.GetReadyToUse() {
+		// external-snapshotter records member readiness only from the
+		// successful Create response; keep the operation pending until it
+		// can persist a complete, usable member set.
+		return nil, status.Errorf(codes.Aborted, "group snapshot %s is not ready", grp.Name)
+	}
+	return &csi.CreateVolumeGroupSnapshotResponse{GroupSnapshot: result}, nil
 }
 
 // refuseMemberMismatch fails fast when the named group already exists

--- a/internal/csi/groupcontroller_test.go
+++ b/internal/csi/groupcontroller_test.go
@@ -63,23 +63,11 @@ func TestCreateVolumeGroupSnapshotCreatesMembersAndGroup(t *testing.T) {
 	c := &Controller{Client: cl}
 
 	// Deliberately unsorted: member order must not depend on it.
-	resp, err := c.CreateVolumeGroupSnapshot(t.Context(), &csi.CreateVolumeGroupSnapshotRequest{
+	_, err := c.CreateVolumeGroupSnapshot(t.Context(), &csi.CreateVolumeGroupSnapshotRequest{
 		Name: groupGsnap1, SourceVolumeIds: []string{volSrc, volPvc1},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	gs := resp.GetGroupSnapshot()
-	if gs.GetGroupSnapshotId() != groupGsnap1 || gs.GetReadyToUse() {
-		t.Fatalf("fresh group must report not ready under its id: %+v", gs)
-	}
-	if len(gs.GetSnapshots()) != 2 {
-		t.Fatalf("want 2 member snapshots, got %+v", gs.GetSnapshots())
-	}
-	for _, m := range gs.GetSnapshots() {
-		if m.GetGroupSnapshotId() != groupGsnap1 {
-			t.Fatalf("members must carry the group id: %+v", m)
-		}
+	if status.Code(err) != codes.Aborted {
+		t.Fatalf("fresh group must remain pending, got %v", err)
 	}
 
 	grp := &miroirv1alpha1.MiroirSnapshotGroup{}
@@ -118,14 +106,40 @@ func TestCreateVolumeGroupSnapshotIdempotent(t *testing.T) {
 		Name: groupGsnap1, SourceVolumeIds: []string{volSrc, volPvc1},
 	}
 
-	if _, err := c.CreateVolumeGroupSnapshot(t.Context(), req); err != nil {
-		t.Fatal(err)
+	if _, err := c.CreateVolumeGroupSnapshot(t.Context(), req); status.Code(err) != codes.Aborted {
+		t.Fatalf("fresh group must remain pending, got %v", err)
 	}
-	if _, err := c.CreateVolumeGroupSnapshot(t.Context(), req); err != nil {
-		t.Fatalf("identical retry must succeed: %v", err)
+	if _, err := c.CreateVolumeGroupSnapshot(t.Context(), req); status.Code(err) != codes.Aborted {
+		t.Fatalf("identical pending retry must remain pending, got %v", err)
 	}
 
-	_, err := c.CreateVolumeGroupSnapshot(t.Context(), &csi.CreateVolumeGroupSnapshotRequest{
+	grp := &miroirv1alpha1.MiroirSnapshotGroup{}
+	if err := cl.Get(t.Context(), types.NamespacedName{Name: groupGsnap1}, grp); err != nil {
+		t.Fatal(err)
+	}
+	grp.Status.ReadyToUse = true
+	if err := cl.Status().Update(t.Context(), grp); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range grp.Spec.SnapshotNames {
+		snap := &miroirv1alpha1.MiroirSnapshot{}
+		if err := cl.Get(t.Context(), types.NamespacedName{Name: name}, snap); err != nil {
+			t.Fatal(err)
+		}
+		snap.Status.ReadyToUse = true
+		if err := cl.Status().Update(t.Context(), snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	resp, err := c.CreateVolumeGroupSnapshot(t.Context(), req)
+	if err != nil {
+		t.Fatalf("ready identical retry must succeed: %v", err)
+	}
+	if !resp.GetGroupSnapshot().GetReadyToUse() || len(resp.GetGroupSnapshot().GetSnapshots()) != 2 {
+		t.Fatalf("ready retry must return every usable member: %+v", resp.GetGroupSnapshot())
+	}
+
+	_, err = c.CreateVolumeGroupSnapshot(t.Context(), &csi.CreateVolumeGroupSnapshotRequest{
 		Name: groupGsnap1, SourceVolumeIds: []string{volSrc},
 	})
 	if status.Code(err) != codes.AlreadyExists {

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -1077,8 +1077,10 @@ func (d *Driver) Restart(ctx context.Context, name string) error {
 // keep the minor assignment (see RemoveConfig): the kernel minor stays
 // pinned until a reboot, releasing the number would hand it to a new
 // volume, and the startup orphan sweep reaps it once the reboot clears
-// the state. Already-detached (Diskless) and not-in-kernel are
-// no-ops so a retry after a failed backing delete converges. A resource
+// the state. Remaining peer connections are removed after the detach so
+// the zombie resource releases its replication port. Already-detached
+// resources still shed those connections, while not-in-kernel resources
+// are no-ops so a retry after a failed backing delete converges. A resource
 // wearing the teardown wedge signature is refused like everywhere else —
 // mid-detach is exactly the state a second detach would race.
 func (d *Driver) ForceDetach(ctx context.Context, name string, minor int32) error {
@@ -1093,14 +1095,19 @@ func (d *Driver) ForceDetach(ctx context.Context, name string, minor int32) erro
 		if res.wedgeSignature() {
 			return fmt.Errorf("force-detach %s: %w", name, ErrWedged)
 		}
-		if len(res.Devices) == 0 || res.Devices[0].DiskState == DiskDiskless {
-			return nil
-		}
-		if err := d.disconnectPeers(ctx, name, res.peerIDs()); err != nil {
+		peerIDs := res.peerIDs()
+		if err := d.disconnectPeers(ctx, name, peerIDs); err != nil {
 			return err
 		}
-		if _, err := d.Exec(ctx, "drbdsetup", "detach", strconv.Itoa(int(minor)), "--force"); err != nil {
-			return fmt.Errorf("force-detach %s: %w", name, err)
+		if len(res.Devices) > 0 && res.Devices[0].DiskState != DiskDiskless {
+			if _, err := d.Exec(ctx, "drbdsetup", "detach", strconv.Itoa(int(minor)), "--force"); err != nil {
+				return fmt.Errorf("force-detach %s: %w", name, err)
+			}
+		}
+		for _, id := range peerIDs {
+			if _, err := d.Exec(ctx, "drbdsetup", "del-peer", name, strconv.Itoa(int(id))); err != nil {
+				return fmt.Errorf("remove %s peer %d: %w", name, id, err)
+			}
 		}
 		return nil
 	}

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1216,10 +1216,11 @@ func TestMetadataAdoptedTracksMarker(t *testing.T) {
 	}
 }
 
-// ForceDetach disconnects the peers, then force-detaches the backing by
-// minor — the escape hatch for a deletion whose down is permanently
-// refused by an orphaned opener (issue #319). No down is spawned and the
-// rendered config survives: the caller keeps the zombie minor reserved
+// ForceDetach disconnects the peers, force-detaches the backing by minor,
+// then removes the peer definitions. It is the escape hatch for a deletion
+// whose down is permanently refused by an orphaned opener (issue #319).
+// No down is spawned and the rendered config survives: the caller keeps
+// the zombie minor reserved
 // until the post-reboot orphan sweep reaps it.
 func TestForceDetachDisconnectsAndDetaches(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{
@@ -1237,6 +1238,7 @@ func TestForceDetachDisconnectsAndDetaches(t *testing.T) {
 	}
 	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
 	fe.calledWith(t, "drbdsetup detach 1422 --force")
+	fe.calledWith(t, "drbdsetup del-peer pvc-1 1")
 	fe.notCalledWith(t, "drbdsetup down")
 	if _, err := os.Stat(d.path(volPvc1 + ".res")); err != nil {
 		t.Fatalf("rendered config must survive a force-detach: %v", err)
@@ -1261,6 +1263,24 @@ func TestForceDetachAlreadyDisklessNoop(t *testing.T) {
 	if err := d.ForceDetach(t.Context(), volPvc1, 1422); err != nil {
 		t.Fatal(err)
 	}
+	fe.notCalledWith(t, "drbdsetup detach")
+}
+
+// A retry after the backing was detached must still remove connections
+// that reserve the deleted volume's endpoint in the kernel.
+func TestForceDetachDisklessRemovesPeers(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Primary",
+			"devices":[{"disk-state":"Diskless"}],
+			"connections":[{"peer-node-id":1,"connection-state":"StandAlone"}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.ForceDetach(t.Context(), volPvc1, 1422); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
+	fe.calledWith(t, "drbdsetup del-peer pvc-1 1")
 	fe.notCalledWith(t, "drbdsetup detach")
 }
 

--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -203,7 +203,7 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 
 		// FormatAndMount formats only when the device has no filesystem —
 		// the mkfs-if-blank step.
-		if err := d.Mounter.FormatAndMount(dev, target, fsType, flags); err != nil {
+		if err := d.Mounter.FormatAndMount(dev, target, fsType, xfsCloneMountFlags(vol, format, flags)); err != nil {
 			if rerr := recoverFrozenBdev(ctx, d, vol, dev, err); rerr != nil {
 				return rerr
 			}
@@ -248,6 +248,16 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 		return status.Errorf(codes.Internal, "record activated flag: %v", err)
 	}
 	return nil
+}
+
+// XFS refuses to mount a snapshot-derived filesystem while its source with
+// the same on-disk UUID is mounted on the node. nouuid gives each mount an
+// in-memory identity without mutating the crash-consistent snapshot image.
+func xfsCloneMountFlags(vol *miroirv1alpha1.MiroirVolume, format string, flags []string) []string {
+	if format != "xfs" || vol.Spec.Source == nil || slices.Contains(flags, "nouuid") {
+		return flags
+	}
+	return append(slices.Clone(flags), "nouuid")
 }
 
 // resourceRestarter is the optional Deps.DRBD upgrade the frozen-bdev

--- a/internal/stage/stage_test.go
+++ b/internal/stage/stage_test.go
@@ -19,6 +19,7 @@ package stage
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -111,5 +112,35 @@ func TestRecoverFrozenBdevNeedsRestarter(t *testing.T) {
 	err := recoverFrozenBdev(t.Context(), Deps{DRBD: statusOnlyDRBD{}}, replicatedVolume(), "/dev/drbd1378", errFrozenMount)
 	if err != nil {
 		t.Fatalf("a status-only DRBD dep must fall through to the generic wrap, got %v", err)
+	}
+}
+
+func TestXFSCloneMountFlags(t *testing.T) {
+	const noatime = "noatime"
+	vol := replicatedVolume()
+	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-1"}
+	original := []string{noatime}
+	got := xfsCloneMountFlags(vol, "xfs", original)
+	if !slices.Equal(got, []string{noatime, "nouuid"}) {
+		t.Fatalf("flags = %v, want noatime,nouuid", got)
+	}
+	if !slices.Equal(original, []string{noatime}) {
+		t.Fatalf("input flags were mutated: %v", original)
+	}
+}
+
+func TestXFSCloneMountFlagsSkipsOtherFilesystemsAndSources(t *testing.T) {
+	vol := replicatedVolume()
+	flags := []string{"relatime"}
+	if got := xfsCloneMountFlags(vol, "xfs", flags); !slices.Equal(got, flags) {
+		t.Fatalf("non-clone flags = %v, want %v", got, flags)
+	}
+	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-1"}
+	if got := xfsCloneMountFlags(vol, "ext4", flags); !slices.Equal(got, flags) {
+		t.Fatalf("ext4 clone flags = %v, want %v", got, flags)
+	}
+	withNoUUID := []string{"nouuid"}
+	if got := xfsCloneMountFlags(vol, "xfs", withNoUUID); !slices.Equal(got, withNoUUID) {
+		t.Fatalf("existing nouuid flags = %v, want %v", got, withNoUUID)
 	}
 }


### PR DESCRIPTION
## What

Three independent correctness fixes surfaced while expanding the storage conformance coverage. Landing them ahead of the testdriver-capability expansion so that flip sits on already-hardened code.

Third in the conformance series, after the [serial](https://github.com/home-operations/miroir/pull/331) and [rwx](https://github.com/home-operations/miroir/pull/332) legs. Pure Go; no CI/testdriver changes here.

## Fixes

- **`fix(drbd): release orphaned replication endpoint`** — `ForceDetach` detached the disk but left peer connections attached, so the zombie resource kept holding its replication port; a later volume reusing that endpoint couldn't connect. Peers are now removed after the detach. Already-detached resources still shed their connections, and not-in-kernel resources stay a no-op so a retry after a failed backing delete still converges. (`reconciler_test.go` updated to assert the `del-peer` call.)

- **`fix(csi): hold group snapshot create until members are ready`** — external-snapshotter records member readiness only from a *successful* `CreateVolumeGroupSnapshot` response, so returning a not-yet-ready group left it unable to persist a complete member set. Return `Aborted` until the group is ready so the call is retried and members land intact.

- **`fix(stage): mount xfs clones with a unique identity`** — XFS refuses to mount a snapshot-derived filesystem while its same-UUID source is mounted on the node. Add `nouuid` for xfs volumes that have a source, giving each clone an in-memory identity without mutating the crash-consistent snapshot image.

## Testing

`go build ./...`, `go vet`, and `gofmt` clean; `go test ./internal/drbd/ ./internal/agent/ ./internal/csi/ ./internal/stage/` all pass. Each fix carries updated unit tests. The e2e lanes exercising these paths (including the upcoming xfs/capacity expansion) run in CI.
