### PR TITLE
fix(agent): auto-recover a resync DRBD armed but never started

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -89,6 +89,11 @@ type VolumeReconciler struct {
 	// several times per second. See recoverSplitBrain.
 	recoveryMu   sync.Mutex
 	lastRecovery map[string]time.Time
+	// stuckSince (same lock) stamps when a stranded-bitmap signature was
+	// first seen per volume; recovery waits out one poll interval so a
+	// status snapshot mid real handshake is never acted on. See
+	// recoverStuckResync.
+	stuckSince map[string]time.Time
 
 	// busyFails counts consecutive ErrBusy teardown outcomes per volume.
 	// Past busyFailLimit the loop escalates — Warning Event, status
@@ -318,6 +323,7 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	connected := diskfulPeersConnected(st, vol, r.NodeName)
 	splitActive := r.handleSplitBrain(ctx, vol, resource, st, connected)
+	stuckActive := r.recoverStuckResync(ctx, vol, st, localDiskless)
 	diskFailed := diskFailedLatch(vol, r.NodeName, st, localDiskless)
 	if !localDiskless {
 		recordVolumeMetrics(vol, poolName, replicaView(st, vol, r.NodeName, localDiskless))
@@ -347,15 +353,21 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Cache only the settled state: a mid-grow pass (short requeue, size
-	// withheld) must keep taking the full pipeline until the grow lands, and
-	// a split-brain volume — locally seen or peer-reported — must re-enter it
-	// every poll so recoverSplitBrain keeps retrying until the connections
-	// re-form.
-	if requeue == drbdPollInterval && reportSize == vol.Spec.SizeBytes && !splitActive {
+	r.storeIfSettled(vol, st, requeue, reportSize, splitActive || stuckActive)
+	return ctrl.Result{RequeueAfter: requeue}, nil
+}
+
+// storeIfSettled caches the pass fingerprint only for a settled state: a
+// mid-grow pass (short requeue, size withheld) must keep taking the full
+// pipeline until the grow lands, and a volume under active recovery must
+// re-enter it every poll — a split-brain (locally seen or peer-reported) so
+// recoverSplitBrain keeps retrying until the connections re-form, and a
+// stranded bitmap (whose kernel state is otherwise steady) so
+// recoverStuckResync's confirmation clock is re-read.
+func (r *VolumeReconciler) storeIfSettled(vol *miroirv1alpha1.MiroirVolume, st drbd.Status, requeue time.Duration, reportSize int64, recovering bool) {
+	if requeue == drbdPollInterval && reportSize == vol.Spec.SizeBytes && !recovering {
 		r.storeRealized(vol.Generation, vol.Name, st, true)
 	}
-	return ctrl.Result{RequeueAfter: requeue}, nil
 }
 
 // fastPath reports whether this reconcile can settle without the realize
@@ -430,6 +442,7 @@ func statusEqual(a, b drbd.Status) bool {
 		a.ResyncPercent == b.ResyncPercent &&
 		a.Quorum == b.Quorum &&
 		a.OutOfSyncKiB == b.OutOfSyncKiB &&
+		maps.Equal(a.StuckResyncPeers, b.StuckResyncPeers) &&
 		maps.Equal(a.PeerConnected, b.PeerConnected) &&
 		// A peer disk-state flip (DUnknown → Inconsistent at birth) can be
 		// the only change in a pass — without it the winner's fingerprint
@@ -470,12 +483,14 @@ func (r *VolumeReconciler) volumeGone(name string, err error) error {
 	return nil
 }
 
-// dropRecovery forgets a torn-down volume's split-brain debounce stamp so a
-// later volume under the same name starts with a clean slate.
+// dropRecovery forgets a torn-down volume's split-brain debounce and
+// stuck-resync confirmation stamps so a later volume under the same name
+// starts with a clean slate.
 func (r *VolumeReconciler) dropRecovery(name string) {
 	r.recoveryMu.Lock()
 	defer r.recoveryMu.Unlock()
 	delete(r.lastRecovery, name)
+	delete(r.stuckSince, name)
 }
 
 // reconcileDeletion tears down the local leg of a deleted volume. Only
@@ -822,6 +837,73 @@ func peerReportedSplitBrain(vol *miroirv1alpha1.MiroirVolume, self string) bool 
 		}
 	}
 	return false
+}
+
+// recoverStuckResync heals a resync DRBD armed but will never start (issue
+// #390): a rapid promote/demote/promote of a diskless primary mints two
+// current UUIDs back to back, a diskful leg handshakes against a
+// one-generation-stale view of its peer and sets a full bitmap slot
+// (WFBitMapS, peer-disk clamped Consistent), and a second after-unstable
+// pass — equal UUIDs by then — collapses the pending exchange back to
+// Established without undoing it. The kernel never re-examines the bits
+// while the connection stays up (its missed-end-of-resync rescue only runs
+// at connect), so the volume sits with degraded redundancy accounting until
+// the connection cycles.
+//
+// Recovery cycles exactly the stuck peer connections, re-running their
+// handshakes. Safe on any volume, held data or not: identical data (the
+// race above) reconnects with zero movement — equal current UUIDs classify
+// the stale bitmap as a missed resync end and discard it — and genuinely
+// divergent data starts the resync the bits called for. No Activated gate,
+// unlike split-brain recovery, because nothing is ever discarded.
+//
+// The signature must persist through a full poll interval before recovery
+// runs: a status snapshot can catch a live handshake between setting the
+// bitmap and starting its resync, and cycling that would abort real work.
+// Each attempt re-arms the window, flooring retries. Returns true while the
+// signature is live so the caller keeps the volume out of the fast path —
+// the stuck state is otherwise steady, and a stored fingerprint would park
+// the confirmation clock unread.
+func (r *VolumeReconciler) recoverStuckResync(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, st drbd.Status, localDiskless bool) bool {
+	// A diskless leg holds no bitmap, so it can never be the stranded
+	// side; whatever it sees is a diskful pair's business to resolve.
+	if localDiskless || len(st.StuckResyncPeers) == 0 {
+		r.recoveryMu.Lock()
+		delete(r.stuckSince, vol.Name)
+		r.recoveryMu.Unlock()
+		return false
+	}
+	r.recoveryMu.Lock()
+	since, seen := r.stuckSince[vol.Name]
+	if !seen {
+		if r.stuckSince == nil {
+			r.stuckSince = map[string]time.Time{}
+		}
+		r.stuckSince[vol.Name] = time.Now()
+		r.recoveryMu.Unlock()
+		return true
+	}
+	if time.Since(since) < drbdPollInterval {
+		r.recoveryMu.Unlock()
+		return true
+	}
+	r.stuckSince[vol.Name] = time.Now()
+	r.recoveryMu.Unlock()
+
+	log := ctrl.LoggerFrom(ctx)
+	for peerID := range st.StuckResyncPeers {
+		log.Info("cycling peer connection to re-run the sync handshake (out-of-sync bitmap, no resync starting)",
+			"volume", vol.Name, "peerNodeID", peerID, "outOfSyncKiB", st.OutOfSyncKiB)
+		if err := r.DRBD.CyclePeerConnection(ctx, vol.Name, peerID); err != nil {
+			log.Error(err, "stuck-resync connection cycle failed", "volume", vol.Name, "peerNodeID", peerID)
+			continue
+		}
+		if r.Recorder != nil {
+			r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "StuckResyncRecovered", "CycleConnection",
+				"DRBD set an out-of-sync bitmap toward peer node %d without starting a resync; cycled the connection so the handshake resolves it", peerID)
+		}
+	}
+	return true
 }
 
 // mintBirthUUID creates a fresh volume's birth generation and returns the

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -3450,6 +3450,127 @@ func TestFastPathMissesOnPeerReportedSplitBrain(t *testing.T) {
 	fe.calledWith(t, "drbdadm connect --discard-my-data pvc-1")
 }
 
