### PR TITLE
fix(snapshot): lift possibly-set barrier on failed suspend-io and sweep mid-runtime

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -713,37 +713,7 @@ func main() {
 			os.Exit(1)
 		}
 		freezer := agent.NewFreezer()
-		if drbdReady {
-			// Mid-runtime twin of the startup/shutdown barrier sweeps: a
-			// suspend-io that wedges (LINBIT/drbd#137) can set the kernel
-			// flag without the snapshot round recording it, leaving the
-			// volume frozen until the agent restarts. The sweep lifts any
-			// suspended-user barrier no recorded round claims (live rounds
-			// within SuspendDeadline are skipped by the fresh-round check
-			// inside resumeStaleBarriers). A round is briefly invisible
-			// between its suspend-io and its status patch; if a tick lands
-			// in that gap it can lift a live coordinator's barrier — the
-			// cut phase re-asserts suspend-io per leg, so the damage is a
-			// moment of unprotected writes, not divergent legs. API-list
-			// failures are logged, not fatal — the next tick retries.
-			if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-				ticker := time.NewTicker(barrierSweepInterval)
-				defer ticker.Stop()
-				for {
-					select {
-					case <-ctx.Done():
-						return nil
-					case <-ticker.C:
-						if err := resumeStaleBarriers(drbdDriver, freezer, nodeName, apiShutdownWait); err != nil {
-							setupLog.Error(err, "periodic barrier sweep incomplete")
-						}
-					}
-				}
-			})); err != nil {
-				setupLog.Error(err, "unable to add periodic barrier sweep")
-				os.Exit(1)
-			}
-		}
+		addBarrierSweep(mgr, drbdReady, drbdDriver, freezer, nodeName)
 		snapReconciler := &agent.SnapshotReconciler{
 			Client:   mgr.GetClient(),
 			NodeName: nodeName,
@@ -844,9 +814,7 @@ const apiStartupWait = 45 * time.Second
 // drbdShutdownTimeout bounds the Secondary-teardown sweep at shutdown.
 const drbdShutdownTimeout = 15 * time.Second
 
-// barrierSweepInterval paces the mid-runtime stranded-barrier sweep (the
-// startup/shutdown sweeps' twin). Rounds are void at agent.SuspendDeadline
-// (60s), so a 5-minute cadence only touches barriers no live round owns.
+// barrierSweepInterval paces the periodic stranded-barrier sweep (addBarrierSweep).
 const barrierSweepInterval = 5 * time.Minute
 
 // apiShutdownWait bounds the shutdown barrier sweep's API access: the
@@ -988,6 +956,39 @@ func agentShutdownBarrierSweep(driver *drbd.Driver, nodeName string) {
 func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver, nodeName string) {
 	agentShutdownDownSecondaries(cordon, driver)
 	agentShutdownBarrierSweep(driver, nodeName)
+}
+
+// addBarrierSweep runs the startup/shutdown stranded-barrier sweep
+// mid-runtime too: a wedged suspend-io (LINBIT/drbd#137) can set the kernel
+// flag after drbdadm reported failure, leaving a frozen volume no recorded
+// round owns until the agent restarts. resumeStaleBarriers skips live rounds
+// (fresh ioSuspended timestamp); a round past agent.SuspendDeadline is void
+// by protocol anyway. A round is briefly invisible between its suspend-io
+// and its status patch, so a tick can in theory lift a live coordinator's
+// barrier — bounded: the cut phase re-asserts suspend-io per leg. API-list
+// failures are logged, not fatal: the next tick retries.
+func addBarrierSweep(mgr manager.Manager, drbdReady bool, driver *drbd.Driver, freezer *agent.Freezer,
+	nodeName string) {
+	if !drbdReady {
+		return
+	}
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		ticker := time.NewTicker(barrierSweepInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ticker.C:
+				if err := resumeStaleBarriers(driver, freezer, nodeName, apiShutdownWait); err != nil {
+					setupLog.Error(err, "periodic barrier sweep incomplete")
+				}
+			}
+		}
+	})); err != nil {
+		setupLog.Error(err, "unable to add periodic barrier sweep")
+		os.Exit(1)
+	}
 }
 
 // sweepOrphans removes DRBD state with no owning volume on this node,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -660,7 +660,8 @@ func main() {
 			}
 			// Lift any IO barrier left by a previous agent crash; same
 			// fatal-only-on-API-failure contract.
