### PR TITLE
fix(csi): relocate a shrink-restore off a legless scheduler selection

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -724,9 +724,9 @@ func diskfulOf(reps []miroirv1alpha1.Replica) []miroirv1alpha1.Replica {
 // a different diskful count than the source volume had (issue #305).
 // Growing appends freshly placed FullSync joiners — their content
 // arrives over the wire, so unlike the CoW legs they may land anywhere
-// the pool reaches. Shrinking keeps a subset of the source legs, including
-// the scheduler-selected completed leg when topology is constrained, then
-// seed first and Done legs preferred. The source tie-breaker (if any) is
+// the pool reaches. Shrinking keeps a subset of the source legs — the
+// scheduler-selected leg when complete, else a relocation decided by
+// shrinkPin — then seed first and Done legs preferred. The source tie-breaker (if any) is
 // discarded and re-derived for the final shape, and node ids are
 // re-numbered around the preserved legs — a leg cloning DRBD metadata
 // keeps the id that metadata is keyed by, everything else takes the
@@ -739,16 +739,14 @@ func (c *Controller) reshapeRestore(ctx context.Context, nodes nodemap.Map, reqs
 	case len(diskful) > target:
 		pin := ""
 		if !remoteAccess {
-			pin = selectedTopologyNode(reqs)
-			if reqs != nil && len(reqs.GetRequisite()) > 0 && pin == "" {
-				return nil, status.Error(codes.ResourceExhausted,
-					"no complete source snapshot leg satisfies the requested topology")
+			selected := selectedTopologyNode(reqs)
+			var err error
+			if pin, err = shrinkPin(reqs, diskful, selected); err != nil {
+				return nil, err
 			}
-			if pin != "" && !slices.ContainsFunc(diskful, func(rep miroirv1alpha1.Replica) bool {
-				return rep.Node == pin && !rep.FullSync
-			}) {
-				return nil, status.Errorf(codes.ResourceExhausted,
-					"no complete source snapshot leg exists on topology node %q", pin)
+			if selected != "" && pin != selected {
+				log.Info("shrink restore relocating off a selected node with no complete snapshot leg",
+					"volume", name, "selected", selected, "kept", cmp.Or(pin, diskful[0].Node))
 			}
 		}
 		diskful = keepRestoreLegs(diskful, target, pin)
@@ -827,6 +825,46 @@ func keepRestoreLegs(diskful []miroirv1alpha1.Replica, target int, pin string) [
 		}
 	}
 	return kept
+}
+
+// shrinkPin resolves the topology selection against a shrink-restore's
+// complete legs. A selected node holding a complete leg is honored. A
+// legless selection is a scheduling artifact, not a constraint: preferred
+// topology is best-effort, and the scheduler cannot see leg placement
+// (capacity tracking has no per-volume dimension), so refusing would only
+// replay the same selection forever and strand the PVC in
+// ProvisioningFailed (#406). The shrink instead relocates to a complete
+// leg within requisite — the hard bound (allowedTopologies,
+// strict-topology) — and the response's AccessibleTopology re-places the
+// consumer. Only when requisite admits no complete leg does the refusal
+// stand: that volume cannot exist where the request demands it.
+func shrinkPin(reqs *csi.TopologyRequirement, diskful []miroirv1alpha1.Replica, selected string) (string, error) {
+	complete := func(node string) bool {
+		return slices.ContainsFunc(diskful, func(rep miroirv1alpha1.Replica) bool {
+			return rep.Node == node && !rep.FullSync
+		})
+	}
+	if selected == "" || complete(selected) {
+		return selected, nil
+	}
+	requisite := map[string]bool{}
+	for _, top := range reqs.GetRequisite() {
+		if node := top.GetSegments()[constants.TopologyKey]; node != "" {
+			requisite[node] = true
+		}
+	}
+	// The seed is always complete (resolveSource refuses otherwise) and
+	// keepRestoreLegs keeps it first, so it needs no pin.
+	if len(requisite) == 0 || requisite[diskful[0].Node] {
+		return "", nil
+	}
+	for _, rep := range diskful {
+		if !rep.FullSync && requisite[rep.Node] {
+			return rep.Node, nil
+		}
+	}
+	return "", status.Errorf(codes.ResourceExhausted,
+		"no complete source snapshot leg exists on topology node %q or within the requested topology", selected)
 }
 
 // selectedTopologyNode returns the scheduler-selected node from a

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -1282,6 +1282,104 @@ func TestCreateVolumeRestoreShrinkRefusesSelectedIncompleteLeg(t *testing.T) {
 	}
 }
 
+// A WaitForFirstConsumer selection with no complete snapshot leg (a
+// tie-breaker's node, or one outside the replica set) is a scheduling
+// artifact: the scheduler cannot see leg placement, so a refusal makes it
+// re-select the same node forever and the PVC strands in
+// ProvisioningFailed (#406). The shrink must relocate to the seed leg and
+// let the response topology re-place the consumer.
+func TestCreateVolumeRestoreShrinkRelocatesOffLeglessSelection(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1, Address: staleAddrB},
+				{Node: nodeC, NodeID: 2, Address: addrC, Diskless: true},
+			},
+		},
+	}
+	c := reshapeController(t, srcVol)
+	req := restoreReq("1")
+	// The non-strict WFFC shape: requisite is the whole cluster, preferred
+	// is rotated so the selected (legless) node leads.
+	req.AccessibilityRequirements = &csi.TopologyRequirement{
+		Requisite: []*csi.Topology{
+			{Segments: map[string]string{constants.TopologyKey: nodeA}},
+			{Segments: map[string]string{constants.TopologyKey: nodeB}},
+			{Segments: map[string]string{constants.TopologyKey: nodeC}},
+		},
+		Preferred: []*csi.Topology{
+			{Segments: map[string]string{constants.TopologyKey: nodeC}},
+			{Segments: map[string]string{constants.TopologyKey: nodeA}},
+			{Segments: map[string]string{constants.TopologyKey: nodeB}},
+		},
+	}
+
+	resp, err := c.CreateVolume(t.Context(), req)
+	if err != nil {
+		t.Fatalf("a legless selection must relocate, not refuse: %v", err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Spec.Replicas) != 1 || got.Spec.Replicas[0].Node != nodeA {
+		t.Fatalf("the relocated shrink must keep the seed leg: %+v", got.Spec.Replicas)
+	}
+	if top := resp.Volume.AccessibleTopology; len(top) != 1 || top[0].GetSegments()[constants.TopologyKey] != nodeA {
+		t.Fatalf("the restored PV must re-place the consumer on the kept leg: %+v", top)
+	}
+}
+
+// Requisite stays a hard bound during relocation: when allowedTopologies
+// excludes the seed's node, the shrink must keep a complete leg inside
+// requisite instead of the seed.
+func TestCreateVolumeRestoreShrinkRelocationHonorsRequisite(t *testing.T) {
+	srcVol := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes:    5 << 30,
+			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
+			DRBD:         &miroirv1alpha1.DRBDSpec{Port: 7000},
+			Replicas: []miroirv1alpha1.Replica{
+				{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 0, Address: staleAddrA},
+				{Node: nodeB, Backend: miroirv1alpha1.BackendLVMThin, NodeID: 1, Address: staleAddrB},
+			},
+		},
+	}
+	c := reshapeController(t, srcVol)
+	req := restoreReq("1")
+	req.AccessibilityRequirements = &csi.TopologyRequirement{
+		Requisite: []*csi.Topology{
+			{Segments: map[string]string{constants.TopologyKey: nodeB}},
+			{Segments: map[string]string{constants.TopologyKey: nodeC}},
+		},
+		Preferred: []*csi.Topology{
+			{Segments: map[string]string{constants.TopologyKey: nodeC}},
+			{Segments: map[string]string{constants.TopologyKey: nodeB}},
+		},
+	}
+
+	resp, err := c.CreateVolume(t.Context(), req)
+	if err != nil {
+		t.Fatalf("a complete leg inside requisite must satisfy the relocation: %v", err)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volNew}, got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Spec.Replicas) != 1 || got.Spec.Replicas[0].Node != nodeB {
+		t.Fatalf("the kept leg must lie within requisite, not on the excluded seed: %+v", got.Spec.Replicas)
+	}
+	if top := resp.Volume.AccessibleTopology; len(top) != 1 || top[0].GetSegments()[constants.TopologyKey] != nodeB {
+		t.Fatalf("the restored PV must pin to the requisite leg: %+v", top)
+	}
+}
+
 // Shrinking keeps Done legs over post-snapshot FullSync ones — dropping
 // a free CoW clone while keeping a leg that must full-resync would be
 // pure waste — and the re-derived tie-breaker takes the smallest unused