+// --- stuck resync (issue #390) --------------------------------------------
+
+const (
+	// stuckStatusJSON is the stranded-bitmap signature: out-of-sync bits
+	// toward a connected peer whose replication sits Established and whose
+	// disk is parked Consistent — a resync DRBD armed and abandoned.
+	stuckStatusJSON = `[{"name":"pvc-1","role":"Secondary",
+		"devices":[{"disk-state":"UpToDate","quorum":true}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"replication-state":"Established","peer-disk-state":"Consistent","out-of-sync":5171836}]}]}]`
+	healthyStatusJSON = `[{"name":"pvc-1","role":"Secondary",
+		"devices":[{"disk-state":"UpToDate","quorum":true}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected",
+			"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate"}]}]}]`
+)
+
+// stuckResyncSetup builds a settled, Activated 2-replica DRBD volume on
+// node-a (node id 0) whose kernel wears the stranded-bitmap signature
+// toward node-b (node id 1). Activated on purpose: unlike split-brain
+// recovery, the connection cycle discards nothing, so held data is no gate.
+func stuckResyncSetup(t *testing.T) (*VolumeReconciler, *fakeDRBDExec) {
+	t.Helper()
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.QuorumPolicy = miroirv1alpha1.QuorumLastManStanding
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas[0].NodeID = 0
+	v.Spec.Replicas[0].Address = addrA
+	v.Spec.Replicas[1].NodeID = 1
+	v.Spec.Replicas[1].Address = addrB
+	v.Status.Activated = true
+	// Both legs settled at spec size so the pass is steady-state and the
+	// fingerprint gate hinges on the stuck signature alone.
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, SizeBytes: 1 << 30},
+		nodeB: {DeviceCreated: true, SizeBytes: 1 << 30},
+	}
+
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "pvc-1.res"), []byte(
+		"resource \"pvc-1\" {\n    on \"node-a\" {\n        device minor 1000;\n    }\n}\n",
+	), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	fe := &fakeDRBDExec{statusJSON: stuckStatusJSON}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		Build()
+	r := &VolumeReconciler{
+		Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
+	}
+	return r, fe
+}
+
+// backdateStuck rewinds the confirmation clock so the next pass treats the
+// signature as having persisted through a full poll interval.
+func backdateStuck(t *testing.T, r *VolumeReconciler) {
+	t.Helper()
+	r.recoveryMu.Lock()
+	defer r.recoveryMu.Unlock()
+	if _, ok := r.stuckSince[volPvc1]; !ok {
+		t.Fatal("confirmation clock not armed")
+	}
+	r.stuckSince[volPvc1] = time.Now().Add(-drbdPollInterval - time.Second)
+}
+
+// The first sighting only arms the confirmation clock — a status snapshot
+// can catch a live handshake mid-transition. Once the signature has
+// persisted through a poll interval, recovery cycles exactly the stuck
+// peer connection, held data notwithstanding (the volume is Activated).
+func TestReconcileStuckResyncCyclesAfterConfirmation(t *testing.T) {
+	r, fe := stuckResyncSetup(t)
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdsetup disconnect")
+	backdateStuck(t, r)
+	reconcile(t, r, volPvc1)
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
+	fe.calledWith(t, "drbdsetup connect pvc-1 1")
+}
+
+// Within the confirmation window nothing is cycled, however many passes run
+// (DRBD events can requeue the volume several times per interval).
+func TestReconcileStuckResyncDebounced(t *testing.T) {
+	r, fe := stuckResyncSetup(t)
+	reconcile(t, r, volPvc1)
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdsetup disconnect")
+}
+
+// The stuck signature keeps the volume out of the fast path (its kernel
+// state is otherwise steady), and a healthy pass parks it again and resets
+// the confirmation clock — a signature that clears and returns must
+// re-confirm from scratch.
+func TestReconcileStuckResyncFingerprintLifecycle(t *testing.T) {
+	r, fe := stuckResyncSetup(t)
+	reconcile(t, r, volPvc1)
+	r.realizedMu.Lock()
+	_, parked := r.realized[volPvc1]
+	r.realizedMu.Unlock()
+	if parked {
+		t.Fatal("stuck volume must not park in the fast path")
+	}
+
+	fe.statusJSON = healthyStatusJSON
+	reconcile(t, r, volPvc1)
+	r.realizedMu.Lock()
+	_, parked = r.realized[volPvc1]
+	r.realizedMu.Unlock()
+	if !parked {
+		t.Fatal("healthy volume must park in the fast path")
+	}
+	r.recoveryMu.Lock()
+	_, armed := r.stuckSince[volPvc1]
+	r.recoveryMu.Unlock()
+	if armed {
+		t.Fatal("healthy pass must reset the confirmation clock")
+	}
+}
+
 // --- birth generation ---------------------------------------------------
 
 const (

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -941,6 +941,27 @@ func (d *Driver) ResolveSplitBrain(ctx context.Context, r Resource) error {
 	return nil
 }
 
+// CyclePeerConnection disconnects and reconnects one peer so DRBD re-runs
+// that connection's sync handshake — the only trigger for the
+// missed-end-of-resync rescue, which is gated on a fresh connect and is
+// what resolves a stranded bitmap (issue #390): equal current UUIDs
+// discard it outright, divergent ones start the resync the bits called
+// for. drbdsetup on both legs: it takes the peer by node id with no
+// config parse, and unlike drbdadm's disconnect it keeps the peer and
+// path objects, so the connect below re-activates them in place. Should
+// the connect still fail, the next pass's adjust reconnects the parked
+// leg.
+func (d *Driver) CyclePeerConnection(ctx context.Context, name string, peerID int32) error {
+	id := strconv.Itoa(int(peerID))
+	if _, err := d.Exec(ctx, "drbdsetup", "disconnect", name, id); err != nil {
+		return fmt.Errorf("disconnect %s peer %s: %w", name, id, err)
+	}
+	if _, err := d.Exec(ctx, "drbdsetup", "connect", name, id); err != nil {
+		return fmt.Errorf("connect %s peer %s: %w", name, id, err)
+	}
+	return nil
+}
+
 // WipeMetadata destroys the DRBD metadata on a backing device so it cannot
 // carry a stale generation identifier into a reuse. The resource must be
 // down first — drbdmeta refuses an attached device. Callers treat it as
@@ -1185,6 +1206,13 @@ const DiskDiskless = "Diskless"
 // means a previous down was killed mid-flight — see ErrWedged.
 const diskDetaching = "Detaching"
 
+// diskConsistent is the peer-disk state of data that is consistent but not
+// yet trusted as current. On a connected peer it is transient — the sync
+// handshake resolves it to UpToDate or Outdated — so a peer parked
+// Consistent over an Established connection is the stranded-bitmap
+// signature (see Status.StuckResyncPeers).
+const diskConsistent = "Consistent"
+
 // connStandAlone is the connection state of a peer DRBD gave up
 // reconnecting to. drbdsetup disconnect refuses it (-9), so a StandAlone
 // entry can linger in status through every teardown attempt.
@@ -1252,6 +1280,16 @@ type Status struct {
 	// drbdsetup reports it) — the data-loss exposure if the healthiest
 	// peer is lost. Grows while a peer is down with no resync running.
 	OutOfSyncKiB int64
+	// StuckResyncPeers holds the DRBD node ids of peers wearing the
+	// stranded-bitmap signature: connection Connected, replication
+	// Established, peer-disk Consistent, out-of-sync above zero. DRBD set
+	// a bitmap slot toward the peer and then abandoned the exchange
+	// without starting the resync (a stale after-unstable handshake,
+	// issue #390); nothing in-kernel re-examines it while the connection
+	// stays up. Only the leg holding the bitmap sees it — the peer still
+	// reads this node as UpToDate — so at most one node acts on it. Nil
+	// when no peer is stuck.
+	StuckResyncPeers map[int32]bool
 }
 
 // drbdsetup status --json shapes (the fields miroir reads).
@@ -1348,6 +1386,18 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 				}
 			}
 			s.OutOfSyncKiB = max(s.OutOfSyncKiB, pd.OutOfSyncKiB)
