### PR TITLE
fix(csi): round volume sizes up to the 512-byte sector LVM requires

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -113,6 +113,31 @@ func TestLVMThinCreateIdempotent(t *testing.T) {
 	fe.calledWith(t, "lvchange --activate y vg-miroir/pvc-1")
 }
 
+// A misaligned size still reaching the backend (a CR spec from before the
+// controller aligned requests) must not be handed to lvm verbatim: it
+// refuses sizes that are not 512-byte multiples (#413).
+func TestLVMThinCreateAlignsToSector(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lvs vg-miroir/pvc-1", "", errors.New("Failed to find logical volume"))
+	b := newLVMThin(cfg, fe.run)
+
+	if _, err := b.Create(t.Context(), "pvc-1", 10<<30+1); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "--virtualsize 10737418752b")
+}
+
+func TestLVMThinResizeAlignsToSector(t *testing.T) {
+	fe := &fakeExec{}
+	fe.respond("lv_size", "  10737418240\n", nil)
+	b := newLVMThin(cfg, fe.run)
+
+	if err := b.Resize(t.Context(), "pvc-1", 10<<30+1); err != nil {
+		t.Fatal(err)
+	}
+	fe.calledWith(t, "lvextend --size 10737418752b")
+}
+
 func TestLVMThinResizeSkipsWhenBigEnough(t *testing.T) {
 	fe := &fakeExec{}
 	fe.respond("lv_size", "  10737418240\n", nil)

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -25,6 +25,12 @@ import (
 	"time"
 )
 
+// lvmSectorSize is the granularity lvcreate/lvextend require byte sizes to
+// be multiples of. The controller aligns requests already; aligning here
+// too covers CR specs that predate it (#413), and rounding up keeps the
+// "realize at least the requested size" contract.
+const lvmSectorSize = 512
+
 // lvmThin provisions thin LVs in a dm-thin pool.
 type lvmThin struct {
 	vg       string
@@ -188,7 +194,7 @@ func (l *lvmThin) Create(ctx context.Context, vol string, sizeBytes int64) (stri
 	if !ok {
 		_, err = l.lvm(ctx, "lvcreate",
 			"--type", "thin",
-			"--virtualsize", fmt.Sprintf("%db", sizeBytes),
+			"--virtualsize", fmt.Sprintf("%db", alignSize(sizeBytes, lvmSectorSize)),
 			"--thinpool", l.pool,
 			"--name", vol,
 			"--setactivationskip", "n",
@@ -217,7 +223,7 @@ func (l *lvmThin) Resize(ctx context.Context, vol string, sizeBytes int64) error
 		return nil // already big enough (idempotent retry)
 	}
 	if _, err := l.lvm(ctx, "lvextend",
-		"--size", fmt.Sprintf("%db", sizeBytes),
+		"--size", fmt.Sprintf("%db", alignSize(sizeBytes, lvmSectorSize)),
 		l.ref(vol)); err != nil {
 		return fmt.Errorf("lvextend %s to %d: %w", vol, sizeBytes, err)
 	}

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -154,6 +154,15 @@ func (c *Controller) ControllerGetCapabilities(_ context.Context, _ *csi.Control
 	return resp, nil
 }
 
+// sectorSize is the granularity LVM sizes must be multiples of; PVC sizes
+// carry no such guarantee (1G = 10^9).
+const sectorSize = 512
+
+// alignSector rounds sizeBytes up to the next sector multiple.
+func alignSector(sizeBytes int64) int64 {
+	return (sizeBytes + sectorSize - 1) &^ (sectorSize - 1)
+}
+
 // CreateVolume provisions a MiroirVolume and waits until its agents report
 // Ready. Idempotent by volume name.
 func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
@@ -169,12 +178,22 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	if sizeBytes == 0 {
 		sizeBytes = 1 << 30 // spec allows omitting capacity_range; pick a sane floor
 		if limitBytes > 0 && limitBytes < sizeBytes {
-			sizeBytes = limitBytes
+			// No required floor to honor here, so a misaligned limit
+			// rounds down — up would overshoot the only bound given.
+			sizeBytes = limitBytes &^ (sectorSize - 1)
+			if sizeBytes == 0 {
+				return nil, status.Errorf(codes.OutOfRange,
+					"limit %d is below the %d-byte sector size", limitBytes, sectorSize)
+			}
 		}
 	}
+	// LVM refuses sizes that are not sector multiples (#413). Round up once,
+	// before the size is stored or compared anywhere, so the CR spec, the
+	// overcommit accounting, and the reported PV capacity all agree.
+	sizeBytes = alignSector(sizeBytes)
 	if limitBytes > 0 && sizeBytes > limitBytes {
 		return nil, status.Errorf(codes.OutOfRange,
-			"required %d exceeds limit %d", sizeBytes, limitBytes)
+			"required %d (sector-aligned) exceeds limit %d", sizeBytes, limitBytes)
 	}
 
 	params, err := parseClassParams(req.GetParameters())
@@ -1081,7 +1100,9 @@ func (c *Controller) handleCreateErr(ctx context.Context, err error, vol *miroir
 	if first := existing.Spec.FirstDiskfulReplica(); first != nil {
 		existingPool = nodemap.PoolOrDefault(first.Pool)
 	}
-	if existing.Spec.SizeBytes != sizeBytes || existingDiskful != replicas ||
+	// Sizes compare sector-aligned: a CR predating the alignment in
+	// CreateVolume can hold the raw misaligned size of this same request.
+	if alignSector(existing.Spec.SizeBytes) != sizeBytes || existingDiskful != replicas ||
 		(replicas > 1 && existing.Spec.QuorumPolicy != quorum) ||
 		existingSource != sourceSnapshot || existingPool != pool ||
 		(existing.Spec.Export != nil) != (vol.Spec.Export != nil) {
@@ -1089,6 +1110,16 @@ func (c *Controller) handleCreateErr(ctx context.Context, err error, vol *miroir
 			"volume %s exists with size=%d diskful=%d quorum=%s source=%q pool=%s rwx=%t (requested size=%d replicas=%d quorum=%s source=%q pool=%s rwx=%t)",
 			vol.Name, existing.Spec.SizeBytes, existingDiskful, existing.Spec.QuorumPolicy, existingSource, existingPool, existing.Spec.Export != nil,
 			sizeBytes, replicas, quorum, sourceSnapshot, pool, vol.Spec.Export != nil)
+	}
+	if existing.Spec.SizeBytes < sizeBytes {
+		// Pre-alignment CR: its agents keep refusing the stored misaligned
+		// size, so growing the spec to the aligned size is what lets the
+		// wedged volume finally provision on this retry.
+		base := existing.DeepCopy()
+		existing.Spec.SizeBytes = sizeBytes
+		if err := c.Client.Patch(ctx, existing, client.MergeFrom(base)); err != nil {
+			return status.Errorf(codes.Unavailable, "align size of existing volume %s: %v", vol.Name, err)
+		}
 	}
 	*vol = *existing
 	return nil
@@ -1473,6 +1504,7 @@ func (c *Controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	if newSize == 0 {
 		return nil, status.Error(codes.InvalidArgument, "capacity range is required")
 	}
+	newSize = alignSector(newSize) // lvextend refuses misaligned sizes, as lvcreate does
 	vol := &miroirv1alpha1.MiroirVolume{}
 	if err := c.Client.Get(ctx, types.NamespacedName{Name: req.GetVolumeId()}, vol); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -207,6 +207,86 @@ func TestCreateVolumeIdempotent(t *testing.T) {
 	}
 }
 
+// Requested sizes align up to the 512-byte sector before they are stored or
+// compared anywhere: LVM refuses misaligned sizes outright (#413).
+func TestCreateVolumeAlignsSizeToSector(t *testing.T) {
+	cases := []struct {
+		name     string
+		rng      *csi.CapacityRange
+		wantCode codes.Code
+		wantSize int64
+	}{
+		{"misaligned required rounds up", &csi.CapacityRange{RequiredBytes: 1<<30 + 1}, codes.OK, 1<<30 + 512},
+		{"aligned required unchanged", &csi.CapacityRange{RequiredBytes: 1 << 30, LimitBytes: 1 << 30}, codes.OK, 1 << 30},
+		{"rounded size exceeds limit", &csi.CapacityRange{RequiredBytes: 1<<30 + 1, LimitBytes: 1<<30 + 1}, codes.OutOfRange, 0},
+		{"limit-only rounds down", &csi.CapacityRange{LimitBytes: 1<<30 - 1}, codes.OK, 1<<30 - 512},
+		{"limit-only below sector size", &csi.CapacityRange{LimitBytes: 100}, codes.OutOfRange, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newScheme(t)
+			c := &Controller{Client: readyOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+			resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+				Name:               volPvc1,
+				VolumeCapabilities: volCaps(),
+				CapacityRange:      tc.rng,
+			})
+			if status.Code(err) != tc.wantCode {
+				t.Fatalf("code = %v, want %v (err %v)", status.Code(err), tc.wantCode, err)
+			}
+			if tc.wantCode != codes.OK {
+				return
+			}
+			if resp.Volume.CapacityBytes != tc.wantSize {
+				t.Fatalf("capacity = %d, want %d", resp.Volume.CapacityBytes, tc.wantSize)
+			}
+			vol := &miroirv1alpha1.MiroirVolume{}
+			if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volPvc1}, vol); err != nil {
+				t.Fatal(err)
+			}
+			if vol.Spec.SizeBytes != tc.wantSize {
+				t.Fatalf("spec size = %d, want %d", vol.Spec.SizeBytes, tc.wantSize)
+			}
+		})
+	}
+}
+
+// A CR created before the controller aligned sizes still holds the raw
+// misaligned request (wedged on lvmthin, healthy on zfs/loopfile). The
+// idempotent retry must adopt it as the same request and grow its spec to
+// the aligned size so a wedged agent's lvcreate finally succeeds.
+func TestCreateVolumeAdoptsPreAlignmentCR(t *testing.T) {
+	s := newScheme(t)
+	existing := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 1<<30 + 1,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
+		},
+	}
+	c := &Controller{Client: readyOnGet(s, existing), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
+
+	resp, err := c.CreateVolume(t.Context(), &csi.CreateVolumeRequest{
+		Name:               volPvc1,
+		VolumeCapabilities: volCaps(),
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: 1<<30 + 1},
+	})
+	if err != nil {
+		t.Fatalf("retry of the same misaligned request must adopt the CR: %v", err)
+	}
+	if resp.Volume.CapacityBytes != 1<<30+512 {
+		t.Fatalf("capacity = %d, want %d", resp.Volume.CapacityBytes, 1<<30+512)
+	}
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volPvc1}, vol); err != nil {
+		t.Fatal(err)
+	}
+	if vol.Spec.SizeBytes != 1<<30+512 {
+		t.Fatalf("existing spec must grow to the aligned size, got %d", vol.Spec.SizeBytes)
+	}
+}
+
 func TestCreateVolumeSucceedsWhenDegraded(t *testing.T) {
 	s := newScheme(t)
 	c := &Controller{Client: degradedOnGet(s), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
@@ -740,6 +820,46 @@ func TestControllerExpandSucceedsOnceRealized(t *testing.T) {
 	}
 	if resp.CapacityBytes != 10<<30 {
 		t.Fatalf("stale request must report the larger spec size, got %d", resp.CapacityBytes)
+	}
+}
+
+// Expansion aligns like creation: lvextend refuses misaligned sizes (#413).
+func TestControllerExpandAlignsSizeToSector(t *testing.T) {
+	s := newScheme(t)
+	v := &miroirv1alpha1.MiroirVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Spec: miroirv1alpha1.MiroirVolumeSpec{
+			SizeBytes: 5 << 30,
+			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
+		},
+		Status: miroirv1alpha1.MiroirVolumeStatus{
+			PerNode: map[string]miroirv1alpha1.ReplicaStatus{
+				nodeA: {SizeBytes: 6 << 30}, // already realized past the target
+			},
+		},
+	}
+	c := &Controller{
+		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(v).
+			WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).Build(),
+		ProvisionTimeout: time.Second,
+	}
+
+	resp, err := c.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
+		VolumeId:      volPvc1,
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 5<<30 + 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.CapacityBytes != 5<<30+512 {
+		t.Fatalf("capacity = %d, want %d", resp.CapacityBytes, 5<<30+512)
+	}
+	vol := &miroirv1alpha1.MiroirVolume{}
+	if err := c.Client.Get(t.Context(), types.NamespacedName{Name: volPvc1}, vol); err != nil {
+		t.Fatal(err)
+	}
+	if vol.Spec.SizeBytes != 5<<30+512 {
+		t.Fatalf("spec size = %d, want %d", vol.Spec.SizeBytes, 5<<30+512)
 	}
 }
 


