### PR TITLE
docs: explain the replica and peer-slot limits as a scope decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ troubleshooting.
 
 ## When _not_ to use it
 
-- You need >3 replicas. DRBD9 itself supports more, but the
-  controller validates `1..3`, metadata reserves `--max-peers 7`, and
-  the quorum policies assume 2 data replicas plus a tie-breaker.
+- You need >3 replicas. DRBD9 itself allows up to 32 nodes on a
+  single resource, so this is a scope decision, not a DRBD limit: the
+  controller validates `1..3`, metadata reserves `--max-peers 7`
+  slots per leg (enough for 2 peer replicas, the tie-breaker, 2
+  remote clients, and rebuild headroom), and the quorum policies
+  assume 2 data replicas plus a tie-breaker. More than that means
+  redesigning the vote math and recreating on-disk metadata: LINSTOR
+  territory.
 - You need iSCSI targets or a standalone NFS/file server. miroir
   serves block devices, plus a per-volume NFS export for
   `ReadWriteMany` (see [RWX](https://miroir.home-operations.com/rwx/));

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,9 +45,14 @@ flowchart LR
 
 ## When _not_ to use it
 
-- You need >3 replicas. DRBD9 itself supports more, but the
-  controller validates `1..3`, metadata reserves `--max-peers 7`, and
-  the quorum policies assume 2 data replicas plus a tie-breaker.
+- You need >3 replicas. DRBD9 itself allows up to 32 nodes on a
+  single resource, so this is a scope decision, not a DRBD limit: the
+  controller validates `1..3`, metadata reserves `--max-peers 7`
+  slots per leg (enough for 2 peer replicas, the tie-breaker, 2
+  remote clients, and rebuild headroom), and the quorum policies
+  assume 2 data replicas plus a tie-breaker. More than that means
+  redesigning the vote math and recreating on-disk metadata: LINSTOR
+  territory.
 - You need iSCSI targets or a standalone NFS/file server. miroir
   serves block devices, plus a per-volume NFS export for
   `ReadWriteMany` (see [ReadWriteMany (RWX)](rwx.md)); it


### PR DESCRIPTION
Expands the ">3 replicas" bullet in the "When not to use it" section (docs/index.md and its README mirror) to explain where the numbers come from: DRBD9 allows up to 32 nodes on a single resource, so the `1..3` replica validation and the `--max-peers 7` metadata reservation are a deliberate scope decision, not a DRBD limit. Spells out what the 7 slots budget for (peer replicas, tie-breaker, remote clients, rebuild headroom) and why going past it means redesigning the quorum vote math and recreating on-disk metadata.