+			// Out-of-sync bits toward a connected peer with no resync
+			// running and the peer-disk parked Consistent: a bitmap DRBD
+			// armed and abandoned (issue #390). Every condition earns its
+			// keep — verify findings leave the peer-disk UpToDate, and a
+			// live bitmap exchange sits in WFBitMap*, not Established.
+			if c.ConnectionState == connConnected && pd.ReplicationState == replEstablished &&
+				pd.PeerDiskState == diskConsistent && pd.OutOfSyncKiB > 0 {
+				if s.StuckResyncPeers == nil {
+					s.StuckResyncPeers = map[int32]bool{}
+				}
+				s.StuckResyncPeers[c.PeerNodeID] = true
+			}
 		}
 		// Single-volume resources: the first peer-device carries the peer's
 		// disk state.

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1620,6 +1621,81 @@ func TestStatusQuorumLost(t *testing.T) {
 	if s.Resyncing {
 		t.Fatalf("Off replication must not read as resync: %+v", s)
 	}
+}
+
+// StuckResyncPeers flags only the stranded-bitmap signature (issue #390):
+// Connected + Established + peer-disk Consistent + out-of-sync. A running
+// resync (replication not Established), verify findings (peer-disk stays
+// UpToDate), and a clean Consistent peer must all stay unflagged.
+func TestStatusStuckResyncPeers(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
+			"devices":[{"disk-state":"UpToDate","quorum":true}],
+			"connections":[
+				{"peer-node-id":1,"connection-state":"Connected",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"Consistent","out-of-sync":5171836}]},
+				{"peer-node-id":2,"connection-state":"Connected",
+					"peer_devices":[{"replication-state":"SyncSource","peer-disk-state":"Consistent","percent-in-sync":50,"out-of-sync":1024}]},
+				{"peer-node-id":3,"connection-state":"Connected",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":12}]},
+				{"peer-node-id":4,"connection-state":"Connected",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"Consistent","out-of-sync":0}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	s, err := d.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.StuckResyncPeers) != 1 || !s.StuckResyncPeers[1] {
+		t.Fatalf("want only peer 1 flagged stuck, got %v", s.StuckResyncPeers)
+	}
+}
+
+// A healthy volume reports no stuck peers — nil, so fingerprint comparison
+// via maps.Equal treats it the same as an empty map.
+func TestStatusStuckResyncPeersNilWhenHealthy(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
+			"devices":[{"disk-state":"UpToDate","quorum":true}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected",
+				"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate"}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	s, err := d.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.StuckResyncPeers != nil {
+		t.Fatalf("want nil StuckResyncPeers on a healthy volume, got %v", s.StuckResyncPeers)
+	}
+}
+
+// CyclePeerConnection disconnects then reconnects exactly the given peer,
+// by node id, via drbdsetup (no config parse).
+func TestCyclePeerConnection(t *testing.T) {
+	fe := &fakeExec{}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := d.CyclePeerConnection(t.Context(), volPvc1, 1); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"drbdsetup disconnect " + volPvc1 + " 1",
+		"drbdsetup connect " + volPvc1 + " 1",
+	}
+	if !slices.Equal(fe.calls, want) {
+		t.Fatalf("want %v, got %v", want, fe.calls)
+	}
+}
+
+// A failed disconnect must not be followed by a connect — the cycle is
+// retried whole on a later pass.
+func TestCyclePeerConnectionDisconnectFails(t *testing.T) {
+	fe := &fakeExec{errOn: map[string]error{"disconnect": errors.New("exit status 11")}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	if err := d.CyclePeerConnection(t.Context(), volPvc1, 1); err == nil {
+		t.Fatal("want disconnect error")
+	}
+	fe.notCalledWith(t, "drbdsetup connect")
 }
 
 // A fully in-sync volume reports ResyncPercent 100, and connection-level


### PR DESCRIPTION
## Problem

#390: a rapid promote → demote → promote of a diskless primary (~100 ms apart, an hourly-backup access pattern) mints two current UUIDs back to back. A diskful leg runs the after-unstable sync handshake against a one-generation-stale view of its peer: `uuid_compare()=source-set-bitmap by rule=history-self` sets a full bitmap slot, the peer-disk is clamped `Consistent`, and the leg enters `WFBitMapS`. By the time the peer evaluates the same offer both currents are equal, so it stays `Established` and never replies with its bitmap; a second after-unstable pass on the stuck side then collapses `WFBitMapS → Established` without undoing the slot (`drbd_resync()`, `drbd_receiver.c:6610` at drbd-9.3.3).

Nothing in-kernel recovers in place: the missed-end-of-resync rescue (`drbd_uuid_detect_finished_resyncs`) is gated on `repl_state == L_OFF`, i.e. a fresh connect. No upstream fix exists as of drbd master — the volume sits with `out-of-sync` ≈ the whole device, one replica trusted only `Consistent`, and the CR reading `Ready`, indefinitely.

## Fix

Detect the stranded-bitmap signature in the status parser and cycle exactly the stuck peer connection so the reconnect handshake resolves it.

- **Signature** (`Status.StuckResyncPeers`): connection `Connected` + replication `Established` + peer-disk `Consistent` + `out-of-sync > 0`. Each condition earns its keep: verify findings leave the peer-disk `UpToDate` (so the verify feature's deliberately-manual policy is untouched), a live bitmap exchange sits in `WFBitMap*`, and disconnected-peer accumulation isn't `Connected`. The signature is only visible on the leg holding the bitmap — the peer still reads this node as `UpToDate` — so exactly one node acts, no coordination needed.
- **Confirmation window**: the signature must persist through a full poll interval before recovery runs, so a status snapshot catching a real handshake mid-transition is never acted on. Each attempt re-arms the window, flooring retries. While the signature is live the volume stays out of the fast path (its kernel state is otherwise steady and would park there with the clock unread).
- **Remediation** (`Driver.CyclePeerConnection`): `drbdsetup disconnect <res> <peer-id>` + `drbdsetup connect <res> <peer-id>` — drbdsetup keeps the peer/path objects across a disconnect (unlike drbdadm's, which is del-peer), so the connect re-activates them in place; if it still fails, the next pass's adjust reconnects the parked leg. Safe on any volume, held data or not — nothing is ever discarded (hence no `Activated` gate, unlike split-brain recovery): identical data reconnects with zero movement (equal current UUIDs classify the stale bitmap as a missed resync end and drop it — confirmed by the manual remediation in #390, `sent:0/received:0`), and genuinely divergent data starts the resync the bits called for.
- A Warning event (`StuckResyncRecovered`) records each cycle for the audit trail.

## Verified

- Unit tests for the parser signature (positive + the three near-miss shapes), the cycle command sequence, confirmation/debounce behavior, fast-path exclusion, and clock reset on a healthy pass.
- `golangci-lint run ./...` 0 issues; `go vet` + full unit suite green (linux container; darwin can't compile the CSI packages).
- `drbdsetup connect`-after-`disconnect` semantics verified against drbd-utils `user/v9/drbdsetup.c` (both `CTX_PEER_NODE`; `disconnect` ≠ `del-peer`).

## Not in scope

- Surfacing peer-view degradation in the CR (`computePhase` keys on each node's own `DiskState`, so the stuck window still reads `Ready`): with auto-recovery the state lasts ≤ ~2 poll intervals, and phase-flapping semantics deserve their own discussion.
- An upstream report to LINBIT/drbd with the root-cause analysis is worth filing separately; this recovery stays correct either way (it acts on the state, not the cause).

Fixes #390