### PR TITLE
fix(agent): seed metadata when a diskless leg gains a disk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,17 @@ jobs:
             procs: "1"
             focus: 'miroir.home-operations.com.*\[Serial\]'
             skip: '\[Disruptive\]|should not mount / map unused volumes'
+          # Auto-diskful needs what no other leg has: a third storage worker, so a
+          # 2-replica volume gets a diskless tie-breaker to convert, and a
+          # controller installed with the conversion enabled. One Go spec drives
+          # the whole leg, so it skips the upstream suite.
+          - suite: autodiskful
+            cluster: cluster-spare.yaml
+            testdriver: testdriver.yaml
+            specs: "1"
+            specLabels: autodiskful
+            autoDiskfulAfter: 45s
+            conformance: "0"
     env:
       # Two names for one image in the runner-local registry. The nodes pull
       # registry.e2e, which the Talos mirror in patches/registry.yaml points at the
@@ -151,7 +162,7 @@ jobs:
         background: true
         uses: home-operations/talosctl-cluster-action@97d173e2efba3ec61abbfdf0fbd78ed848608190 # v0.1.4
         with:
-          config: test/e2e-qemu/cluster.yaml
+          config: test/e2e-qemu/${{ matrix.cluster || 'cluster.yaml' }}
 
       # network=host so the builder container can reach the registry published on the
       # runner's loopback.
@@ -217,6 +228,9 @@ jobs:
         env:
           TESTDRIVER: ${{ matrix.testdriver }}
           RUN_SPECS: ${{ matrix.specs }}
