### PR TITLE
ci(e2e): adopt talosctl-cluster-action v0.1.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,9 +273,10 @@ jobs:
       - name: Create cluster
         id: cluster
         background: true
-        uses: home-operations/talosctl-cluster-action@dc28a9d63dec2bc23d8777cdbd3a1f96e6988e5a # v0.1.5
+        uses: home-operations/talosctl-cluster-action@42a2d1c476f87245e2d1882ec825fb31368b9686 # v0.1.6
         with:
           config: test/e2e-qemu/${{ matrix.cluster || 'cluster.yaml' }}
+          cache: true
 
       - name: Download the images
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -85,12 +85,10 @@ set -gx SCHEMATIC_ID (curl -sfX POST \
 
 sudo -E (mise which talosctl) cluster create qemu \
     --name miroir-e2e \
-    --cidr 10.5.0.0/24 \
     --schematic-id "$SCHEMATIC_ID" \
     --controlplanes 1 --workers 2 --memory-workers 5GiB \
     --disks virtio:8GiB,virtio:20GiB,virtio:20GiB \
     --config-patch @patches/modules.yaml \
-    --config-patch @patches/registry.yaml \
     --talosconfig-destination /tmp/miroir-e2e/talosconfig
 sudo chown -R (id -u):(id -g) /tmp/miroir-e2e
 
@@ -123,7 +121,9 @@ sudo -E (mise which talosctl) cluster destroy --name miroir-e2e -f
 ```
 
 That is `cluster.yaml` spelled out as flags, minus the ephemeral profile the action
-applies for you (see below); the document stays the source of truth for the shape.
+applies for you (see below) and minus `patches/registry.yaml`, whose `${GATEWAY}`
+placeholder only the action substitutes -- the CI-only mirror it configures is dead
+weight locally anyway. The document stays the source of truth for the shape.
 
 `test.sh` refuses to run unless `CLUSTER_NAME` looks like an e2e cluster and both the
 kubectl context and the node names agree with it, so it cannot be pointed at a real
@@ -148,8 +148,9 @@ than `image.sh` so the layers land in that cache, which `image.sh` has no way to
 
 Each leg still runs its own registry on the runner, so the images never cross the
 internet. The nodes reach them as `registry.e2e`, which the mirror in
-`patches/registry.yaml` points at port 5000 on the QEMU bridge gateway. That mirror
-entry is inert for a local run, where nothing references `registry.e2e`.
+`patches/registry.yaml` points at port 5000 on the QEMU bridge gateway through the
+action's `${GATEWAY}` substitution. That mirror entry is CI-only: a local run has no
+substitution and nothing references `registry.e2e` anyway, so leave the patch out.
 
 ## How the chart is installed
 

--- a/test/e2e-qemu/cluster-spare.yaml
+++ b/test/e2e-qemu/cluster-spare.yaml
@@ -19,8 +19,6 @@ spec:
   workers:
     count: 3
     memory: 3GiB
-  network:
-    cidr: 10.5.0.0/24
   qemu:
     schematic: "@schematic.yaml"
     disks:

--- a/test/e2e-qemu/cluster.yaml
+++ b/test/e2e-qemu/cluster.yaml
@@ -23,10 +23,6 @@ spec:
     # A worker runs DRBD, dm-thin, kubelet and every test pod; 3GiB left them tight
     # enough to OOM under the parallel conformance suite.
     memory: 5GiB
-  network:
-    # Explicit because patches/registry.yaml hardcodes the gateway, the first address
-    # of this range. It is also talosctl's default.
-    cidr: 10.5.0.0/24
   qemu:
     schematic: "@schematic.yaml"
     # The first disk goes to every node (the system disk); the rest are attached to

--- a/test/e2e-qemu/patches/registry.yaml
+++ b/test/e2e-qemu/patches/registry.yaml
@@ -1,11 +1,12 @@
 # CI runs a plain-HTTP registry on the runner and pushes the miroir images there, so
-# the nodes pull them over the QEMU bridge instead of from the internet. 10.5.0.1 is
-# the bridge gateway, the first address of spec.network.cidr; a leg that changes that
-# range has to change this with it. Inert for a local run, where nothing resolves
-# registry.e2e unless CONTROLLER_IMAGE / AGENT_IMAGE name it.
+# the nodes pull them over the QEMU bridge instead of from the internet. The action
+# substitutes ${GATEWAY} with the bridge gateway, so the patch follows whatever CIDR
+# the document picks. Only the action substitutes: a local run must not pass this
+# patch raw (and has no reason to; nothing resolves registry.e2e unless
+# CONTROLLER_IMAGE / AGENT_IMAGE name it).
 machine:
   registries:
     mirrors:
       registry.e2e:
         endpoints:
-          - http://10.5.0.1:5000
+          - http://${GATEWAY}:5000


### PR DESCRIPTION
Bumps the e2e cluster action pin from v0.1.5 to [v0.1.6](https://github.com/home-operations/talosctl-cluster-action/releases/tag/v0.1.6) and adopts two of its features:

- **`cache: true`** — the Image Factory boot assets (`~/.talos/cache`) ride the Actions cache, keyed on Talos version/schematic/presets/factory URL, so only the first run per combination downloads boot media. With the drbd+zfs schematic in play that is a per-run ISO download saved on every leg. Safe by construction: talosctl's own lookup is by full source URL, so a hit cannot serve wrong bytes.
- **`${GATEWAY}` substitution** — `patches/registry.yaml` no longer hardcodes `10.5.0.1`. The explicit `network.cidr` in `cluster.yaml` and `cluster-spare.yaml` existed only to keep that hardcode honest, so it is gone too; the documents are back on talosctl's default. Since only the action substitutes, the README's local-run command drops `--config-patch @patches/registry.yaml` (and `--cidr`) — the mirror was documented as inert locally already, and an unsubstituted `${GATEWAY}` would not survive machine config validation.

The third v0.1.6 feature, the maintenance-preset API wait, does not apply here — no leg uses the maintenance preset.