### PR TITLE
ci: split the conformance leg and build the e2e images once

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,16 @@ env:
   # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
   HELM_UNITTEST_VERSION: "v1.1.2"
 
+  # The tags e2e-images builds under and every leg pushes to its own
+  # runner-local registry. The nodes pull the registry.e2e names instead (see
+  # the go-e2e env), which the Talos mirror in patches/registry.yaml points at
+  # port 5000 on the bridge gateway. The split matters beyond taste: test.sh
+  # splits *_IMAGE on ':' for the Helm repo and tag, so the host:port push form
+  # would parse wrong there.
+  PUSH_CONTROLLER_IMAGE: localhost:5000/miroir-controller:e2e
+  PUSH_AGENT_IMAGE: localhost:5000/miroir-agent:e2e
+  PUSH_GATEWAY_IMAGE: localhost:5000/miroir-gateway:e2e
+
 jobs:
   docs:
     if: ${{ github.event_name != 'push' }}
@@ -36,12 +46,111 @@ jobs:
     with:
       deploy: false
 
+  # Built once and handed to every e2e leg, so they all install identical bytes
+  # instead of six builds racing one GHA cache scope apiece.
+  e2e-images:
+    if: >-
+      ${{ github.event_name != 'push'
+      && !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
+    name: E2E Images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Nothing here runs a pinned tool; the builds happen inside Docker and
+      # only the Go version is read back out of the config.
+      - name: Setup Mise
+        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
+        with:
+          install: false
+
+      - name: Resolve toolchain versions
+        id: tools
+        run: echo "go=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # load: true rather than a push, so one docker save can export all three
+      # at once and share the layers gateway inherits from agent. One writer per
+      # scope now, so each cache-to is unconditional.
+      - name: Build controller image
+        id: controller-image
+        background: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          load: true
+          target: controller
+          tags: ${{ env.PUSH_CONTROLLER_IMAGE }}
+          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
+          cache-from: type=gha,scope=e2e-controller
+          cache-to: type=gha,mode=max,scope=e2e-controller
+
+      - name: Build agent image
+        id: agent-image
+        background: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          load: true
+          target: agent
+          tags: ${{ env.PUSH_AGENT_IMAGE }}
+          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
+          cache-from: type=gha,scope=e2e-agent
+          cache-to: type=gha,mode=max,scope=e2e-agent
+
+      # Gateway extends the agent stage, so buildx reuses it and only layers on
+      # the ganesha packages.
+      - name: Build gateway image
+        id: gateway-image
+        background: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          load: true
+          target: gateway
+          tags: ${{ env.PUSH_GATEWAY_IMAGE }}
+          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
+          cache-from: type=gha,scope=e2e-gateway
+          cache-to: type=gha,mode=max,scope=e2e-gateway
+
+      - wait: [controller-image, agent-image, gateway-image]
+
+      # One tarball for all three: gateway shares every agent layer, so saving
+      # them together is barely larger than the agent alone. gzip because the
+      # daemon may export layers uncompressed depending on its image store, and
+      # docker load reads either. shell: bash for the pipefail the implicit
+      # `bash -e` default lacks -- a failed save would otherwise leave gzip's
+      # exit status to pass the step and hand every leg a truncated tarball.
+      - name: Export the images
+        shell: bash
+        run: |
+          docker save \
+            "${PUSH_CONTROLLER_IMAGE}" "${PUSH_AGENT_IMAGE}" "${PUSH_GATEWAY_IMAGE}" \
+            | gzip -1 > "${RUNNER_TEMP}/e2e-images.tar.gz"
+
+      - name: Upload the images
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-images
+          path: ${{ runner.temp }}/e2e-images.tar.gz
+          retention-days: 1
+
   go-e2e:
     if: >-
       ${{ github.event_name != 'push'
       && !(startsWith(github.head_ref, 'release-please--')
       && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Go E2E (${{ matrix.suite }})
+    needs: e2e-images
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
@@ -52,11 +161,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # miroir's own Go specs, then the upstream external-storage suite, both
-          # against the local (lvmthin, replicas:1) class.
-          - suite: conformance
+          # miroir's own Go specs against the local (lvmthin, replicas:1) class.
+          # Its own leg because run back to back with the upstream suite below
+          # they made a single 38-minute lane, and neither needs the other's
+          # state -- a fresh cluster costs ~6 minutes, the split saves ~14.
+          - suite: specs
             testdriver: testdriver-local.yaml
             specs: "1"
+            conformance: "0"
+            capacity: "true"
+          # The upstream external-storage suite against that same local class.
+          - suite: local
+            testdriver: testdriver-local.yaml
             capacity: "true"
           # The upstream suite against the replicated (DRBD, replicas:2) class,
           # group snapshots included.
@@ -94,17 +210,11 @@ jobs:
             autoDiskfulAfter: 2m
             conformance: "0"
     env:
-      # Two names for one image in the runner-local registry. The nodes pull
-      # registry.e2e, which the Talos mirror in patches/registry.yaml points at the
-      # bridge gateway; buildx pushes to the same registry over loopback. The split
-      # matters beyond taste: test.sh splits *_IMAGE on ':' for the Helm repo and
-      # tag, so the host:port push form would parse wrong there.
+      # What the chart is pointed at, and so what the nodes pull: the other half
+      # of the two-names-for-one-image split described on the PUSH_* vars above.
       CONTROLLER_IMAGE: registry.e2e/miroir-controller:e2e
       AGENT_IMAGE: registry.e2e/miroir-agent:e2e
       GATEWAY_IMAGE: registry.e2e/miroir-gateway:e2e
-      PUSH_CONTROLLER_IMAGE: localhost:5000/miroir-controller:e2e
-      PUSH_AGENT_IMAGE: localhost:5000/miroir-agent:e2e
-      PUSH_GATEWAY_IMAGE: localhost:5000/miroir-gateway:e2e
       # test.sh packages the chart, pushes it here, and installs it back over OCI, so
       # the run exercises the distributed artifact rather than the working tree.
       CHART_REGISTRY: oci://localhost:5000/charts
@@ -126,9 +236,7 @@ jobs:
       - name: Resolve toolchain versions
         id: tools
         working-directory: .
-        run: |
-          echo "go=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
-          echo "talos=$(mise config get tools.talos)" >> "$GITHUB_OUTPUT"
+        run: echo "talos=$(mise config get tools.talos)" >> "$GITHUB_OUTPUT"
 
       # Host prep is ours to do: the cluster action provisions and nothing else.
       - name: Install QEMU
@@ -143,9 +251,10 @@ jobs:
           sudo mkswap /mnt/e2e-swapfile
           sudo swapon /mnt/e2e-swapfile
 
-      # The conformance leg compiles and runs miroir's Go specs; both legs read the
-      # module cache, only the conformance one uses it.
+      # Only the legs that set RUN_SPECS compile Go; the rest drive a prebuilt
+      # e2e.test and need nothing from the module cache.
       - name: Cache Go modules and build
+        if: ${{ matrix.specs == '1' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -157,9 +266,10 @@ jobs:
       - name: Start image registry
         run: docker run -d --name e2e-registry -p 5000:5000 registry:3
 
-      # Booting the VMs and building the images share no inputs, so they overlap.
-      # talosctl comes from mise, whose shim the action unwraps itself, because the
-      # QEMU provisioner runs under sudo.
+      # Booting the VMs and filling the registry share no inputs, so they overlap
+      # the way the builds this leg used to run did. talosctl comes from mise,
+      # whose shim the action unwraps itself, because the QEMU provisioner runs
+      # under sudo.
       - name: Create cluster
         id: cluster
         background: true
@@ -167,60 +277,25 @@ jobs:
         with:
           config: test/e2e-qemu/${{ matrix.cluster || 'cluster.yaml' }}
 
-      # network=host so the builder container can reach the registry published on the
-      # runner's loopback.
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Download the images
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          driver-opts: network=host
+          name: e2e-images
+          path: ${{ runner.temp }}
 
-      # Both images are byte-identical across legs, so they share one cache scope per
-      # image. Only one leg writes each back: concurrent cache-to writes to the same
-      # scope evict each other, so the replicated leg writes and conformance reads.
-      - name: Build controller image
-        id: controller-image
-        background: true
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: true
-          target: controller
-          tags: ${{ env.PUSH_CONTROLLER_IMAGE }}
-          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
-          cache-from: type=gha,scope=e2e-controller
-          cache-to: ${{ matrix.suite == 'replicated' && 'type=gha,mode=max,scope=e2e-controller' || '' }}
+      # Straight into this leg's own registry, so the nodes still pull over
+      # loopback and nothing crosses the internet.
+      - name: Load the images into the registry
+        run: |
+          docker load -i "${RUNNER_TEMP}/e2e-images.tar.gz"
+          docker push "${PUSH_CONTROLLER_IMAGE}"
+          docker push "${PUSH_AGENT_IMAGE}"
+          docker push "${PUSH_GATEWAY_IMAGE}"
 
-      - name: Build agent image
-        id: agent-image
-        background: true
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: true
-          target: agent
-          tags: ${{ env.PUSH_AGENT_IMAGE }}
-          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
-          cache-from: type=gha,scope=e2e-agent
-          cache-to: ${{ matrix.suite == 'replicated' && 'type=gha,mode=max,scope=e2e-agent' || '' }}
-
-      # Gateway extends the agent stage, so buildx reuses it and only layers on
-      # the ganesha packages.
-      - name: Build gateway image
-        id: gateway-image
-        background: true
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: true
-          target: gateway
-          tags: ${{ env.PUSH_GATEWAY_IMAGE }}
-          build-args: GO_VERSION=${{ steps.tools.outputs.go }}
-          cache-from: type=gha,scope=e2e-gateway
-          cache-to: ${{ matrix.suite == 'replicated' && 'type=gha,mode=max,scope=e2e-gateway' || '' }}
-
-      - wait: [cluster, controller-image, agent-image, gateway-image]
+      - wait: [cluster]
 
       - name: Cache conformance test binaries
+        if: ${{ matrix.conformance != '0' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: test/conformance/.bin
@@ -431,6 +506,7 @@ jobs:
     name: Build Success
     needs:
       - docs
+      - e2e-images
       - go-e2e
       - go-lint
       - go-test

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,9 @@
 rules:
-  # The e2e legs (the go-e2e job in ci.yaml) build an image with `load: true`:
-  # it is loaded into the kind cluster for the test and never pushed to a
-  # registry or released, so there is no published artifact for a poisoned
-  # tool/layer cache to compromise.
+  # The e2e-images job in ci.yaml builds from a cached layer set, but what it
+  # produces only ever reaches the throwaway QEMU clusters the e2e legs boot --
+  # a runner-local registry, never one outside it and never a release -- so
+  # there is no published artifact for a poisoned tool/layer cache to
+  # compromise.
   cache-poisoning:
     ignore:
       - ci.yaml

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -17,7 +17,8 @@ so a failure names the path that broke:
 
 | Leg           | Runs                                                   | Class               |
 | ------------- | ------------------------------------------------------ | ------------------- |
-| `conformance` | miroir's Go specs, then the parallel upstream suite    | `miroir-local`      |
+| `specs`       | miroir's own Go specs                                  | `miroir-local`      |
+| `local`       | the parallel upstream block/filesystem suite           | `miroir-local`      |
 | `replicated`  | the parallel upstream block/filesystem suite           | `miroir-replicated` |
 | `zfs`         | the parallel upstream block/filesystem suite           | `miroir-zfs`        |
 | `rwx`         | the parallel upstream filesystem-only RWX/ROX suite    | `miroir-replicated` |
@@ -25,14 +26,16 @@ so a failure names the path that broke:
 | `autodiskful` | the auto-diskful Go spec only, on `cluster-spare.yaml` | `miroir-replicated` |
 
 miroir's Go specs (`test/e2e`) assert the local lifecycle, snapshot/restore, block and
-placement behaviour the upstream suite does not; the conformance leg runs them
-(`RUN_SPECS=1`) against the miroir-local (lvmthin, replicas: 1) class before the long
-external-storage run. The replicated leg drives that upstream suite against the DRBD
-(replicas: 2) class, group snapshots included; the zfs leg drives it against the same
-DRBD shape backed by the zfs pool instead, so replication pairs zvol with zvol and
-the zfs snapshot/restore path runs under the suite. The rwx leg enables the NFS
-gateway and advertises only filesystem volume modes, while the serial leg gives
-exclusive-cluster specs a single Ginkgo process.
+placement behaviour the upstream suite does not; the specs leg runs them
+(`RUN_SPECS=1`, `RUN_CONFORMANCE=0`) against the miroir-local (lvmthin, replicas: 1)
+class, and the local leg drives the upstream suite against that same class. They used
+to share one leg and run back to back, which made it the longest by about fourteen
+minutes; a cluster of their own costs each about six. The replicated leg drives that
+upstream suite against the DRBD (replicas: 2) class, group snapshots included; the zfs
+leg drives it against the same DRBD shape backed by the zfs pool instead, so
+replication pairs zvol with zvol and the zfs snapshot/restore path runs under the
+suite. The rwx leg enables the NFS gateway and advertises only filesystem volume
+modes, while the serial leg gives exclusive-cluster specs a single Ginkgo process.
 
 The autodiskful leg is the one that boots a different shape. Auto-diskful converts a
 settled diskless leg into a local replica, and a 2-replica volume only gets a diskless
@@ -42,7 +45,7 @@ set. Its spec is the only one carrying the `autodiskful` Ginkgo label: every oth
 runs `SPEC_LABELS=!autodiskful` and skips it, and this leg selects it and skips the
 upstream suite (`RUN_CONFORMANCE=0`) rather than replaying it on a third cluster.
 
-The conformance and zfs legs enable CSI storage capacity publication (the replicated
+The specs, local and zfs legs enable CSI storage capacity publication (the replicated
 block lane keeps it off, where DRBD's full-size reservation on every replica starves
 the scheduler during parallel-clone specs); the upstream definitions exercise ext4,
 xfs, topology and mount options. Real per-node kernels and real block devices are the
@@ -97,7 +100,7 @@ set -gx CLUSTER_NAME miroir-e2e
 set -gx KUBECONFIG /tmp/miroir-e2e/kubeconfig
 set -gx TALOSCONFIG /tmp/miroir-e2e/talosconfig
 set -gx TESTDRIVER testdriver.yaml # or testdriver-local.yaml / testdriver-zfs.yaml / testdriver-rwx.yaml
-set -gx RUN_SPECS 1                # also run the Go specs (the conformance leg does)
+set -gx RUN_SPECS 1                # also run the Go specs (CI gives them their own leg)
 set -gx STORAGE_CAPACITY_ENABLED true
 # Required with testdriver-rwx.yaml:
 set -gx GATEWAY_ENABLED true
@@ -134,14 +137,17 @@ set -gx CONTROLLER_IMAGE ghcr.io/you/miroir-controller:dev
 set -gx AGENT_IMAGE ghcr.io/you/miroir-agent:dev
 ```
 
-CI instead fixes the tags up front and builds them concurrently with the cluster,
-since the build and the VMs share no inputs; `test.sh` then finds the images already
-built and skips straight to installing them. CI builds through
-`docker/build-push-action` rather than `image.sh` so the layers land in the GitHub
-Actions cache, which `image.sh` has no way to reach.
+CI instead builds all three once, in the `e2e-images` job that runs ahead of the
+matrix, and hands them to every leg as a single `docker save` tarball (~135MB, since
+gateway shares every agent layer). Each leg loads that tarball while its VMs boot and
+pushes it into its own registry, so the legs install identical bytes rather than
+whatever each rebuild produced, and one job owns each GitHub Actions cache scope
+instead of every leg racing for it. `test.sh` finds the images already tagged and
+skips straight to installing them. CI builds through `docker/build-push-action` rather
+than `image.sh` so the layers land in that cache, which `image.sh` has no way to reach.
 
-CI also runs its own registry on the runner and pushes there, so the images never
-cross the internet. The nodes reach them as `registry.e2e`, which the mirror in
+Each leg still runs its own registry on the runner, so the images never cross the
+internet. The nodes reach them as `registry.e2e`, which the mirror in
 `patches/registry.yaml` points at port 5000 on the QEMU bridge gateway. That mirror
 entry is inert for a local run, where nothing references `registry.e2e`.
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,8 +1,8 @@
 //go:build e2e
 
 // Package e2e drives a Helm-deployed miroir through the CSI volume lifecycle on
-// the Talos QEMU cluster $KUBECONFIG points at (test/e2e-qemu runs it as part of
-// the conformance leg). It is build-tagged so `mise run test` never compiles it.
+// the Talos QEMU cluster $KUBECONFIG points at (test/e2e-qemu runs it as the
+// specs leg). It is build-tagged so `mise run test` never compiles it.
 //
 // Scope: the local backend (miroir-local / lvmthin / replicas:1), plus the
 // orphaned-hold teardown spec, which needs a replicated (DRBD) volume. The rest


### PR DESCRIPTION
The `conformance` leg ran miroir's Go specs and the upstream external-storage suite back to back, which made it the longest lane by about fourteen minutes. Neither suite needs the other's state, so they get a leg each.

Every leg also rebuilt all three images itself, so a shared `e2e-images` job now builds them once and hands them to the matrix.

## Why

Timings from a green run on #364 (`30453357794`):

| leg | job total | test step |
| --- | --- | --- |
| **conformance** | **38m02** | **33m48** |
| zfs | 28m02 | 23m50 |
| replicated | 22m51 | 18m08 |
| rwx | 8m59 | 5m05 |
| serial | 8m06 | 3m54 |

The conformance leg's 33m48 was 1m39 install + **13m47** Go specs + **18m09** upstream suite. Splitting those gives roughly a 20m leg and a 24m leg, so the critical path drops to about 28m and `zfs` becomes the new ceiling.

There is no slack left inside a leg. Sum-of-spec-time against wall clock at `procs=4`, from the JUnit artifacts:

| leg | Σ spec time | wall | speedup |
| --- | --- | --- | --- |
| conformance | 68.7m (109 specs) | 18m09 | 3.78× / 95% |
| zfs | 79.4m (120 specs) | 23m50 | 3.33× / 83% |
| replicated | 57.6m (119 specs) | 18m08 | 3.18× / 79% |

`procs` cannot go higher either — the runner is 4 CPU / 15.61 GiB already hosting three VMs. More clusters is the only lever, which is what this change spends.

## Changes

**Split** — `conformance` becomes `specs` (Go specs, `conformance: "0"`) and `local` (upstream suite), both on `testdriver-local.yaml` with capacity on. This reuses the `RUN_CONFORMANCE` knob and `conformance: "0"` convention already in `test.sh` for the autodiskful leg, so **`test.sh` is unchanged**.

**Shared images** — a new `e2e-images` job builds controller/agent/gateway with `load: true`, exports all three in one `docker save | gzip` (~135MB, since gateway shares every agent layer) and uploads it as an artifact. Each leg downloads and loads it into its own runner-local registry while its VMs boot, so nodes still pull over loopback and `patches/registry.yaml` is untouched.

Fallout that cleaned up on its own:

- The gateway image was built by every leg and installed by one. Building once removes that without a special case.
- The `cache-to: ${{ matrix.suite == 'replicated' && … }}` ordering hack is gone. One job owns each scope, so each `cache-to` is unconditional and the cache cannot go unwritten if that leg is renamed or fails early.
- `setup-buildx` and its `network=host` are gone from the legs entirely.
- The Go module cache is now gated on `matrix.specs == '1'`, and the e2e.test download on `matrix.conformance != '0'`.

## Verified

The image path was run locally end to end rather than assumed: built all three, `docker save` of the set is 135MB, `docker load` restores all three `localhost:5000/…:e2e` tags, and pushing into a real `registry:3` gives a catalog with all three.

`actionlint` (with the shared workflow-lint action's own ignore flags), `zizmor`, `shellcheck`, `go vet -tags e2e` and `golangci-lint` are clean.

One bug caught while writing it: GitHub's implicit `run` shell is `bash -e {0}` with **no `pipefail`**, so a failed `docker save` would have exited 0 via `gzip` and handed every leg a truncated tarball. That step sets `shell: bash`.

## Tradeoff

The shared build job **adds** its own duration to the front of every leg, since the per-leg builds were previously hidden behind the cluster boot. The wall-clock win here comes from the split; the build job buys identical bytes across legs and the cache-scope cleanup. It also scales — the more the matrix shards, the more a single build amortises.

## Next

Sharding the heavy upstream legs by `[Testpattern: …]` should take the critical path to roughly 14-16m. `run.sh` already reads `FOCUS`/`SKIP` from env, so it is matrix-only work — but setting `SKIP` in a matrix row **overrides** run.sh's default `\[Disruptive\]|\[Serial\]|…`, which would re-admit Serial specs into a parallel shard. That wants append semantics first.