### PR TITLE
fix(agent): snapshot volumes whose DRBD Primary is a diskless leg

### DIFF
--- a/docs/remote-consumers.md
+++ b/docs/remote-consumers.md
@@ -51,6 +51,12 @@ Trade-offs to understand:
   blocks volume deletion until the node returns or the entry is
   removed by hand (it holds no quorum vote, so the volume itself
   stays healthy).
+- **Snapshots work, coordinated through the consumer.** Writes
+  originate at the diskless Primary, so the snapshot round raises its
+  write barrier (and the filesystem freeze — the mount lives there
+  too) on the consumer's node first, then cuts the legs on the diskful
+  replicas as usual. The same applies when the consumer stages through
+  a tie-breaker leg.
 
 ## Auto-diskful
 

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -34,7 +34,9 @@ When a 2-replica `freeze` volume is created and a third storage node
 in the topology holds neither leg, the controller adds that node
 as a diskless tie-breaker: a DRBD peer configured with `disk none` that
 joins quorum voting but stores nothing; no backing device, no
-capacity used, no part in snapshots or CSI topology. With 3 votes,
+capacity used, no snapshot leg, no part in CSI topology (when a pod
+stages the volume through it, it does coordinate the snapshot write
+barrier — see [remote consumers](remote-consumers.md)). With 3 votes,
 losing any single node (a data leg _or_ the tie-breaker) leaves a
 majority of 2 and the volume keeps serving.
 

