### PR TITLE
docs: stage kopiur backups on an unreplicated class

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -463,6 +463,76 @@ resource and schedules backups into it.
 
 ///
 
+### Stage kopiur backups unreplicated
+
+kopiur's `copyMethod: Snapshot` provisions a short-lived staged PVC
+from each VolumeSnapshot and deletes it once the mover job has
+uploaded (`Clone` stages the same way from a CSI clone). That staged
+PVC inherits the source PVC's StorageClass unless
+`spec.staging.storageClassName` overrides it, so a replicated
+application volume gets a replicated staging volume on every backup:
+a second DRBD leg comes up and syncs, plus a diskless tie-breaker on
+a 2-replica `freeze` class, for data that is deleted minutes later.
+On a frequent schedule that reads as constant resync activity.
+
+Give the staged PVC its own `replicas: "1"` class. A restore is a
+node-local copy-on-write clone, so that class must name the **same
+pool** as the source: the controller refuses a cross-pool restore
+with `restore must stay in the source volume's pool`, and kopiur
+rejects a class belonging to another CSI driver with
+`StagedClassMismatch`. Keep `csi.storage.k8s.io/fstype` in step with
+the source class too; the staged clone arrives already formatted.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: miroir-replicated-fast
+provisioner: miroir.home-operations.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  miroir.home-operations.com/replicas: "2"
+  miroir.home-operations.com/pool: fast
+  miroir.home-operations.com/quorum: freeze
+  csi.storage.k8s.io/fstype: ext4
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: miroir-replicated-fast-staging
+provisioner: miroir.home-operations.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  miroir.home-operations.com/replicas: "1"
+  miroir.home-operations.com/pool: fast # must match the source class
+  csi.storage.k8s.io/fstype: ext4
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: postgres
+  namespace: databases
+spec:
+  repository:
+    name: primary
+  copyMethod: Snapshot
+  volumeSnapshotClassName: miroir-snap
+  staging:
+    storageClassName: miroir-replicated-fast-staging
+  sources:
+    - pvc:
+        name: postgres-data
+  retention:
+    keepDaily: 14
+```
+
+The application PVC is untouched: `spec.staging` governs the staged
+copy only, and dropping replication from a throwaway volume costs
+nothing (the snapshot it clones still lives on the replicated
+source).
+
 ## 5. Expand online
 
 Edit the PVC's `spec.resources.requests.storage`. The agent grows

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -28,3 +28,9 @@
   `7100`) to move miroir's range; existing volumes keep their ports.
   Full forensics in
   [#148](https://github.com/home-operations/miroir/issues/148).
+- **Resync activity on every kopiur backup**: kopiur's staged PVC
+  inherits the source PVC's StorageClass, so a replicated volume gets
+  a replicated (and therefore syncing) staging volume once per backup
+  cycle. Point `spec.staging.storageClassName` at a `replicas: "1"`
+  class naming the same pool, per
+  [Stage kopiur backups unreplicated](quickstart.md#stage-kopiur-backups-unreplicated).


### PR DESCRIPTION
Reported by a user seeing frequent resyncs while running kopiur backups against replicated miroir volumes.

kopiur’s staged PVC inherits its source PVC’s StorageClass unless `spec.staging.storageClassName` overrides it, so a replicated application volume mints a replicated throwaway staging volume on every backup cycle: a second DRBD leg comes up and syncs (plus a diskless tie-breaker on a 2-replica `freeze` class) for data that is deleted minutes later.

The fix is a dedicated `replicas: "1"` staging class that keeps the source class’s pool, since a restore is a node-local CoW clone and the controller refuses to cross pools (`restore must stay in the source volume’s pool`, `internal/csi/controller.go`). Shrinking to one replica on restore is already supported and documented in `docs/replication.md`; this just spells out the kopiur wiring.

- `docs/quickstart.md`: new "Stage kopiur backups unreplicated" subsection under Snapshot and restore, with the source class, the staging class, and the SnapshotPolicy that points at it.
- `docs/troubleshooting.md`: "Resync activity on every kopiur backup" entry linking to it.

`mkdocs build --strict` passes.