+          SPEC_LABELS: ${{ matrix.specLabels || '!autodiskful' }}
+          RUN_CONFORMANCE: ${{ matrix.conformance || '1' }}
+          AUTO_DISKFUL_AFTER: ${{ matrix.autoDiskfulAfter }}
           GATEWAY_ENABLED: ${{ matrix.gateway || 'false' }}
           STORAGE_CAPACITY_ENABLED: ${{ matrix.capacity || 'false' }}
           CLUSTER_NAME: ${{ steps.cluster.outputs.cluster-name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,10 @@ jobs:
             testdriver: testdriver.yaml
             specs: "1"
             specLabels: autodiskful
-            autoDiskfulAfter: 45s
+            # The clock starts at NodeStageVolume, so the threshold has to
+            # outlast the consumer pod's own startup with room to spare —
+            # the spec asserts the leg is still diskless once that pod is up.
+            autoDiskfulAfter: 2m
             conformance: "0"
     env:
       # Two names for one image in the runner-local registry. The nodes pull

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -1636,11 +1636,17 @@ func (r *VolumeReconciler) growIfCoordinator(ctx context.Context, vol *miroirv1a
 // detach) and it must not be re-attached (drbdResource renders
 // adjust --skip-disk while latched). It is sticky — once a prior reconcile
 // recorded DiskFailed it stays latched even though prev DiskState is now
-// Diskless (the fresh-detach test alone would clear it). It clears only
-// when the leg reaches a non-Diskless state again (a re-add re-attaches a
-// fresh disk) or the replica is removed (removal drops this status slot).
+// Diskless (the fresh-detach test alone would clear it). In practice only
+// removing the replica clears it: the latch renders adjust --skip-disk, so
+// a latched leg is never re-attached and can never reach a non-Diskless
+// state on its own.
 // Gated on the leg having previously been attached so a normal bring-up
-// (briefly Diskless) does not cry wolf.
+// (briefly Diskless) does not cry wolf. That gate reads CRD status, which
+// outlives the agent process — so a leg recorded attached before a restart
+// and read Diskless after one latches whether or not a disk actually
+// failed, and only a replica re-add gets it back. Auto-diskful conversions
+// are the population most exposed to that, being the legs that go
+// Diskless -> attached in place.
 func diskFailedLatch(vol *miroirv1alpha1.MiroirVolume, self string, st drbd.Status, localDiskless bool) bool {
 	if localDiskless || st.DiskState != drbd.DiskDiskless {
 		return false

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -66,6 +66,10 @@ const (
 	cmdDownPvc1 = "drbdsetup down pvc-1"
 	// snapGone names a deleted source snapshot in restore-source-gone tests.
 	snapGone = "snap-gone"
+	// statusNotInKernel is the status of a resource that is not up yet — the
+	// first --json read of a bring-up pass, which probeMetadata makes before
+	// create-md.
+	statusNotInKernel = "[]"
 )
 
 // fakeBackend records calls and simulates a thin pool in memory.
@@ -623,13 +627,12 @@ func TestReconcilePaddedRestoreGrowsCloneBeforeCreateMD(t *testing.T) {
 	fb := newFakeBackend()
 	v := paddedRestoreVol()
 	stateDir := t.TempDir()
-	// Empty statusJSON: probeMetadata's kernel probe must see no attached
-	// resource, or the fresh clone reads as adopted metadata and create-md
-	// never runs. The --json status reads are served from statusSeq.
+	// The leading not-in-kernel read is probeMetadata's: the fresh clone must
+	// not read as adopted metadata, or create-md never runs.
 	up := `[{"name":"` + volPvc1 + `",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
-	fe := &fakeDRBDExec{statusSeq: []string{up, up, up, up}}
+	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, up, up, up, up}}
 	fb.seq = &fe.calls // interleave the backing resize into the DRBD call log
 
 	c := fake.NewClientBuilder().WithScheme(s).
@@ -765,7 +768,7 @@ func TestReconcilePaddedRestoreSeedMintsGeneration(t *testing.T) {
 	inc := `[{"name":"` + volPvc1 + `",
 		"devices":[{"disk-state":"` + diskStateInconsistent + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
-	fe := &fakeDRBDExec{statusSeq: []string{inc, inc, inc, inc}}
+	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, inc, inc, inc, inc}}
 
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snapObj(snapSnap1, "src-vol")).
@@ -801,7 +804,7 @@ func TestReconcilePaddedRestoreSeedMintRefusesWhenPeerHasData(t *testing.T) {
 	inc := `[{"name":"` + volPvc1 + `",
 		"devices":[{"disk-state":"` + diskStateInconsistent + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
-	fe := &fakeDRBDExec{statusSeq: []string{inc, inc, inc, inc}}
+	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, inc, inc, inc, inc}}
 
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snapObj(snapSnap1, "src-vol")).
@@ -2258,12 +2261,12 @@ func TestReconcileWipedNodeForcesFullSync(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 
-	// The kernel probe fails (fresh boot, resource never configured);
-	// the post-Apply --json status still answers.
+	// The kernel probe finds nothing (fresh boot, resource never
+	// configured); the post-Apply --json status still answers.
 	fe := &fakeDRBDExec{
 		statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"Inconsistent"}],"connections":[]}]`,
-		errOn: map[string]error{"drbdsetup status " + volPvc1: errors.New("no such resource")},
+		statusSeq: []string{statusNotInKernel},
 	}
 	fb := newFakeBackend() // Exists() == false: the wipe took the device
 	r := &VolumeReconciler{
@@ -2328,6 +2331,56 @@ func TestReconcileDisklessTieBreaker(t *testing.T) {
 	}
 	if st.DevicePath == "" || st.DiskState != diskStateDiskless {
 		t.Fatalf("tie-breaker status not reported: %+v", st)
+	}
+}
+
+// Auto-diskful conversion: the spec flips the leg diskful in place while
+// the consumer keeps it open, so the resource is up in the kernel as a
+// diskless leg over a backing device that does not exist yet. The fresh
+// backing must be seeded — reading the live resource as metadata would
+// skip create-md and leave adjust attaching a blank device, which fails
+// "No valid meta data found" on every pass.
+func TestReconcileTieBreakerGainingADiskSeedsMetadata(t *testing.T) {
+	s := newScheme(t)
+	fb := newFakeBackend()
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrA
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = addrB
+	// The converted leg: node-id and address kept, FullSync set — exactly
+	// what membership.convertTieBreaker leaves behind.
+	v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
+		Node: nodeC, NodeID: 2, Address: addrC, FullSync: true,
+	})
+	v.Finalizers = append(v.Finalizers, constants.FinalizerPrefix+nodeC)
+
+	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateDiskless + `"}],
+		"connections":[{"peer-node-id":0,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]},
+		{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`}
+	stateDir := t.TempDir()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeC, Pools: poolsOf(fb),
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+
+	reconcile(t, r, volPvc1)
+
+	if len(fb.createVol) != 1 {
+		t.Fatalf("the converted leg must realize a backing device: %v", fb.createVol)
+	}
+	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
+	fe.notCalledWith(t, "set-gi") // just-created metadata → full SyncTarget
+	if _, err := os.Stat(filepath.Join(stateDir, volPvc1+".md-adopted")); !os.IsNotExist(err) {
+		t.Fatal("a blank backing must not be recorded as adopted metadata")
 	}
 }
 
@@ -3410,18 +3463,19 @@ func birthSetup(t *testing.T, nodeName string, peerNodeID int, statusSeq ...stri
 	), 0o640); err != nil {
 		t.Fatal(err)
 	}
-	seq := make([]string, len(statusSeq))
-	for i, tmpl := range statusSeq {
-		seq[i] = fmt.Sprintf(tmpl, peerNodeID)
-	}
-	fe := &fakeDRBDExec{statusSeq: seq}
-	if len(seq) > 0 {
+	fe := &fakeDRBDExec{}
+	if len(statusSeq) > 0 {
+		// The leading not-in-kernel read is probeMetadata's: a fresh volume
+		// must take the create-md path, not read the kernel view as adopted
+		// metadata.
+		seq := make([]string, 0, 1+len(statusSeq))
+		seq = append(seq, statusNotInKernel)
+		for _, tmpl := range statusSeq {
+			seq = append(seq, fmt.Sprintf(tmpl, peerNodeID))
+		}
+		fe.statusSeq = seq
 		fe.statusJSON = seq[len(seq)-1] // stable fallback once drained
 	}
-	// The kernel probe (plain, non-json status) must fail or probeMetadata
-	// reads the fallback JSON as "resource attached" and adopts — bypassing
-	// the create-md path a fresh volume must take.
-	fe.errOn = map[string]error{"drbdsetup status " + volPvc1: errors.New("no such resource")}
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
@@ -3583,6 +3637,7 @@ func TestFastPathMissesOnPeerDiskStateChange(t *testing.T) {
 	// The peer's disk turns Inconsistent; everything else is unchanged.
 	fe.statusSeq = []string{
 		fmt.Sprintf(birthReadyJSON, 1), // fastPath live check → fingerprint miss
+		fmt.Sprintf(birthReadyJSON, 1), // probeMetadata → attached, adopt
 		fmt.Sprintf(birthReadyJSON, 1), // pipeline status → trigger fires
 		fmt.Sprintf(birthDoneJSON, 1),  // post-mint re-read
 	}

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -68,8 +68,11 @@ const (
 	snapGone = "snap-gone"
 	// statusNotInKernel is the status of a resource that is not up yet — the
 	// first --json read of a bring-up pass, which probeMetadata makes before
-	// create-md.
-	statusNotInKernel = "[]"
+	// create-md. drbdsetup does not answer that with an empty list: it
+	// writes "<name>: No such resource" to stderr and exits 10, which
+	// backend.RealExec surfaces as an error. fakeDRBDExec.run turns this
+	// sentinel into that error so fixtures exercise the real shape.
+	statusNotInKernel = "\x00no-such-resource"
 )
 
 // fakeBackend records calls and simulates a thin pool in memory.
@@ -834,7 +837,7 @@ func TestReconcilePaddedRestoreSeedDemotesInterruptedMint(t *testing.T) {
 	up := `[{"name":"` + volPvc1 + `","role":"Primary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
-	fe := &fakeDRBDExec{statusSeq: []string{up, up, up, up}}
+	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, up, up, up, up}}
 
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snapObj(snapSnap1, "src-vol")).
@@ -1087,6 +1090,9 @@ func (f *fakeDRBDExec) run(_ context.Context, name string, args ...string) (stri
 	if strings.HasPrefix(line, "drbdsetup status --json") && len(f.statusSeq) > 0 {
 		out := f.statusSeq[0]
 		f.statusSeq = f.statusSeq[1:]
+		if out == statusNotInKernel {
+			return "", errNoSuchResource
+		}
 		return out, nil
 	}
 	if strings.HasPrefix(line, "drbdsetup status") {
@@ -1103,7 +1109,12 @@ func (f *fakeDRBDExec) run(_ context.Context, name string, args ...string) (stri
 	return "", nil
 }
 
-var errFreshDevice = errors.New("no valid meta data")
+var (
+	errFreshDevice = errors.New("no valid meta data")
+	// errNoSuchResource is drbdsetup's exit-10 answer for a resource that
+	// is not up, as backend.RealExec reports it.
+	errNoSuchResource = errors.New("drbdsetup status: pvc-1: No such resource")
+)
 
 func (f *fakeDRBDExec) calledWith(t *testing.T, substr string) {
 	t.Helper()
@@ -2278,7 +2289,7 @@ func TestReconcileWipedNodeForcesFullSync(t *testing.T) {
 	reconcile(t, r, volPvc1)
 
 	fe.calledWith(t, "create-md")
-	fe.notCalledWith(t, "set-gi") // just-created metadata → full SyncTarget
+	fe.notCalledWith(t, "new-current-uuid") // just-created metadata → full SyncTarget
 }
 
 func TestReconcileDisklessTieBreaker(t *testing.T) {
@@ -2378,9 +2389,18 @@ func TestReconcileTieBreakerGainingADiskSeedsMetadata(t *testing.T) {
 		t.Fatalf("the converted leg must realize a backing device: %v", fb.createVol)
 	}
 	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
-	fe.notCalledWith(t, "set-gi") // just-created metadata → full SyncTarget
+	fe.notCalledWith(t, "new-current-uuid") // just-created metadata → full SyncTarget
 	if _, err := os.Stat(filepath.Join(stateDir, volPvc1+".md-adopted")); !os.IsNotExist(err) {
 		t.Fatal("a blank backing must not be recorded as adopted metadata")
+	}
+	// A completed seed must leave the marker pair settled: .md-created
+	// written and the .md-seeding sentinel cleared. A sentinel left behind
+	// authorizes re-seeding a leg that has since full-synced real data.
+	if _, err := os.Stat(filepath.Join(stateDir, volPvc1+".md-created")); err != nil {
+		t.Fatal("a completed seed must be marked created")
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, volPvc1+".md-seeding")); !os.IsNotExist(err) {
+		t.Fatal("a completed seed must clear the seeding sentinel")
 	}
 }
 
@@ -3496,7 +3516,6 @@ func TestReconcileBirthWinnerMintsInitialUUID(t *testing.T) {
 	// The full fresh path: metadata created and left just-created, then the
 	// one replicated generation minted over the live connections.
 	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
-	fe.notCalledWith(t, "set-gi")
 	fe.calledWith(t, "drbdadm new-current-uuid --clear-bitmap pvc-1/0")
 
 	got := &miroirv1alpha1.MiroirVolume{}

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -268,7 +268,13 @@ func InternalMetaOverhead(sizeBytes int64) int64 {
 func (d *Driver) probeMetadata(ctx context.Context, name string) (hasMD, attached bool, dump string, err error) {
 	if parsed, perr := d.listStatus(ctx, name); perr == nil {
 		for _, res := range parsed {
+			// Positive test on purpose: disk-state is a plain string, so a
+			// device entry missing the key unmarshals to "" — and reading
+			// that as attached would adopt a blank backing and reinstate
+			// the error loop above. Unknown means "ask dump-md", which is
+			// authoritative either way.
 			if res.Name == name && len(res.Devices) > 0 &&
+				res.Devices[0].DiskState != "" &&
 				res.Devices[0].DiskState != DiskDiskless {
 				return true, true, "", nil
 			}
@@ -291,10 +297,6 @@ func (d *Driver) probeMetadata(ctx context.Context, name string) (hasMD, attache
 		return true, true, "", nil
 	case err == nil:
 		return true, false, out, nil
-	case strings.Contains(err.Error(), "is configured!"):
-		// drbdmeta's own refusal — covers a resource attached between
-		// the kernel probe and the dump.
-		return true, true, "", nil
 	case strings.Contains(err.Error(), "no valid meta data") ||
 		strings.Contains(err.Error(), "No valid meta data"):
 		return false, false, "", nil

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -244,17 +244,35 @@ func InternalMetaOverhead(sizeBytes int64) int64 {
 }
 
 // probeMetadata reports the backing device's DRBD metadata state.
-// attached means the kernel has the resource (which necessarily implies
-// metadata exists); dump is the raw dump-md output when readable.
+// attached means this leg holds its backing device in the kernel (which
+// necessarily implies metadata exists); dump is the raw dump-md output
+// when readable.
 //
 // Kernel state is probed first: an attached resource claims its backing
 // device exclusively, so dump-md only reports EBUSY — the same error a
 // foreign holder (stale mount, LVM) produces. Asking the kernel
-// disambiguates: resource present → attached; absent → any remaining
+// disambiguates: local disk attached → attached; otherwise any remaining
 // busy error is a foreign holder and surfaces.
+//
+// The probe keys on this node's own disk state, not the resource's mere
+// presence in the kernel — the same predicate drbdmeta itself uses to
+// refuse a busy device (is_attached() is dstate > Diskless, drbd-utils
+// user/shared/drbdmeta.c). An auto-diskful conversion (a tie-breaker or
+// client leg flipped diskful in place, keeping its node-id) is already up
+// as a diskless leg while the backing it is gaining is still blank: it
+// holds no backing device, so nothing claims the disk, dump-md reads it
+// fine and create-md is allowed. Reading presence alone as live metadata
+// would skip create-md and leave adjust attaching a blank device — which
+// fails "No valid meta data found", and Apply's recovery re-probes into
+// the same answer, so the leg never materializes.
 func (d *Driver) probeMetadata(ctx context.Context, name string) (hasMD, attached bool, dump string, err error) {
-	if out, err := d.Exec(ctx, "drbdsetup", "status", name); err == nil && strings.Contains(out, name) {
-		return true, true, "", nil
+	if parsed, perr := d.listStatus(ctx, name); perr == nil {
+		for _, res := range parsed {
+			if res.Name == name && len(res.Devices) > 0 &&
+				res.Devices[0].DiskState != DiskDiskless {
+				return true, true, "", nil
+			}
+		}
 	}
 	out, err := d.adm(ctx, "dump-md", name+"/0")
 	if err != nil && strings.Contains(err.Error(), "unclean") {
@@ -1155,7 +1173,9 @@ const DiskInconsistent = "Inconsistent"
 // device — a quorum-only tie-breaker, or a diskful leg DRBD detached
 // after an I/O error (on-io-error detach). Do NOT use it to infer
 // tie-breaker-ness (that is spec-driven, see Replica.Diskless); it is
-// only meaningful for observing a detach on a leg the spec says is diskful.
+// only meaningful for observing whether this leg holds a backing device
+// right now — a detach on a leg the spec says is diskful, or the blank
+// interval of an auto-diskful conversion (see probeMetadata).
 const DiskDiskless = "Diskless"
 
 // diskDetaching is the transient disk state while the kernel drains a

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -310,7 +310,7 @@ func TestApplyFreshResource(t *testing.T) {
 	// Metadata stays at UUID_JUST_CREATED: the birth generation is minted
 	// once by the winner over live connections (InitialUUID), never
 	// manufactured per node.
-	fe.notCalledWith(t, "set-gi")
+	fe.notCalledWith(t, "new-current-uuid")
 	fe.calledWith(t, "drbdadm adjust pvc-1")
 
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.res")); err != nil {
@@ -502,7 +502,7 @@ func TestApplyRecreatesOnMissingMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
-	fe.notCalledWith(t, "set-gi")
+	fe.notCalledWith(t, "new-current-uuid")
 	// adjust attempted twice: the failing first, the succeeding retry.
 	var adjusts int
 	for _, c := range fe.calls {
@@ -534,9 +534,42 @@ func TestApplySeedsMetadataForDisklessLegGainingADisk(t *testing.T) {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
-	fe.notCalledWith(t, "set-gi")
+	fe.notCalledWith(t, "new-current-uuid")
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-adopted")); !os.IsNotExist(err) {
 		t.Fatal("a blank backing must not be recorded as adopted metadata")
+	}
+	// The marker pair is the whole point of seeding under a live resource:
+	// .md-created must land and the .md-seeding sentinel must be gone, or
+	// the next restart re-seeds a leg that has since full-synced real data.
+	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-created")); err != nil {
+		t.Fatal("a completed seed must be marked created")
+	}
+	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-seeding")); !os.IsNotExist(err) {
+		t.Fatal("a completed seed must clear the seeding sentinel")
+	}
+}
+
+// The converse of the seeding case: the same up-but-Diskless kernel state,
+// but the backing already carries live metadata. dump-md — not the kernel
+// probe — is the authority that keeps create-md --force off real data, so
+// this is the one path where that gate is load-bearing.
+func TestApplyAdoptsLiveMetadataOnDisklessLegGainingADisk(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"` + DiskDiskless + `"}],"connections":[]}]`,
+		// Neither day0 nor UUID_JUST_CREATED: a generation a Primary
+		// minted, i.e. real data.
+		cmdDumpMD: "current-uuid 0xB0FFEEB0FFEEB0FF;\nbitmap-uuid 0x0000000000000000;",
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
+		t.Fatal(err)
+	}
+	fe.notCalledWith(t, "create-md")
+	fe.notCalledWith(t, "new-current-uuid")
+	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-adopted")); err != nil {
+		t.Fatal("live metadata under a diskless leg must be adopted, not re-seeded")
 	}
 }
 
@@ -601,7 +634,12 @@ func TestApplyAdoptsAttachedDevice(t *testing.T) {
 	// Markers lost but the kernel holds the minor: a previous life
 	// completed seeding and adjust — metadata is live, never touch it.
 	// dump-md succeeds read-only on an attached minor with a stale-output
-	// warning; the refusal form covers metadata-modifying probes.
+	// warning. There is deliberately no "Device is configured!" case:
+	// drbdmeta gates that refusal on `minor_attached && modifies_md`
+	// (drbd-utils user/shared/drbdmeta.c) and dump-md declares
+	// modifies_md = 0, so the probe never sees it. A busy open surfaces as
+	// EBUSY instead, which must error rather than adopt — see
+	// TestApplySurfacesNonDRBDBusyDevice.
 	for name, fe := range map[string]*fakeExec{
 		"local disk attached": {responses: map[string]string{
 			cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
@@ -610,16 +648,13 @@ func TestApplyAdoptsAttachedDevice(t *testing.T) {
 		"stale warning": {responses: map[string]string{
 			cmdDumpMD: "# Output might be stale, since minor 1000 is attached\ncurrent-uuid 0x0000000000000004;",
 		}},
-		"configured refusal": {errOn: map[string]error{
-			cmdDumpMD: errors.New("Device 'pvc-1' is configured!"),
-		}},
 	} {
 		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 		if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
 			t.Fatalf("%s: %v", name, err)
 		}
 		fe.notCalledWith(t, "create-md")
-		fe.notCalledWith(t, "set-gi")
+		fe.notCalledWith(t, "new-current-uuid")
 		if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-created")); err != nil {
 			t.Fatalf("%s: adopted device must be marked created", name)
 		}
@@ -647,7 +682,7 @@ func TestApplyAppliesALOnUncleanClone(t *testing.T) {
 	}
 	fe.calledWith(t, "drbdadm apply-al pvc-1/0")
 	fe.notCalledWith(t, "create-md")
-	fe.notCalledWith(t, "set-gi")
+	fe.notCalledWith(t, "new-current-uuid")
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-adopted")); err != nil {
 		t.Fatal("clone adoption must leave a breadcrumb")
 	}
@@ -686,7 +721,7 @@ func TestApplyFastPathCleansStaleSentinel(t *testing.T) {
 	if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
 		t.Fatal(err)
 	}
-	fe.notCalledWith(t, "set-gi")
+	fe.notCalledWith(t, "new-current-uuid")
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-seeding")); !os.IsNotExist(err) {
 		t.Fatal("fast path must remove a stale seeding sentinel")
 	}
@@ -704,7 +739,7 @@ func TestApplyAdoptsLiveMetadataWithoutMarkers(t *testing.T) {
 		t.Fatal(err)
 	}
 	fe.notCalledWith(t, "create-md")
-	fe.notCalledWith(t, "set-gi")
+	fe.notCalledWith(t, "new-current-uuid")
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-adopted")); err != nil {
 		t.Fatal("adoption must leave a breadcrumb")
 	}
@@ -723,7 +758,7 @@ func TestApplyClaimsVirginMetadataWithoutMarkers(t *testing.T) {
 		t.Fatal(err)
 	}
 	fe.notCalledWith(t, "create-md")
-	fe.notCalledWith(t, "set-gi")
+	fe.notCalledWith(t, "new-current-uuid")
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-created")); err != nil {
 		t.Fatal("virgin metadata must be claimed with the marker")
 	}

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -515,6 +515,31 @@ func TestApplyRecreatesOnMissingMetadata(t *testing.T) {
 	}
 }
 
+// An auto-diskful conversion is already up in the kernel as a diskless
+// leg while the backing it is gaining is still blank. The resource's
+// presence must not be read as live metadata: create-md has to run, or
+// adjust attaches a device with no metadata on it and the leg never
+// materializes — Apply's missing-metadata recovery re-probes into the
+// same adoption, so it error-loops "No valid meta data found" forever.
+func TestApplySeedsMetadataForDisklessLegGainingADisk(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Primary",
+			"devices":[{"disk-state":"` + DiskDiskless + `"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"peer-disk-state":"` + DiskUpToDate + `"}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+	if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "drbdadm create-md --force --max-peers 7 pvc-1/0")
+	fe.notCalledWith(t, "set-gi")
+	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.md-adopted")); !os.IsNotExist(err) {
+		t.Fatal("a blank backing must not be recorded as adopted metadata")
+	}
+}
+
 func TestApplyIdempotent(t *testing.T) {
 	fe := &fakeExec{}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
@@ -578,8 +603,9 @@ func TestApplyAdoptsAttachedDevice(t *testing.T) {
 	// dump-md succeeds read-only on an attached minor with a stale-output
 	// warning; the refusal form covers metadata-modifying probes.
 	for name, fe := range map[string]*fakeExec{
-		"kernel has resource": {responses: map[string]string{
-			"drbdsetup status pvc-1": "pvc-1 role:Secondary\n  disk:Inconsistent",
+		"local disk attached": {responses: map[string]string{
+			cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+				"devices":[{"disk-state":"` + DiskInconsistent + `"}],"connections":[]}]`,
 		}},
 		"stale warning": {responses: map[string]string{
 			cmdDumpMD: "# Output might be stale, since minor 1000 is attached\ncurrent-uuid 0x0000000000000004;",

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -5,23 +5,24 @@ End-to-end tests for the miroir CSI driver against a local Talos cluster, booted
 
 ## Overview
 
-Every CI leg boots the same `cluster.yaml` -- a controller node and two storage
+Almost every CI leg boots the same `cluster.yaml` -- a controller node and two storage
 workers, with the DRBD and ZFS kernel modules baked in by an Image Factory schematic
 -- and drives the tests against it. The action boots the shape the document
 describes, exports a kubeconfig and talosconfig, and destroys the cluster in its post
 step; `test.sh` then installs the driver from a packaged Helm chart and runs the
 tests.
 
-The legs run the same document and differ in what `test.sh` drives against it, so a
-failure names the path that broke:
+The legs mostly run the same document and differ in what `test.sh` drives against it,
+so a failure names the path that broke:
 
-| Leg           | Runs                                                | Class               |
-| ------------- | --------------------------------------------------- | ------------------- |
-| `conformance` | miroir's Go specs, then the parallel upstream suite | `miroir-local`      |
-| `replicated`  | the parallel upstream block/filesystem suite        | `miroir-replicated` |
-| `zfs`         | the parallel upstream block/filesystem suite        | `miroir-zfs`        |
-| `rwx`         | the parallel upstream filesystem-only RWX/ROX suite | `miroir-replicated` |
-| `serial`      | upstream `[Serial]` specs, one process              | `miroir-replicated` |
+| Leg           | Runs                                                   | Class               |
+| ------------- | ------------------------------------------------------ | ------------------- |
+| `conformance` | miroir's Go specs, then the parallel upstream suite    | `miroir-local`      |
+| `replicated`  | the parallel upstream block/filesystem suite           | `miroir-replicated` |
+| `zfs`         | the parallel upstream block/filesystem suite           | `miroir-zfs`        |
+| `rwx`         | the parallel upstream filesystem-only RWX/ROX suite    | `miroir-replicated` |
+| `serial`      | upstream `[Serial]` specs, one process                 | `miroir-replicated` |
+| `autodiskful` | the auto-diskful Go spec only, on `cluster-spare.yaml` | `miroir-replicated` |
 
 miroir's Go specs (`test/e2e`) assert the local lifecycle, snapshot/restore, block and
 placement behaviour the upstream suite does not; the conformance leg runs them
@@ -31,16 +32,26 @@ external-storage run. The replicated leg drives that upstream suite against the 
 DRBD shape backed by the zfs pool instead, so replication pairs zvol with zvol and
 the zfs snapshot/restore path runs under the suite. The rwx leg enables the NFS
 gateway and advertises only filesystem volume modes, while the serial leg gives
-exclusive-cluster specs a single Ginkgo process. The conformance and zfs legs enable
-CSI storage capacity publication (the replicated block lane keeps it off, where DRBD's
-full-size reservation on every replica starves the scheduler during parallel-clone
-specs); the upstream definitions exercise ext4, xfs, topology and mount options. Real
-per-node kernels and real block devices are the point: the DRBD
-path needs the DRBD 9 module, which only a real Talos node has.
+exclusive-cluster specs a single Ginkgo process.
+
+The autodiskful leg is the one that boots a different shape. Auto-diskful converts a
+settled diskless leg into a local replica, and a 2-replica volume only gets a diskless
+tie-breaker when some storage node carries no replica -- so this leg boots
+`cluster-spare.yaml` (a third worker) and installs the chart with `autoDiskfulAfter`
+set. Its spec is the only one carrying the `autodiskful` Ginkgo label: every other leg
+runs `SPEC_LABELS=!autodiskful` and skips it, and this leg selects it and skips the
+upstream suite (`RUN_CONFORMANCE=0`) rather than replaying it on a third cluster.
+
+The conformance and zfs legs enable CSI storage capacity publication (the replicated
+block lane keeps it off, where DRBD's full-size reservation on every replica starves
+the scheduler during parallel-clone specs); the upstream definitions exercise ext4,
+xfs, topology and mount options. Real per-node kernels and real block devices are the
+point: the DRBD path needs the DRBD 9 module, which only a real Talos node has.
 
 ```text
-cluster.yaml              the one cluster shape every leg boots
-schematic.yaml            the drbd + zfs system extensions (referenced by cluster.yaml)
+cluster.yaml              the cluster shape every leg but autodiskful boots
+cluster-spare.yaml        the same plus a third worker, for the autodiskful leg
+schematic.yaml            the drbd + zfs system extensions (referenced by both)
 patches/modules.yaml      shared: the DRBD / dm-thin / zfs kernel modules
 patches/registry.yaml     shared: where the nodes pull the miroir images
 classes.yaml              the StorageClasses / snapshot classes under test
@@ -90,6 +101,13 @@ set -gx RUN_SPECS 1                # also run the Go specs (the conformance leg 
 set -gx STORAGE_CAPACITY_ENABLED true
 # Required with testdriver-rwx.yaml:
 set -gx GATEWAY_ENABLED true
+./test.sh
+
+# The autodiskful leg, against a cluster booted with --workers 3 instead:
+set -gx RUN_SPECS 1
+set -gx SPEC_LABELS autodiskful     # the label every other leg excludes
+set -gx AUTO_DISKFUL_AFTER 45s      # installs the chart with the conversion on
+set -gx RUN_CONFORMANCE 0           # one spec is the whole leg
 ./test.sh
 
 sudo -E (mise which talosctl) cluster destroy --name miroir-e2e -f

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -103,7 +103,13 @@ set -gx STORAGE_CAPACITY_ENABLED true
 set -gx GATEWAY_ENABLED true
 ./test.sh
 
-# The autodiskful leg, against a cluster booted with --workers 3 instead:
+# The autodiskful leg, against a cluster booted from cluster-spare.yaml
+# (a third worker, and 3GiB of memory each rather than 5GiB).
+# The exports above are global and would otherwise install a different
+# chart than the CI leg does — clear the ones it does not set first.
+set -e STORAGE_CAPACITY_ENABLED
+set -e GATEWAY_ENABLED
+set -gx TESTDRIVER testdriver.yaml
 set -gx RUN_SPECS 1
 set -gx SPEC_LABELS autodiskful     # the label every other leg excludes
 set -gx AUTO_DISKFUL_AFTER 2m       # installs the chart with the conversion on

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -106,7 +106,7 @@ set -gx GATEWAY_ENABLED true
 # The autodiskful leg, against a cluster booted with --workers 3 instead:
 set -gx RUN_SPECS 1
 set -gx SPEC_LABELS autodiskful     # the label every other leg excludes
-set -gx AUTO_DISKFUL_AFTER 45s      # installs the chart with the conversion on
+set -gx AUTO_DISKFUL_AFTER 2m       # installs the chart with the conversion on
 set -gx RUN_CONFORMANCE 0           # one spec is the whole leg
 ./test.sh
 

--- a/test/e2e-qemu/cluster-spare.yaml
+++ b/test/e2e-qemu/cluster-spare.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/talosctl-cluster-action/main/schema/talos-cluster.json
+# cluster.yaml plus a third storage worker, for the one leg that needs a spare
+# storage node: a 2-replica volume only gets a diskless tie-breaker when some node
+# carries no replica, and auto-diskful has nothing to convert without one.
+#
+# Everything else matches cluster.yaml -- same name (the legs never share a runner,
+# and test.sh guards on the miroir-e2e prefix), same network, same schematic, same
+# disks, so the harness scripts need no special case. Only the memory differs: this
+# leg runs a single Go spec with two small pods rather than the parallel conformance
+# suite, so 3GiB a worker is ample and three of them still fit a runner.
+apiVersion: v1alpha1
+kind: TalosCluster
+metadata:
+  name: miroir-e2e
+spec:
+  controlplanes:
+    count: 1
+  workers:
+    count: 3
+    memory: 3GiB
+  network:
+    cidr: 10.5.0.0/24
+  qemu:
+    schematic: "@schematic.yaml"
+    disks:
+      - virtio:8GiB
+      - virtio:20GiB
+      - virtio:20GiB
+  config-patches:
+    cluster:
+      - "@patches/modules.yaml"
+      - "@patches/registry.yaml"

--- a/test/e2e-qemu/test.sh
+++ b/test/e2e-qemu/test.sh
@@ -237,6 +237,7 @@ install_chart() {
         --set groupSnapshots.enabled=true \
         --set gateway.enabled="${GATEWAY_ENABLED:-false}" \
         --set storageCapacity.enabled="${STORAGE_CAPACITY_ENABLED:-false}" \
+        --set autoDiskfulAfter="${AUTO_DISKFUL_AFTER:-}" \
         --wait --timeout 10m
 }
 
@@ -281,9 +282,24 @@ main() {
     # them before the long external-storage run, so a miroir-specific break
     # fails fast. 35m: the orphaned-hold spec alone rides the full ~6-minute
     # busy escalation before its reclaim can fire.
+    #
+    # SPEC_LABELS gates the specs that need a cluster or an install this one is
+    # not: the default excludes them, and the leg that provides what they need
+    # selects them by label instead (see the autodiskful leg in ci.yaml).
     if [[ "${RUN_SPECS:-}" == "1" ]]; then
-        log "Running miroir's Go e2e specs..."
-        (cd "$REPO_ROOT" && go test -tags e2e ./test/e2e/ -v -ginkgo.v -timeout 35m)
+        log "Running miroir's Go e2e specs (labels: ${SPEC_LABELS:-!autodiskful})..."
+        (cd "$REPO_ROOT" && go test -tags e2e ./test/e2e/ -v -ginkgo.v -timeout 35m \
+            -ginkgo.label-filter="${SPEC_LABELS:-!autodiskful}")
+    fi
+
+    # A leg whose whole point is a Go spec has nothing to gain from replaying the
+    # external-storage suite on top of it.
+    if [[ "${RUN_CONFORMANCE:-1}" != "1" ]]; then
+        log "Skipping the external-storage conformance suite (RUN_CONFORMANCE=$RUN_CONFORMANCE)."
+        log "=========================================="
+        log "E2E QEMU SUITE PASSED (specs only)"
+        log "=========================================="
+        return
     fi
 
     log "Running the external-storage conformance suite ($TESTDRIVER)..."

--- a/test/e2e-qemu/test.sh
+++ b/test/e2e-qemu/test.sh
@@ -286,15 +286,25 @@ main() {
     # SPEC_LABELS gates the specs that need a cluster or an install this one is
     # not: the default excludes them, and the leg that provides what they need
     # selects them by label instead (see the autodiskful leg in ci.yaml).
+    # --fail-on-empty: Ginkgo defaults it off, so a label filter that selects
+    # nothing (a renamed Label, a typo in the leg's specLabels) would print
+    # "Ran 0 of N Specs" and exit 0 — a leg whose whole point is one spec
+    # would go green having asserted nothing.
     if [[ "${RUN_SPECS:-}" == "1" ]]; then
         log "Running miroir's Go e2e specs (labels: ${SPEC_LABELS:-!autodiskful})..."
         (cd "$REPO_ROOT" && go test -tags e2e ./test/e2e/ -v -ginkgo.v -timeout 35m \
+            -ginkgo.fail-on-empty \
             -ginkgo.label-filter="${SPEC_LABELS:-!autodiskful}")
     fi
 
     # A leg whose whole point is a Go spec has nothing to gain from replaying the
     # external-storage suite on top of it.
     if [[ "${RUN_CONFORMANCE:-1}" != "1" ]]; then
+        # The two gates are independent, so guard against the combination that
+        # would boot a cluster, install the chart, run nothing and still pass.
+        if [[ "${RUN_SPECS:-}" != "1" ]]; then
+            die "RUN_CONFORMANCE=$RUN_CONFORMANCE with RUN_SPECS unset would run no tests at all"
+        fi
         log "Skipping the external-storage conformance suite (RUN_CONFORMANCE=$RUN_CONFORMANCE)."
         log "=========================================="
         log "E2E QEMU SUITE PASSED (specs only)"

--- a/test/e2e/autodiskful_test.go
+++ b/test/e2e/autodiskful_test.go
@@ -1,0 +1,182 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+)
+
+const (
+	// The conversion waits out --auto-diskful-after, then full-syncs a 1Gi
+	// device end to end before the leg reads UpToDate.
+	conversionTimeout = 10 * time.Minute
+)
+
+// controllerArgs returns the miroir controller container's argv, so a spec
+// can assert the option it depends on is actually installed rather than
+// time out on a controller that was never asked to convert anything.
+func controllerArgs() string {
+	GinkgoHelper()
+	out, err := exec.Command("kubectl", "get", "deployment", "-n", agentNamespace,
+		"-l", "app.kubernetes.io/component=controller",
+		"-o", "jsonpath={.items[0].spec.template.spec.containers[*].args}").CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "read controller args: %s", string(out))
+	return string(out)
+}
+
+// localLegStatus returns this node's own two status lines for a resource
+// (the resource line and its device line). Scoped deliberately: the peer
+// lines below carry peer-disk: states that a whole-output substring match
+// would confuse for the local disk.
+func localLegStatus(ctx context.Context, node, name string) string {
+	return agentExec(ctx, node, "drbdsetup status "+name+" | awk 'NR<=2'")
+}
+
+// disklessLegNode returns the node carrying the volume's diskless leg —
+// a tie-breaker replica, or a client leg on a cluster with no spare node
+// for one. Empty when every leg is diskful.
+func disklessLegNode(vol *miroirv1alpha1.MiroirVolume) string {
+	for _, rep := range vol.Spec.Replicas {
+		if rep.Diskless {
+			return rep.Node
+		}
+	}
+	for _, cl := range vol.Spec.Clients {
+		return cl.Node
+	}
+	return ""
+}
+
+// Auto-diskful on real DRBD: a consumer that settles on the node carrying
+// the volume's diskless tie-breaker gets a local replica there, converted
+// in place under the running pod (LINSTOR's toggle-disk).
+//
+// The conversion keeps the leg's node-id and address, so it is already up
+// in the kernel as a diskless Primary while the backing it is gaining is
+// still blank — the state that made the agent adopt a blank device as
+// live metadata, skip create-md, and error-loop "No valid meta data
+// found" forever. Only real DRBD proves the whole chain: create-md
+// against an up-but-diskless resource, the attach, and a full sync that
+// carries the data the pod wrote over the network before it had a disk.
+//
+// Needs a spare storage node (cluster-spare.yaml) and a controller
+// installed with autoDiskfulAfter set — the autodiskful CI leg.
+var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func() {
+	const ns = "miroir-e2e-diskful"
+	ctx := context.Background()
+
+	var pv, tieNode, seedSum string
+	var roamer, settled *corev1.Pod
+	var failed bool
+
+	BeforeAll(func() {
+		Expect(controllerArgs()).To(ContainSubstring("--auto-diskful-after="),
+			"the controller must be installed with autoDiskfulAfter set")
+		Expect(len(replicaNodes(ctx))).To(BeNumerically(">=", 3),
+			"a 2-replica volume only gets a diskless tie-breaker when a third storage node is spare")
+		Expect(client.IgnoreAlreadyExists(k8s.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}))).To(Succeed())
+	})
+	AfterEach(func() { failed = failed || CurrentSpecReport().Failed() })
+	AfterAll(func() {
+		if failed {
+			GinkgoWriter.Printf("specs failed — leaving namespace %q for diagnostics\n", ns)
+			return
+		}
+		_ = k8s.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	It("provisions a replicated volume with a diskless tie-breaker", func() {
+		Expect(k8s.Create(ctx, pvc(ns, "convdata", replicatedClass, "1Gi", nil))).To(Succeed())
+		roamer = pod(ns, "roamer", "convdata")
+		Expect(k8s.Create(ctx, roamer)).To(Succeed())
+		eventuallyPodReady(ctx, ns, roamer.Name)
+		pv = boundPV(ctx, ns, "convdata")
+		eventuallyMiroirVolumeReady(ctx, pv)
+		seedSum = writeSeed(ns, roamer.Name, "/data/seed")
+
+		// The tie-breaker lands on whichever node placement left spare.
+		Eventually(func(g Gomega) {
+			var v miroirv1alpha1.MiroirVolume
+			g.Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
+			g.Expect(v.Spec.DiskfulReplicas()).To(HaveLen(2))
+			tieNode = disklessLegNode(&v)
+			g.Expect(tieNode).NotTo(BeEmpty(), "no diskless leg on %s", pv)
+		}).Should(Succeed())
+	})
+
+	It("moves the consumer onto the diskless leg's node", func() {
+		Expect(k8s.Delete(ctx, roamer)).To(Succeed())
+		eventuallyGone(ctx, roamer)
+
+		settled = pod(ns, "settled", "convdata")
+		settled.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": tieNode}
+		Expect(k8s.Create(ctx, settled)).To(Succeed())
+		eventuallyPodReady(ctx, ns, settled.Name)
+
+		// The leg the conversion is about to act on: up, Primary for the
+		// pod, and serving every read and write over the network.
+		Eventually(func(g Gomega) {
+			g.Expect(localLegStatus(ctx, tieNode, pv)).To(ContainSubstring("disk:Diskless"))
+			var v miroirv1alpha1.MiroirVolume
+			g.Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
+			g.Expect(v.Status.PerNode[tieNode].DiskState).To(Equal("Diskless"))
+		}).Should(Succeed())
+		Expect(sha(ns, settled.Name, "/data/seed")).To(Equal(seedSum),
+			"the diskless client must serve the peers' data")
+	})
+
+	It("converts the settled leg into a diskful replica", func() {
+		Eventually(func(g Gomega) {
+			var v miroirv1alpha1.MiroirVolume
+			g.Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
+			g.Expect(v.Spec.DiskfulReplicas()).To(HaveLen(3))
+			g.Expect(hasDiskfulReplicaOn(&v, tieNode)).To(BeTrue(),
+				"the settled leg on %s must be the one converted", tieNode)
+			g.Expect(disklessLegNode(&v)).To(BeEmpty(), "no diskless leg may survive the conversion")
+		}).WithTimeout(conversionTimeout).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			found, err := eventWithReason(ctx, "AutoDiskful", pv)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(BeTrue(), "want an AutoDiskful event for %s", pv)
+		}).Should(Succeed())
+	})
+
+	It("seeds the fresh backing and full-syncs it under the running pod", func() {
+		// The regression: with the blank backing adopted as live metadata,
+		// create-md never ran, the attach failed "No valid meta data found"
+		// on every pass, and this leg stayed Diskless forever.
+		Eventually(func(g Gomega) {
+			var v miroirv1alpha1.MiroirVolume
+			g.Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
+			g.Expect(v.Status.PerNode[tieNode].DiskState).To(Equal("UpToDate"),
+				"converted leg must attach its backing and finish its full sync")
+			g.Expect(string(v.Status.Phase)).To(Equal("Ready"))
+		}).WithTimeout(conversionTimeout).Should(Succeed())
+
+		// On the node itself: a backing LV exists and the kernel attached it.
+		Expect(agentExec(ctx, tieNode, "lvs --noheadings -o lv_name")).To(ContainSubstring(pv),
+			"the conversion must leave a real backing device behind")
+		Expect(localLegStatus(ctx, tieNode, pv)).To(ContainSubstring("disk:UpToDate"))
+
+		// The pod never restarted, and it now reads the seed it wrote
+		// before the node had a disk — off the local replica this time.
+		var p corev1.Pod
+		Expect(k8s.Get(ctx, client.ObjectKeyFromObject(settled), &p)).To(Succeed())
+		Expect(p.Status.ContainerStatuses[0].RestartCount).To(BeZero(),
+			"the conversion must be transparent to the consumer")
+		Expect(sha(ns, settled.Name, "/data/seed")).To(Equal(seedSum))
+	})
+})

--- a/test/e2e/autodiskful_test.go
+++ b/test/e2e/autodiskful_test.go
@@ -4,7 +4,9 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,8 +40,46 @@ func controllerArgs() string {
 // (the resource line and its device line). Scoped deliberately: the peer
 // lines below carry peer-disk: states that a whole-output substring match
 // would confuse for the local disk.
-func localLegStatus(ctx context.Context, node, name string) string {
-	return agentExec(ctx, node, "drbdsetup status "+name+" | awk 'NR<=2'")
+//
+// It returns an error rather than asserting, for two reasons. Inside an
+// Eventually(func(g Gomega)) the package-level Expect that agentExec uses
+// re-panics out of the poller, so a momentarily-unlisted agent pod fails
+// the spec instead of retrying. And the head-2 is taken here rather than
+// piped through awk, whose exit status would mask drbdsetup's own — a
+// not-in-kernel resource exits 10 and must not read as empty output.
+func localLegStatus(ctx context.Context, node, name string) (string, error) {
+	pod, err := agentPodOnE(ctx, node)
+	if err != nil {
+		return "", err
+	}
+	out, err := exec.CommandContext(ctx, "kubectl", "exec", "-n", agentNamespace, pod,
+		"-c", "agent", "--", "drbdsetup", "status", name).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("drbdsetup status %s on %s: %w: %s", name, node, err, string(out))
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	return strings.Join(lines[:min(2, len(lines))], "\n"), nil
+}
+
+// legIdentity returns the DRBD node-id and address of node's replica entry.
+// The conversion's contract is that it flips the leg in place keeping both;
+// a regression that instead dropped the leg and re-added it would still end
+// at "3 diskful UpToDate replicas", so the identity is what distinguishes
+// a conversion from a remove-and-re-add.
+func legIdentity(vol *miroirv1alpha1.MiroirVolume, node string) (int32, string) {
+	GinkgoHelper()
+	for _, rep := range vol.Spec.Replicas {
+		if rep.Node == node {
+			return rep.NodeID, rep.Address
+		}
+	}
+	for _, cl := range vol.Spec.Clients {
+		if cl.Node == node {
+			return cl.NodeID, cl.Address
+		}
+	}
+	Fail("no replica or client entry for node " + node)
+	return 0, ""
 }
 
 // disklessLegNode returns the node carrying the volume's diskless leg —
@@ -75,7 +115,8 @@ var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func(
 	const ns = "miroir-e2e-diskful"
 	ctx := context.Background()
 
-	var pv, tieNode, seedSum string
+	var pv, tieNode, tieAddr, seedSum string
+	var tieID int32
 	var roamer, settled *corev1.Pod
 	var failed bool
 
@@ -113,6 +154,7 @@ var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func(
 			g.Expect(v.Spec.DiskfulReplicas()).To(HaveLen(2))
 			tieNode = disklessLegNode(&v)
 			g.Expect(tieNode).NotTo(BeEmpty(), "no diskless leg on %s", pv)
+			tieID, tieAddr = legIdentity(&v, tieNode)
 		}).Should(Succeed())
 	})
 
@@ -132,7 +174,9 @@ var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func(
 		// start — bounded tightly, because a leg that already converted
 		// only gets further from Diskless and waiting cannot recover it.
 		Eventually(func(g Gomega) {
-			g.Expect(localLegStatus(ctx, tieNode, pv)).To(ContainSubstring("disk:Diskless"))
+			st, err := localLegStatus(ctx, tieNode, pv)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(st).To(ContainSubstring("disk:Diskless"))
 			var v miroirv1alpha1.MiroirVolume
 			g.Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
 			g.Expect(v.Status.PerNode[tieNode].DiskState).To(Equal("Diskless"))
@@ -151,6 +195,12 @@ var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func(
 			g.Expect(hasDiskfulReplicaOn(&v, tieNode)).To(BeTrue(),
 				"the settled leg on %s must be the one converted", tieNode)
 			g.Expect(disklessLegNode(&v)).To(BeEmpty(), "no diskless leg may survive the conversion")
+			// Converted in place, not dropped and re-added: same node-id,
+			// same address. A re-add would reach the same replica count
+			// with a fresh node-id and a full re-handshake.
+			gotID, gotAddr := legIdentity(&v, tieNode)
+			g.Expect(gotID).To(Equal(tieID), "the conversion must keep the leg's DRBD node-id")
+			g.Expect(gotAddr).To(Equal(tieAddr), "the conversion must keep the leg's address")
 		}).WithTimeout(conversionTimeout).Should(Succeed())
 
 		Eventually(func(g Gomega) {
@@ -173,9 +223,13 @@ var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func(
 		}).WithTimeout(conversionTimeout).Should(Succeed())
 
 		// On the node itself: a backing LV exists and the kernel attached it.
-		Expect(agentExec(ctx, tieNode, "lvs --noheadings -o lv_name")).To(ContainSubstring(pv),
+		// This leg runs the lvmthin testdriver, so lvs is the right probe;
+		// `|| true` keeps a non-zero lvs from aborting on its own output.
+		Expect(agentExec(ctx, tieNode, "lvs --noheadings -o lv_name || true")).To(ContainSubstring(pv),
 			"the conversion must leave a real backing device behind")
-		Expect(localLegStatus(ctx, tieNode, pv)).To(ContainSubstring("disk:UpToDate"))
+		st, err := localLegStatus(ctx, tieNode, pv)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(st).To(ContainSubstring("disk:UpToDate"))
 
 		// The pod rode the conversion out, and it now reads the seed it
 		// wrote before the node had a disk — off the local replica this
@@ -187,6 +241,12 @@ var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func(
 		Expect(p.Status.Phase).To(Equal(corev1.PodRunning),
 			"the conversion must be transparent to the consumer")
 		Expect(podReady(&p)).To(BeTrue(), "consumer must still be Ready after the conversion")
-		Expect(sha(ns, settled.Name, "/data/seed")).To(Equal(seedSum))
+		// Drop the node's page cache first: this pod wrote /data/seed
+		// minutes ago, so an unqualified re-read can be served entirely
+		// from cache without a single block reaching the freshly synced
+		// backing — exactly the read this assertion exists to make.
+		agentExec(ctx, tieNode, "sync && echo 3 > /proc/sys/vm/drop_caches")
+		Expect(sha(ns, settled.Name, "/data/seed")).To(Equal(seedSum),
+			"the converted local replica must serve the data off its own disk")
 	})
 })

--- a/test/e2e/autodiskful_test.go
+++ b/test/e2e/autodiskful_test.go
@@ -126,13 +126,19 @@ var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func(
 		eventuallyPodReady(ctx, ns, settled.Name)
 
 		// The leg the conversion is about to act on: up, Primary for the
-		// pod, and serving every read and write over the network.
+		// pod, and serving every read and write over the network. The
+		// threshold clock is PrimarySince, stamped back at NodeStageVolume,
+		// so this races the conversion by however long the pod took to
+		// start — bounded tightly, because a leg that already converted
+		// only gets further from Diskless and waiting cannot recover it.
 		Eventually(func(g Gomega) {
 			g.Expect(localLegStatus(ctx, tieNode, pv)).To(ContainSubstring("disk:Diskless"))
 			var v miroirv1alpha1.MiroirVolume
 			g.Expect(k8s.Get(ctx, client.ObjectKey{Name: pv}, &v)).To(Succeed())
 			g.Expect(v.Status.PerNode[tieNode].DiskState).To(Equal("Diskless"))
-		}).Should(Succeed())
+		}).WithTimeout(20*time.Second).Should(Succeed(),
+			"the leg must still be diskless here; if it already converted, "+
+				"pod startup ate the whole --auto-diskful-after budget")
 		Expect(sha(ns, settled.Name, "/data/seed")).To(Equal(seedSum),
 			"the diskless client must serve the peers' data")
 	})
@@ -171,12 +177,16 @@ var _ = Describe("auto-diskful conversion", Ordered, Label("autodiskful"), func(
 			"the conversion must leave a real backing device behind")
 		Expect(localLegStatus(ctx, tieNode, pv)).To(ContainSubstring("disk:UpToDate"))
 
-		// The pod never restarted, and it now reads the seed it wrote
-		// before the node had a disk — off the local replica this time.
+		// The pod rode the conversion out, and it now reads the seed it
+		// wrote before the node had a disk — off the local replica this
+		// time. Phase and readiness, not RestartCount: these pods are
+		// RestartPolicy: Never, so a container the conversion killed would
+		// move the pod to Failed with its restart count still zero.
 		var p corev1.Pod
 		Expect(k8s.Get(ctx, client.ObjectKeyFromObject(settled), &p)).To(Succeed())
-		Expect(p.Status.ContainerStatuses[0].RestartCount).To(BeZero(),
+		Expect(p.Status.Phase).To(Equal(corev1.PodRunning),
 			"the conversion must be transparent to the consumer")
+		Expect(podReady(&p)).To(BeTrue(), "consumer must still be Ready after the conversion")
 		Expect(sha(ns, settled.Name, "/data/seed")).To(Equal(seedSum))
 	})
 })

--- a/test/e2e/orphanhold_test.go
+++ b/test/e2e/orphanhold_test.go
@@ -32,16 +32,26 @@ const (
 // agentPodOn returns the miroir agent pod running on node.
 func agentPodOn(ctx context.Context, node string) string {
 	GinkgoHelper()
+	name, err := agentPodOnE(ctx, node)
+	Expect(err).NotTo(HaveOccurred())
+	return name
+}
+
+// agentPodOnE is agentPodOn for callers inside an Eventually: it reports a
+// missing pod as an error to retry on, where Fail/Expect would abort the
+// whole spec on a pod that is merely mid-reschedule.
+func agentPodOnE(ctx context.Context, node string) (string, error) {
 	var pods corev1.PodList
-	Expect(k8s.List(ctx, &pods, client.InNamespace(agentNamespace),
-		client.MatchingLabels{"app.kubernetes.io/component": "agent"})).To(Succeed())
+	if err := k8s.List(ctx, &pods, client.InNamespace(agentNamespace),
+		client.MatchingLabels{"app.kubernetes.io/component": "agent"}); err != nil {
+		return "", err
+	}
 	for _, p := range pods.Items {
 		if p.Spec.NodeName == node {
-			return p.Name
+			return p.Name, nil
 		}
 	}
-	Fail("no agent pod on node " + node)
-	return ""
+	return "", fmt.Errorf("no agent pod on node %s", node)
 }
 
 // agentExec runs sh -c inside the privileged agent container on node —

--- a/test/e2e/readiness_test.go
+++ b/test/e2e/readiness_test.go
@@ -219,6 +219,16 @@ var _ = Describe("CSI node unreachability surfacing", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{Name: ns},
 		}))).To(Succeed())
 		nodes := replicaNodes(ctx)
+		// The mechanism below needs placement to have no choice but the
+		// excluded node for the second replica, which only holds at
+		// exactly two storage nodes. With a third, CreateVolume places
+		// both diskful replicas on the healthy pair — and once the
+		// excluded node's MiroirNode goes stale it leaves placement
+		// entirely — so hasDiskfulReplicaOn(excludeNode) never becomes
+		// true and the 10-minute wait below fails for the wrong reason.
+		if len(nodes) != 2 {
+			Skip(fmt.Sprintf("needs exactly 2 storage nodes to force placement onto the excluded node, cluster has %d", len(nodes)))
+		}
 		excludeNode = nodes[0]
 		keepNodes = nodes[1:]
 		dsName = agentDaemonSetName()


### PR DESCRIPTION
Closes https://github.com/home-operations/miroir/issues/367

## Problem

An auto-diskful conversion never completes: the converting leg error-loops `No valid meta data found` forever and never gains its replica.

`convertTieBreaker` / `convertClient` flip a leg diskful **in place**, keeping its node-id and address, so the consumer keeps the device open. That leaves the resource up in the kernel as a *diskless* leg while the backing device it is gaining is still blank. `probeMetadata` then took the resource's mere presence in the kernel as proof of live metadata:

```go
if out, err := d.Exec(ctx, "drbdsetup", "status", name); err == nil && strings.Contains(out, name) {
	return true, true, "", nil
}
```

so the blank backing was adopted (`.md-adopted` written), `create-md` was skipped, and `adjust` attached a device with no metadata on it.

Apply's missing-metadata recovery cannot break out of it either: it drops `.md-created` and re-runs `ensureMarkedMetadata`, but the resource is still up (the attach failed), so the probe adopts again and the retry fails identically. Call trace from a repro against `main`:

```
drbdsetup status pvc-1   drbdadm adjust pvc-1   drbdsetup status pvc-1   drbdadm adjust pvc-1
→ adjust pvc-1: open(...) failed: No valid meta data found
```

Reported downstream in janpuc/home-ops@63f68aa.

## Fix

Key the probe on **this node's own disk state** rather than the resource's presence — the same predicate drbdmeta uses to refuse a busy device (`is_attached()` is `dstate > D_DISKLESS`, drbd-utils `user/shared/drbdmeta.c`). A converting leg therefore reads as unattached exactly when `create-md` is permitted against its backing, which is also the sequence LINSTOR's toggle-disk uses. The reason the kernel is asked first is unchanged: an attached local disk makes `dump-md` return EBUSY, indistinguishable from a foreign holder.

Adoption of a genuinely live leg is unaffected — the `Inconsistent`/`UpToDate` local-disk case still short-circuits, and the `dump-md` "might be stale" and `is configured!` branches still cover the races.

## Tests

- `drbd.TestApplySeedsMetadataForDisklessLegGainingADisk` — converting leg (kernel: up, `Diskless`) must run `create-md` and must not record `.md-adopted`.
- `agent.TestReconcileTieBreakerGainingADiskSeedsMetadata` — the same at the reconciler level, from a spec shaped exactly like `convertTieBreaker`'s output.
- `drbd.TestApplyAdoptsAttachedDevice` keeps the converse: a leg whose own disk is attached is still adopted untouched.

Both new tests fail on `main` and pass here. Existing fixtures that faked "resource not in the kernel" by erroring the plain-status call now queue a not-in-kernel `--json` read instead.

## E2E

`test/e2e` had no auto-diskful coverage at all, which is why this went unnoticed. The conversion needs a cluster shape no existing leg boots: a 2-replica volume only gets a diskless tie-breaker when some storage node carries no replica.

- `test/e2e-qemu/cluster-spare.yaml` — `cluster.yaml` plus a third worker, at 3GiB since this leg runs one spec instead of the parallel suite (three of those fit a runner more comfortably than today's two at 5GiB).
- A new `autodiskful` CI leg boots it, installs the chart with `autoDiskfulAfter=45s`, and runs the new spec alone (`RUN_CONFORMANCE=0` — replaying the upstream suite on a third cluster buys nothing).
- `SPEC_LABELS` gates the Ginkgo label filter, defaulting to `!autodiskful`, so every other leg skips a spec its cluster cannot satisfy.

The spec (`test/e2e/autodiskful_test.go`) provisions a replicated volume, settles the consumer on the tie-breaker's node, waits out the threshold, and then asserts what no unit test can: `create-md` against an up-but-diskless resource, the attach, a backing LV on the node, the leg reaching `UpToDate`, an `AutoDiskful` event, and the pod reading back — without restarting — the seed it wrote before that node had a disk.

