### PR TITLE
fix(csi): log retryable status codes below error level

### DIFF
--- a/internal/csi/server.go
+++ b/internal/csi/server.go
@@ -114,12 +114,30 @@ func recoverInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	return handler(ctx, req)
 }
 
+// retryableCode reports whether miroir's handlers use this status code as a
+// "call again" signal to the CO rather than a failure: Aborted for an
+// operation intentionally kept pending (a settling group snapshot), and
+// Unavailable/DeadlineExceeded for resources not ready yet. The sidecars
+// retry these until they succeed, so a healthy cluster emits them routinely.
+func retryableCode(c codes.Code) bool {
+	switch c {
+	case codes.Aborted, codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	}
+	return false
+}
+
 func logInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	resp, err := handler(ctx, req)
-	if err != nil {
-		log.Error(err, "rpc failed", "method", info.FullMethod)
-	} else {
+	switch {
+	case err == nil:
 		log.V(1).Info("rpc ok", "method", info.FullMethod)
+	case retryableCode(status.Code(err)):
+		// Expected flow control, not a failure; error level (with its
+		// stacktrace) would make every retry round look like an outage.
+		log.V(1).Info("rpc pending, CO will retry", "method", info.FullMethod, "reason", err.Error())
+	default:
+		log.Error(err, "rpc failed", "method", info.FullMethod)
 	}
 	return resp, err
 }

--- a/internal/csi/server_test.go
+++ b/internal/csi/server_test.go
@@ -18,8 +18,11 @@ package csi
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -36,6 +39,50 @@ func TestRecoverInterceptorRecoversPanic(t *testing.T) {
 	}
 	if got := status.Code(err); got != codes.Internal {
 		t.Fatalf("expected codes.Internal, got %v (err=%v)", got, err)
+	}
+}
+
+// captureLog swaps the package logger for one that records emitted lines at
+// verbosity 0, so V(1) output is dropped and only error-level lines land.
+func captureLog(t *testing.T) *[]string {
+	t.Helper()
+	var lines []string
+	orig := log
+	log = funcr.New(func(_, args string) { lines = append(lines, args) }, funcr.Options{})
+	t.Cleanup(func() { log = orig })
+	return &lines
+}
+
+// Retryable codes are flow control (a settling group snapshot answers
+// Aborted until ready), so they must not log at error level; the error
+// itself still passes through to the CO unchanged.
+func TestLogInterceptorRetryableNotErrorLevel(t *testing.T) {
+	for _, code := range []codes.Code{codes.Aborted, codes.Unavailable, codes.DeadlineExceeded} {
+		lines := captureLog(t)
+		info := &grpc.UnaryServerInfo{FullMethod: "/csi.v1.GroupController/CreateVolumeGroupSnapshot"}
+		want := status.Errorf(code, "not ready")
+		_, err := logInterceptor(context.Background(), nil, info,
+			func(context.Context, any) (any, error) { return nil, want })
+		if !errors.Is(err, want) {
+			t.Fatalf("%v: error not passed through: got %v", code, err)
+		}
+		if len(*lines) != 0 {
+			t.Fatalf("%v: expected no error-level lines, got %v", code, *lines)
+		}
+	}
+}
+
+// Genuinely unexpected codes keep the error-level log.
+func TestLogInterceptorUnexpectedIsErrorLevel(t *testing.T) {
+	lines := captureLog(t)
+	info := &grpc.UnaryServerInfo{FullMethod: "/csi.v1.Controller/CreateVolume"}
+	_, err := logInterceptor(context.Background(), nil, info,
+		func(context.Context, any) (any, error) { return nil, status.Errorf(codes.Internal, "boom") })
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("error not passed through: got %v", err)
+	}
+	if len(*lines) != 1 || !strings.Contains((*lines)[0], "rpc failed") {
+		t.Fatalf("expected one rpc failed line, got %v", *lines)
 	}
 }
 


### PR DESCRIPTION
## Summary

`logInterceptor` treated every non-nil handler error identically, so the intentional `codes.Aborted` "call me again" signal from `CreateVolumeGroupSnapshot` was logged at error level with a full stacktrace on every retry round of a healthy group snapshot.

This classifies by gRPC status code instead:

- `Aborted`, `Unavailable`, and `DeadlineExceeded` — the codes miroir's handlers use as retryable flow-control signals — log at `V(1)` as `rpc pending, CO will retry`, no stacktrace.
- Everything else keeps the existing `log.Error` treatment.

The error still passes through to the CO unchanged, so sidecar retry behavior is untouched. As noted in the issue, the `Warning` events emitted by `csi-snapshotter` are inherent to returning an error from the RPC and are out of scope here.

## Testing

New tests swap the package logger for a `funcr` capture at verbosity 0 and assert that retryable codes emit no error-level lines (while passing the error through) and that unexpected codes still log `rpc failed`. Verified `GOOS=linux go build ./...` and `go vet` locally; relying on CI for the test run since the module only builds on Linux.

Fixes #379