### PR TITLE
fix(agent): release DRBD backings before shutdown

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -756,31 +756,36 @@ func main() {
 			shutdownEarly)
 	}
 	err = mgr.Start(managerCtx)
-	if shutdownSweep != nil {
-		if signalCtx.Err() != nil {
-			// The early pass starts as soon as SIGTERM arrives, while the
-			// manager is still stopping. Repeat after it stops to cover races
-			// with reconciliation that was active at signal time.
-			waitEarlyCleanup()
-			shutdownSweep()
-		} else {
-			// A topology-triggered manager restart is not a node shutdown.
-			disarmEarlyCleanup()
-			if err != nil && managerCtx.Err() == nil {
-				// Preserve the defensive cleanup for an unexpected manager
-				// failure, even though no OS signal was observed.
-				shutdownSweep()
-			} else {
-				// Barrier recovery remains useful after every manager stop,
-				// but topology restarts must not tear down Secondaries.
-				shutdownBarrierSweep()
-			}
-		}
-	}
+	err = finishManagerShutdown(err, signalCtx, managerCtx, shutdownSweep,
+		shutdownBarrierSweep, waitEarlyCleanup, disarmEarlyCleanup)
 	if err != nil {
 		setupLog.Error(err, "manager exited")
 		os.Exit(1)
 	}
+}
+
+// finishManagerShutdown completes the shutdown coordination after the
+// manager has stopped. Signal shutdown repeats the early teardown; an
+// internal restart only recovers barriers, while an unexpected manager error
+// keeps the defensive full sweep.
+func finishManagerShutdown(err error, signalCtx, managerCtx context.Context,
+	shutdownSweep, shutdownBarrierSweep, waitEarlyCleanup, disarmEarlyCleanup func(),
+) error {
+	if shutdownSweep == nil {
+		return err
+	}
+	if signalCtx.Err() != nil {
+		waitEarlyCleanup()
+		shutdownSweep()
+		return err
+	}
+	disarmEarlyCleanup()
+	if err != nil && managerCtx.Err() == nil {
+		shutdownSweep()
+		return err
+	}
+	shutdownBarrierSweep()
+	return err
 }
 
 // apiStartupWait bounds how long the startup sweeps wait for the API server,
@@ -801,7 +806,7 @@ const apiShutdownWait = 5 * time.Second
 // armSignalShutdown starts cleanup as soon as the OS signal arrives, rather
 // than waiting for controller-runtime to finish stopping its runnables. The
 // disarm path is used for an internal manager restart.
