### PR TITLE
test(e2e): expand storage conformance coverage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,12 +44,14 @@ jobs:
           - suite: conformance
             testdriver: testdriver-local.yaml
             specs: "1"
+            capacity: "true"
           # The upstream suite against the replicated (DRBD, replicas:2) class,
           # group snapshots included.
           - suite: replicated
             testdriver: testdriver.yaml
           - suite: zfs
             testdriver: testdriver-zfs.yaml
+            capacity: "true"
           # Filesystem-only multi-node access through the NFS gateway. Keeping this
           # separate avoids advertising unsupported raw-block RWX.
           - suite: rwx

--- a/test/conformance/testdriver-local.yaml
+++ b/test/conformance/testdriver-local.yaml
@@ -11,6 +11,11 @@ DriverInfo:
     Max: 10Gi
   SupportedFsType:
     ext4: {}
+    xfs: {}
+  SupportedMountOption:
+    noatime: {}
+  TopologyKeys:
+    - miroir.home-operations.com/node
   Capabilities:
     persistence: true
     block: true
@@ -27,5 +32,6 @@ DriverInfo:
     singleNodeVolume: true
     # RWX needs the replicated (DRBD) path; the local driver can't exercise it.
     RWX: false
+    multiplePVsSameID: true
     readWriteOncePod: true
-    capacity: false
+    capacity: true

--- a/test/conformance/testdriver-zfs.yaml
+++ b/test/conformance/testdriver-zfs.yaml
@@ -16,6 +16,9 @@ DriverInfo:
     Max: 10Gi
   SupportedFsType:
     ext4: {}
+    xfs: {}
+  SupportedMountOption:
+    noatime: {}
   Capabilities:
     persistence: true
     block: true
@@ -31,9 +34,9 @@ DriverInfo:
     pvcDataSource: true
     topology: true
     singleNodeVolume: false
-    # RWX is implemented (NFS gateway over a replicated volume) but the
-    # upstream RWX specs need real DRBD + ganesha, not kind. Flip to true
-    # once the smoke suite's RWX scenario passes on a real cluster.
+    # The filesystem-only testdriver-rwx.yaml covers multi-node access without
+    # also enabling unsupported raw-block RWX patterns in this block-capable run.
     RWX: false
+    multiplePVsSameID: true
     readWriteOncePod: true
-    capacity: false
+    capacity: true

--- a/test/conformance/testdriver.yaml
+++ b/test/conformance/testdriver.yaml
@@ -16,6 +16,9 @@ DriverInfo:
     Max: 10Gi
   SupportedFsType:
     ext4: {}
+    xfs: {}
+  SupportedMountOption:
+    noatime: {}
   Capabilities:
     persistence: true
     block: true
@@ -31,9 +34,13 @@ DriverInfo:
     pvcDataSource: true
     topology: true
     singleNodeVolume: false
-    # RWX is implemented (NFS gateway over a replicated volume) but the
-    # upstream RWX specs need real DRBD + ganesha, not kind. Flip to true
-    # once the smoke suite's RWX scenario passes on a real cluster.
+    # The filesystem-only testdriver-rwx.yaml covers multi-node access without
+    # also enabling unsupported raw-block RWX patterns in this block-capable run.
     RWX: false
+    multiplePVsSameID: true
     readWriteOncePod: true
+    # Left off on the replicated block lane: DRBD reserves the full size on
+    # every replica, so published capacity runs tight and the scheduler
+    # starves the parallel-clone specs. testdriver-zfs.yaml covers capacity on
+    # the same 2-replica shape.
     capacity: false

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -15,11 +15,13 @@ tests.
 The legs run the same document and differ in what `test.sh` drives against it, so a
 failure names the path that broke:
 
-| Leg           | Runs                                       | Class               |
-| ------------- | ------------------------------------------ | ------------------- |
-| `conformance` | miroir's Go specs, then the upstream suite | `miroir-local`      |
-| `replicated`  | the upstream suite                         | `miroir-replicated` |
-| `zfs`         | the upstream suite                         | `miroir-zfs`        |
+| Leg           | Runs                                                | Class               |
+| ------------- | --------------------------------------------------- | ------------------- |
+| `conformance` | miroir's Go specs, then the parallel upstream suite | `miroir-local`      |
+| `replicated`  | the parallel upstream block/filesystem suite        | `miroir-replicated` |
+| `zfs`         | the parallel upstream block/filesystem suite        | `miroir-zfs`        |
+| `rwx`         | the parallel upstream filesystem-only RWX/ROX suite | `miroir-replicated` |
+| `serial`      | upstream `[Serial]` specs, one process              | `miroir-replicated` |
 
 miroir's Go specs (`test/e2e`) assert the local lifecycle, snapshot/restore, block and
 placement behaviour the upstream suite does not; the conformance leg runs them
