### PR TITLE
fix(helm): stamp Chart.yaml version on release

### DIFF
--- a/charts/miroir/Chart.yaml
+++ b/charts/miroir/Chart.yaml
@@ -2,10 +2,11 @@ apiVersion: v2
 name: miroir
 description: Replicated block storage for small Kubernetes clusters — CSI on LVM thin, ZFS, or loopfile backends with synchronous DRBD9 replication
 type: application
-# Placeholder — CI overrides both at publish time (helm package
-# --version/--app-version from the release tag).
-version: 0.0.1
-appVersion: 0.0.1
+# release-please stamps both on release; the release workflow re-stamps them at
+# package time (helm package --version/--app-version), so this keeps the repo
+# copy from going stale rather than feeding the published chart.
+version: 0.11.10 # x-release-please-version
+appVersion: "0.11.10" # x-release-please-version
 kubeVersion: ">=1.31.0"
 home: https://github.com/home-operations/miroir
 sources:

--- a/charts/miroir/README.md
+++ b/charts/miroir/README.md
@@ -1,6 +1,8 @@
 # miroir
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.11.10&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.11.10&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 Replicated block storage for small Kubernetes clusters — CSI on LVM thin, ZFS, or loopfile backends with synchronous DRBD9 replication
 

--- a/charts/miroir/README.md.gotmpl
+++ b/charts/miroir/README.md.gotmpl
@@ -1,6 +1,14 @@
 {{ template "chart.header" . }}
 
-{{ template "chart.badgesSection" . }}
+{{- /* Hand-rolled badges instead of chart.badgesSection so release-please can
+stamp the version: its updater replaces only the first semver on an annotated
+line and would swallow a `-color` suffix as a prerelease, so each version badge
+uses the static/v1 query form (version followed by `&`), keeps the version out
+of its alt text, and carries its own annotation. Keeps the committed README in
+sync with the stamped Chart.yaml. */}}
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 {{ template "chart.description" . }}
 

--- a/charts/miroir/tests/agent_test.yaml
+++ b/charts/miroir/tests/agent_test.yaml
@@ -39,9 +39,11 @@ tests:
     set:
     documentIndex: 0
     asserts:
-      - equal:
+      # The tag floats with the release-please-stamped appVersion; assert the
+      # repo:semver shape rather than a hardcoded version.
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/home-operations/miroir-agent:0.0.1"
+          pattern: ^ghcr\.io/home-operations/miroir-agent:\d+\.\d+\.\d+$
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/charts/miroir/tests/controller_test.yaml
+++ b/charts/miroir/tests/controller_test.yaml
@@ -65,9 +65,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].name
           value: controller
-      - equal:
+      # The tag floats with the release-please-stamped appVersion; assert the
+      # repo:semver shape rather than a hardcoded version.
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/home-operations/miroir-controller:0.0.1"
+          pattern: ^ghcr\.io/home-operations/miroir-controller:\d+\.\d+\.\d+$
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
@@ -538,9 +540,8 @@ tests:
   - it: withholds the gateway args by default (RWX is opt-in)
     documentIndex: 0
     asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: --gateway-image=ghcr.io/home-operations/miroir-gateway:0.0.1
+      - notExists:
+          path: spec.template.spec.containers[0].args[?(@ =~ /^--gateway-image=/)]
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --gateway-service-account=miroir-gateway
@@ -552,9 +553,11 @@ tests:
     set:
       gateway.enabled: true
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --gateway-image=ghcr.io/home-operations/miroir-gateway:0.0.1
+      # The tag floats with the release-please-stamped appVersion; assert the
+      # repo:semver shape rather than a hardcoded version.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[?(@ =~ /^--gateway-image=/)]
+          pattern: ^--gateway-image=ghcr\.io/home-operations/miroir-gateway:\d+\.\d+\.\d+$
       - contains:
           path: spec.template.spec.containers[0].args
           content: --gateway-service-account=miroir-gateway

--- a/charts/miroir/tests/helpers_test.yaml
+++ b/charts/miroir/tests/helpers_test.yaml
@@ -105,9 +105,11 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
-      - equal:
+      # The label floats with the release-please-stamped chart version; assert
+      # the name-semver shape rather than a hardcoded version.
+      - matchRegex:
           path: metadata.labels["helm.sh/chart"]
-          value: miroir-0.0.1
+          pattern: ^miroir-\d+\.\d+\.\d+$
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
           value: controller

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,11 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
-      "always-update": true
+      "always-update": true,
+      "extra-files": [
+        { "type": "generic", "path": "charts/miroir/Chart.yaml" },
+        "charts/miroir/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Ports home-operations/tuppr#414 + home-operations/tuppr#415 to miroir.

`charts/miroir/Chart.yaml` carried a `0.0.1` placeholder, so the in-repo chart never
showed the version it corresponds to; only the release workflow's
`helm package --version/--app-version` gave the published artifact a real one.
release-please now stamps `version`/`appVersion` (current release: `0.11.10`), and the
release workflow still re-stamps at package time, so the committed copy simply stops
going stale.

### Why the typed generic updater

`Chart.yaml` is registered as `{"type": "generic"}` in `extra-files` rather than a bare
path. release-please picks its updater from the file extension, and the YAML updater
re-serializes the document: every comment in `Chart.yaml` would be dropped, and
`appVersion` would not be stamped at all. The generic updater only rewrites the semver
on lines annotated with `x-release-please-version`.

### Consequences

- `README.md.gotmpl` drops `chart.badgesSection` for hand-rolled badges. The generic
  updater replaces only the first semver on an annotated line, and the shields.io
  `badge/AppVersion-1.2.3-informational` path form would let it swallow
  `-informational` as a prerelease suffix. The `static/v1` query form terminates the
  version with `&`, keeps the version out of the alt text, and each version badge
  carries its own annotation, so the committed README stays in sync with the stamped
  `Chart.yaml`.
- Chart tests that hardcoded the placeholder now assert shape instead of a version:
  the controller and agent image tags, the `--gateway-image=` controller flag, and the
  `helm.sh/chart` label. They no longer need editing on every release. The
  default-gateway ("withholds the gateway args") case became `notExists` on a filtered
  path, because a `notContains` against a hardcoded tag would silently pass whether or
  not the flag was emitted.

Nothing about the published artifact changes: `helm package` in `.github/workflows/release.yaml`
and the e2e harness both pass `--version`/`--app-version` explicitly, and every image
tag in e2e is set explicitly too.

### Verification

| Gate | Result |
| --- | --- |
| `mise run helm-lint` | pass (`1 chart(s) linted, 0 chart(s) failed`; pre-existing `icon is recommended` info) |
| `mise run helm-test` (helm-unittest) | pass: 11/11 suites, 119/119 tests |
| `mise run helm-docs-check` | pass (no diff in `charts/*/README.md`, `charts/*/values.schema.json`) |
| `oxfmt --check` on the touched JSON/YAML | pass |
| lefthook pre-commit (`format-json`, `format-yaml`, `helm-docs`) | pass, no restaging |

The two rewritten gateway assertions were checked for vacuity by inverting them
(`notExists` with the gateway enabled, and a deliberately wrong pattern); both failed as
expected before being finalized. No Go code is touched, so the Go gates are unaffected.
