### PR TITLE
fix(agent): flag the WFBitMapS-parked shape of a stranded bitmap as stuck resync

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -847,9 +847,12 @@ func peerReportedSplitBrain(vol *miroirv1alpha1.MiroirVolume, self string) bool 
 //     promote/demote/promote of a diskless primary mints two current UUIDs
 //     back to back, a diskful leg handshakes against a one-generation-stale
 //     view of its peer and sets a full bitmap slot (WFBitMapS, peer-disk
-//     clamped Consistent), and a second after-unstable pass — equal UUIDs
-//     by then — collapses the pending exchange back to Established without
-//     undoing it (StuckResyncPeers).
+//     clamped Consistent). From there a timing lottery picks the terminal
+//     shape: a second after-unstable pass — equal UUIDs by then — collapses
+//     the pending exchange back to Established without undoing it, or that
+//     pass never runs and the leg parks in WFBitMapS waiting for a bitmap
+//     reply the peer already discarded (issue #397). Both wear
+//     StuckResyncPeers.
 //   - Bits stranded by a bitmap clear the kernel refused mid peer-teardown
 //     ("bitmap locked", issue #389), everything otherwise healthy
 //     (StaleBitmapPeers, behind staleBitmapActionable's gates — the same

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -1209,8 +1209,8 @@ const diskDetaching = "Detaching"
 // diskConsistent is the peer-disk state of data that is consistent but not
 // yet trusted as current. On a connected peer it is transient — the sync
 // handshake resolves it to UpToDate or Outdated — so a peer parked
-// Consistent over an Established connection is the stranded-bitmap
-// signature (see Status.StuckResyncPeers).
+// Consistent over an up connection with out-of-sync bits is the
+// stranded-bitmap signature (see Status.StuckResyncPeers).
 const diskConsistent = "Consistent"
 
 // connStandAlone is the connection state of a peer DRBD gave up
@@ -1226,12 +1226,15 @@ const rolePrimary = "Primary"
 
 // Peer-device replication states the status parser distinguishes. Anything
 // other than Established/Off means an active resync or verify; VerifyS/VerifyT
-// narrow that to an online verify.
+// narrow that to an online verify, and WFBitMapS is the source side of a
+// bitmap exchange — normally milliseconds, but parked forever when the peer
+// discarded the exchange (see Status.StuckResyncPeers).
 const (
 	replEstablished = "Established"
 	replOff         = "Off"
 	replVerifyS     = "VerifyS"
 	replVerifyT     = "VerifyT"
+	replWFBitMapS   = "WFBitMapS"
 )
 
 // Status reports this node's view of one resource.