@@ -27,9 +29,14 @@ placement behaviour the upstream suite does not; the conformance leg runs them
 external-storage run. The replicated leg drives that upstream suite against the DRBD
 (replicas: 2) class, group snapshots included; the zfs leg drives it against the same
 DRBD shape backed by the zfs pool instead, so replication pairs zvol with zvol and
-the zfs snapshot/restore path runs under the suite. Real per-node kernels and real
-block devices are the point: the DRBD path needs the DRBD 9 module, which only a real
-Talos node has.
+the zfs snapshot/restore path runs under the suite. The rwx leg enables the NFS
+gateway and advertises only filesystem volume modes, while the serial leg gives
+exclusive-cluster specs a single Ginkgo process. The conformance and zfs legs enable
+CSI storage capacity publication (the replicated block lane keeps it off, where DRBD's
+full-size reservation on every replica starves the scheduler during parallel-clone
+specs); the upstream definitions exercise ext4, xfs, topology and mount options. Real
+per-node kernels and real block devices are the point: the DRBD
+path needs the DRBD 9 module, which only a real Talos node has.
 
 ```text
 cluster.yaml              the one cluster shape every leg boots
@@ -78,8 +85,11 @@ talosctl kubeconfig /tmp/miroir-e2e/kubeconfig --nodes 10.5.0.2 --force
 set -gx CLUSTER_NAME miroir-e2e
 set -gx KUBECONFIG /tmp/miroir-e2e/kubeconfig
 set -gx TALOSCONFIG /tmp/miroir-e2e/talosconfig
-set -gx TESTDRIVER testdriver.yaml # or testdriver-local.yaml / testdriver-zfs.yaml
-set -gx RUN_SPECS 1                 # also run the Go specs (the conformance leg does)
+set -gx TESTDRIVER testdriver.yaml # or testdriver-local.yaml / testdriver-zfs.yaml / testdriver-rwx.yaml
+set -gx RUN_SPECS 1                # also run the Go specs (the conformance leg does)
+set -gx STORAGE_CAPACITY_ENABLED true
+# Required with testdriver-rwx.yaml:
+set -gx GATEWAY_ENABLED true
 ./test.sh
 
 sudo -E (mise which talosctl) cluster destroy --name miroir-e2e -f

--- a/test/e2e-qemu/diagnostics.sh
+++ b/test/e2e-qemu/diagnostics.sh
@@ -21,6 +21,9 @@ echo "---- controller logs ----"
 kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=controller --tail=200 --all-containers
 echo "---- agent logs ----"
 kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=agent --tail=200 --all-containers
+echo "---- gateway logs ----"
+kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=gateway --tail=200 --all-containers --prefix
+kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=gateway --tail=200 --all-containers --prefix --previous
 echo "---- drbd state ----"
 for n in $workers; do
     echo "== $n =="


### PR DESCRIPTION
> **Stacked on #333** (drbd/csi/stage fixes). The new xfs advertisement needs the `stage` `nouuid` clone fix from #333, so this is a **draft** until #333 merges; then I'll rebase onto `main` and mark it ready. CI here will be red on xfs clone specs until that lands.

## What

Final leg of the conformance-coverage series (after [serial #331](https://github.com/home-operations/miroir/pull/331), [rwx #332](https://github.com/home-operations/miroir/pull/332), and fixes #333). Expands the upstream external-storage suite's coverage of the existing driver.

- **Testdrivers** (`testdriver.yaml`, `testdriver-zfs.yaml`, `testdriver-local.yaml`): advertise `xfs` and the `noatime` mount option, add `multiplePVsSameID: true`, and give the local driver `TopologyKeys`. The suite now exercises xfs, mount options, and topology alongside ext4.
- **CSI storage capacity**: enabled on the `conformance` (local, 1x) and `zfs` (2x zpool) lanes via `capacity: "true"` in the matrix (the `STORAGE_CAPACITY_ENABLED` plumbing landed with the rwx leg).
- **Docs/diagnostics**: document the full five-leg matrix in the README and capture gateway logs in `diagnostics.sh`.

## Why the replicated block lane keeps capacity off

On the source branch (#328) the only failing spec was `provisioning should provision storage with pvc data source in parallel [Slow]` on the **replicated** lane: with storage capacity on, DRBD reserves the full volume size on **every** replica, so the published `CSIStorageCapacity` runs tight, the scheduler starts rejecting pods (`did not have enough free storage`), and under that pressure a parallel clone came up empty. The **zfs** lane is also two-replica but backed by a zpool and handles capacity fine, so it retains capacity coverage on the replicated shape. `testdriver.yaml` therefore keeps `capacity: false` (which also keeps the `serial` lane, that shares it, unchanged).

## Testing

`yq` parses all testdrivers and the workflow; `capacity` resolves to false/true/true for replicated/zfs/local as intended; `diagnostics.sh` passes `bash -n`. Full e2e runs in CI once rebased on #333. The identical capability set (minus replicated capacity) was green on the source branch's conformance/zfs/rwx/serial lanes.