-func armSignalShutdown(signalCtx context.Context, cleanup func()) (wait, disarm func()) {
+func armSignalShutdown(signalCtx context.Context, cleanup func()) (waitForCleanup, disarm func()) {
 	done := make(chan struct{})
 	stop := make(chan struct{})
 	var once sync.Once

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -750,14 +750,13 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	var waitEarlyCleanup, disarmEarlyCleanup func()
+	var earlyCleanup *signalShutdown
 	if shutdownSweep != nil {
-		waitEarlyCleanup, disarmEarlyCleanup = armSignalShutdown(signalCtx,
-			shutdownEarly)
+		earlyCleanup = armSignalShutdown(signalCtx, shutdownEarly)
 	}
 	err = mgr.Start(managerCtx)
 	err = finishManagerShutdown(err, signalCtx, managerCtx, shutdownSweep,
-		shutdownBarrierSweep, waitEarlyCleanup, disarmEarlyCleanup)
+		shutdownBarrierSweep, earlyCleanup)
 	if err != nil {
 		setupLog.Error(err, "manager exited")
 		os.Exit(1)
@@ -769,22 +768,25 @@ func main() {
 // internal restart only recovers barriers, while an unexpected manager error
 // keeps the defensive full sweep.
 func finishManagerShutdown(err error, signalCtx, managerCtx context.Context,
-	shutdownSweep, shutdownBarrierSweep, waitEarlyCleanup, disarmEarlyCleanup func(),
+	shutdownSweep, shutdownBarrierSweep func(), earlyCleanup *signalShutdown,
 ) error {
 	if shutdownSweep == nil {
 		return err
 	}
 	if signalCtx.Err() != nil {
-		waitEarlyCleanup()
+		earlyCleanup.finish()
 		shutdownSweep()
 		return err
 	}
-	disarmEarlyCleanup()
 	if err != nil && managerCtx.Err() == nil {
+		earlyCleanup.finish()
 		shutdownSweep()
 		return err
 	}
 	shutdownBarrierSweep()
+	if earlyCleanup.finish() {
+		shutdownSweep()
+	}
 	return err
 }
 
@@ -803,30 +805,57 @@ const drbdShutdownTimeout = 15 * time.Second
 // guarantee a SIGKILL mid-sweep.
 const apiShutdownWait = 5 * time.Second
 
-// armSignalShutdown starts cleanup as soon as the OS signal arrives, rather
-// than waiting for controller-runtime to finish stopping its runnables. The
-// disarm path is used for an internal manager restart.
-func armSignalShutdown(signalCtx context.Context, cleanup func()) (waitForCleanup, disarm func()) {
-	done := make(chan struct{})
-	stop := make(chan struct{})
-	var once sync.Once
+// signalShutdown starts cleanup as soon as the OS signal arrives, rather
+// than waiting for controller-runtime to finish stopping its runnables. Its
+// finish method commits an internal restart only after the barrier sweep; its
+// result reports whether signal cleanup won that race.
+type signalShutdown struct {
+	signalCtx context.Context
+	cleanup   func()
+
+	mu        sync.Mutex
+	committed bool
+	done      chan struct{}
+	stop      chan struct{}
+}
+
+func armSignalShutdown(signalCtx context.Context, cleanup func()) *signalShutdown {
+	s := &signalShutdown{
+		signalCtx: signalCtx,
+		cleanup:   cleanup,
+		done:      make(chan struct{}),
+		stop:      make(chan struct{}),
+	}
 	go func() {
 		select {
 		case <-signalCtx.Done():
-			cleanup()
-		case <-stop:
-			select {
-			case <-signalCtx.Done():
-				cleanup()
-			default:
+			s.mu.Lock()
+			committed := s.committed
+			s.mu.Unlock()
+			if !committed {
+				s.cleanup()
 			}
+		case <-s.stop:
 		}
-		close(done)
+		close(s.done)
 	}()
-	return func() { <-done }, func() {
-		once.Do(func() { close(stop) })
-		<-done
+	return s
+}
+
+// finish joins the helper. It linearizes an internal restart against signal
+// cancellation: a signal observed before the commit wins and returns true.
+func (s *signalShutdown) finish() bool {
+	s.mu.Lock()
+	if s.signalCtx.Err() != nil {
+		s.mu.Unlock()
+		<-s.done
+		return true
 	}
+	s.committed = true
+	close(s.stop)
+	s.mu.Unlock()
+	<-s.done
+	return false
 }
 
 // apiWithRetry retries one API call until it succeeds, hits a terminal

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -539,16 +540,19 @@ func main() {
 
 	identity := &csi.Identity{Version: version, WithController: mode == modeController}
 
-	// Agent mode only, run after the manager stops (SIGTERM): release DRBD
-	// backings when the node is going down and lift any leftover write
-	// barrier — both are kernel state that outlives the process.
+	// Agent mode only, run around manager shutdown: release DRBD backings when
+	// the node is going down and lift any leftover write barrier — both are
+	// kernel state that outlives the process.
 	var shutdownSweep func()
+	var shutdownBarrierSweep func()
+	var shutdownEarly func()
 
-	// The signal context is created before the mode switch so the agent's
-	// topology watcher can stop the manager gracefully (restart-to-reload)
-	// through the same cancellation path a SIGTERM takes.
-	ctx, stop := context.WithCancel(ctrl.SetupSignalHandler())
-	defer stop()
+	// Keep OS-signal cancellation separate from manager cancellation: the
+	// topology watcher can restart the manager without looking like a node
+	// shutdown.
+	signalCtx := ctrl.SetupSignalHandler()
+	managerCtx, stopManager := context.WithCancel(signalCtx)
+	defer stopManager()
 
 	switch mode {
 	case modeController:
@@ -595,7 +599,7 @@ func main() {
 		// holds no storage either and gets the same treatment —
 		// setupAgentPools would read zero pools as "every pool failed" and
 		// crash-loop.
-		miroirNode, found := agentTopology(mgr, nodeName, stop)
+		miroirNode, found := agentTopology(mgr, nodeName, stopManager)
 		var flat nodemap.Node
 		if found {
 			flat = nodemap.FromSpec(miroirNode.Spec)
@@ -662,6 +666,8 @@ func main() {
 		var drbdEvents chan event.GenericEvent
 		if drbdReady {
 			shutdownSweep = func() { agentShutdownSweep(cordon, drbdDriver, nodeName) }
+			shutdownBarrierSweep = func() { agentShutdownBarrierSweep(drbdDriver, nodeName) }
+			shutdownEarly = func() { agentShutdownDownSecondaries(cordon, drbdDriver) }
 			// events2 turns kernel state changes into immediate reconciles;
 			// the 30s poll remains as the safety net.
 			drbdEvents = make(chan event.GenericEvent, 64)
@@ -744,12 +750,32 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	err = mgr.Start(ctx)
-	// The sweep must run even when the manager exits with an error — a
-	// runnable blowing the shutdown grace is exactly the case where a
-	// cordoned node still needs its DRBD backings released for reboot.
+	var waitEarlyCleanup, disarmEarlyCleanup func()
 	if shutdownSweep != nil {
-		shutdownSweep()
+		waitEarlyCleanup, disarmEarlyCleanup = armSignalShutdown(signalCtx,
+			shutdownEarly)
+	}
+	err = mgr.Start(managerCtx)
+	if shutdownSweep != nil {
+		if signalCtx.Err() != nil {
+			// The early pass starts as soon as SIGTERM arrives, while the
+			// manager is still stopping. Repeat after it stops to cover races
+			// with reconciliation that was active at signal time.
+			waitEarlyCleanup()
+			shutdownSweep()
+		} else {
+			// A topology-triggered manager restart is not a node shutdown.
+			disarmEarlyCleanup()
+			if err != nil && managerCtx.Err() == nil {
+				// Preserve the defensive cleanup for an unexpected manager
+				// failure, even though no OS signal was observed.
+				shutdownSweep()
+			} else {
+				// Barrier recovery remains useful after every manager stop,
+				// but topology restarts must not tear down Secondaries.
+				shutdownBarrierSweep()
+			}
+		}
 	}
 	if err != nil {
 		setupLog.Error(err, "manager exited")
@@ -771,6 +797,32 @@ const drbdShutdownTimeout = 15 * time.Second
 // DownSecondaries can already spend 45s of it. apiStartupWait would
 // guarantee a SIGKILL mid-sweep.
 const apiShutdownWait = 5 * time.Second
+
+// armSignalShutdown starts cleanup as soon as the OS signal arrives, rather
+// than waiting for controller-runtime to finish stopping its runnables. The
+// disarm path is used for an internal manager restart.
+func armSignalShutdown(signalCtx context.Context, cleanup func()) (wait, disarm func()) {
+	done := make(chan struct{})
+	stop := make(chan struct{})
+	var once sync.Once
+	go func() {
+		select {
+		case <-signalCtx.Done():
+			cleanup()
+		case <-stop:
+			select {
+			case <-signalCtx.Done():
+				cleanup()
+			default:
+			}
+		}
+		close(done)
+	}()
+	return func() { <-done }, func() {
+		once.Do(func() { close(stop) })
+		<-done
+	}
+}
 
 // apiWithRetry retries one API call until it succeeds, hits a terminal
 // (non-transient) error, or the budget elapses — so a control plane still
@@ -817,13 +869,10 @@ func transientAPIError(err error) bool {
 	}
 }
 
-// agentShutdownSweep runs after the agent's manager stops (SIGTERM). A
-// cordoned node is being drained for a reboot or upgrade: release Secondary
-// backings so the backend pool can export. Gated on cordon because an
-// ungated teardown would disconnect idle replicas on every pod rollout. A
-// leftover write barrier is also kernel state that must not outlive the
-// process.
-func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver, nodeName string) {
+// agentShutdownDownSecondaries releases Secondary backings only for a
+// cordoned node. The early signal path deliberately does not perform API
+// access, so it can start before manager shutdown has completed.
+func agentShutdownDownSecondaries(cordon *agent.CordonWatcher, driver *drbd.Driver) {
 	if cordon.Cordoned() {
 		ctx, cancel := context.WithTimeout(context.Background(), drbdShutdownTimeout)
 		defer cancel()
@@ -832,6 +881,9 @@ func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver, nodeNa
 			setupLog.Error(err, "DRBD shutdown teardown failed; node reboot may stall")
 		}
 	}
+}
+
+func agentShutdownBarrierSweep(driver *drbd.Driver, nodeName string) {
 	// Short API budget: the chart grants 60s of termination grace and the
 	// manager stop + DownSecondaries already spend up to 45s of it. A
 	// stranded barrier missed here is lifted by the startup sweep on the
@@ -839,6 +891,12 @@ func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver, nodeNa
 	if err := resumeStaleBarriers(driver, agent.NewFreezer(), nodeName, apiShutdownWait); err != nil {
 		setupLog.Error(err, "shutdown barrier sweep failed")
 	}
+}
+
+// agentShutdownSweep is the final idempotent shutdown pass.
+func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver, nodeName string) {
+	agentShutdownDownSecondaries(cordon, driver)
+	agentShutdownBarrierSweep(driver, nodeName)
 }
 
 // sweepOrphans removes DRBD state with no owning volume on this node,

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -193,8 +193,10 @@ func TestFinishManagerShutdownInternalRestartOnlySweepsBarrier(t *testing.T) {
 	var full, barrier int
 	unexpectedCleanup := make(chan struct{}, 1)
 	shutdown := armSignalShutdown(signalCtx, func() { unexpectedCleanup <- struct{}{} })
-	finishManagerShutdown(nil, signalCtx, managerCtx,
-		func() { full++ }, func() { barrier++ }, shutdown)
+	if err := finishManagerShutdown(nil, signalCtx, managerCtx,
+		func() { full++ }, func() { barrier++ }, shutdown); err != nil {
+		t.Fatalf("finish manager shutdown: %v", err)
+	}
 	if full != 0 || barrier != 1 {
 		t.Fatalf("full = %d, barrier = %d; want 0, 1", full, barrier)
 	}
@@ -212,8 +214,10 @@ func TestFinishManagerShutdownSignalBeforeManagerStopRunsFullSweep(t *testing.T)
 	cancelManager()
 	var full, barrier int
 	shutdown := armSignalShutdown(signalCtx, func() {})
-	finishManagerShutdown(nil, signalCtx, managerCtx,
-		func() { full++ }, func() { barrier++ }, shutdown)
+	if err := finishManagerShutdown(nil, signalCtx, managerCtx,
+		func() { full++ }, func() { barrier++ }, shutdown); err != nil {
+		t.Fatalf("finish manager shutdown: %v", err)
+	}
 	if full != 1 || barrier != 0 {
 		t.Fatalf("full = %d, barrier = %d; want 1, 0", full, barrier)
 	}
@@ -227,10 +231,12 @@ func TestFinishManagerShutdownSignalDuringBarrierRunsFullSweep(t *testing.T) {
 	earlyCleaned := make(chan struct{})
 	var full, barrier int
 	shutdown := armSignalShutdown(signalCtx, func() { close(earlyCleaned) })
-	finishManagerShutdown(nil, signalCtx, managerCtx, func() { full++ }, func() {
+	if err := finishManagerShutdown(nil, signalCtx, managerCtx, func() { full++ }, func() {
 		barrier++
 		cancelSignal()
-	}, shutdown)
+	}, shutdown); err != nil {
+		t.Fatalf("finish manager shutdown: %v", err)
+	}
 	if full != 1 || barrier != 1 {
 		t.Fatalf("full = %d, barrier = %d; want 1, 1", full, barrier)
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -158,9 +158,11 @@ func TestArmSignalShutdownRunsCleanupOnSignal(t *testing.T) {
 	signalCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	cleaned := make(chan struct{})
-	wait, _ := armSignalShutdown(signalCtx, func() { close(cleaned) })
+	shutdown := armSignalShutdown(signalCtx, func() { close(cleaned) })
 	cancel()
-	wait()
+	if !shutdown.finish() {
+		t.Fatal("signal cleanup must win after signal cancellation")
+	}
 	select {
 	case <-cleaned:
 	case <-time.After(time.Second):
@@ -168,13 +170,14 @@ func TestArmSignalShutdownRunsCleanupOnSignal(t *testing.T) {
 	}
 }
 
-func TestArmSignalShutdownDisarmsForInternalCancellation(t *testing.T) {
+func TestArmSignalShutdownFinishesForInternalRestart(t *testing.T) {
 	signalCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	cleaned := make(chan struct{})
-	wait, disarm := armSignalShutdown(signalCtx, func() { close(cleaned) })
-	disarm()
-	wait()
+	shutdown := armSignalShutdown(signalCtx, func() { close(cleaned) })
+	if shutdown.finish() {
+		t.Fatal("internal restart must win before signal cancellation")
+	}
 	select {
 	case <-cleaned:
 		t.Fatal("internal manager cancellation ran shutdown cleanup")
@@ -182,18 +185,59 @@ func TestArmSignalShutdownDisarmsForInternalCancellation(t *testing.T) {
 	}
 }
 
-func TestArmSignalShutdownDisarmAfterSignalRunsCleanup(t *testing.T) {
-	signalCtx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	cleaned := make(chan struct{})
-	wait, disarm := armSignalShutdown(signalCtx, func() { close(cleaned) })
-	cancel()
-	disarm()
-	wait()
+func TestFinishManagerShutdownInternalRestartOnlySweepsBarrier(t *testing.T) {
+	signalCtx, cancelSignal := context.WithCancel(t.Context())
+	defer cancelSignal()
+	managerCtx, cancelManager := context.WithCancel(t.Context())
+	cancelManager()
+	var full, barrier int
+	unexpectedCleanup := make(chan struct{}, 1)
+	shutdown := armSignalShutdown(signalCtx, func() { unexpectedCleanup <- struct{}{} })
+	finishManagerShutdown(nil, signalCtx, managerCtx,
+		func() { full++ }, func() { barrier++ }, shutdown)
+	if full != 0 || barrier != 1 {
+		t.Fatalf("full = %d, barrier = %d; want 0, 1", full, barrier)
+	}
 	select {
-	case <-cleaned:
-	case <-time.After(time.Second):
-		t.Fatal("signal cleanup did not run when disarmed after signal")
+	case <-unexpectedCleanup:
+		t.Fatal("internal restart ran early cleanup")
+	default:
+	}
+}
+
+func TestFinishManagerShutdownSignalBeforeManagerStopRunsFullSweep(t *testing.T) {
+	signalCtx, cancelSignal := context.WithCancel(t.Context())
+	managerCtx, cancelManager := context.WithCancel(t.Context())
+	cancelSignal()
+	cancelManager()
+	var full, barrier int
+	shutdown := armSignalShutdown(signalCtx, func() {})
+	finishManagerShutdown(nil, signalCtx, managerCtx,
+		func() { full++ }, func() { barrier++ }, shutdown)
+	if full != 1 || barrier != 0 {
+		t.Fatalf("full = %d, barrier = %d; want 1, 0", full, barrier)
+	}
+}
+
+func TestFinishManagerShutdownSignalDuringBarrierRunsFullSweep(t *testing.T) {
+	signalCtx, cancelSignal := context.WithCancel(t.Context())
+	defer cancelSignal()
+	managerCtx, cancelManager := context.WithCancel(t.Context())
+	cancelManager()
+	earlyCleaned := make(chan struct{})
+	var full, barrier int
+	shutdown := armSignalShutdown(signalCtx, func() { close(earlyCleaned) })
+	finishManagerShutdown(nil, signalCtx, managerCtx, func() { full++ }, func() {
+		barrier++
+		cancelSignal()
+	}, shutdown)
+	if full != 1 || barrier != 1 {
+		t.Fatalf("full = %d, barrier = %d; want 1, 1", full, barrier)
+	}
+	select {
+	case <-earlyCleaned:
+	default:
+		t.Fatal("signal cleanup did not complete")
 	}
 }
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -197,7 +197,7 @@ func TestArmSignalShutdownDisarmAfterSignalRunsCleanup(t *testing.T) {
 	}
 }
 
-func TestAgentShutdownDownSecondariesRequiresCordon(t *testing.T) {
+func TestAgentShutdownDownSecondariesRequiresCordon(_ *testing.T) {
 	// A nil driver is intentional: an uncordoned node must return before any
 	// teardown is attempted.
 	agentShutdownDownSecondaries(&agent.CordonWatcher{}, nil)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/agent"
 )
 
 func TestCSIServerRunsOnEveryReplica(t *testing.T) {
@@ -150,4 +152,53 @@ func TestCacheOptionsAgentPinsOwnNode(t *testing.T) {
 	if byNode.Field == nil || byNode.Field.String() != "metadata.name=node-a" {
 		t.Fatalf("Node informer must be pinned to the node's own object, got %v", byNode.Field)
 	}
+}
+
+func TestArmSignalShutdownRunsCleanupOnSignal(t *testing.T) {
+	signalCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	cleaned := make(chan struct{})
+	wait, _ := armSignalShutdown(signalCtx, func() { close(cleaned) })
+	cancel()
+	wait()
+	select {
+	case <-cleaned:
+	case <-time.After(time.Second):
+		t.Fatal("signal cleanup did not run")
+	}
+}
+
+func TestArmSignalShutdownDisarmsForInternalCancellation(t *testing.T) {
+	signalCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	cleaned := make(chan struct{})
+	wait, disarm := armSignalShutdown(signalCtx, func() { close(cleaned) })
+	disarm()
+	wait()
+	select {
+	case <-cleaned:
+		t.Fatal("internal manager cancellation ran shutdown cleanup")
+	default:
+	}
+}
+
+func TestArmSignalShutdownDisarmAfterSignalRunsCleanup(t *testing.T) {
+	signalCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	cleaned := make(chan struct{})
+	wait, disarm := armSignalShutdown(signalCtx, func() { close(cleaned) })
+	cancel()
+	disarm()
+	wait()
+	select {
+	case <-cleaned:
+	case <-time.After(time.Second):
+		t.Fatal("signal cleanup did not run when disarmed after signal")
+	}
+}
+
+func TestAgentShutdownDownSecondariesRequiresCordon(t *testing.T) {
+	// A nil driver is intentional: an uncordoned node must return before any
+	// teardown is attempted.
+	agentShutdownDownSecondaries(&agent.CordonWatcher{}, nil)
 }


### PR DESCRIPTION
## Summary
- start cordon-gated DRBD secondary teardown immediately on OS shutdown
- keep topology-triggered manager restarts from tearing down replicas
- add a final teardown pass after manager shutdown and cover signal/disarm ordering

## Testing
- go test ./cmd ./internal/agent
- git diff --check