### PR TITLE
fix(csi): refuse to reformat a restore whose device reads blank

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -623,7 +623,7 @@ func main() {
 			// the probe's fatal below-floor exit would crash-loop a
 			// consumer-only node over a check that protects nothing here.
 			clientDRBD := &drbd.Driver{StateDir: drbdStateDir, Exec: backend.RealExec}
-			node := csi.NewNode(mgr.GetClient(), nodeName, clientDRBD)
+			node := csi.NewNode(mgr.GetClient(), mgr.GetAPIReader(), nodeName, clientDRBD)
 			node.ClientOnly = true
 			serveCSI(mgr, csiSocket, identity, nil, node)
 			break
@@ -755,7 +755,7 @@ func main() {
 		// Scheduled online verify — the only cross-leg integrity check. Needs
 		// the DRBD kernel side, so it is gated on drbdReady like the sweeps.
 		addVerifyScheduler(mgr, nodeName, drbdReady, verifySchedule, drbdDriver)
-		node := csi.NewNode(mgr.GetClient(), nodeName, drbdDriver)
+		node := csi.NewNode(mgr.GetClient(), mgr.GetAPIReader(), nodeName, drbdDriver)
 		serveCSI(mgr, csiSocket, identity, nil, node)
 
 	default:

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -54,6 +54,9 @@ type Node struct {
 	// reconciler lags, and staging on a stale UpToDate mounts (or worse,
 	// formats) a diverged replica.
 	DRBD stage.DRBDStatus
+	// APIReader is the uncached read the staging pipeline confirms a
+	// restore's formatted flag with; see stage.Deps.Reader.
+	APIReader client.Reader
 	// ClientOnly marks a node with no MiroirNode: no volume reconciler
 	// runs there, so an added client leg would never be realized — the
 	// pod would wedge in ContainerCreating, the spec entry would burn one
@@ -74,19 +77,26 @@ type Thawer interface {
 }
 
 // NewNode wires a Node service with the host mount/format tooling.
-func NewNode(c client.Client, nodeName string, d stage.DRBDStatus) *Node {
+func NewNode(c client.Client, r client.Reader, nodeName string, d stage.DRBDStatus) *Node {
 	return &Node{
-		Client:   c,
-		NodeName: nodeName,
-		Mounter:  mount.NewSafeFormatAndMount(mount.New(""), utilexec.New()),
-		DRBD:     d,
-		Freezer:  agent.NewFreezer(),
+		Client:    c,
+		APIReader: r,
+		NodeName:  nodeName,
+		Mounter:   mount.NewSafeFormatAndMount(mount.New(""), utilexec.New()),
+		DRBD:      d,
+		Freezer:   agent.NewFreezer(),
 	}
 }
 
 // deps bundles the node's tooling for the shared staging pipeline.
 func (n *Node) deps() stage.Deps {
-	return stage.Deps{Client: n.Client, NodeName: n.NodeName, Mounter: n.Mounter, DRBD: n.DRBD}
+	return stage.Deps{
+		Client:   n.Client,
+		Reader:   n.APIReader,
+		NodeName: n.NodeName,
+		Mounter:  n.Mounter,
+		DRBD:     n.DRBD,
+	}
 }
 
 // NodeGetInfo reports this node's name and topology segment (§6.5).

--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -53,6 +53,21 @@ type Deps struct {
 	// reconciler lags, and staging on a stale UpToDate mounts (or worse,
 	// formats) a diverged replica.
 	DRBD DRBDStatus
+	// Reader is the uncached API reader the blank-restore check needs: a
+	// clone inherits its source's Formatted flag from the controller
+	// moments before the first stage, and the node's informer cache still
+	// carries the volume as unformatted for as long as the watch takes to
+	// deliver it. Falls back to the cached client when unset (tests, and
+	// the gateway whose client is uncached already).
+	Reader client.Reader
+}
+
+// reader returns the uncached reader when one is wired, else the client.
+func (d Deps) reader() client.Reader {
+	if d.Reader != nil {
+		return d.Reader
+	}
+	return d.Client
 }
 
 // Device resolves the volume's local device from the CRD and verifies
@@ -189,11 +204,16 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 		if err != nil {
 			return status.Errorf(codes.Internal, "probe filesystem on %s: %v", dev, err)
 		}
-		if format == "" && vol.Status.Formatted {
-			return status.Errorf(codes.DataLoss,
-				"volume %s was formatted before but %s reads blank — refusing to reformat", vol.Name, dev)
-		}
-		if format != "" {
+		if format == "" {
+			formatted, err := formattedBefore(ctx, d, vol)
+			if err != nil {
+				return err
+			}
+			if formatted {
+				return status.Errorf(codes.DataLoss,
+					"volume %s was formatted before but %s reads blank — refusing to reformat", vol.Name, dev)
+			}
+		} else {
 			// Record before mounting so a clone that arrived with a
 			// filesystem is protected from then on.
 			if err := MarkFormatted(ctx, d.Client, vol); err != nil {
@@ -291,6 +311,27 @@ func recoverFrozenBdev(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVo
 	}
 	return status.Errorf(codes.Unavailable,
 		"cleared a leaked filesystem freeze on %s by restarting %s; retry the stage", dev, vol.Name)
+}
+
+// formattedBefore reports whether the volume ever carried a filesystem.
+// A restore whose cached answer is "never" is confirmed against the API
+// server first: the controller stamps the clone's inherited flag between
+// the Create and the first stage, so the node's cache can still be
+// showing the volume unformatted exactly while the blank-device refusal
+// matters. Left uncorroborated, a blank clone is mkfs'd instead of
+// refused — the silent half of the data loss the flag exists to catch. A
+// confirmation that cannot be read is Unavailable, not a licence to
+// format.
+func formattedBefore(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVolume) (bool, error) {
+	if vol.Status.Formatted || vol.Spec.Source == nil {
+		return vol.Status.Formatted, nil
+	}
+	live := &miroirv1alpha1.MiroirVolume{}
+	if err := d.reader().Get(ctx, types.NamespacedName{Name: vol.Name}, live); err != nil {
+		return false, status.Errorf(codes.Unavailable,
+			"volume %s: confirming the formatted flag before formatting a restore: %v", vol.Name, err)
+	}
+	return live.Status.Formatted, nil
 }
 
 // MarkFormatted flips the Formatted status flag once; shared by the

--- a/internal/stage/stage_test.go
+++ b/internal/stage/stage_test.go
@@ -25,10 +25,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 	"github.com/home-operations/miroir/internal/drbd"
 )
+
+const snapName = "snap-1"
 
 type statusOnlyDRBD struct{}
 
@@ -115,10 +118,91 @@ func TestRecoverFrozenBdevNeedsRestarter(t *testing.T) {
 	}
 }
 
+// apiReader answers the formatted-flag confirmation from one volume and
+// counts the reads, standing in for the uncached API reader.
+type apiReader struct {
+	vol  *miroirv1alpha1.MiroirVolume
+	err  error
+	gets int
+}
+
+func (r *apiReader) Get(_ context.Context, key client.ObjectKey, obj client.Object,
+	_ ...client.GetOption) error {
+	r.gets++
+	if r.err != nil {
+		return r.err
+	}
+	v, ok := obj.(*miroirv1alpha1.MiroirVolume)
+	if !ok || r.vol == nil || key.Name != r.vol.Name {
+		return errors.New("no such volume")
+	}
+	r.vol.DeepCopyInto(v)
+	return nil
+}
+
+func (r *apiReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return nil
+}
+
+func restoredVolume() *miroirv1alpha1.MiroirVolume {
+	vol := replicatedVolume()
+	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapName}
+	return vol
+}
+
+// The cache carries a restore as never-formatted for as long as the watch
+// takes to deliver the controller's inherited flag; a blank clone staged
+// inside that window must be refused, not reformatted.
+func TestFormattedBeforeConfirmsRestoreAgainstTheAPI(t *testing.T) {
+	live := restoredVolume()
+	live.Status.Formatted = true
+	r := &apiReader{vol: live}
+	formatted, err := formattedBefore(t.Context(), Deps{Reader: r}, restoredVolume())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !formatted {
+		t.Fatal("a stale cached flag must lose to the API server's")
+	}
+	if r.gets != 1 {
+		t.Fatalf("the confirmation must read once, read %d times", r.gets)
+	}
+}
+
+func TestFormattedBeforeFormatsARestoreOfAnUnformattedSource(t *testing.T) {
+	r := &apiReader{vol: restoredVolume()}
+	formatted, err := formattedBefore(t.Context(), Deps{Reader: r}, restoredVolume())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if formatted {
+		t.Fatal("a source that never carried a filesystem must still mkfs")
+	}
+}
+
+func TestFormattedBeforeSkipsTheReadForFreshVolumes(t *testing.T) {
+	r := &apiReader{err: errors.New("must not be read")}
+	formatted, err := formattedBefore(t.Context(), Deps{Reader: r}, replicatedVolume())
+	if err != nil || formatted {
+		t.Fatalf("a volume with no content source answers from the cache, got %v %v", formatted, err)
+	}
+	if r.gets != 0 {
+		t.Fatalf("no confirmation read may run for a fresh volume, ran %d", r.gets)
+	}
+}
+
+func TestFormattedBeforeRefusesToGuessOnAReadFailure(t *testing.T) {
+	r := &apiReader{err: errors.New("apiserver unreachable")}
+	_, err := formattedBefore(t.Context(), Deps{Reader: r}, restoredVolume())
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("an unreadable flag must hand kubelet a retry, got %v", err)
+	}
+}
+
 func TestXFSCloneMountFlags(t *testing.T) {
 	const noatime = "noatime"
 	vol := replicatedVolume()
-	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-1"}
+	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapName}
 	original := []string{noatime}
 	got := xfsCloneMountFlags(vol, "xfs", original)
 	if !slices.Equal(got, []string{noatime, "nouuid"}) {
@@ -135,7 +219,7 @@ func TestXFSCloneMountFlagsSkipsOtherFilesystemsAndSources(t *testing.T) {
 	if got := xfsCloneMountFlags(vol, "xfs", flags); !slices.Equal(got, flags) {
 		t.Fatalf("non-clone flags = %v, want %v", got, flags)
 	}
-	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: "snap-1"}
+	vol.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapName}
 	if got := xfsCloneMountFlags(vol, "ext4", flags); !slices.Equal(got, flags) {
 		t.Fatalf("ext4 clone flags = %v, want %v", got, flags)
 	}


### PR DESCRIPTION
A restored volume whose device comes up blank is silently `mkfs`'d instead of refused, so the consumer mounts an empty filesystem and the restore reads as successful. This closes the silent half; the underlying "why was the device blank" is still open (see below).

## What CI showed

Both merge-queue runs of #364 failed `Go E2E (replicated)` on restore data-consistency specs. kubelet derives the staging directory from `sha256(volume handle)`, which lets the ginkgo timeline be correlated to the agent logs. For `volumegroupsnapshottable-2633` in [run 30474605146](https://github.com/home-operations/miroir/actions/runs/30474605146):

| PVC | volume | staged |
|---|---|---|
| `restored-…-0` | `pvc-9d27148c…` (`sha256` `ca643272…`) | **mkfs ext4** on `/dev/drbd1008` @ 17:38:51 |
| `restored-…-1` | `pvc-a141f9e3…` (`sha256` `a0eac492…`) | **mkfs ext4** on `/dev/drbd1006` @ 17:38:51 |
| `restored-…-2` | `pvc-a2b31493…` | no mkfs, data intact |

The two the test flagged were reformatted at NodeStage. Their sources were mkfs'd at 17:38:15/17:38:19 and the group snapshot was cut at 17:38:31, so `MiroirSnapshot.Status.SourceFormatted` should have been true and `CreateVolume` should have stamped the clones `Formatted` — which would have tripped the existing `codes.DataLoss` refusal in `stage.EnsureFilesystem` instead of formatting.

## Why the refusal did not fire

The refusal reads `vol.Status.Formatted` from whatever `stage.Device` loaded, and the node service is built on the manager's **cached** client (`csi.NewNode(mgr.GetClient(), …)`). The controller stamps a clone's inherited flag through the `APIReader` immediately after `Create` (`controller.go:1900`), and the restore is staged seconds later — comfortably inside the window where the node's informer cache can still carry the volume as never-formatted. The guard then reads false and mkfs proceeds.

## The change

`stage.Deps` gains an uncached `Reader` (same convention as `SnapshotReconciler.Reader` and `Controller.APIReader`, falling back to the cached client when unset). When a device reads blank on a volume with `Spec.Source != nil`, the "never formatted" answer is confirmed against the API server before mkfs; a confirmation that cannot be read is `Unavailable`, so kubelet retries instead of formatting on a guess.

- Fresh volumes are untouched: no content source, no extra read, first-stage mkfs as before.
- A restore of a genuinely unformatted source still formats — the live flag says so.
- The gateway needs no wiring; its client is already uncached.

## What this does not fix

Why the leg was blank while DRBD reported it UpToDate. Ruled out by reading: `birthInitPending` excludes every `Spec.Source != nil` volume, the group cut does `be.Sync` and gates on local + peer `UpToDate`, `publishMembers` does set `SourceFormatted`, snapshot LV names are not truncated so members cannot collide, and a missing snapshot LV fails loudly in `CreateFromSnapshot`. Pinning it needs the volume CR, `drbdsetup status` and agent logs from the moment of staging; `diagnostics.sh` runs at suite end, after the namespace is gone, and the agents log nothing at info level on the restore path. Worth a follow-up that dumps per-spec state on failure.

After this change that failure mode surfaces as a `DataLoss` stage refusal — a stuck pod with a named cause — instead of a pod that comes up holding an empty filesystem.

## Verified

`go build ./...`, `go vet ./...`, the unit suite, `test-integration` (27 specs, envtest) and `golangci-lint run` all pass. New unit tests cover the stale-cache refusal, the unformatted-source restore that must still format, the fresh-volume path taking no extra read, and the read failure surfacing `Unavailable`.