@@ -1282,13 +1285,16 @@ type Status struct {
 	OutOfSyncKiB int64
 	// StuckResyncPeers holds the DRBD node ids of peers wearing the
 	// stranded-bitmap signature: connection Connected, replication
-	// Established, peer-disk Consistent, out-of-sync above zero. DRBD set
-	// a bitmap slot toward the peer and then abandoned the exchange
-	// without starting the resync (a stale after-unstable handshake,
-	// issue #390); nothing in-kernel re-examines it while the connection
-	// stays up. Only the leg holding the bitmap sees it — the peer still
-	// reads this node as UpToDate — so at most one node acts on it. Nil
-	// when no peer is stuck.
+	// Established or WFBitMapS, peer-disk Consistent, out-of-sync above
+	// zero. DRBD set a bitmap slot toward the peer and then the exchange
+	// died without starting the resync (a stale after-unstable handshake,
+	// issue #390): either a second after-unstable pass collapsed it back
+	// to Established (#390's original shape), or that pass never ran and
+	// the leg parked in WFBitMapS waiting for a bitmap reply the peer
+	// already discarded (issue #397). Nothing in-kernel re-examines
+	// either while the connection stays up. Only the leg holding the
+	// bitmap sees it — the peer still reads this node as UpToDate — so at
+	// most one node acts on it. Nil when no peer is stuck.
 	StuckResyncPeers map[int32]bool
 	// StaleBitmapPeers holds the DRBD node ids of Primary peers this leg
 	// carries a one-sided out-of-sync bitmap toward while everything
@@ -1400,10 +1406,18 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 			s.OutOfSyncKiB = max(s.OutOfSyncKiB, pd.OutOfSyncKiB)
 			// Out-of-sync bits toward a connected peer with no resync
 			// running and the peer-disk parked Consistent: a bitmap DRBD
-			// armed and abandoned (issue #390). Every condition earns its
-			// keep — verify findings leave the peer-disk UpToDate, and a
-			// live bitmap exchange sits in WFBitMap*, not Established.
-			if c.ConnectionState == connConnected && pd.ReplicationState == replEstablished &&
+			// armed and abandoned (issue #390). The race's terminal shape
+			// is a timing lottery — Established when a second
+			// after-unstable pass collapsed the exchange, WFBitMapS when
+			// it never ran and the peer discarded the bitmap reply (issue
+			// #397) — so both count. Every other condition earns its
+			// keep: verify findings leave the peer-disk UpToDate, a live
+			// WFBitMapS completes in milliseconds (the reconciler's
+			// confirmation window filters it), and WFBitMapT stays
+			// excluded because the target side never wears the
+			// Consistent peer-disk clamp.
+			if c.ConnectionState == connConnected &&
+				(pd.ReplicationState == replEstablished || pd.ReplicationState == replWFBitMapS) &&
 				pd.PeerDiskState == diskConsistent && pd.OutOfSyncKiB > 0 {
 				if s.StuckResyncPeers == nil {
 					s.StuckResyncPeers = map[int32]bool{}

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1623,10 +1623,11 @@ func TestStatusQuorumLost(t *testing.T) {
 	}
 }
 
-// StuckResyncPeers flags only the stranded-bitmap signature (issue #390):
-// Connected + Established + peer-disk Consistent + out-of-sync. A running
-// resync (replication not Established), verify findings (peer-disk stays
-// UpToDate), and a clean Consistent peer must all stay unflagged.
+// StuckResyncPeers flags only the stranded-bitmap signature: Connected +
+// peer-disk Consistent + out-of-sync, replication Established (issue #390)
+// or parked WFBitMapS (issue #397). A running resync, verify findings
+// (peer-disk stays UpToDate), a clean Consistent peer, and the WFBitMapT
+// target side must all stay unflagged.
 func TestStatusStuckResyncPeers(t *testing.T) {
 	fe := &fakeExec{responses: map[string]string{
 		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `",
@@ -1639,15 +1640,21 @@ func TestStatusStuckResyncPeers(t *testing.T) {
 				{"peer-node-id":3,"connection-state":"Connected",
 					"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":12}]},
 				{"peer-node-id":4,"connection-state":"Connected",
-					"peer_devices":[{"replication-state":"Established","peer-disk-state":"Consistent","out-of-sync":0}]}]}]`,
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"Consistent","out-of-sync":0}]},
+				{"peer-node-id":5,"connection-state":"Connected",
+					"peer_devices":[{"replication-state":"WFBitMapS","peer-disk-state":"Consistent","out-of-sync":5171836}]},
+				{"peer-node-id":6,"connection-state":"Connected",
+					"peer_devices":[{"replication-state":"WFBitMapT","peer-disk-state":"UpToDate","out-of-sync":5171836}]},
+				{"peer-node-id":7,"connection-state":"Connected",
+					"peer_devices":[{"replication-state":"WFBitMapS","peer-disk-state":"Consistent","out-of-sync":0}]}]}]`,
 	}}
 	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 	s, err := d.Status(t.Context(), volPvc1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(s.StuckResyncPeers) != 1 || !s.StuckResyncPeers[1] {
-		t.Fatalf("want only peer 1 flagged stuck, got %v", s.StuckResyncPeers)
+	if len(s.StuckResyncPeers) != 2 || !s.StuckResyncPeers[1] || !s.StuckResyncPeers[5] {
+		t.Fatalf("want peers 1 and 5 flagged stuck, got %v", s.StuckResyncPeers)
 	}
 }
 


### PR DESCRIPTION
Fixes #397.

The #390 race has two terminal shapes, decided by whether the second after-unstable pass runs at strand time. The Established shape is what #391's `StuckResyncPeers` signature matches and recovers within ~2 poll intervals. The other shape parks in `WFBitMapS` waiting for a bitmap reply the peer already discarded (`unexpected repl_state (Established) in receive_bitmap`), and nothing in-kernel retries it - so it only cleared when the next promote rolled the same dice, a full backup period later on hourly-backup volumes (hence the daily `MiroirVolumeOutOfSync` flaps), and never on a volume whose diskless leg promotes once.

This extends the stranded-bitmap signature in the status parser to also set `StuckResyncPeers[peer]` for:

```
connection Connected + replication WFBitMapS + peer-disk Consistent + out-of-sync > 0
```

feeding the existing `recoverStuckResync` path unchanged (same confirmation window, same `CyclePeerConnection`, same event).

- The one-poll confirmation window already covers the reason `WFBitMap*` was excluded in #391: a genuinely live bitmap exchange completes in milliseconds, so one that survives the window plus the poll that armed it is not live.
- Even a cycled-while-live exchange costs nothing: `CyclePeerConnection` discards nothing, and the exchange re-arms at reconnect.
- `WFBitMapT` stays excluded: the target side never wears the `Consistent` peer-disk clamp.
- Verify findings remain untouched: a verify leaves peer-disk `UpToDate` and replication `Established`, matching neither shape.

Tested with `mise run test`, `mise run lint`, `mise run vet` (all clean). `TestStatusStuckResyncPeers` now covers the parked `WFBitMapS` shape, the excluded `WFBitMapT` side, and a zero-oos `WFBitMapS`.