### PR TITLE
fix(agent): self-heal a stale out-of-sync bitmap instead of only alerting

### DIFF
--- a/charts/miroir/templates/prometheusrule.tpl
+++ b/charts/miroir/templates/prometheusrule.tpl
@@ -235,8 +235,11 @@ spec:
             description: >-
               A peer has been out of sync for over an hour without a resync
               draining it — a down peer accumulating exposure, a stalled
-              resync, or blocks flagged by drbdadm verify. A verify finding
-              needs a disconnect/connect cycle to resync.
+              resync, or blocks flagged by drbdadm verify. Stale bitmaps on
+              healthy connections are auto-cycled by the agent, so a
+              persistent alert usually means a verify finding, which stays
+              manual: it needs a disconnect/connect cycle to resync (see
+              the troubleshooting guide).
             {{- with .Values.monitoring.prometheusRule.additionalRuleAnnotations }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -28,6 +28,25 @@
   `7100`) to move miroir's range; existing volumes keep their ports.
   Full forensics in
   [#148](https://github.com/home-operations/miroir/issues/148).
+- **`MiroirVolumeOutOfSync` firing while everything reads healthy**:
+  `out-of-sync` bits toward a peer with no resync draining them. With the
+  connection `Connected` and both disks `UpToDate`, this is one of two
+  things. A _stale bitmap_ — bits stranded by a refused clear during peer
+  teardown, or a resync DRBD armed and abandoned after a rapid
+  promote/demote — is detected and self-healed: the agent cycles the
+  affected peer connection within a couple of poll cycles and emits a
+  `StuckResyncRecovered` event; the re-run handshake discards the bitmap
+  (identical data moves nothing) or starts the resync it called for. A
+  _`drbdadm verify` finding_ (`lastVerifyOutOfSyncBytes` non-zero in the
+  coordinator's status slot, `VerifyOutOfSync` event) is a
+  genuine data difference and is deliberately left manual — auto-resyncing
+  would destroy the evidence of which leg was wrong. Inspect first, then
+  find the affected peer with
+  `drbdsetup status <res> --verbose --statistics` on the alerting node
+  (the connection whose `out-of-sync` is non-zero) and cycle it:
+  `drbdsetup disconnect <res> <peer-node-id>` followed by
+  `drbdsetup connect <res> <peer-node-id>` resyncs the flagged blocks
+  from the UpToDate side.
 - **Resync activity on every kopiur backup**: kopiur's staged PVC
   inherits the source PVC's StorageClass, so a replicated volume gets
   a replicated (and therefore syncing) staging volume once per backup

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -443,6 +443,7 @@ func statusEqual(a, b drbd.Status) bool {
 		a.Quorum == b.Quorum &&
 		a.OutOfSyncKiB == b.OutOfSyncKiB &&
 		maps.Equal(a.StuckResyncPeers, b.StuckResyncPeers) &&
+		maps.Equal(a.StaleBitmapPeers, b.StaleBitmapPeers) &&
 		maps.Equal(a.PeerConnected, b.PeerConnected) &&
 		// A peer disk-state flip (DUnknown → Inconsistent at birth) can be
 		// the only change in a pass — without it the winner's fingerprint
@@ -839,23 +840,32 @@ func peerReportedSplitBrain(vol *miroirv1alpha1.MiroirVolume, self string) bool 
 	return false
 }
 
-// recoverStuckResync heals a resync DRBD armed but will never start (issue
-// #390): a rapid promote/demote/promote of a diskless primary mints two
-// current UUIDs back to back, a diskful leg handshakes against a
-// one-generation-stale view of its peer and sets a full bitmap slot
-// (WFBitMapS, peer-disk clamped Consistent), and a second after-unstable
-// pass — equal UUIDs by then — collapses the pending exchange back to
-// Established without undoing it. The kernel never re-examines the bits
-// while the connection stays up (its missed-end-of-resync rescue only runs
-// at connect), so the volume sits with degraded redundancy accounting until
-// the connection cycles.
+// recoverStuckResync heals the two out-of-sync bitmaps DRBD leaves behind
+// with nothing to drain them:
 //
-// Recovery cycles exactly the stuck peer connections, re-running their
-// handshakes. Safe on any volume, held data or not: identical data (the
-// race above) reconnects with zero movement — equal current UUIDs classify
-// the stale bitmap as a missed resync end and discard it — and genuinely
-// divergent data starts the resync the bits called for. No Activated gate,
-// unlike split-brain recovery, because nothing is ever discarded.
+//   - A resync armed but never started (issue #390): a rapid
+//     promote/demote/promote of a diskless primary mints two current UUIDs
+//     back to back, a diskful leg handshakes against a one-generation-stale
+//     view of its peer and sets a full bitmap slot (WFBitMapS, peer-disk
+//     clamped Consistent), and a second after-unstable pass — equal UUIDs
+//     by then — collapses the pending exchange back to Established without
+//     undoing it (StuckResyncPeers).
+//   - Bits stranded by a bitmap clear the kernel refused mid peer-teardown
+//     ("bitmap locked", issue #389), everything otherwise healthy
+//     (StaleBitmapPeers, behind staleBitmapActionable's gates — the same
+//     kernel shape is a verify finding, which stays manual).
+//
+// Neither drains in place: the kernel only reconciles a dirty bitmap on a
+// connection transition (its missed-end-of-resync rescue runs at connect),
+// so the volume sits with degraded redundancy accounting until the
+// connection cycles.
+//
+// Recovery cycles exactly the affected peer connections, re-running their
+// handshakes. Safe on any volume, held data or not: identical data
+// reconnects with zero movement — the re-handshake classifies the stale
+// bitmap as a missed resync end and discards it — and genuinely divergent
+// data starts the resync the bits called for. No Activated gate, unlike
+// split-brain recovery, because nothing is ever discarded.
 //
 // The signature must persist through a full poll interval before recovery
 // runs: a status snapshot can catch a live handshake between setting the
@@ -865,9 +875,18 @@ func peerReportedSplitBrain(vol *miroirv1alpha1.MiroirVolume, self string) bool 
 // the stuck state is otherwise steady, and a stored fingerprint would park
 // the confirmation clock unread.
 func (r *VolumeReconciler) recoverStuckResync(ctx context.Context, vol *miroirv1alpha1.MiroirVolume, st drbd.Status, localDiskless bool) bool {
+	peers := st.StuckResyncPeers
+	if r.staleBitmapActionable(vol, st) {
+		if peers == nil {
+			peers = st.StaleBitmapPeers
+		} else {
+			peers = maps.Clone(peers)
+			maps.Copy(peers, st.StaleBitmapPeers)
+		}
+	}
 	// A diskless leg holds no bitmap, so it can never be the stranded
 	// side; whatever it sees is a diskful pair's business to resolve.
-	if localDiskless || len(st.StuckResyncPeers) == 0 {
+	if localDiskless || len(peers) == 0 {
 		r.recoveryMu.Lock()
 		delete(r.stuckSince, vol.Name)
 		r.recoveryMu.Unlock()
@@ -891,7 +910,7 @@ func (r *VolumeReconciler) recoverStuckResync(ctx context.Context, vol *miroirv1
 	r.recoveryMu.Unlock()
 
 	log := ctrl.LoggerFrom(ctx)
-	for peerID := range st.StuckResyncPeers {
+	for peerID := range peers {
 		log.Info("cycling peer connection to re-run the sync handshake (out-of-sync bitmap, no resync starting)",
 			"volume", vol.Name, "peerNodeID", peerID, "outOfSyncKiB", st.OutOfSyncKiB)
 		if err := r.DRBD.CyclePeerConnection(ctx, vol.Name, peerID); err != nil {
@@ -900,7 +919,32 @@ func (r *VolumeReconciler) recoverStuckResync(ctx context.Context, vol *miroirv1
 		}
 		if r.Recorder != nil {
 			r.Recorder.Eventf(vol, nil, corev1.EventTypeWarning, "StuckResyncRecovered", "CycleConnection",
-				"DRBD set an out-of-sync bitmap toward peer node %d without starting a resync; cycled the connection so the handshake resolves it", peerID)
+				"DRBD carried an out-of-sync bitmap toward peer node %d with no resync running; cycled the connection so the handshake resolves it", peerID)
+		}
+	}
+	return true
+}
+
+// staleBitmapActionable reports whether the stale-bitmap candidates in
+// StaleBitmapPeers are safe to cycle (issue #389). Their kernel shape is
+// indistinguishable from a verify finding, so everything else must read
+// healthy — a Secondary leg with an UpToDate disk and quorum, every
+// diskful peer connected and UpToDate, no resync, verify, or split-brain
+// in flight — and the coordinator's last recorded verify must not have
+// findings outstanding: auto-resyncing a real finding would destroy the
+// evidence of which leg was wrong, so that case stays manual (the record
+// clears once a later verify reports 0 after the operator's own cycle).
+func (r *VolumeReconciler) staleBitmapActionable(vol *miroirv1alpha1.MiroirVolume, st drbd.Status) bool {
+	if len(st.StaleBitmapPeers) == 0 || st.Primary || st.DiskState != drbd.DiskUpToDate ||
+		!st.Quorum || st.Resyncing || st.SplitBrain {
+		return false
+	}
+	if !diskfulPeersConnected(st, vol, r.NodeName) || !diskfulPeersUpToDate(st, vol, r.NodeName) {
+		return false
+	}
+	if coord := vol.Spec.FirstDiskfulReplica(); coord != nil {
+		if v := vol.Status.PerNode[coord.Node].LastVerifyOutOfSyncBytes; v != nil && *v > 0 {
+			return false
 		}
 	}
 	return true

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -3571,6 +3571,82 @@ func TestReconcileStuckResyncFingerprintLifecycle(t *testing.T) {
 	}
 }
 
+// staleBitmapStatusJSON is the stale one-sided-bitmap signature (issue
+// #389): out-of-sync bits toward a connected, UpToDate Primary peer with
+// replication Established and this leg Secondary — everything healthy but
+// the bits, which nothing drains.
+const staleBitmapStatusJSON = `[{"name":"pvc-1","role":"Secondary",
+	"devices":[{"disk-state":"UpToDate","quorum":true}],
+	"connections":[{"peer-node-id":1,"connection-state":"Connected","peer-role":"Primary",
+		"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":5242880}]}]}]`
+
+// A stale one-sided bitmap toward a healthy Primary peer is cycled once the
+// signature outlives the confirmation window, exactly like a stranded
+// after-unstable bitmap.
+func TestReconcileStaleBitmapCyclesAfterConfirmation(t *testing.T) {
+	r, fe := stuckResyncSetup(t)
+	fe.statusJSON = staleBitmapStatusJSON
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdsetup disconnect")
+	backdateStuck(t, r)
+	reconcile(t, r, volPvc1)
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
+	fe.calledWith(t, "drbdsetup connect pvc-1 1")
+}
+
+// The same kernel shape with a verify finding on record is a genuine
+// data-difference report, not a stale bitmap: auto-resyncing it would
+// destroy the evidence of which leg was wrong, so it stays manual — the
+// confirmation clock never even arms.
+func TestReconcileStaleBitmapVerifyFindingStaysManual(t *testing.T) {
+	r, fe := stuckResyncSetup(t)
+	fe.statusJSON = staleBitmapStatusJSON
+	var v miroirv1alpha1.MiroirVolume
+	if err := r.Get(t.Context(), types.NamespacedName{Name: volPvc1}, &v); err != nil {
+		t.Fatal(err)
+	}
+	// node-a is the first diskful replica — the verify coordinator whose
+	// slot records findings.
+	finding := int64(4096)
+	slot := v.Status.PerNode[nodeA]
+	slot.LastVerifyOutOfSyncBytes = &finding
+	v.Status.PerNode[nodeA] = slot
+	if err := r.Status().Update(t.Context(), &v); err != nil {
+		t.Fatal(err)
+	}
+	reconcile(t, r, volPvc1)
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdsetup disconnect")
+	r.recoveryMu.Lock()
+	_, armed := r.stuckSince[volPvc1]
+	r.recoveryMu.Unlock()
+	if armed {
+		t.Fatal("a verify finding must keep the confirmation clock unarmed")
+	}
+}
+
+// A resync already in flight anywhere on the volume defers the stale-bitmap
+// verdict — the state is not steady, so the clock never arms and nothing is
+// cycled, even though the stale signature itself is present toward peer 1.
+func TestReconcileStaleBitmapResyncInFlightStaysManual(t *testing.T) {
+	r, fe := stuckResyncSetup(t)
+	fe.statusJSON = `[{"name":"pvc-1","role":"Secondary",
+		"devices":[{"disk-state":"UpToDate","quorum":true}],
+		"connections":[
+			{"peer-node-id":1,"connection-state":"Connected","peer-role":"Primary",
+				"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":5242880}]},
+			{"peer-node-id":2,"connection-state":"Connected",
+				"peer_devices":[{"replication-state":"SyncSource","peer-disk-state":"Inconsistent","percent-in-sync":50,"out-of-sync":1024}]}]}]`
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdsetup disconnect")
+	r.recoveryMu.Lock()
+	_, armed := r.stuckSince[volPvc1]
+	r.recoveryMu.Unlock()
+	if armed {
+		t.Fatal("an in-flight resync must keep the confirmation clock unarmed")
+	}
+}
+
 // --- birth generation ---------------------------------------------------
 
 const (

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -1290,6 +1290,18 @@ type Status struct {
 	// reads this node as UpToDate — so at most one node acts on it. Nil
 	// when no peer is stuck.
 	StuckResyncPeers map[int32]bool
+	// StaleBitmapPeers holds the DRBD node ids of Primary peers this leg
+	// carries a one-sided out-of-sync bitmap toward while everything
+	// reads healthy: connection Connected, replication Established,
+	// peer-disk UpToDate, out-of-sync above zero. Bits stranded by a
+	// bitmap clear the kernel refused mid peer-teardown ("bitmap locked")
+	// never drain on their own — DRBD only reconciles a dirty bitmap on a
+	// connection transition (issue #389). The same kernel shape is also a
+	// verify finding, which must stay manual — the agent gates on the
+	// recorded verify outcome before acting. Restricted to Primary peers
+	// so the resync direction at the re-handshake is unambiguous. Nil
+	// when none.
+	StaleBitmapPeers map[int32]bool
 }
 
 // drbdsetup status --json shapes (the fields miroir reads).
@@ -1397,6 +1409,19 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 					s.StuckResyncPeers = map[int32]bool{}
 				}
 				s.StuckResyncPeers[c.PeerNodeID] = true
+			}
+			// A one-sided bitmap toward a healthy Primary peer with no
+			// resync running: stale bits from a refused clear (issue
+			// #389) — or a verify finding, which the agent's gates keep
+			// manual. The peer-role restriction keeps the resync
+			// direction at the re-handshake unambiguous.
+			if c.ConnectionState == connConnected && c.PeerRole == rolePrimary &&
+				pd.ReplicationState == replEstablished &&
+				pd.PeerDiskState == DiskUpToDate && pd.OutOfSyncKiB > 0 {
+				if s.StaleBitmapPeers == nil {
+					s.StaleBitmapPeers = map[int32]bool{}
+				}
+				s.StaleBitmapPeers[c.PeerNodeID] = true
 			}
 		}
 		// Single-volume resources: the first peer-device carries the peer's

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1651,6 +1651,38 @@ func TestStatusStuckResyncPeers(t *testing.T) {
 	}
 }
 
+// StaleBitmapPeers flags a one-sided bitmap toward a healthy Primary peer
+// (issue #389): Connected + Established + peer-disk UpToDate + out-of-sync,
+// peer role Primary. A Secondary peer (ambiguous resync direction), a
+// Consistent peer-disk (that is the stuck-resync signature), and a clean
+// peer must all stay unflagged.
+func TestStatusStaleBitmapPeers(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"UpToDate","quorum":true}],
+			"connections":[
+				{"peer-node-id":1,"connection-state":"Connected","peer-role":"Primary",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":5242880}]},
+				{"peer-node-id":2,"connection-state":"Connected","peer-role":"Secondary",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":4096}]},
+				{"peer-node-id":3,"connection-state":"Connected","peer-role":"Primary",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"Consistent","out-of-sync":4096}]},
+				{"peer-node-id":4,"connection-state":"Connected","peer-role":"Primary",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":0}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	s, err := d.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.StaleBitmapPeers) != 1 || !s.StaleBitmapPeers[1] {
+		t.Fatalf("want only peer 1 flagged stale, got %v", s.StaleBitmapPeers)
+	}
+	if len(s.StuckResyncPeers) != 1 || !s.StuckResyncPeers[3] {
+		t.Fatalf("want only peer 3 flagged stuck, got %v", s.StuckResyncPeers)
+	}
+}
+
 // A healthy volume reports no stuck peers — nil, so fingerprint comparison
 // via maps.Equal treats it the same as an empty map.
 func TestStatusStuckResyncPeersNilWhenHealthy(t *testing.T) {
@@ -1667,6 +1699,9 @@ func TestStatusStuckResyncPeersNilWhenHealthy(t *testing.T) {
 	}
 	if s.StuckResyncPeers != nil {
 		t.Fatalf("want nil StuckResyncPeers on a healthy volume, got %v", s.StuckResyncPeers)
+	}
+	if s.StaleBitmapPeers != nil {
+		t.Fatalf("want nil StaleBitmapPeers on a healthy volume, got %v", s.StaleBitmapPeers)
 	}
 }
 


### PR DESCRIPTION
Fixes: #389 

Stacked on #391 (merge that first; this reuses its detection/recovery plumbing).

## Problem

#389: a bitmap clear the kernel refuses mid peer-teardown (`FIXME ... op clear, bitmap locked for 'peer demote'`) strands one-sided out-of-sync bits toward a healthy peer. Everything reads `Connected` + `UpToDate` + `quorum:yes`, no resync runs, and DRBD only reconciles a dirty bitmap on a connection transition — so the bits never drain, `MiroirVolumeOutOfSync` fires indefinitely, and the fix is a manual disconnect/connect. Ordinary node churn (a diskless client joining and leaving) is enough to reach it.

This is a second stuck-bitmap shape next to #390's: there the bitmap holder's peer-disk is parked `Consistent`; here everything is `UpToDate` — which is also exactly what a `drbdadm verify` finding looks like, so #391's detection deliberately excluded it.

## Fix

Route the shape through #391's recovery, with the gates the issue proposed:

- **Parser** (`Status.StaleBitmapPeers`): `Connected` + `Established` + peer-disk `UpToDate` + `out-of-sync > 0`, restricted to **Primary peers** so the resync direction at the re-handshake is unambiguous. Combined with the agent-side Secondary check this is the issue's "only act from a Secondary leg with a Primary peer".
- **Agent gates** (`staleBitmapActionable`): local leg Secondary, disk `UpToDate`, quorum, no resync/verify/split-brain in flight, every diskful peer connected and `UpToDate` — and **skip when the coordinator's `lastVerifyOutOfSyncBytes` records findings**: a real verify finding is evidence of which leg was wrong, and auto-resyncing would destroy it, so that case stays manual (the gate clears once a later verify records 0).
- **Remediation**: the same confirmation window (signature must outlive a poll interval; each attempt re-arms it) and per-peer `drbdsetup disconnect`/`connect` cycle from #391, same `StuckResyncRecovered` event. Data-safe in both directions: identical bytes reconcile with zero movement, real divergence resyncs from the `UpToDate` side.

Shipped **auto-on, no chart knob**: the verify-finding gate removes the one case where acting is wrong, and #391 already auto-heals the sibling shape without a knob — happy to add an opt-out if you want one.

## Also (the actionable-alert half of the issue)

- `docs/troubleshooting.md`: a `MiroirVolumeOutOfSync` entry — what self-heals now, what stays manual, and the exact `drbdsetup status --verbose --statistics` → `disconnect`/`connect` commands with the peer-id syntax.
- The alert description now says stale bitmaps self-heal, so a persistent alert usually means a verify finding.

**Not included**: the per-peer label on `miroir_volume_out_of_sync_bytes` — it changes series cardinality and every consumer (alert expr, dashboard), so it deserves its own change if still wanted now that the alert should only persist for verify findings.

## Verified

- Unit tests: parser signature (direction gate, stuck-vs-stale disambiguation, oos=0), recovery after confirmation, verify-finding gate (clock never arms), in-flight-resync gate.
- `golangci-lint` 0 issues, full Go suite green (linux container), helm-unittest + helm-lint green, docs build `--strict` clean.

Fixes #389