-			if err := resumeStaleBarriers(drbdDriver, agent.NewFreezer(), nodeName, apiStartupWait); err != nil {
+			if err := resumeStaleBarriers(context.Background(), drbdDriver,
+				agent.NewFreezer(), nodeName, apiStartupWait); err != nil {
 				setupLog.Error(err, "barrier resume sweep failed")
 				os.Exit(1)
 			}
@@ -947,7 +948,8 @@ func agentShutdownBarrierSweep(driver *drbd.Driver, nodeName string) {
 	// manager stop + DownSecondaries already spend up to 45s of it. A
 	// stranded barrier missed here is lifted by the startup sweep on the
 	// next boot.
-	if err := resumeStaleBarriers(driver, agent.NewFreezer(), nodeName, apiShutdownWait); err != nil {
+	if err := resumeStaleBarriers(context.Background(), driver,
+		agent.NewFreezer(), nodeName, apiShutdownWait); err != nil {
 		setupLog.Error(err, "shutdown barrier sweep failed")
 	}
 }
@@ -965,8 +967,10 @@ func agentShutdownSweep(cordon *agent.CordonWatcher, driver *drbd.Driver, nodeNa
 // (fresh ioSuspended timestamp); a round past agent.SuspendDeadline is void
 // by protocol anyway. A round is briefly invisible between its suspend-io
 // and its status patch, so a tick can in theory lift a live coordinator's
-// barrier — bounded: the cut phase re-asserts suspend-io per leg. API-list
-// failures are logged, not fatal: the next tick retries.
+// barrier — bounded: the cut phase re-asserts suspend-io per leg (though
+// not the thawed freeze, so that round's cut degrades from fs-consistent
+// to crash-consistent). API-list failures are logged, not fatal: the next
+// tick retries.
 func addBarrierSweep(mgr manager.Manager, drbdReady bool, driver *drbd.Driver, freezer *agent.Freezer,
 	nodeName string) {
 	if !drbdReady {
@@ -980,7 +984,7 @@ func addBarrierSweep(mgr manager.Manager, drbdReady bool, driver *drbd.Driver, f
 			case <-ctx.Done():
 				return nil
 			case <-ticker.C:
-				if err := resumeStaleBarriers(driver, freezer, nodeName, apiShutdownWait); err != nil {
+				if err := resumeStaleBarriers(ctx, driver, freezer, nodeName, apiShutdownWait); err != nil {
 					setupLog.Error(err, "periodic barrier sweep incomplete")
 				}
 			}
@@ -1034,7 +1038,8 @@ func sweepOrphans(nodeName string, driver *drbd.Driver) error {
 // Returns an error only when the snapshot list cannot be fetched; resume
 // failures are per-resource, logged here — one wedged resource must not
 // strand the other frozen volumes' barriers (issue #195).
-func resumeStaleBarriers(driver *drbd.Driver, freezer *agent.Freezer, nodeName string, apiBudget time.Duration) error {
+func resumeStaleBarriers(ctx context.Context, driver *drbd.Driver, freezer *agent.Freezer,
+	nodeName string, apiBudget time.Duration) error {
 	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
 	if err != nil {
 		return err
@@ -1079,7 +1084,7 @@ func resumeStaleBarriers(driver *drbd.Driver, freezer *agent.Freezer, nodeName s
 			}
 		}
 	}
-	suspended, err := driver.UserSuspended(context.Background())
+	suspended, err := driver.UserSuspended(ctx)
 	if err != nil {
 		// No kernel view (e.g. module not loaded yet) also means nothing
 		// can be suspended — don't block agent startup on it.
@@ -1094,7 +1099,7 @@ func resumeStaleBarriers(driver *drbd.Driver, freezer *agent.Freezer, nodeName s
 		}
 		stale = append(stale, vol)
 		setupLog.Info("lifting stale IO barrier", "volume", vol)
-		if err := driver.ResumeIO(context.Background(), vol); err != nil {
+		if err := driver.ResumeIO(ctx, vol); err != nil {
 			errs = append(errs, fmt.Errorf("resume stale barrier on %s: %w", vol, err))
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -713,6 +713,37 @@ func main() {
 			os.Exit(1)
 		}
 		freezer := agent.NewFreezer()
+		if drbdReady {
+			// Mid-runtime twin of the startup/shutdown barrier sweeps: a
+			// suspend-io that wedges (LINBIT/drbd#137) can set the kernel
+			// flag without the snapshot round recording it, leaving the
+			// volume frozen until the agent restarts. The sweep lifts any
+			// suspended-user barrier no recorded round claims (live rounds
+			// within SuspendDeadline are skipped by the fresh-round check
+			// inside resumeStaleBarriers). A round is briefly invisible
+			// between its suspend-io and its status patch; if a tick lands
+			// in that gap it can lift a live coordinator's barrier — the
+			// cut phase re-asserts suspend-io per leg, so the damage is a
+			// moment of unprotected writes, not divergent legs. API-list
+			// failures are logged, not fatal — the next tick retries.
+			if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+				ticker := time.NewTicker(barrierSweepInterval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return nil
+					case <-ticker.C:
+						if err := resumeStaleBarriers(drbdDriver, freezer, nodeName, apiShutdownWait); err != nil {
+							setupLog.Error(err, "periodic barrier sweep incomplete")
+						}
+					}
+				}
+			})); err != nil {
+				setupLog.Error(err, "unable to add periodic barrier sweep")
+				os.Exit(1)
+			}
+		}
 		snapReconciler := &agent.SnapshotReconciler{
 			Client:   mgr.GetClient(),
 			NodeName: nodeName,
@@ -813,10 +844,16 @@ const apiStartupWait = 45 * time.Second
 // drbdShutdownTimeout bounds the Secondary-teardown sweep at shutdown.
 const drbdShutdownTimeout = 15 * time.Second
 
+// barrierSweepInterval paces the mid-runtime stranded-barrier sweep (the
+// startup/shutdown sweeps' twin). Rounds are void at agent.SuspendDeadline
+// (60s), so a 5-minute cadence only touches barriers no live round owns.
+const barrierSweepInterval = 5 * time.Minute
+
 // apiShutdownWait bounds the shutdown barrier sweep's API access: the
 // termination grace budget is 60s and the manager stop plus
 // DownSecondaries can already spend 45s of it. apiStartupWait would
-// guarantee a SIGKILL mid-sweep.
+// guarantee a SIGKILL mid-sweep. The periodic mid-runtime sweep reuses it:
+// a short per-tick budget whose failure just logs and retries next tick.
 const apiShutdownWait = 5 * time.Second
 
 // signalShutdown starts cleanup as soon as the OS signal arrives, rather
@@ -1055,6 +1092,7 @@ func resumeStaleBarriers(driver *drbd.Driver, freezer *agent.Freezer, nodeName s
 			continue
 		}
 		stale = append(stale, vol)
+		setupLog.Info("lifting stale IO barrier", "volume", vol)
 		if err := driver.ResumeIO(context.Background(), vol); err != nil {
 			errs = append(errs, fmt.Errorf("resume stale barrier on %s: %w", vol, err))
 		}

--- a/internal/agent/groupsnapshot.go
+++ b/internal/agent/groupsnapshot.go
@@ -309,7 +309,10 @@ func (r *GroupSnapshotReconciler) raiseBarriers(ctx context.Context, grp *miroir
 			// joins the resume: a wedged suspend-io (LINBIT/drbd#137) can
 			// report failure after the kernel flag already landed.
 			thawMounted(ctx, r.Freezer, r.NodeName, m.vol)
-			_ = r.resumeMine(ctx, grp, append(suspended, m))
+			if rerr := r.resumeMine(ctx, grp, append(suspended, m)); rerr != nil {
+				ctrl.LoggerFrom(ctx).Info("resume after failed suspend-io incomplete; periodic sweep covers recovery",
+					"volume", m.vol.Name, "error", rerr.Error())
+			}
 			return r.barrierFailed(ctx, grp, m.vol, err)
 		}
 		suspended = append(suspended, m)

--- a/internal/agent/groupsnapshot.go
+++ b/internal/agent/groupsnapshot.go
@@ -305,9 +305,11 @@ func (r *GroupSnapshotReconciler) raiseBarriers(ctx context.Context, grp *miroir
 		}
 		if err := r.suspendIO(ctx, m.vol.Name); err != nil {
 			// A half-raised node must not stay half-frozen behind a failed
-			// raise; the retry re-raises the lot.
+			// raise; the retry re-raises the lot. The failed leg itself
+			// joins the resume: a wedged suspend-io (LINBIT/drbd#137) can
+			// report failure after the kernel flag already landed.
 			thawMounted(ctx, r.Freezer, r.NodeName, m.vol)
-			_ = r.resumeMine(ctx, grp, suspended)
+			_ = r.resumeMine(ctx, grp, append(suspended, m))
 			return r.barrierFailed(ctx, grp, m.vol, err)
 		}
 		suspended = append(suspended, m)

--- a/internal/agent/groupsnapshot_test.go
+++ b/internal/agent/groupsnapshot_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -186,6 +187,32 @@ func TestGroupSnapshotBarrierSpansVolumes(t *testing.T) {
 	reconcileGroup(t, rP)
 	feP.calledWith(t, "drbdadm resume-io "+volPvc1)
 	feP.calledWith(t, "drbdadm resume-io "+volPvc2)
+}
+
+// A failed suspend-io mid-raise can still have set the kernel flag (the
+// wedge kills drbdadm after the ioctl landed). The failed leg must join
+// the half-raised sweep's resume — leaving it freezes the volume behind
+// a round the group never recorded.
+func TestGroupFailedSuspendLiftsKernelFlag(t *testing.T) {
+	c := groupClient(t, groupVol(volPvc1), groupVol(volPvc2),
+		memberObj(memberOf1, volPvc1), memberObj(memberOf2, volPvc2), groupObj())
+
+	fe := &fakeDRBDExec{statusJSON: groupStatusPrimary,
+		errOn: map[string]error{cmdSuspendIO + " " + volPvc2: errors.New(
+			"exit status 20: Command 'drbdsetup suspend-io 1002' did not terminate within 5 seconds")}}
+	r := &GroupSnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+
+	if _, err := r.Reconcile(t.Context(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: groupG1}}); err == nil {
+		t.Fatal("the failed raise must surface as an error for the fast backoff")
+	}
+	// The half-raised leg resumes as before; the failed leg itself must
+	// join the sweep — its kernel flag may have landed despite the error.
+	fe.calledWith(t, "drbdadm suspend-io "+volPvc1)
+	fe.calledWith(t, "drbdadm suspend-io "+volPvc2)
+	fe.calledWith(t, "drbdadm resume-io "+volPvc1)
+	fe.calledWith(t, "drbdadm resume-io "+volPvc2)
 }
 
 // A round whose deadline passes with legs missing is voided whole: Done

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -411,6 +411,24 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 	}
 	if err := r.suspendIO(ctx, vol.Name); err != nil {
 		r.thaw(ctx, vol)
+		// A suspend-io that reports failure may still have set the kernel
+		// flag: the wedge (LINBIT/drbd#137) kills drbdadm after the ioctl
+		// landed. LINSTOR fixed the same wedge by resuming after a
+		// suspend-io timeout. otherRoundActive sees recorded rounds only —
+		// a sibling invisible since its own suspend-io (not yet patched)
+		// could theoretically have its barrier lifted here; accepted, same
+		// race family as resumeUnlessSiblingRound.
+		active, aerr := r.otherRoundActive(ctx, snap)
+		switch {
+		case aerr != nil:
+			ctrl.LoggerFrom(ctx).Info("sibling-round check failed after failed suspend-io; periodic sweep covers recovery",
+				"volume", vol.Name, "error", aerr.Error())
+		case !active:
+			if rerr := r.resumeIO(ctx, vol.Name); rerr != nil {
+				ctrl.LoggerFrom(ctx).Error(rerr, "cannot lift possibly-set barrier after failed suspend-io",
+					"volume", vol.Name)
+			}
+		}
 		return r.barrierFailed(ctx, snap, vol, err)
 	}
 	r.clearBarrierFails(snap.Name)

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -43,6 +43,8 @@ const (
 	snapCallSnapshot = "snapshot " + volPvc1 + "@" + snapSnap1
 	// cmdStatus keys fakeDRBDExec.errOn for `drbdsetup status`.
 	cmdStatus = "status"
+	// cmdSuspendIO keys fakeDRBDExec.errOn for `drbdadm suspend-io`.
+	cmdSuspendIO = "suspend-io"
 )
 
 //nolint:unparam // future tests will vary the volume
@@ -191,7 +193,7 @@ func TestSnapshotBarrierStuckParksAfterLimit(t *testing.T) {
 		statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
 			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 			"connections":[{"connection-state":"Connected"}]}]`,
-		errOn: map[string]error{"suspend-io": errors.New(
+		errOn: map[string]error{cmdSuspendIO: errors.New(
 			"exit status 20: Command 'drbdsetup suspend-io 1001' did not terminate within 5 seconds")},
 	}
 	rec := events.NewFakeRecorder(8)
@@ -242,7 +244,7 @@ func TestSnapshotFailedSuspendLiftsKernelFlag(t *testing.T) {
 		statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
 			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 			"connections":[{"connection-state":"Connected"}]}]`,
-		errOn: map[string]error{"suspend-io": errors.New(
+		errOn: map[string]error{cmdSuspendIO: errors.New(
 			"exit status 20: Command 'drbdsetup suspend-io 1001' did not terminate within 5 seconds")},
 	}
 	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
@@ -286,7 +288,7 @@ func TestSnapshotFailedSuspendDefersToSiblingRound(t *testing.T) {
 			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 			"connections":[{"connection-state":"Connected","peer-role":"Primary",
 			"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`,
-		errOn: map[string]error{"suspend-io": errors.New(
+		errOn: map[string]error{cmdSuspendIO: errors.New(
 			"exit status 20: Command 'drbdsetup suspend-io 1001' did not terminate within 5 seconds")},
 	}
 	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
@@ -716,7 +718,7 @@ func TestSnapshotSecondaryDefersToPeerPrimary(t *testing.T) {
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, snapSnap1)
 
-	fe.notCalledWith(t, "suspend-io")
+	fe.notCalledWith(t, cmdSuspendIO)
 }
 
 // Regression: an expired round voids every leg, the retry backs off,
@@ -1023,7 +1025,7 @@ func TestSnapshotWaitsForHealthyReplication(t *testing.T) {
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, snapSnap1)
 
-	fe.notCalledWith(t, "suspend-io")
+	fe.notCalledWith(t, cmdSuspendIO)
 	if len(fb.snapCalls) != 0 {
 		t.Fatalf("no leg may be cut while replication is degraded: %v", fb.snapCalls)
 	}
@@ -1203,7 +1205,7 @@ func TestSnapshotRoundWaitsForSibling(t *testing.T) {
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	res := reconcileSnap(t, r, "snap-b")
 
-	fe.notCalledWith(t, "suspend-io")
+	fe.notCalledWith(t, cmdSuspendIO)
 	if res.RequeueAfter == 0 {
 		t.Fatal("must requeue to wait for the sibling round to close")
 	}
@@ -1389,7 +1391,7 @@ func TestSnapshotWaitsForResyncingPeer(t *testing.T) {
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 	reconcileSnap(t, r, snapSnap1)
 
-	fe.notCalledWith(t, "suspend-io")
+	fe.notCalledWith(t, cmdSuspendIO)
 	if len(fb.snapCalls) != 0 {
 		t.Fatalf("no leg may be cut while a peer resyncs: %v", fb.snapCalls)
 	}
@@ -1429,13 +1431,13 @@ func TestSnapshotOpenDefersToKernelBarrier(t *testing.T) {
 	// Sibling round open: neither raise nor lift — the sibling owns it.
 	r, fe := build(t, true)
 	reconcileSnap(t, r, snapSnap1)
-	fe.notCalledWith(t, "suspend-io")
+	fe.notCalledWith(t, cmdSuspendIO)
 	fe.notCalledWith(t, "resume-io")
 
 	// No sibling round: the barrier is stale — lift it, raise next pass.
 	r, fe = build(t, false)
 	reconcileSnap(t, r, snapSnap1)
-	fe.notCalledWith(t, "suspend-io")
+	fe.notCalledWith(t, cmdSuspendIO)
 	fe.calledWith(t, "drbdadm resume-io pvc-1")
 }
 
@@ -1513,7 +1515,7 @@ func TestSnapshotSiblingCheckReadsThroughAPIReader(t *testing.T) {
 	reconcileSnap(t, r, snapSnap1)
 
 	fe.notCalledWith(t, "resume-io")
-	fe.notCalledWith(t, "suspend-io")
+	fe.notCalledWith(t, cmdSuspendIO)
 }
 
 // The filesystem freeze brackets the replicated round on the node that
@@ -1590,7 +1592,7 @@ func TestSnapshotSuspendFailureThawsFreeze(t *testing.T) {
 	fe := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"connection-state":"Connected"}]}]`,
-		errOn: map[string]error{"suspend-io": errors.New("exit status 20")}}
+		errOn: map[string]error{cmdSuspendIO: errors.New("exit status 20")}}
 	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
 		DRBD:    &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run},
 		Freezer: mountedFreezer(rec, map[string]string{devDrbd1000: mntStage1})}

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -221,6 +221,85 @@ func TestSnapshotBarrierStuckParksAfterLimit(t *testing.T) {
 	}
 }
 
+// A failed suspend-io can still have set the kernel flag (the wedge kills
+// drbdadm after the ioctl landed). The failed raise must lift that
+// possibly-set flag itself — leaving it freezes the volume behind a round
+// the status machine never recorded.
+func TestSnapshotFailedSuspendLiftsKernelFlag(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{
+		statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+			"connections":[{"connection-state":"Connected"}]}]`,
+		errOn: map[string]error{"suspend-io": errors.New(
+			"exit status 20: Command 'drbdsetup suspend-io 1001' did not terminate within 5 seconds")},
+	}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}
+	if _, err := r.Reconcile(t.Context(), req); err == nil {
+		t.Fatal("the failed raise must surface as an error for the fast backoff")
+	}
+	fe.calledWith(t, "drbdadm suspend-io "+volPvc1)
+	fe.calledWith(t, "drbdadm resume-io "+volPvc1)
+}
+
+// Same failed raise on the peer path, but a sibling snapshot's recorded
+// round co-holds the kernel barrier: resume-io must stay silent — lifting
+// it would tear the sibling's live barrier.
+func TestSnapshotFailedSuspendDefersToSiblingRound(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+	}
+	now := metav1.Now()
+	// The peer raise path: snap's own round is recorded (nodeB is the
+	// Primary/coordinator) and nodeA has not raised its barrier yet.
+	snap := snapObj(snapSnap1, volPvc1, nodeA, nodeB)
+	snap.Status.IOSuspended = true
+	snap.Status.SuspendedAt = &now
+	sibling := snapObj(snapSnap1+"-sibling", volPvc1, nodeA, nodeB)
+	sibling.Status.IOSuspended = true
+	sibling.Status.SuspendedAt = &now
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snap, sibling).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fe := &fakeDRBDExec{
+		statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+			"connections":[{"connection-state":"Connected","peer-role":"Primary",
+			"peer_devices":[{"peer-disk-state":"` + diskStateUpToDate + `"}]}]}]`,
+		errOn: map[string]error{"suspend-io": errors.New(
+			"exit status 20: Command 'drbdsetup suspend-io 1001' did not terminate within 5 seconds")},
+	}
+	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}
+	if _, err := r.Reconcile(t.Context(), req); err == nil {
+		t.Fatal("the failed raise must surface as an error for the fast backoff")
+	}
+	fe.calledWith(t, "drbdadm suspend-io "+volPvc1)
+	fe.notCalledWith(t, "drbdadm resume-io")
+}
+
 // On a wedged module the status read is the call that fails (hanging
 // until execTimeout kills it); it must ride the same bounded retry as
 // suspend-io or the give-up never engages.


### PR DESCRIPTION
## Problem

A wedged \`drbdadm suspend-io\` (LINBIT/drbd#137: \`drbdsetup\` hangs past drbdadm's 5s kill, but the kernel \`suspended-user\` flag still lands) leaves the volume frozen with no recorded round owning the barrier. Stranded-barrier recovery only ran at agent startup/shutdown, so a mid-runtime wedge froze IO until someone restarted the agent — observed as a 7h volume freeze after a nightly snapshot failed with \`exit status 20: Command 'drbdsetup suspend-io 1004' did not terminate within 5 seconds\`.

LINSTOR hit the same wedge and fixed it as "Snapshot: also resume-io after timeout of suspend-io".

## Changes

- **\`raiseBarrier\` (per-snapshot and group):** on a failed suspend-io, best-effort \`resume-io\` when no recorded sibling round holds the barrier. The group path now includes the failed leg in its \`resumeMine\` sweep. (\`cutLeg\`/\`cutLegs\` unchanged: there the barrier is the round's own, and not resuming on error is a deliberate byte-identity invariant.)
- **Periodic runtime barrier sweep (5m)** in the agent, reusing \`resumeStaleBarriers\` with its fresh-round check, so a barrier no recorded round claims gets lifted without an agent restart. Logs each lifted barrier.
- Tests: happy path asserts resume-io after suspend-io failure; sibling-round-active path asserts resume-io is NOT issued.

Known-accepted races are documented at the call sites (a round is briefly invisible between its suspend-io and its status patch; the cut phase re-asserts suspend-io per leg).