### PR DESCRIPTION
Fixes #413.

`lvcreate --virtualsize` and `lvextend --size` refuse byte sizes that are not multiples of 512, so a PVC requesting e.g. `1073741825` (1Gi + 1) failed hard on lvmthin pools: the agent's lvcreate exits 3, the MiroirVolume wedges in `Failed`, and the PVC stays `Pending` retrying forever. Expansion to a misaligned size hit the same wall.

### What changed

- **`CreateVolume` / `ControllerExpandVolume` align the requested size up to the next 512-byte multiple once, early** — before it is stored or compared anywhere — so the CR spec, the create-idempotency check, the snapshot/clone size floors, the overcommit accounting, and the reported PV capacity all agree. Rounding up satisfies the CSI `required_bytes` contract (provision at least the request).
- **`limit_bytes` is checked against the rounded size** and returns `OutOfRange` when rounding overshoots it (e.g. required = limit = a misaligned value is unsatisfiable). The limit-only default branch (`required_bytes` unset, limit < 1Gi) instead rounds the limit *down*: there is no required floor to honor there, and rounding up would fail a satisfiable request. A limit below 512 is `OutOfRange`.
- **The create-idempotency check compares sector-aligned, and grows a pre-alignment CR's spec to the aligned size.** CRs created before this change can hold the raw misaligned size — wedged on lvmthin, healthy on zfs/loopfile (those backends tolerate misalignment internally). Without this, the retry of a wedged PVC would flip to a spurious `AlreadyExists` after upgrading; with it, the spec grows to the aligned size and the volume provisions on the external-provisioner's next retry, no manual deletion needed.
- **The lvmthin backend also aligns defensively** in `Create`/`Resize`, covering any pre-alignment spec that still reaches an agent (and keeping the "realize at least the requested size" contract the zfs `alignSize` comment relies on).

Alignment is to the 512-byte sector, not the thin-pool chunk size: lvcreate only requires sector alignment and LVM rounds allocation to the chunk internally (and chunk sizes aren't necessarily powers of two, so the bitmask helper wouldn't apply to them anyway).

The `ResourceExhausted` misclassification of hard agent failures noted in the issue is left for a separate issue, as proposed there — this change makes the trigger unreachable.

### Tests

- Controller: table-driven alignment cases (misaligned required rounds up into spec + response capacity, rounded-over-limit → `OutOfRange`, limit-only rounds down, limit < 512 → `OutOfRange`), pre-alignment CR adoption + spec grow on idempotent retry, and expansion alignment.
- Backend: lvcreate/lvextend receive the aligned size for a misaligned input.

Full unit suite + the upstream csi-test sanity suite pass (linux via podman), `golangci-lint` 2.12.2 clean.