--- a/internal/agent/groupsnapshot.go
+++ b/internal/agent/groupsnapshot.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -61,6 +62,18 @@ import (
 // replica). Every participating node freezes and cuts its own legs, so
 // the driver's identity matters for liveness only, never for the
 // freeze's correctness.
+//
+// Diskless Primaries (a remote consumer's client leg, or a tie-breaker
+// whose own node stages the volume) join the round as legless
+// barrier-raisers: writes originate there, so their barrier (and the
+// filesystem freeze, which lives with the mount) must be up before any
+// leg of their volume is cut — but they hold nothing to cut (issue
+// #409). The driver records the expectation at round open as a Pending
+// slot for every diskless leg whose published status shows Primary;
+// the cut gate then blocks on those slots exactly like diskful ones.
+// Slots are matched against the live spec, so a leg unstaged mid-round
+// stops blocking the moment it leaves the spec, and idle (Secondary)
+// diskless legs never enter the round at all.
 //
 // Only replicated (DRBD) volumes can join a group: suspend-io is the
 // only write barrier miroir has, and a 1-replica volume without DRBD
@@ -143,14 +156,16 @@ func (r *GroupSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	mine := myLegs(members, r.NodeName)
-	if len(mine) == 0 {
+	disklessMine := myActiveDisklessLegs(grp, members, r.NodeName)
+	if len(mine) == 0 && len(disklessMine) == 0 {
 		return ctrl.Result{}, nil
 	}
+	participating := append(slices.Clone(mine), disklessMine...)
 
 	if grp.Status.ReadyToUse {
 		// A barrier can outlive the round by a moment; lift stray local
 		// ones — unless a sibling round owns the kernel flag by now.
-		for _, m := range mine {
+		for _, m := range participating {
 			if st, err := r.drbdStatus(ctx, m.vol.Name); err == nil && st.Suspended {
 				if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name, m.vol); err != nil {
 					return ctrl.Result{}, err
@@ -164,7 +179,7 @@ func (r *GroupSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	for _, m := range mine {
+	for _, m := range participating {
 		if m.vol.Spec.DRBD == nil {
 			// Defense in depth: the CSI layer refuses unreplicated members
 			// (no write barrier — see the type comment). Waiting on one
@@ -181,14 +196,15 @@ func (r *GroupSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	return r.reconcileRound(ctx, grp, members, mine)
+	return r.reconcileRound(ctx, grp, members, mine, disklessMine)
 }
 
 // reconcileRound is the group barrier state machine proper, entered once
-// this node verifiably holds diskful legs of a live, fully-resolved
-// group.
-func (r *GroupSnapshotReconciler) reconcileRound(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, members, mine []groupMember) (ctrl.Result, error) {
-	sts, healthy, kernelSuspended, res, err := r.localView(ctx, grp, mine)
+// this node verifiably holds legs (diskful, or active diskless) of a
+// live, fully-resolved group.
+func (r *GroupSnapshotReconciler) reconcileRound(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, members, mine, disklessMine []groupMember) (ctrl.Result, error) {
+	participating := append(slices.Clone(mine), disklessMine...)
+	sts, healthy, kernelSuspended, res, err := r.localView(ctx, grp, mine, disklessMine)
 	if err != nil || res.RequeueAfter > 0 {
 		return res, err
 	}
@@ -196,33 +212,36 @@ func (r *GroupSnapshotReconciler) reconcileRound(ctx context.Context, grp *miroi
 	driver := r.isDriver(members, sts)
 	expired := grp.Status.SuspendedAt != nil &&
 		time.Since(grp.Status.SuspendedAt.Time) > SuspendDeadline
+	pendingDiskless := r.pendingDisklessLegs(grp, disklessMine)
 
 	switch {
 	case driver && !grp.Status.IOSuspended && healthy && !kernelSuspended:
 		// The !kernelSuspended guard is the kernel-truth half of the
 		// one-round-per-volume rule (see reconcileReplicated's twin).
-		return r.openRound(ctx, grp, members, mine)
+		return r.openRound(ctx, grp, members, mine, disklessMine, sts)
 
 	case !driver && grp.Status.IOSuspended && !expired && healthy &&
-		!myLegsAll(grp, mine, r.NodeName, miroirv1alpha1.SnapshotSuspended):
-		return r.raiseBarriers(ctx, grp, members, mine, false)
+		(!myLegsAll(grp, mine, r.NodeName, miroirv1alpha1.SnapshotSuspended) || len(pendingDiskless) > 0):
+		return r.raiseBarriers(ctx, grp, members, mine, pendingDiskless, false)
 
 	case grp.Status.IOSuspended && !expired && healthy &&
 		allSlotsSuspended(grp, members) && !myLegsAll(grp, mine, r.NodeName, miroirv1alpha1.SnapshotDone):
+		// Unreachable for a node with no diskful legs: myLegsAll over
+		// nothing is vacuously Done.
 		return r.cutLegs(ctx, grp, mine)
 
 	case driver && grp.Status.IOSuspended:
-		return r.collectSlots(ctx, grp, members, mine, expired)
+		return r.collectSlots(ctx, grp, members, mine, disklessMine, expired)
 
 	case grp.Status.IOSuspended && expired && kernelSuspended:
 		// Dead round, driver gone before voiding it: self-expire the
 		// local barriers; the void patch stays the driver's.
-		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.resumeMine(ctx, grp, mine)
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, r.resumeMine(ctx, grp, participating)
 
 	case !grp.Status.IOSuspended && kernelSuspended:
 		// The round ended (voided) while local barriers were still up —
 		// unless a sibling round owns one of them by now.
-		for _, m := range mine {
+		for _, m := range participating {
 			if sts[m.vol.Name].Suspended {
 				if err := r.resumeUnlessOtherRound(ctx, grp, m.vol.Name, m.vol); err != nil {
 					return ctrl.Result{RequeueAfter: 2 * time.Second}, err
@@ -239,12 +258,13 @@ func (r *GroupSnapshotReconciler) reconcileRound(ctx context.Context, grp *miroi
 // health gate as the per-snapshot round (a barrier over diverged or
 // resyncing legs cuts diverged legs, and a peer that can never raise
 // its own barrier only freezes the group until the deadline voids it),
-// and whether any local barrier is up in the kernel. A failing status
-// read rides the bounded barrier-failure retry.
-func (r *GroupSnapshotReconciler) localView(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, mine []groupMember) (sts map[string]drbd.Status, healthy, kernelSuspended bool, res ctrl.Result, err error) {
+// and whether any local barrier is up in the kernel. A diskless leg is
+// never UpToDate itself, so it gates on its peers only. A failing
+// status read rides the bounded barrier-failure retry.
+func (r *GroupSnapshotReconciler) localView(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, mine, disklessMine []groupMember) (sts map[string]drbd.Status, healthy, kernelSuspended bool, res ctrl.Result, err error) {
 	sts = map[string]drbd.Status{}
 	healthy = true
-	for _, m := range mine {
+	for i, m := range append(slices.Clone(mine), disklessMine...) {
 		st, err := r.drbdStatus(ctx, m.vol.Name)
 		if err != nil {
 			res, err := r.barrierFailed(ctx, grp, m.vol, err)
@@ -253,7 +273,7 @@ func (r *GroupSnapshotReconciler) localView(ctx context.Context, grp *miroirv1al
 		sts[m.vol.Name] = st
 		if !diskfulPeersConnected(st, m.vol, r.NodeName) ||
 			!diskfulPeersUpToDate(st, m.vol, r.NodeName) ||
-			st.DiskState != drbd.DiskUpToDate {
+			(i < len(mine) && st.DiskState != drbd.DiskUpToDate) {
 			healthy = false
 		}
 		if st.Suspended {
@@ -267,8 +287,12 @@ func (r *GroupSnapshotReconciler) localView(ctx context.Context, grp *miroirv1al
 // the previous round's failure is still inside its retry backoff or any
 // member volume has a live sibling round (a standalone snapshot's or
 // another group's).
-func (r *GroupSnapshotReconciler) openRound(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, members, mine []groupMember) (ctrl.Result, error) {
-	if myState := grp.Status.PerLeg[slotKey(mine[0].vol.Name, r.NodeName)]; myState == miroirv1alpha1.SnapshotError &&
+func (r *GroupSnapshotReconciler) openRound(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, members, mine, disklessMine []groupMember, sts map[string]drbd.Status) (ctrl.Result, error) {
+	first := mine
+	if len(first) == 0 {
+		first = disklessMine
+	}
+	if myState := grp.Status.PerLeg[slotKey(first[0].vol.Name, r.NodeName)]; myState == miroirv1alpha1.SnapshotError &&
 		grp.Status.SuspendedAt != nil &&
 		time.Since(grp.Status.SuspendedAt.Time) < suspendRetryBackoff {
 		return ctrl.Result{RequeueAfter: suspendRetryBackoff}, nil
@@ -278,24 +302,35 @@ func (r *GroupSnapshotReconciler) openRound(ctx context.Context, grp *miroirv1al
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, err
 		}
 	}
-	return r.raiseBarriers(ctx, grp, members, mine, true)
+	// The driver's own diskless Primaries raise with the open, keyed on
+	// live DRBD state; a Secondary diskless leg has no writes to fence.
+	var disklessRaise []groupMember
+	for _, m := range disklessMine {
+		if sts[m.vol.Name].Primary {
+			disklessRaise = append(disklessRaise, m)
+		}
+	}
+	return r.raiseBarriers(ctx, grp, members, mine, disklessRaise, true)
 }
 
 // raiseBarriers freezes every local member leg and records it. The
 // driver's raise opens the round (ioSuspended + deadline clock + a slot
 // reset across EVERY member, so a slow node's Done from a voided round
 // cannot pair with this round's cuts); a peer records only its own
-// slots.
-func (r *GroupSnapshotReconciler) raiseBarriers(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, members, mine []groupMember, opensRound bool) (ctrl.Result, error) {
+// slots. disklessRaise names this node's diskless legs the raise also
+// fences: the driver's live Primaries at open, a peer's Pending slots.
+func (r *GroupSnapshotReconciler) raiseBarriers(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, members, mine, disklessRaise []groupMember, opensRound bool) (ctrl.Result, error) {
 	// A leg whose pool cannot be resolved could never cut behind the
-	// barrier: fail before the group-wide freeze, not after.
+	// barrier: fail before the group-wide freeze, not after. Diskless
+	// legs hold no pool and never cut.
 	for _, m := range mine {
 		if _, err := r.backendFor(m.vol); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
-	suspended := make([]groupMember, 0, len(mine))
-	for _, m := range mine {
+	raise := append(slices.Clone(mine), disklessRaise...)
+	suspended := make([]groupMember, 0, len(raise))
+	for _, m := range raise {
 		// Freeze strictly before this leg's suspend (see the per-snapshot
 		// round's twin): the writeback must replicate while the leg still
 		// accepts IO.
@@ -331,18 +366,29 @@ func (r *GroupSnapshotReconciler) raiseBarriers(ctx context.Context, grp *miroir
 				for _, rep := range m.vol.Spec.DiskfulReplicas() {
 					g.Status.PerLeg[slotKey(m.vol.Name, rep.Node)] = miroirv1alpha1.SnapshotPending
 				}
+				// Expect every remote diskless Primary (per published
+				// status — the driver cannot observe a remote role live):
+				// its barrier must be up before its volume's legs cut, so
+				// it gets a Pending slot the cut gate blocks on. Slots of
+				// legs that are not Primary stay untouched; stale values
+				// from a prior round are never Pending and never block.
+				for _, node := range disklessNodes(m.vol) {
+					if node != r.NodeName && m.vol.Status.PerNode[node].PrimarySince != nil {
+						g.Status.PerLeg[slotKey(m.vol.Name, node)] = miroirv1alpha1.SnapshotPending
+					}
+				}
 			}
-			for _, m := range mine {
+			for _, m := range raise {
 				g.Status.PerLeg[slotKey(m.vol.Name, r.NodeName)] = miroirv1alpha1.SnapshotSuspended
 			}
 		})
 	} else {
-		err = r.patchMySlots(ctx, grp, mine, miroirv1alpha1.SnapshotSuspended)
+		err = r.patchMySlots(ctx, grp, raise, miroirv1alpha1.SnapshotSuspended)
 	}
 	if err != nil {
 		// The barrier is only real once recorded; a failed patch must not
 		// leave IO frozen until the retry.
-		_ = r.resumeMine(ctx, grp, mine)
+		_ = r.resumeMine(ctx, grp, raise)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: time.Second}, nil
@@ -384,7 +430,7 @@ func (r *GroupSnapshotReconciler) cutLegs(ctx context.Context, grp *miroirv1alph
 // publish the members, and seal; deadline passed → resume and void the
 // round (Done slots included: they were cut under a barrier that
 // failed, and the retry recuts them).
-func (r *GroupSnapshotReconciler) collectSlots(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, members, mine []groupMember, expired bool) (ctrl.Result, error) {
+func (r *GroupSnapshotReconciler) collectSlots(ctx context.Context, grp *miroirv1alpha1.MiroirSnapshotGroup, members, mine, disklessMine []groupMember, expired bool) (ctrl.Result, error) {
 	done, total := 0, 0
 	for _, m := range members {
 		for _, rep := range m.vol.Spec.DiskfulReplicas() {
@@ -400,7 +446,7 @@ func (r *GroupSnapshotReconciler) collectSlots(ctx context.Context, grp *miroirv
 	// Resume before reporting anything else: a frozen volume is an
 	// outage, a late group snapshot is just not ready. A barrier a
 	// sibling round co-holds stays for the sibling (see resumeMine).
-	if err := r.resumeMine(ctx, grp, mine); err != nil {
+	if err := r.resumeMine(ctx, grp, append(slices.Clone(mine), disklessMine...)); err != nil {
 		return ctrl.Result{}, err
 	}
 	if done == total {
@@ -422,9 +468,19 @@ func (r *GroupSnapshotReconciler) collectSlots(ctx context.Context, grp *miroirv
 			for _, rep := range m.vol.Spec.DiskfulReplicas() {
 				g.Status.PerLeg[slotKey(m.vol.Name, rep.Node)] = miroirv1alpha1.SnapshotPending
 			}
+			// A dead diskless expectation must not leak into the next
+			// round's cut gate (only Pending blocks it); the reopen
+			// recomputes the expected set from fresh status.
+			for _, node := range disklessNodes(m.vol) {
+				if g.Status.PerLeg[slotKey(m.vol.Name, node)] == miroirv1alpha1.SnapshotPending {
+					g.Status.PerLeg[slotKey(m.vol.Name, node)] = miroirv1alpha1.SnapshotError
+				}
+			}
 		}
-		for _, m := range mine {
-			g.Status.PerLeg[slotKey(m.vol.Name, r.NodeName)] = miroirv1alpha1.SnapshotError
+		for _, m := range append(slices.Clone(mine), disklessMine...) {
+			if key := slotKey(m.vol.Name, r.NodeName); g.Status.PerLeg[key] != "" {
+				g.Status.PerLeg[key] = miroirv1alpha1.SnapshotError
+			}
 		}
 		// Restamp so the retry backoff counts from this failure.
 		now := metav1.Now()
@@ -532,10 +588,47 @@ func diskfulOn(vol *miroirv1alpha1.MiroirVolume, node string) bool {
 	return false
 }
 
+// disklessNodes lists the nodes holding a diskless leg of vol:
+// tie-breaker replicas and client legs.
+func disklessNodes(vol *miroirv1alpha1.MiroirVolume) []string {
+	var nodes []string
+	for _, rep := range vol.Spec.Replicas {
+		if rep.Diskless {
+			nodes = append(nodes, rep.Node)
+		}
+	}
+	for _, cl := range vol.Spec.Clients {
+		nodes = append(nodes, cl.Node)
+	}
+	return nodes
+}
+
+// myActiveDisklessLegs filters the members whose volume has a diskless
+// leg on this node that the round involves: its published status shows
+// Primary (a write origin that must raise a barrier — and, over the
+// first member volume, drives the round), or a round slot already names
+// it. Idle (Secondary, unslotted) diskless legs stay out, so a
+// tie-breaker node is not churned by every group it could never affect.
+func myActiveDisklessLegs(grp *miroirv1alpha1.MiroirSnapshotGroup, members []groupMember, node string) []groupMember {
+	var mine []groupMember
+	for _, m := range members {
+		if !slices.Contains(disklessNodes(m.vol), node) {
+			continue
+		}
+		if m.vol.Status.PerNode[node].PrimarySince != nil ||
+			grp.Status.PerLeg[slotKey(m.vol.Name, node)] != "" {
+			mine = append(mine, m)
+		}
+	}
+	return mine
+}
+
 // isDriver elects this node by the first member volume's coordinator
-// rule. A node without a diskful leg of that volume never drives — it
-// cannot even observe that volume's DRBD state — but still raises and
-// cuts its own legs as a peer.
+// rule. A node without a leg of that volume never drives — it cannot
+// even observe that volume's DRBD state — but still raises and cuts its
+// own legs as a peer. A diskless Primary of the first member CAN drive:
+// it observes the volume through its own leg, and the coordinator rule
+// elects it (everyone else defers on PeerPrimary), legless or not.
 func (r *GroupSnapshotReconciler) isDriver(members []groupMember, sts map[string]drbd.Status) bool {
 	vol0 := members[0].vol
 	st, ok := sts[vol0.Name]
@@ -543,6 +636,19 @@ func (r *GroupSnapshotReconciler) isDriver(members []groupMember, sts map[string
 		return false
 	}
 	return coordinatorFor(r.NodeName, vol0, st)
+}
+
+// pendingDisklessLegs filters this node's diskless legs whose round slot
+// is Pending — expected write origins that have not raised yet; a peer's
+// raise covers them alongside its diskful legs.
+func (r *GroupSnapshotReconciler) pendingDisklessLegs(grp *miroirv1alpha1.MiroirSnapshotGroup, disklessMine []groupMember) []groupMember {
+	var pending []groupMember
+	for _, m := range disklessMine {
+		if grp.Status.PerLeg[slotKey(m.vol.Name, r.NodeName)] == miroirv1alpha1.SnapshotPending {
+			pending = append(pending, m)
+		}
+	}
+	return pending
 }
 
 // myLegsAll reports whether every one of this node's slots has reached
@@ -559,12 +665,21 @@ func myLegsAll(grp *miroirv1alpha1.MiroirSnapshotGroup, mine []groupMember, node
 }
 
 // allSlotsSuspended reports whether every diskful leg of every member
-// volume has raised its barrier (Done implies it did).
+// volume has raised its barrier (Done implies it did), and no expected
+// diskless Primary (Pending slot) is still unraised — cutting past one
+// would cut legs its writes keep landing in. Diskless slots are matched
+// against the live spec, so a leg unstaged mid-round (its slot lingers)
+// stops blocking the moment it leaves the spec.
 func allSlotsSuspended(grp *miroirv1alpha1.MiroirSnapshotGroup, members []groupMember) bool {
 	for _, m := range members {
 		for _, rep := range m.vol.Spec.DiskfulReplicas() {
 			st := grp.Status.PerLeg[slotKey(m.vol.Name, rep.Node)]
 			if st != miroirv1alpha1.SnapshotSuspended && st != miroirv1alpha1.SnapshotDone {
+				return false
+			}
+		}
+		for _, node := range disklessNodes(m.vol) {
+			if grp.Status.PerLeg[slotKey(m.vol.Name, node)] == miroirv1alpha1.SnapshotPending {
 				return false
 			}
 		}

--- a/internal/agent/groupsnapshot_test.go
+++ b/internal/agent/groupsnapshot_test.go
@@ -189,6 +189,80 @@ func TestGroupSnapshotBarrierSpansVolumes(t *testing.T) {
 	feP.calledWith(t, "drbdadm resume-io "+volPvc2)
 }
 
+// Issue #409, group variant: a member volume consumed remotely (diskless
+// client Primary on a node that is not the driver) must have its
+// client's barrier up before ANY leg cuts — the client is where that
+// volume's writes originate — and the round must still complete. The
+// driver records the expectation as a Pending slot from the client's
+// published Primary status; the cut gate blocks on it.
+func TestGroupSnapshotWaitsForRemoteClientPrimary(t *testing.T) {
+	now := metav1.Now()
+	v2 := groupVol(volPvc2)
+	v2.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeC, NodeID: 2, Address: addrC}}
+	v2.Status.PerNode[nodeC] = miroirv1alpha1.ReplicaStatus{
+		DiskState: diskStateDiskless, PrimarySince: &now,
+	}
+	c := groupClient(t, groupVol(volPvc1), v2,
+		memberObj(memberOf1, volPvc1), memberObj(memberOf2, volPvc2), groupObj())
+
+	feK := &fakeDRBDExec{statusJSON: groupStatusPrimary}
+	fbK := newFakeBackend()
+	rK := &GroupSnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fbK),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feK.run}}
+	feP := &fakeDRBDExec{statusJSON: groupStatusPeer}
+	fbP := newFakeBackend()
+	rP := &GroupSnapshotReconciler{Client: c, NodeName: nodeB, Pools: poolsOf(fbP),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feP.run}}
+	feC := &fakeDRBDExec{statusJSON: `[{"name":"any","role":"Primary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateDiskless + `"}],
+		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected"}]}]`}
+	fbC := newFakeBackend()
+	rC := &GroupSnapshotReconciler{Client: c, NodeName: nodeC, Pools: poolsOf(fbC),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feC.run}}
+
+	// Driver opens: its own legs Suspended, the remote client expected.
+	reconcileGroup(t, rK)
+	grp := &miroirv1alpha1.MiroirSnapshotGroup{}
+	_ = c.Get(t.Context(), types.NamespacedName{Name: groupG1}, grp)
+	if grp.Status.PerLeg[slotKey(volPvc2, nodeC)] != miroirv1alpha1.SnapshotPending {
+		t.Fatalf("driver must expect the remote client Primary: %+v", grp.Status)
+	}
+
+	// Both diskful nodes suspended — but the client has not raised yet,
+	// so nobody may cut.
+	reconcileGroup(t, rP)
+	reconcileGroup(t, rK)
+	reconcileGroup(t, rP)
+	if len(fbK.snapCalls) != 0 || len(fbP.snapCalls) != 0 {
+		t.Fatalf("no leg may cut before the client's barrier is up: %v / %v",
+			fbK.snapCalls, fbP.snapCalls)
+	}
+
+	// The client raises its barrier (it has no leg to cut) …
+	reconcileGroup(t, rC)
+	feC.calledWith(t, "drbdadm suspend-io "+volPvc2)
+	_ = c.Get(t.Context(), types.NamespacedName{Name: groupG1}, grp)
+	if grp.Status.PerLeg[slotKey(volPvc2, nodeC)] != miroirv1alpha1.SnapshotSuspended {
+		t.Fatalf("client must record its barrier: %+v", grp.Status)
+	}
+
+	// … and the round proceeds: cut, collect, seal.
+	reconcileGroup(t, rK)
+	reconcileGroup(t, rP)
+	reconcileGroup(t, rK)
+	_ = c.Get(t.Context(), types.NamespacedName{Name: groupG1}, grp)
+	if !grp.Status.ReadyToUse || grp.Status.IOSuspended {
+		t.Fatalf("group must seal ready behind the client's barrier: %+v", grp.Status)
+	}
+	if len(fbC.snapCalls) != 0 {
+		t.Fatalf("the client holds no leg and must not touch a backend: %v", fbC.snapCalls)
+	}
+
+	// The sealed group lifts the client's barrier.
+	reconcileGroup(t, rC)
+	feC.calledWith(t, "drbdadm resume-io "+volPvc2)
+}
+
 // A failed suspend-io mid-raise can still have set the kernel flag (the
 // wedge kills drbdadm after the ioctl landed). The failed leg must join
 // the half-raised sweep's resume — leaving it freezes the volume behind

--- a/internal/agent/snapshot.go
+++ b/internal/agent/snapshot.go
@@ -71,7 +71,11 @@ const suspendRetryBackoff = 30 * time.Second
 //
 // The coordinator is the Primary when one exists (it is where writes
 // originate, so its barrier must be first up and last down), else
-// replicas[0].
+// replicas[0]. A diskless Primary — a remote consumer's client leg, or a
+// tie-breaker whose own node stages the volume — coordinates leglessly:
+// it raises the barrier and the filesystem freeze (both live where the
+// writes and the mount are) but holds no leg to cut; the diskful
+// replicas cut behind its barrier (issue #409).
 type SnapshotReconciler struct {
 	client.Client
 	NodeName string
@@ -253,7 +257,10 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, r.removeFinalizer(ctx, snap)
 	}
 
-	if !replicaOn(vol, r.NodeName) {
+	// Client legs participate too: a diskless Primary must coordinate
+	// the round (see the type comment), and nothing else on its node
+	// watches the snapshot.
+	if !replicaOn(vol, r.NodeName) && vol.Spec.ClientForNode(r.NodeName) == nil {
 		return ctrl.Result{}, nil
 	}
 
@@ -340,6 +347,7 @@ func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miro
 		return r.barrierFailed(ctx, snap, vol, err)
 	}
 	coordinator := r.isCoordinator(vol, st)
+	localDiskful := diskfulOn(vol, r.NodeName)
 	myState := snap.Status.PerNode[r.NodeName]
 	expired := snap.Status.SuspendedAt != nil &&
 		time.Since(snap.Status.SuspendedAt.Time) > SuspendDeadline
@@ -352,10 +360,11 @@ func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miro
 	// only — a degraded volume must still resume. Only diskful peers
 	// count: a downed tie-breaker holds no leg, and gating on its link
 	// would block every snapshot in exactly the degraded mode the
-	// tie-breaker exists to survive.
+	// tie-breaker exists to survive. A diskless leg is likewise never
+	// UpToDate itself, so a diskless coordinator gates on its peers only.
 	healthy := diskfulPeersConnected(st, vol, r.NodeName) &&
 		diskfulPeersUpToDate(st, vol, r.NodeName) &&
-		st.DiskState == drbd.DiskUpToDate
+		(!localDiskful || st.DiskState == drbd.DiskUpToDate)
 
 	switch {
 	case coordinator && !snap.Status.IOSuspended && healthy && !st.Suspended:
@@ -367,11 +376,11 @@ func (r *SnapshotReconciler) reconcileReplicated(ctx context.Context, snap *miro
 		// bottom lifts it, and the next pass opens cleanly.
 		return r.openRound(ctx, snap, vol, myState)
 
-	case !coordinator && snap.Status.IOSuspended && !expired && healthy &&
+	case !coordinator && localDiskful && snap.Status.IOSuspended && !expired && healthy &&
 		myState != miroirv1alpha1.SnapshotSuspended && myState != miroirv1alpha1.SnapshotDone:
 		return r.raiseBarrier(ctx, snap, vol, false)
 
-	case snap.Status.IOSuspended && !expired && healthy &&
+	case localDiskful && snap.Status.IOSuspended && !expired && healthy &&
 		myState == miroirv1alpha1.SnapshotSuspended && allSuspended(vol, snap):
 		return r.cutLeg(ctx, snap, vol)
 
@@ -399,9 +408,12 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 	// A leg whose pool cannot be resolved could never cut behind the
 	// barrier: fail before the cluster-wide freeze, not after. (A pool
 	// dropped mid-round — an agent restart with new values — is still
-	// bounded by SuspendDeadline via the expiry paths.)
-	if _, err := r.backendFor(vol); err != nil {
-		return ctrl.Result{}, err
+	// bounded by SuspendDeadline via the expiry paths.) A diskless
+	// coordinator holds no leg and possibly no pools; it never cuts.
+	if diskfulOn(vol, r.NodeName) {
+		if _, err := r.backendFor(vol); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	// Freeze strictly before the local suspend: FIFREEZE writes back the
 	// page cache, and those writes must reach the device (and replicate)
@@ -446,8 +458,9 @@ func (r *SnapshotReconciler) raiseBarrier(ctx context.Context, snap *miroirv1alp
 			// Reset peers: a slow peer's Done from the voided round can
 			// land after the void and would pair its stale leg with
 			// this round's cuts. Only diskful replicas hold legs — a
-			// tie-breaker never joins the round (it can never reach
-			// Suspended: raising requires an UpToDate disk).
+			// diskless leg never joins as a peer (a diskless Primary is
+			// always the coordinator: it sees st.Primary and everyone
+			// else defers on st.PeerPrimary).
 			for _, rep := range vol.Spec.DiskfulReplicas() {
 				if rep.Node != r.NodeName {
 					s.Status.PerNode[rep.Node] = miroirv1alpha1.SnapshotPending
@@ -686,10 +699,13 @@ func (r *SnapshotReconciler) resumeUnlessSiblingRound(ctx context.Context, snap 
 // does. A Secondary that sees its peer Primary must defer — both sides
 // claiming the role is a livelock: the replicas[0] Secondary re-raises a
 // barrier the Primary keeps expiring, and the Primary never takes its
-// own leg because coordinators don't. A promotion racing this choice can
-// still briefly yield two coordinators — recoverable by construction:
-// suspend-io is idempotent, the backends treat an existing snapshot as
-// success, and both sides resume.
+// own leg because coordinators don't. This holds for a DISKLESS Primary
+// too (a client leg or a staged tie-breaker): it coordinates leglessly,
+// and electing a diskful stand-in instead would cut legs the Primary
+// keeps writing into. A promotion racing this choice can still briefly
+// yield two coordinators — recoverable by construction: suspend-io is
+// idempotent, the backends treat an existing snapshot as success, and
+// both sides resume.
 func (r *SnapshotReconciler) isCoordinator(vol *miroirv1alpha1.MiroirVolume, st drbd.Status) bool {
 	return coordinatorFor(r.NodeName, vol, st)
 }
@@ -738,12 +754,14 @@ func replicaOn(vol *miroirv1alpha1.MiroirVolume, node string) bool {
 	})
 }
 
-// disklessOn checks whether the local replica (if any) is diskless — a
-// quorum-only tie-breaker that holds no backend data.
+// disklessOn checks whether the local leg (if any) is diskless — a
+// quorum-only tie-breaker or an ephemeral client leg, neither of which
+// holds backend data.
 func (r *SnapshotReconciler) disklessOn(vol *miroirv1alpha1.MiroirVolume) bool {
-	return slices.ContainsFunc(vol.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
-		return rep.Node == r.NodeName && rep.Diskless
-	})
+	return vol.Spec.ClientForNode(r.NodeName) != nil ||
+		slices.ContainsFunc(vol.Spec.Replicas, func(rep miroirv1alpha1.Replica) bool {
+			return rep.Node == r.NodeName && rep.Diskless
+		})
 }
 
 // patchOwnState records only this node's slot in the active snapshot barrier.

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -574,6 +574,136 @@ func TestSnapshotProceedsWithTieBreakerDown(t *testing.T) {
 	}
 }
 
+// Regression (issue #409): a volume whose DRBD Primary is a diskless
+// client leg (remote consumer) must still snapshot. The client node is
+// where writes originate, so IT coordinates: barrier first up, no leg to
+// cut, collect and resume. Before the fix nobody coordinated — every
+// diskful replica deferred on PeerPrimary and the client node never
+// entered the round — and the snapshot hung with no status at all.
+func TestSnapshotClientPrimaryCoordinatesLeglessly(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Clients = []miroirv1alpha1.VolumeClient{{Node: nodeC, NodeID: 2, Address: addrC}}
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeC: {DiskState: diskStateDiskless},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	// node-c holds the device open through its client leg: Primary,
+	// Diskless — the legless coordinator.
+	fbC := newFakeBackend()
+	feC := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateDiskless + `"}],
+		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected"}]}]`}
+	rC := &SnapshotReconciler{Client: c, NodeName: nodeC, Pools: poolsOf(fbC),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feC.run}}
+	// The diskful replicas see a peer Primary and defer.
+	feA := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected","peer-role":"Primary"}]}]`}
+	fbA := newFakeBackend()
+	rA := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fbA),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feA.run}}
+	feB := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected","peer-role":"Primary"}]}]`}
+	fbB := newFakeBackend()
+	rB := &SnapshotReconciler{Client: c, NodeName: nodeB, Pools: poolsOf(fbB),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feB.run}}
+
+	// Client coordinator opens the round: its barrier rises first.
+	reconcileSnap(t, rC, snapSnap1)
+	feC.calledWith(t, "drbdadm suspend-io pvc-1")
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	_ = c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got)
+	if !got.Status.IOSuspended || got.Status.PerNode[nodeC] != miroirv1alpha1.SnapshotSuspended {
+		t.Fatalf("client Primary must open the round: %+v", got.Status)
+	}
+
+	// Peers raise, cut, and the coordinator collects.
+	reconcileSnap(t, rA, snapSnap1)
+	reconcileSnap(t, rB, snapSnap1)
+	reconcileSnap(t, rA, snapSnap1)
+	reconcileSnap(t, rB, snapSnap1)
+	reconcileSnap(t, rC, snapSnap1)
+
+	if err := c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.ReadyToUse || got.Status.IOSuspended {
+		t.Fatalf("round must complete behind the client's barrier: %+v", got.Status)
+	}
+	feC.calledWith(t, "drbdadm resume-io pvc-1")
+	if len(fbC.snapCalls) != 0 {
+		t.Fatalf("the client holds no leg and must not touch a backend: %v", fbC.snapCalls)
+	}
+	if len(fbA.snapCalls) != 2 || fbA.snapCalls[1] != snapCallSnapshot ||
+		len(fbB.snapCalls) != 2 || fbB.snapCalls[1] != snapCallSnapshot {
+		t.Fatalf("both diskful legs must cut: %v / %v", fbA.snapCalls, fbB.snapCalls)
+	}
+}
+
+// A tie-breaker whose own node stages the volume (diskless replica,
+// DRBD Primary) coordinates the same legless way a client leg does.
+func TestSnapshotTieBreakerPrimaryCoordinates(t *testing.T) {
+	s := newScheme(t)
+	v := vol(volPvc1, nodeA, nodeB)
+	v.Spec.DRBD = &miroirv1alpha1.DRBDSpec{Port: 7000}
+	v.Spec.Replicas = append(v.Spec.Replicas, miroirv1alpha1.Replica{
+		Node: nodeC, NodeID: 2, Address: addrC, Diskless: true,
+	})
+	v.Status.PerNode = map[string]miroirv1alpha1.ReplicaStatus{
+		nodeA: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeB: {DeviceCreated: true, DiskState: diskStateUpToDate},
+		nodeC: {DiskState: diskStateDiskless},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(v, snapObj(snapSnap1, volPvc1, nodeA, nodeB, nodeC)).
+		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirVolume{}).
+		Build()
+
+	fbC := newFakeBackend()
+	feC := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Primary",
+		"devices":[{"disk-state":"` + diskStateDiskless + `"}],
+		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected"}]}]`}
+	rC := &SnapshotReconciler{Client: c, NodeName: nodeC, Pools: poolsOf(fbC),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feC.run}}
+	feA := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected","peer-role":"Primary"}]}]`}
+	rA := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feA.run}}
+	feB := &fakeDRBDExec{statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary","suspended-user":true,
+		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
+		"connections":[{"connection-state":"Connected"},{"connection-state":"Connected","peer-role":"Primary"}]}]`}
+	rB := &SnapshotReconciler{Client: c, NodeName: nodeB, Pools: poolsOf(newFakeBackend()),
+		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feB.run}}
+
+	reconcileSnap(t, rC, snapSnap1)
+	reconcileSnap(t, rA, snapSnap1)
+	reconcileSnap(t, rB, snapSnap1)
+	reconcileSnap(t, rA, snapSnap1)
+	reconcileSnap(t, rB, snapSnap1)
+	reconcileSnap(t, rC, snapSnap1)
+
+	got := &miroirv1alpha1.MiroirSnapshot{}
+	if err := c.Get(t.Context(), types.NamespacedName{Name: snapSnap1}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.ReadyToUse || got.Status.IOSuspended {
+		t.Fatalf("round must complete behind the tie-breaker's barrier: %+v", got.Status)
+	}
+	if len(fbC.snapCalls) != 0 {
+		t.Fatalf("the tie-breaker holds no leg and must not touch a backend: %v", fbC.snapCalls)
+	}
+}
+
 // A peer raising its barrier must record only its own slot, never the
 // coordinator's round fields: a full-status apply could revert a resume or
 // void the coordinator raced, re-freezing IO or resurrecting a stale leg.


### PR DESCRIPTION
Fixes #409.

## The bug

A CSI snapshot of a volume whose DRBD Primary is a **diskless leg** hung forever with no status, no event, and no log line:

- Every diskful replica saw `PeerPrimary` and deferred in `coordinatorFor` — the design says the Primary coordinates, because suspend-io only blocks writes where they originate.
- The Primary was a client leg (`spec.clients`), so its node's snapshot reconciler exited at the `replicaOn` gate and never entered the round.
- Nobody coordinated → the round never opened → the default switch branch requeued every 2s silently, and `CreateSnapshot` kept reporting `ready_to_use: false` with no error for external-snapshotter to surface.

The tie-breaker variant of the same hang existed too: a pod staging through the tie-breaker leg made it Primary, `coordinatorFor` elected it, and the `healthy` gate (`DiskState == UpToDate`, never true for a diskless leg) blocked it from ever opening the round.

## The fix

The diskless Primary joins the round as a **legless coordinator** — the shape the issue's "preferred" option asked for:

- Its barrier rises first (writes originate there) and the filesystem freeze runs on its node (the mount lives there — this also makes remote-consumer snapshots fs-consistent for the first time; previously the #291 freeze ran only on replica nodes, where nothing is mounted).
- The diskful replicas cut behind its barrier, it collects, resumes, and publishes `readyToUse`.
- It never touches a backend: no cut, no pool preflight, deletion short-circuits like a tie-breaker's.

This is small for the standalone round because a diskless Primary is *always* the coordinator (it sees `st.Primary`; everyone else defers on `st.PeerPrimary`), so no peer-side machinery is needed: admit client legs at the gate, waive the local `UpToDate` term of `healthy` for legless nodes, and gate the raise-as-peer/cut cases on `diskfulOn`.

**The group round needs more**: a non-`vol0` member's diskless Primary sits on a node that is *not* the driver, and the driver cannot observe a remote DRBD role live. The driver records the expectation at round open as a `Pending` slot for every diskless leg whose published status shows Primary (`primarySince`); the cut gate then blocks on those slots exactly like diskful ones, and the leg's node raises for its `Pending` slots alongside its diskful legs. Guard rails:

- Slots are matched against the **live spec**, so a leg unstaged mid-round stops blocking the moment it leaves `spec.clients`.
- Only `Pending` ever blocks a cut; voids demote dead `Pending` expectations to `Error` so they cannot leak into the next round's gate.
- Idle (Secondary, unslotted) diskless legs never enter the round, so tie-breaker nodes are not churned by every group on the cluster.
- A mid-round `autoDiskfulAfter` conversion is naturally fenced: the fresh leg is `Inconsistent`, the `healthy` gate blocks cutting until the full-sync completes, and the deadline/retry machinery does the rest.

A diskless Primary of `vol0` itself drives the group round directly (it observes the volume through its own leg; the old "cannot even observe" restriction only applies to nodes with no leg at all).

## Tests

- `TestSnapshotClientPrimaryCoordinatesLeglessly` — the issue's exact repro: client-leg Primary, full round, backend untouched on the client node, both diskful legs cut.
- `TestSnapshotTieBreakerPrimaryCoordinates` — the tie-breaker variant.
- `TestGroupSnapshotWaitsForRemoteClientPrimary` — group round with a remote client Primary on a non-driver member: cut blocks until the client's barrier records, then completes and lifts it.

Full unit suite green with `-race` (linux via podman), `golangci-lint` clean.

## Docs

- `remote-consumers.md`: new trade-off bullet stating snapshots work and are coordinated through the consumer.
- `replication.md`: tie-breaker "no part in snapshots" claim narrowed to "no snapshot leg", with the staged-Primary caveat.

Not included (possible follow-up): the issue's "minimum" fail-loud path (a `SnapshotBlocked` condition surfaced as a CSI error) — with the preferred fix in place the blocked state no longer exists, so I left the error-surfacing scaffolding out.