### PR TITLE
ci: adopt the shared workflow-lint and docs-build actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -378,6 +378,37 @@ jobs:
           helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
           mise run helm-test
 
+  workflow-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
+    name: Workflow Lint
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: false
+
+      - name: Resolve linter versions
+        id: tools
+        run: |
+          echo "actionlint=$(mise config get tools.actionlint)" >> "$GITHUB_OUTPUT"
+          echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
+
+      - name: Lint workflows
+        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        with:
+          actionlint-version: ${{ steps.tools.outputs.actionlint }}
+          zizmor-version: ${{ steps.tools.outputs.zizmor }}
+
   status:
     if: ${{ !cancelled() }}
     name: Build Success
@@ -388,6 +419,7 @@ jobs:
       - go-test
       - helm-lint
       - helm-unittest
+      - workflow-lint
     runs-on: ubuntu-24.04
     permissions: {}
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,24 +27,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Mise
-        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
-        with:
-          experimental: true
-          install_args: --locked
-
-      - name: Configure Pages
-        if: ${{ inputs.deploy }}
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
       - name: Build docs site
-        run: mise run docs
-
-      - name: Upload artifact
-        if: ${{ inputs.deploy }}
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        uses: home-operations/.github/actions/docs-build@d55d4551bf9ad29becda40b66792d94892a6307c # docs-build-1.0.0
         with:
-          path: ./site
+          deploy: ${{ inputs.deploy }}
 
   publish:
     name: Publish to GitHub Pages


### PR DESCRIPTION
Adds the `workflow-lint` job, pinned to `workflow-lint-1.0.0`, resolving the linter versions from this repository's `.mise/config.toml` so CI and the pre-commit hooks run the same builds.

Draft until home-operations/.github#55 merges: converting `docs.yaml` to the shared `docs-build` action needs a released SHA to pin, and that commit lands in this PR.