### PR DESCRIPTION
## Problem

Restoring a replicated snapshot into a class with fewer diskful replicas (`reshapeRestore`'s shrink path) pinned the kept leg to the WaitForFirstConsumer-selected node and refused with `ResourceExhausted` ("no complete source snapshot leg exists on topology node …") when that node held no complete leg.

The refusal relies on csi-provisioner's deselect-and-reschedule to converge, but the scheduler cannot see snapshot-leg placement — CSIStorageCapacity has no per-volume dimension, so every storage node looks equally viable. Any deterministic scoring skew (a soft node affinity, or an emptier recently-rebooted node) makes it re-select the same legless node on every retry, and the PVC strands in `ProvisioningFailed` forever:

```
Warning ProvisioningFailed  restore  rpc error: code = ResourceExhausted desc = no complete source snapshot leg exists on topology node "miroir-e2e-worker-3"
```

Fresh volumes don't have this failure mode: their refusals (overcommit, missing pool) are steered away from by capacity tracking. The shrink-restore is uniquely exposed because only leg placement — invisible to the scheduler — constrains it.

Diagnosed and reproduced by @AlinaNova21 in #406 (see the corrected analysis in the issue comment; the original issue body describes a different, non-existent mechanism).

## Fix

Treat a legless selection as the scheduling artifact it is. The selected node arrives in *preferred* topology, which the CSI spec defines as best-effort — it is a placement hint, not a user constraint. The new `shrinkPin`:

- honors the selected node when a complete (non-FullSync) leg lives there — unchanged locality behavior;
- otherwise relocates to a complete leg **within requisite** (seed preferred), logs the relocation, and lets the response's `AccessibleTopology` re-place the consumer on the kept leg;
- keeps refusing when requisite — the hard bound (`allowedTopologies`, `--strict-topology`) — admits no complete leg: that volume cannot exist where the request demands it.

One behavioral trade-off to be aware of: a pod with a *hard* node affinity to a legless node now gets a bound PVC and a pod pending on "volume node affinity conflict" instead of a repeating `ProvisioningFailed`. That combination (demanding node-local storage on a node that holds no snapshot data) is unsatisfiable either way; the relocation is logged on the controller for diagnosis.

## Tests

- `TestCreateVolumeRestoreShrinkRelocatesOffLeglessSelection` — the #406 shape: non-strict WFFC request with the tie-breaker's node selected; must relocate to the seed and pin the PV there.
- `TestCreateVolumeRestoreShrinkRelocationHonorsRequisite` — requisite excludes the seed; the relocation must keep a complete leg inside requisite, not the seed.
- `TestCreateVolumeRestoreShrinkHonorsSelectedTopology` (existing, unchanged) — a selected node holding a complete leg is still honored.
- `TestCreateVolumeRestoreShrinkRefusesSelectedIncompleteLeg` (existing, unchanged) — a requisite confined to a node with no complete leg still refuses.

Full unit suite and the upstream csi-test sanity suite pass (linux container, Go 1.26.5).