### PR TITLE
fix(go): update to go 1.27.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,3 +1,9 @@
+# go-backend tools (controller-gen, govulncheck) type-check the stdlib of the
+# toolchain that compiled them, so they must be built with the pinned go above,
+# not the older toolchain their own go.mod would resolve via GOTOOLCHAIN=auto.
+[env]
+GOTOOLCHAIN = "local"
+
 [tools]
 actionlint = "1.7.12"
 go = "1.27.0"
@@ -7,7 +13,7 @@ helm = "4.2.4"
 cosign = "3.1.3"
 helm-docs = "1.14.2"
 jq = "1.8.2"
-kube-controller-tools = "0.21.0"
+"go:sigs.k8s.io/controller-tools/cmd/controller-gen" = "v0.21.0"
 kubectl = "1.36.3"
 lefthook = "2.1.10"
 oxfmt = "0.63.0"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,8 +1,8 @@
 [tools]
 actionlint = "1.7.12"
-go = "1.26.6"
+go = "1.27.0"
 "go:golang.org/x/vuln/cmd/govulncheck" = "v1.7.0"
-golangci-lint = "2.12.2"
+golangci-lint = "2.13.0"
 helm = "4.2.4"
 cosign = "3.1.3"
 helm-docs = "1.14.2"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -86,45 +86,45 @@ url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/50328620
 provenance = "cosign"
 
 [[tools.go]]
-version = "1.26.6"
+version = "1.27.0"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e"
-url = "https://dl.google.com/go/go1.26.6.linux-arm64.tar.gz"
+checksum = "sha256:51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda"
+url = "https://dl.google.com/go/go1.27.0.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89"
-url = "https://dl.google.com/go/go1.26.6.linux-amd64.tar.gz"
+checksum = "sha256:675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685"
+url = "https://dl.google.com/go/go1.27.0.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:2dc95ce4675829f2df0e86b28bcef3283635902062a5f0580ca659bf570f3204"
-url = "https://dl.google.com/go/go1.26.6.darwin-arm64.tar.gz"
+checksum = "sha256:90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e"
+url = "https://dl.google.com/go/go1.27.0.darwin-arm64.tar.gz"
 
 [[tools."go:golang.org/x/vuln/cmd/govulncheck"]]
 version = "1.7.0"
 backend = "go:golang.org/x/vuln/cmd/govulncheck"
 
 [[tools.golangci-lint]]
-version = "2.12.2"
+version = "2.13.0"
 backend = "aqua:golangci/golangci-lint"
 
 [tools.golangci-lint."platforms.linux-arm64"]
-checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
+checksum = "sha256:3a91c7bb9c135099a97858bea431d6dd2f54e4bf68d479c776c2350428d60e41"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471362"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
-checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
+checksum = "sha256:a10e8d8359d76b9e2b41da60f9d98bb26fd53c7a453caa82e0a172d6f72fd2ca"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471346"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
-checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
+checksum = "sha256:72eae670097978e61b78a773a25c27439e35d54094fd986cee5eeeb25d7144fd"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471400"
 provenance = "github-attestations"
 
 [[tools.helm]]

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -105,6 +105,10 @@ url = "https://dl.google.com/go/go1.27.0.darwin-arm64.tar.gz"
 version = "1.7.0"
 backend = "go:golang.org/x/vuln/cmd/govulncheck"
 
+[[tools."go:sigs.k8s.io/controller-tools/cmd/controller-gen"]]
+version = "0.21.0"
+backend = "go:sigs.k8s.io/controller-tools/cmd/controller-gen"
+
 [[tools.golangci-lint]]
 version = "2.13.0"
 backend = "aqua:golangci/golangci-lint"
@@ -183,25 +187,6 @@ checksum = "sha256:2d75340ba57a4b4b4c8708a21c2dc8e958a48aaa8bba13b27f77f6e4c0eca
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-macos-arm64"
 url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012783"
 provenance = "github-attestations"
-
-[[tools.kube-controller-tools]]
-version = "0.21.0"
-backend = "github:kubernetes-sigs/controller-tools"
-
-[tools.kube-controller-tools."platforms.linux-arm64"]
-checksum = "sha256:1af64bb144658c61f1b61c6392e17d56dd4f7364497625613ff435d7e468f60b"
-url = "https://github.com/kubernetes-sigs/controller-tools/releases/download/v0.21.0/controller-gen-linux-arm64"
-url_api = "https://api.github.com/repos/kubernetes-sigs/controller-tools/releases/assets/413514955"
-
-[tools.kube-controller-tools."platforms.linux-x64"]
-checksum = "sha256:3ec7994b7a41515a7ad8aef8e517429c0a78060df59d5587ac8662db6a8b035f"
-url = "https://github.com/kubernetes-sigs/controller-tools/releases/download/v0.21.0/controller-gen-linux-amd64"
-url_api = "https://api.github.com/repos/kubernetes-sigs/controller-tools/releases/assets/413514957"
-
-[tools.kube-controller-tools."platforms.macos-arm64"]
-checksum = "sha256:13ac7abcd90dd2129da972024bea7da5be7df2c5404c8f715010490996f4ab43"
-url = "https://github.com/kubernetes-sigs/controller-tools/releases/download/v0.21.0/controller-gen-darwin-arm64"
-url_api = "https://api.github.com/repos/kubernetes-sigs/controller-tools/releases/assets/413514954"
 
 [[tools.kubectl]]
 version = "1.36.3"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,7 +38,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -696,7 +695,7 @@ func main() {
 			drbdEvents = make(chan event.GenericEvent, 64)
 			watcher := &drbd.EventWatcher{Notify: func(ctx context.Context, resource string) {
 				ev := event.GenericEvent{Object: &miroirv1alpha1.MiroirVolume{
-					ObjectMeta: metav1.ObjectMeta{Name: resource},
+					Name: resource,
 				}}
 				select {
 				case drbdEvents <- ev:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/miroir
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/internal/agent/cordon_test.go
+++ b/internal/agent/cordon_test.go
@@ -22,9 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -35,8 +33,8 @@ func TestCordonWatcherTracksUnschedulable(t *testing.T) {
 		t.Fatal(err)
 	}
 	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeA},
-		Spec:       corev1.NodeSpec{Unschedulable: true},
+		Name: nodeA,
+		Spec: corev1.NodeSpec{Unschedulable: true},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(node).Build()
 	w := &CordonWatcher{Client: c, NodeName: nodeA}
@@ -44,7 +42,7 @@ func TestCordonWatcherTracksUnschedulable(t *testing.T) {
 	if w.Cordoned() {
 		t.Fatal("must default to not cordoned before any observation")
 	}
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: nodeA}}
+	req := ctrl.Request{Name: nodeA}
 	if _, err := w.Reconcile(t.Context(), req); err != nil {
 		t.Fatal(err)
 	}
@@ -74,14 +72,14 @@ func TestCordonWatcherSyncsSentinel(t *testing.T) {
 		t.Fatal(err)
 	}
 	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeA},
-		Spec:       corev1.NodeSpec{Unschedulable: true},
+		Name: nodeA,
+		Spec: corev1.NodeSpec{Unschedulable: true},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(node).Build()
 	sentinel := filepath.Join(t.TempDir(), "sub", "cordoned")
 	w := &CordonWatcher{Client: c, NodeName: nodeA, SentinelPath: sentinel}
 
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: nodeA}}
+	req := ctrl.Request{Name: nodeA}
 	if _, err := w.Reconcile(t.Context(), req); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/groupsnapshot_test.go
+++ b/internal/agent/groupsnapshot_test.go
@@ -59,16 +59,12 @@ func memberObj(name, volume string) *miroirv1alpha1.MiroirSnapshot {
 
 func groupObj() *miroirv1alpha1.MiroirSnapshotGroup {
 	return &miroirv1alpha1.MiroirSnapshotGroup{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: miroirv1alpha1.GroupVersion.String(),
-			Kind:       "MiroirSnapshotGroup",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: groupG1,
-			Finalizers: []string{
-				constants.FinalizerPrefix + nodeA,
-				constants.FinalizerPrefix + nodeB,
-			},
+		APIVersion: miroirv1alpha1.GroupVersion.String(),
+		Kind:       "MiroirSnapshotGroup",
+		Name:       groupG1,
+		Finalizers: []string{
+			constants.FinalizerPrefix + nodeA,
+			constants.FinalizerPrefix + nodeB,
 		},
 		Spec: miroirv1alpha1.MiroirSnapshotGroupSpec{
 			SnapshotNames: []string{memberOf1, memberOf2},
@@ -90,7 +86,7 @@ func groupClient(t *testing.T, objs ...client.Object) client.WithWatch {
 func reconcileGroup(t *testing.T, r *GroupSnapshotReconciler) ctrl.Result {
 	t.Helper()
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: groupG1}})
+		ctrl.Request{Name: groupG1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +274,7 @@ func TestGroupFailedSuspendLiftsKernelFlag(t *testing.T) {
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: groupG1}}); err == nil {
+		ctrl.Request{Name: groupG1}); err == nil {
 		t.Fatal("the failed raise must surface as an error for the fast backoff")
 	}
 	// The half-raised leg resumes as before; the failed leg itself must
@@ -409,7 +405,7 @@ func TestGroupAndSingleRoundsExclude(t *testing.T) {
 	rS := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: feS.run}}
 	resS, err := rS.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}})
+		ctrl.Request{Name: snapSnap1})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
@@ -56,7 +55,7 @@ func hasSeries(t *testing.T, family, volume string) bool {
 // metricsVol is an unlabeled volume: its series fall back to the CR name
 // as the pvc label.
 func metricsVol(name string) *miroirv1alpha1.MiroirVolume {
-	return &miroirv1alpha1.MiroirVolume{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	return &miroirv1alpha1.MiroirVolume{Name: name}
 }
 
 const familyUpToDate = "miroir_volume_up_to_date"

--- a/internal/agent/phase_test.go
+++ b/internal/agent/phase_test.go
@@ -34,7 +34,7 @@ const oneOfOne = "1/1"
 
 func phaseVolume(probedAt time.Time) *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA}},
@@ -68,7 +68,7 @@ func TestPhaseReconcilerDegradesVolumeWhenAllAgentsAreStale(t *testing.T) {
 		Build()
 	r := &PhaseReconciler{Client: cl}
 
-	res, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: vol.Name}})
+	res, err := r.Reconcile(t.Context(), ctrl.Request{Name: vol.Name})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestPhaseReconcilerSchedulesFreshProbeExpiry(t *testing.T) {
 		Build()
 	r := &PhaseReconciler{Client: cl}
 
-	res, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: vol.Name}})
+	res, err := r.Reconcile(t.Context(), ctrl.Request{Name: vol.Name})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestPhaseReconcilerClearsLingeringNodeUnreachable(t *testing.T) {
 		Build()
 	r := &PhaseReconciler{Client: cl}
 
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: vol.Name}}); err != nil {
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{Name: vol.Name}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,7 +148,7 @@ func TestPhaseReconcilerClearsLingeringNodeUnreachable(t *testing.T) {
 // must clear the condition here too, not only on Ready.
 func degradedReachableVolume(name string) *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			DRBD:      &miroirv1alpha1.DRBDSpec{},
@@ -192,7 +192,7 @@ func TestPhaseReconcilerClearsNodeUnreachableOnDegradedButReachable(t *testing.T
 		Build()
 	r := &PhaseReconciler{Client: cl}
 
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: vol.Name}}); err != nil {
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{Name: vol.Name}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -225,7 +225,7 @@ func TestPhaseReconcilerKeepsNodeUnreachableWhileProbesStale(t *testing.T) {
 		Build()
 	r := &PhaseReconciler{Client: cl}
 
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: vol.Name}}); err != nil {
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{Name: vol.Name}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/agent/poolstats_test.go
+++ b/internal/agent/poolstats_test.go
@@ -41,7 +41,7 @@ func newPublisher(t *testing.T, pools Pools, rec events.EventRecorder) (*PoolSta
 	// status only and never creates or mutates the spec.
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithStatusSubresource(&miroirv1alpha1.MiroirNode{}).
-		WithObjects(&miroirv1alpha1.MiroirNode{ObjectMeta: metav1.ObjectMeta{Name: nodeA}}).
+		WithObjects(&miroirv1alpha1.MiroirNode{Name: nodeA}).
 		Build()
 	p := &PoolStatsPublisher{
 		Client:   c,

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -201,15 +201,11 @@ func vol(name string, nodes ...string) *miroirv1alpha1.MiroirVolume {
 		finalizers = append(finalizers, constants.FinalizerPrefix+n)
 	}
 	return &miroirv1alpha1.MiroirVolume{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: miroirv1alpha1.GroupVersion.String(),
-			Kind:       "MiroirVolume",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Finalizers: finalizers,
-		},
-		Spec: miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 1 << 30, Replicas: replicas},
+		APIVersion: miroirv1alpha1.GroupVersion.String(),
+		Kind:       "MiroirVolume",
+		Name:       name,
+		Finalizers: finalizers,
+		Spec:       miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 1 << 30, Replicas: replicas},
 	}
 }
 
@@ -217,7 +213,7 @@ func vol(name string, nodes ...string) *miroirv1alpha1.MiroirVolume {
 func reconcile(t *testing.T, r *VolumeReconciler, name string) {
 	t.Helper()
 	_, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: name}})
+		ctrl.Request{Name: name})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +297,7 @@ func TestReconcileUnknownPoolFails(t *testing.T) {
 	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err == nil {
+		ctrl.Request{Name: volPvc1}); err == nil {
 		t.Fatal("unknown pool must error the reconcile")
 	}
 	got := &miroirv1alpha1.MiroirVolume{}
@@ -343,7 +339,7 @@ func TestReconcileReportsBackendError(t *testing.T) {
 	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
 
 	_, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err == nil {
 		t.Fatal("expected error to requeue")
 	}
@@ -417,7 +413,7 @@ func TestReconcileSourceSnapshotGoneAndDeviceMissingParks(t *testing.T) {
 	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb), Recorder: rec}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatalf("an impossible restore must park, not error: %v", err)
 	}
@@ -484,7 +480,7 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 	}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +521,7 @@ func TestReconcileReplicatedVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm resize --assume-clean pvc-1")
@@ -580,7 +576,7 @@ func TestReconcile_RestoreToLargerResizesBackingAfterAttach(t *testing.T) {
 	}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -648,7 +644,7 @@ func TestReconcilePaddedRestoreGrowsCloneBeforeCreateMD(t *testing.T) {
 	}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -698,7 +694,7 @@ func TestReconcilePaddedRestoreFullSyncJoinerPadsBacking(t *testing.T) {
 	}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -783,7 +779,7 @@ func TestReconcilePaddedRestoreSeedMintsGeneration(t *testing.T) {
 	}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -819,7 +815,7 @@ func TestReconcilePaddedRestoreSeedMintRefusesWhenPeerHasData(t *testing.T) {
 	}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -849,7 +845,7 @@ func TestReconcilePaddedRestoreSeedDemotesInterruptedMint(t *testing.T) {
 	}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -909,7 +905,7 @@ func TestReconcile_StatusApplyScopedToOwnSlot(t *testing.T) {
 	}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -974,7 +970,7 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 	}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatalf("a resync in progress must not surface as a reconcile error: %v", err)
 	}
 	fe.notCalledWith(t, "drbdadm resize")
@@ -990,7 +986,7 @@ func TestReconcile_SkipResizeDuringResync(t *testing.T) {
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected","peer_devices":[{"replication-state":"Established"}]}]}]`
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 	fe.calledWith(t, "drbdadm resize --assume-clean pvc-1")
@@ -1052,7 +1048,7 @@ func TestReconcile_ResizeRaceWithResyncIsTransient(t *testing.T) {
 	}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatalf("a resize that raced a resync must not fail the reconcile: %v", err)
 	}
@@ -1386,7 +1382,7 @@ func TestReconcileTeardownDownHeldOpenRetries(t *testing.T) {
 	}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatalf("held-open must be a requeue, not an error: %v", err)
 	}
@@ -1425,7 +1421,7 @@ func TestReconcileTeardownBusyEscalates(t *testing.T) {
 		Client: c, NodeName: nodeA, Pools: poolsOf(fb), Recorder: rec,
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+	req := ctrl.Request{Name: volPvc1}
 
 	for i := 1; i < busyFailLimit; i++ {
 		res, err := r.Reconcile(t.Context(), req)
@@ -1514,7 +1510,7 @@ func TestReconcileBusyStreakResetsOutsideTeardown(t *testing.T) {
 	r = &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb),
 		busyFails: map[string]int{volPvc1: busyFailLimit - 1}}
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil || res.RequeueAfter != 30*time.Second {
 		t.Fatalf("want the 30s removal-blocked requeue, got %v / %v", res.RequeueAfter, err)
 	}
@@ -1585,7 +1581,7 @@ func drainEvents(rec *events.FakeRecorder, substr string) bool {
 func TestReconcileTeardownOrphanHoldReclaims(t *testing.T) {
 	procDir := procFixture(t, map[int]string{1: unrelatedMountinfo})
 	r, fb, fe, rec := orphanHoldFixture(t, procDir)
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+	req := ctrl.Request{Name: volPvc1}
 
 	// Ride the whole busy escalation first: the orphan proof must not
 	// pre-empt a hold NodeUnstage could still release.
@@ -1634,7 +1630,7 @@ func TestReconcileTeardownOrphanHoldReclaims(t *testing.T) {
 func TestReconcileTeardownOrphanHoldLiveOpenerStaysParked(t *testing.T) {
 	procDir := procFixture(t, map[int]string{4242424: unrelatedMountinfo})
 	r, fb, fe, _ := orphanHoldFixture(t, procDir)
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+	req := ctrl.Request{Name: volPvc1}
 
 	for range busyFailLimit + 1 {
 		if _, err := r.Reconcile(t.Context(), req); err != nil {
@@ -1660,7 +1656,7 @@ func TestReconcileTeardownOrphanHoldMountedStaysParked(t *testing.T) {
 		4321: drbd1422Mountinfo,
 	})
 	r, fb, fe, _ := orphanHoldFixture(t, procDir)
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+	req := ctrl.Request{Name: volPvc1}
 
 	for range busyFailLimit + 1 {
 		if _, err := r.Reconcile(t.Context(), req); err != nil {
@@ -1686,7 +1682,7 @@ func TestReconcileTeardownOrphanHoldMountedStaysParked(t *testing.T) {
 func TestReconcileTeardownLiveConsumerEmitsEvent(t *testing.T) {
 	procDir := procFixture(t, map[int]string{4242424: unrelatedMountinfo})
 	r, fb, fe, rec := orphanHoldFixture(t, procDir)
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+	req := ctrl.Request{Name: volPvc1}
 
 	// Ride up to busyFailLimit — orphanHold returns false (pid 4242424 alive).
 	for i := 1; i < busyFailLimit; i++ {
@@ -1750,7 +1746,7 @@ func TestReconcileTeardownWedgedParksRetry(t *testing.T) {
 		DRBD: &drbd.Driver{StateDir: stateDir, Exec: fe.run, Mknod: func(string, uint32, int) error { return nil }},
 	}
 	t.Cleanup(func() { dropVolumeMetrics(volPvc1) })
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}
+	req := ctrl.Request{Name: volPvc1}
 
 	// First sighting: the detach may still be draining — busy retry.
 	res, err := r.Reconcile(t.Context(), req)
@@ -1829,7 +1825,7 @@ func TestReconcileVolumeGoneDropsMetrics(t *testing.T) {
 	t.Cleanup(func() { dropVolumeMetrics(volPvc1) })
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatal(err)
 	}
 	if n := testutil.CollectAndCount(metricWedged); n != 0 {
@@ -2220,8 +2216,8 @@ func TestRealizeBackingRecloneInvalidatesForeignMetadataWipe(t *testing.T) {
 	v := vol(volPvc1, nodeA)
 	v.Spec.Source = &miroirv1alpha1.VolumeSource{SnapshotName: snapSnap1}
 	snap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: "source"},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: "source"},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(v, snap).Build()
 	fb := newFakeBackend()
@@ -2319,7 +2315,7 @@ func TestReconcileDisklessTieBreaker(t *testing.T) {
 	}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2827,7 +2823,7 @@ func TestReportErrorPreservesObservedState(t *testing.T) {
 		Build()
 	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
 	if err := c.Status().Patch(t.Context(), &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 	}, client.RawPatch(types.MergePatchType, []byte(`{
 		"status": {"perNode": {"`+nodeA+`": {
 			"deviceCreated": true, "sizeBytes": 1073741824, "connected": true
@@ -2870,7 +2866,7 @@ func removedReplicaVol() *miroirv1alpha1.MiroirVolume {
 func patchPeersUpToDate(t *testing.T, c client.Client, diskState string) {
 	t.Helper()
 	err := c.Status().Patch(t.Context(), &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 	}, client.RawPatch(types.MergePatchType, []byte(`{
 		"status": {"perNode": {
 			"node-b": {"deviceCreated": true, "diskState": "`+diskState+`", "connected": true},
@@ -2926,8 +2922,8 @@ func TestReconcileRemovalBlockedBySnapshot(t *testing.T) {
 	fb.created[volPvc1] = 1 << 30
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(removedReplicaVol(), &miroirv1alpha1.MiroirSnapshot{
-			ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-			Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volPvc1},
+			Name: snapSnap1,
+			Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volPvc1},
 		}).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
@@ -2935,7 +2931,7 @@ func TestReconcileRemovalBlockedBySnapshot(t *testing.T) {
 	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2966,7 +2962,7 @@ func TestReconcileRemovalBlockedByDegradedPeer(t *testing.T) {
 	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2993,7 +2989,7 @@ func TestReconcileWaitsForIncompleteEntry(t *testing.T) {
 	r := &VolumeReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(fb)}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3812,7 +3808,7 @@ func TestReconcileBirthMintErrorRetries(t *testing.T) {
 	r, fe, _ := birthSetup(t, nodeA, 1, birthReadyJSON)
 	fe.errOn = map[string]error{"new-current-uuid": errors.New("exit status 1")}
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err == nil {
+		ctrl.Request{Name: volPvc1}); err == nil {
 		t.Fatal("a failed mint must surface as a reconcile error")
 	}
 	got := &miroirv1alpha1.MiroirVolume{}
@@ -3994,7 +3990,7 @@ func TestReconcileClientLegWaitsForMembership(t *testing.T) {
 	}
 
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}})
+		ctrl.Request{Name: volPvc1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4179,7 +4175,7 @@ func TestReconcileDRBDStatusProbeFailurePreservesLastProbedAt(t *testing.T) {
 
 	// The reconcile should fail (status probe error), returning an error.
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err == nil {
+		ctrl.Request{Name: volPvc1}); err == nil {
 		t.Fatal("DRBD status probe failure must surface as an error")
 	}
 

--- a/internal/agent/snapshot_test.go
+++ b/internal/agent/snapshot_test.go
@@ -54,12 +54,10 @@ func snapObj(name, volume string, nodes ...string) *miroirv1alpha1.MiroirSnapsho
 		finalizers = append(finalizers, constants.FinalizerPrefix+n)
 	}
 	return &miroirv1alpha1.MiroirSnapshot{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: miroirv1alpha1.GroupVersion.String(),
-			Kind:       "MiroirSnapshot",
-		},
-		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name), Finalizers: finalizers},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volume},
+		APIVersion: miroirv1alpha1.GroupVersion.String(),
+		Kind:       "MiroirSnapshot",
+		Name:       name, UID: types.UID(name), Finalizers: finalizers,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volume},
 	}
 }
 
@@ -67,7 +65,7 @@ func snapObj(name, volume string, nodes ...string) *miroirv1alpha1.MiroirSnapsho
 func reconcileSnap(t *testing.T, r *SnapshotReconciler, name string) ctrl.Result {
 	t.Helper()
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: name}})
+		ctrl.Request{Name: name})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +198,7 @@ func TestSnapshotBarrierStuckParksAfterLimit(t *testing.T) {
 	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}, Recorder: rec}
 
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}
+	req := ctrl.Request{Name: snapSnap1}
 	for i := 1; i < barrierFailLimit; i++ {
 		if _, err := r.Reconcile(t.Context(), req); err == nil {
 			t.Fatalf("failure %d must surface for the fast backoff", i)
@@ -250,7 +248,7 @@ func TestSnapshotFailedSuspendLiftsKernelFlag(t *testing.T) {
 	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}
+	req := ctrl.Request{Name: snapSnap1}
 	if _, err := r.Reconcile(t.Context(), req); err == nil {
 		t.Fatal("the failed raise must surface as an error for the fast backoff")
 	}
@@ -294,7 +292,7 @@ func TestSnapshotFailedSuspendDefersToSiblingRound(t *testing.T) {
 	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}}
 
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}
+	req := ctrl.Request{Name: snapSnap1}
 	if _, err := r.Reconcile(t.Context(), req); err == nil {
 		t.Fatal("the failed raise must surface as an error for the fast backoff")
 	}
@@ -323,7 +321,7 @@ func TestSnapshotStatusFailureParksAfterLimit(t *testing.T) {
 	r := &SnapshotReconciler{Client: c, NodeName: nodeA, Pools: poolsOf(newFakeBackend()),
 		DRBD: &drbd.Driver{StateDir: t.TempDir(), Exec: fe.run}, Recorder: rec}
 
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}
+	req := ctrl.Request{Name: snapSnap1}
 	for i := 1; i < barrierFailLimit; i++ {
 		if _, err := r.Reconcile(t.Context(), req); err == nil {
 			t.Fatalf("failure %d must surface for the fast backoff", i)
@@ -1394,9 +1392,9 @@ func TestSnapshotCollectDefersResumeToSiblingGroupRound(t *testing.T) {
 	member := snapObj("g1-"+volPvc1, volPvc1, nodeA, nodeB)
 	member.Spec.Group = "g1"
 	sibling := &miroirv1alpha1.MiroirSnapshotGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: "g1"},
-		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{member.Name}},
-		Status:     miroirv1alpha1.MiroirSnapshotGroupStatus{IOSuspended: true},
+		Name:   "g1",
+		Spec:   miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{member.Name}},
+		Status: miroirv1alpha1.MiroirSnapshotGroupStatus{IOSuspended: true},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snap, member, sibling).
@@ -1728,7 +1726,7 @@ func TestSnapshotSuspendFailureThawsFreeze(t *testing.T) {
 		Freezer: mountedFreezer(rec, map[string]string{devDrbd1000: mntStage1})}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: snapSnap1}}); err == nil {
+		ctrl.Request{Name: snapSnap1}); err == nil {
 		t.Fatal("a failed suspend must surface")
 	}
 	if calls := rec.recorded(); len(calls) != 2 ||

--- a/internal/agent/topologywatcher.go
+++ b/internal/agent/topologywatcher.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mount "k8s.io/mount-utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -155,7 +154,7 @@ func (w *TopologyWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	// no-ops when nothing drifted.
 	boot := make(chan event.GenericEvent, 1)
 	boot <- event.GenericEvent{Object: &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: w.NodeName},
+		Name: w.NodeName,
 	}}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&miroirv1alpha1.MiroirNode{}, builder.WithPredicates(own)).

--- a/internal/agent/topologywatcher_test.go
+++ b/internal/agent/topologywatcher_test.go
@@ -19,8 +19,6 @@ package agent
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -30,8 +28,8 @@ import (
 
 func watcherNode(pools ...miroirv1alpha1.MiroirNodePool) *miroirv1alpha1.MiroirNode {
 	return &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeA},
-		Spec:       miroirv1alpha1.MiroirNodeSpec{Pools: pools},
+		Name: nodeA,
+		Spec: miroirv1alpha1.MiroirNodeSpec{Pools: pools},
 	}
 }
 
@@ -68,7 +66,7 @@ func runWatcherMounts(t *testing.T, booted []miroirv1alpha1.MiroirNodePool,
 		IsMounted:   isMounted,
 	}
 	if _, err := w.Reconcile(t.Context(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: nodeA},
+		Name: nodeA,
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -236,12 +236,10 @@ func (c *Controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, err
 	}
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: req.GetName(),
-			Labels: constants.PVCRefLabels(
-				req.GetParameters()[paramPVCName],
-				req.GetParameters()[paramPVCNamespace]),
-		},
+		Name: req.GetName(),
+		Labels: constants.PVCRefLabels(
+			req.GetParameters()[paramPVCName],
+			req.GetParameters()[paramPVCNamespace]),
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: sizeBytes,
 			Replicas:  placed,
@@ -331,7 +329,7 @@ func (c *Controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return nil, status.Error(codes.InvalidArgument, "volume id is required")
 	}
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: req.GetVolumeId()},
+		Name: req.GetVolumeId(),
 	}
 	if err := c.Client.Delete(ctx, vol); err != nil && !apierrors.IsNotFound(err) {
 		return nil, status.Errorf(codes.Internal, "delete MiroirVolume: %v", err)
@@ -1603,8 +1601,8 @@ func (c *Controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 // reap it with the source.
 func (c *Controller) ensureSnapshot(ctx context.Context, name string, vol *miroirv1alpha1.MiroirVolume, group string, owned bool) (*miroirv1alpha1.MiroirSnapshot, error) {
 	snap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: vol.Name, Group: group},
+		Name: name,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: vol.Name, Group: group},
 	}
 	if owned {
 		snap.OwnerReferences = []metav1.OwnerReference{
@@ -1663,7 +1661,7 @@ func (c *Controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 	} else if !apierrors.IsNotFound(err) {
 		return nil, status.Errorf(codes.Internal, "get MiroirSnapshot: %v", err)
 	}
-	snap := &miroirv1alpha1.MiroirSnapshot{ObjectMeta: metav1.ObjectMeta{Name: req.GetSnapshotId()}}
+	snap := &miroirv1alpha1.MiroirSnapshot{Name: req.GetSnapshotId()}
 	if err := c.Client.Delete(ctx, snap); err != nil && !apierrors.IsNotFound(err) {
 		return nil, status.Errorf(codes.Internal, "delete MiroirSnapshot: %v", err)
 	}

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -259,7 +259,7 @@ func TestCreateVolumeAlignsSizeToSector(t *testing.T) {
 func TestCreateVolumeAdoptsPreAlignmentCR(t *testing.T) {
 	s := newScheme(t)
 	existing := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1<<30 + 1,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -428,7 +428,7 @@ func TestCreateVolumeRejectsRWXWhenDisabled(t *testing.T) {
 func TestValidateVolumeCapabilitiesRWXMismatch(t *testing.T) {
 	s := newScheme(t)
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA}},
@@ -463,7 +463,7 @@ func TestDeleteVolumeIdempotent(t *testing.T) {
 
 func nodeObj(name, ip string) *corev1.Node {
 	return &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: ip}},
 		},
@@ -746,7 +746,7 @@ func TestCreateVolumeAutoTieBreakerNoSpareNode(t *testing.T) {
 func TestControllerExpandRetryWaitsForRealization(t *testing.T) {
 	s := newScheme(t)
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 10 << 30, // a prior attempt already grew the spec
 			Replicas: []miroirv1alpha1.Replica{
@@ -779,7 +779,7 @@ func TestControllerExpandRetryWaitsForRealization(t *testing.T) {
 func TestControllerExpandSucceedsOnceRealized(t *testing.T) {
 	s := newScheme(t)
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 10 << 30,
 			Replicas: []miroirv1alpha1.Replica{
@@ -827,7 +827,7 @@ func TestControllerExpandSucceedsOnceRealized(t *testing.T) {
 func TestControllerExpandAlignsSizeToSector(t *testing.T) {
 	s := newScheme(t)
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -869,7 +869,7 @@ func TestControllerExpandAlignsSizeToSector(t *testing.T) {
 func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -882,8 +882,8 @@ func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 		},
 	}
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{
 				nodeA: miroirv1alpha1.SnapshotDone,
@@ -935,7 +935,7 @@ func TestCreateVolumeFromSnapshotCleansReplicas(t *testing.T) {
 func TestCreateVolumeFromSnapshotRefusesCrossPool(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas: []miroirv1alpha1.Replica{
@@ -944,8 +944,8 @@ func TestCreateVolumeFromSnapshotRefusesCrossPool(t *testing.T) {
 		},
 	}
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
@@ -985,7 +985,7 @@ func TestCreateVolumeFromSnapshotRefusesCrossPool(t *testing.T) {
 func TestCreateVolumeFromSnapshotAddressOverride(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -997,8 +997,8 @@ func TestCreateVolumeFromSnapshotAddressOverride(t *testing.T) {
 		},
 	}
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{
 				nodeA: miroirv1alpha1.SnapshotDone,
@@ -1051,7 +1051,7 @@ func TestCreateVolumeFromSnapshotAddressOverride(t *testing.T) {
 func TestCreateVolumeFromSnapshotFullSyncsPostSnapshotReplica(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1064,8 +1064,8 @@ func TestCreateVolumeFromSnapshotFullSyncsPostSnapshotReplica(t *testing.T) {
 	}
 	// The snapshot captured only node-a Done; node-b was added afterward.
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
@@ -1120,8 +1120,8 @@ func reshapeController(t *testing.T, srcVol *miroirv1alpha1.MiroirVolume) *Contr
 		done[rep.Node] = miroirv1alpha1.SnapshotDone
 	}
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: srcVol.Name},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: srcVol.Name},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{
 			ReadyToUse: true, SizeBytes: srcVol.Spec.SizeBytes, PerNode: done,
 		},
@@ -1171,7 +1171,7 @@ func restoreReq(replicas string) *csi.CreateVolumeRequest {
 // metadata only because every backing grows past the spec size.
 func TestCreateVolumeRestoreExpandsUnreplicatedSource(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -1217,7 +1217,7 @@ func TestCreateVolumeRestoreExpandsUnreplicatedSource(t *testing.T) {
 // refusing (or pinning a rotation artifact, #258).
 func TestCreateVolumeRestoreExpandTopologyOnSeedNode(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -1254,7 +1254,7 @@ func TestCreateVolumeRestoreExpandTopologyOnSeedNode(t *testing.T) {
 // already carry internal metadata).
 func TestCreateVolumeRestoreExpandsReplicatedSource(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1295,7 +1295,7 @@ func TestCreateVolumeRestoreExpandsReplicatedSource(t *testing.T) {
 // clone's embedded DRBD metadata becomes inert tail bytes.
 func TestCreateVolumeRestoreShrinksToUnreplicated(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1337,7 +1337,7 @@ func TestCreateVolumeRestoreShrinksToUnreplicated(t *testing.T) {
 
 func TestCreateVolumeRestoreShrinkHonorsSelectedTopology(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1370,7 +1370,7 @@ func TestCreateVolumeRestoreShrinkHonorsSelectedTopology(t *testing.T) {
 
 func TestCreateVolumeRestoreShrinkRefusesSelectedIncompleteLeg(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1410,7 +1410,7 @@ func TestCreateVolumeRestoreShrinkRefusesSelectedIncompleteLeg(t *testing.T) {
 // let the response topology re-place the consumer.
 func TestCreateVolumeRestoreShrinkRelocatesOffLeglessSelection(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1460,7 +1460,7 @@ func TestCreateVolumeRestoreShrinkRelocatesOffLeglessSelection(t *testing.T) {
 // requisite instead of the seed.
 func TestCreateVolumeRestoreShrinkRelocationHonorsRequisite(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1506,7 +1506,7 @@ func TestCreateVolumeRestoreShrinkRelocationHonorsRequisite(t *testing.T) {
 // id, not a positional one that would collide with the sparse kept set.
 func TestCreateVolumeRestoreShrinkPrefersDoneLegs(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1559,7 +1559,7 @@ func TestCreateVolumeRestoreShrinkPrefersDoneLegs(t *testing.T) {
 // bare spec, so its joiners must pad too.
 func TestCreateVolumeRestoreInheritsPadding(t *testing.T) {
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -1593,7 +1593,7 @@ func TestCreateVolumeAlreadyExistsCacheLagIsUnavailable(t *testing.T) {
 	// APIReader has the volume; the cached Client (interceptor) 404s it,
 	// simulating an informer that has not caught up.
 	existing := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -1612,7 +1612,7 @@ func TestCreateVolumeAlreadyExistsCacheLagIsUnavailable(t *testing.T) {
 	// Same shape as the existing volume, so handleCreateErr reaches the Get.
 	err := c.handleCreateErr(t.Context(),
 		apierrors.NewAlreadyExists(miroirv1alpha1.GroupVersion.WithResource("miroirvolumes").GroupResource(), volPvc1),
-		&miroirv1alpha1.MiroirVolume{ObjectMeta: metav1.ObjectMeta{Name: volPvc1}},
+		&miroirv1alpha1.MiroirVolume{Name: volPvc1},
 		5<<30, 1, miroirv1alpha1.QuorumLastManStanding, "", poolDefault)
 	if err != nil {
 		t.Fatalf("APIReader has the volume; compatible retry must succeed: %v", err)
@@ -1625,7 +1625,7 @@ func TestCreateVolumeAlreadyExistsCacheLagIsUnavailable(t *testing.T) {
 func TestMarkVolumeFormattedReadsThroughAPIReader(t *testing.T) {
 	s := newScheme(t)
 	existing := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -1704,15 +1704,15 @@ func TestCreateVolumeRefusalNamesAddressConflict(t *testing.T) {
 func TestCreateVolumeFromSnapshotEchoesContentSource(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 	}
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
@@ -1765,15 +1765,15 @@ func TestCreateVolumeFromSnapshotEchoesContentSource(t *testing.T) {
 func TestCreateVolumeFromSnapshotInheritsFormatted(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
 		},
 	}
 	srcSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{
 			ReadyToUse: true, SizeBytes: 5 << 30, SourceFormatted: true,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone},
@@ -1833,7 +1833,7 @@ func TestCreateVolumeRejectsFourReplicas(t *testing.T) {
 func TestCreateVolumeIdempotentRejectsSourceChange(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -1844,14 +1844,14 @@ func TestCreateVolumeIdempotentRejectsSourceChange(t *testing.T) {
 		t.Fatal(err)
 	}
 	snap1 := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
 	snap2 := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: "snap-2"},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: "snap-2",
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30,
 			PerNode: map[string]miroirv1alpha1.SnapshotNodeState{nodeA: miroirv1alpha1.SnapshotDone}},
 	}
@@ -2002,7 +2002,7 @@ func TestParseAllowRemoteAccess(t *testing.T) {
 func TestControllerExpandRefusesBeyondHeadroom(t *testing.T) {
 	s := newScheme(t)
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 10 << 30,
 			Replicas: []miroirv1alpha1.Replica{
@@ -2037,7 +2037,7 @@ func TestControllerExpandRefusesBeyondHeadroom(t *testing.T) {
 func TestControllerExpandAdmitsWithoutStats(t *testing.T) {
 	s := newScheme(t)
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 10 << 30,
 			Replicas: []miroirv1alpha1.Replica{
@@ -2072,15 +2072,15 @@ func TestControllerExpandAdmitsWithoutStats(t *testing.T) {
 func TestCreateSnapshotIdempotent(t *testing.T) {
 	s := newScheme(t)
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 10 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendZFS}},
 		},
 	}
 	other := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-2"},
-		Spec:       miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 1 << 30},
+		Name: "pvc-2",
+		Spec: miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 1 << 30},
 	}
 	c := &Controller{
 		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(v, other).
@@ -2118,8 +2118,8 @@ func TestListVolumesPagination(t *testing.T) {
 	objs := make([]client.Object, 0, 3)
 	for _, name := range []string{"pvc-b", "pvc-a", "pvc-c"} {
 		objs = append(objs, &miroirv1alpha1.MiroirVolume{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Spec:       miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 1 << 30},
+			Name: name,
+			Spec: miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 1 << 30},
 		})
 	}
 	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()}
@@ -2243,7 +2243,7 @@ func cloneReadyClient(s *runtime.Scheme, objs ...client.Object) client.WithWatch
 func TestCreateVolumeCloneCutsInternalSnapshot(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    5 << 30,
 			QuorumPolicy: miroirv1alpha1.QuorumFreeze,
@@ -2310,7 +2310,7 @@ func TestCreateVolumeCloneCutsInternalSnapshot(t *testing.T) {
 func TestCreateVolumeCloneIdempotent(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
@@ -2341,7 +2341,7 @@ func TestCreateVolumeCloneIdempotent(t *testing.T) {
 func TestCreateVolumeCloneShapeChecksRunBeforeCut(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
@@ -2412,22 +2412,20 @@ func TestCreateVolumeRejectsEmptyVolumeSourceID(t *testing.T) {
 func TestDeleteVolumeCleansCloneSourceSnapshot(t *testing.T) {
 	s := newScheme(t)
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volNew},
+		Name: volNew,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Source:    &miroirv1alpha1.VolumeSource{SnapshotName: constants.CloneSnapshotPrefix + volNew},
 		},
 	}
 	cloneSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            constants.CloneSnapshotPrefix + volNew,
-			OwnerReferences: []metav1.OwnerReference{volumeOwnerRef(volSrc)},
-		},
-		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name:            constants.CloneSnapshotPrefix + volNew,
+		OwnerReferences: []metav1.OwnerReference{volumeOwnerRef(volSrc)},
+		Spec:            miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 	}
 	userSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volNew},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volNew},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(vol, cloneSnap, userSnap).Build()
 	c := &Controller{Client: cl}
@@ -2458,21 +2456,19 @@ func TestCreateSnapshotRejectsReservedPrefix(t *testing.T) {
 func TestListSnapshotsHidesCloneSourceSnapshots(t *testing.T) {
 	s := newScheme(t)
 	userSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 	}
 	cloneSnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            constants.CloneSnapshotPrefix + volNew,
-			OwnerReferences: []metav1.OwnerReference{volumeOwnerRef(volSrc)},
-		},
-		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name:            constants.CloneSnapshotPrefix + volNew,
+		OwnerReferences: []metav1.OwnerReference{volumeOwnerRef(volSrc)},
+		Spec:            miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 	}
 	// Named like an internal snapshot but created before the prefix
 	// reservation: no owner reference, so it is the user's.
 	legacySnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + "legacy"},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: constants.CloneSnapshotPrefix + "legacy",
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 	}
 	c := &Controller{Client: fake.NewClientBuilder().WithScheme(s).WithObjects(userSnap, cloneSnap, legacySnap).Build()}
 
@@ -2496,14 +2492,14 @@ func TestListSnapshotsHidesCloneSourceSnapshots(t *testing.T) {
 func TestCreateVolumeCloneNameCollisionCutsNothing(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
 		},
 	}
 	taken := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volNew},
+		Name: volNew,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
@@ -2551,12 +2547,12 @@ func volumeOwnerRef(volume string) metav1.OwnerReference {
 func TestDeleteVolumeSparesLegacyPrefixedSnapshot(t *testing.T) {
 	s := newScheme(t)
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volNew},
-		Spec:       miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 5 << 30},
+		Name: volNew,
+		Spec: miroirv1alpha1.MiroirVolumeSpec{SizeBytes: 5 << 30},
 	}
 	legacySnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + volNew},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Name: constants.CloneSnapshotPrefix + volNew,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(vol, legacySnap).Build()
 	c := &Controller{Client: cl}
@@ -2575,16 +2571,16 @@ func TestDeleteVolumeSparesLegacyPrefixedSnapshot(t *testing.T) {
 func TestCreateVolumeCloneRefusesLegacyPrefixedSnapshot(t *testing.T) {
 	s := newScheme(t)
 	srcVol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volSrc},
+		Name: volSrc,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeB, Backend: miroirv1alpha1.BackendZFS}},
 		},
 	}
 	legacySnap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: constants.CloneSnapshotPrefix + volNew},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
-		Status:     miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
+		Name:   constants.CloneSnapshotPrefix + volNew,
+		Spec:   miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc},
+		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
 	}
 	c := &Controller{Client: cloneReadyClient(s, srcVol, legacySnap), Nodes: testNodes, ProvisionTimeout: 2 * time.Second}
 
@@ -2657,7 +2653,7 @@ func probeTime(offset time.Duration) *metav1.Time {
 // tests (2 diskful replicas, node-a lvmthin, node-b zfs).
 func volumeWithStatus(name string, perNode map[string]miroirv1alpha1.ReplicaStatus) *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas: []miroirv1alpha1.Replica{
@@ -2810,7 +2806,7 @@ func TestWaitReadyClearsNodeUnreachableCondition(t *testing.T) {
 	s := newScheme(t)
 	now := metav1.NewTime(time.Now().Truncate(time.Second))
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-clear"},
+		Name: "pvc-clear",
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas: []miroirv1alpha1.Replica{
@@ -2856,7 +2852,7 @@ func TestWaitReadyNoConditionOnDegraded(t *testing.T) {
 	s := newScheme(t)
 	rec := &testRecorder{}
 	vol := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-degraded"},
+		Name: "pvc-degraded",
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas: []miroirv1alpha1.Replica{
@@ -2988,8 +2984,8 @@ func TestWaitReadyAbsentPerNodeFreshHeartbeat(t *testing.T) {
 		nodeA: {SizeBytes: 5 << 30, LastProbedAt: probeTime(0)},
 	})
 	mn := &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeB},
-		Status:     miroirv1alpha1.MiroirNodeStatus{ObservedAt: probeTime(0)},
+		Name:   nodeB,
+		Status: miroirv1alpha1.MiroirNodeStatus{ObservedAt: probeTime(0)},
 	}
 	c := &Controller{
 		Client:           frozenClient(s, vol, mn),
@@ -3024,8 +3020,8 @@ func TestWaitReadyAbsentPerNodeStaleHeartbeat(t *testing.T) {
 		nodeA: {SizeBytes: 5 << 30, LastProbedAt: probeTime(0)},
 	})
 	mn := &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeB},
-		Status:     miroirv1alpha1.MiroirNodeStatus{ObservedAt: probeTime(-10 * time.Minute)},
+		Name:   nodeB,
+		Status: miroirv1alpha1.MiroirNodeStatus{ObservedAt: probeTime(-10 * time.Minute)},
 	}
 	c := &Controller{
 		Client:           frozenClient(s, vol, mn),

--- a/internal/csi/groupcontroller.go
+++ b/internal/csi/groupcontroller.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
@@ -103,8 +102,8 @@ func (c *Controller) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.Cre
 	}
 
 	grp := &miroirv1alpha1.MiroirSnapshotGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: req.GetName()},
-		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: names},
+		Name: req.GetName(),
+		Spec: miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: names},
 	}
 	// One finalizer per node holding any member leg: each agent lifts its
 	// local barriers before the round object disappears.
@@ -198,7 +197,7 @@ func (c *Controller) cleanupStrayMembers(ctx context.Context, names, owned []str
 		if slices.Contains(owned, name) {
 			continue
 		}
-		snap := &miroirv1alpha1.MiroirSnapshot{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		snap := &miroirv1alpha1.MiroirSnapshot{Name: name}
 		if err := c.Client.Delete(ctx, snap); err != nil && !apierrors.IsNotFound(err) {
 			log.Error(err, "cannot delete stray group member snapshot", "snapshot", name)
 		}
@@ -222,12 +221,12 @@ func (c *Controller) DeleteVolumeGroupSnapshot(ctx context.Context, req *csi.Del
 	if err != nil {
 		return nil, err
 	}
-	grp := &miroirv1alpha1.MiroirSnapshotGroup{ObjectMeta: metav1.ObjectMeta{Name: req.GetGroupSnapshotId()}}
+	grp := &miroirv1alpha1.MiroirSnapshotGroup{Name: req.GetGroupSnapshotId()}
 	if err := c.Client.Delete(ctx, grp); err != nil && !apierrors.IsNotFound(err) {
 		return nil, status.Errorf(codes.Internal, "delete MiroirSnapshotGroup: %v", err)
 	}
 	for _, name := range members {
-		snap := &miroirv1alpha1.MiroirSnapshot{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		snap := &miroirv1alpha1.MiroirSnapshot{Name: name}
 		if err := c.Client.Delete(ctx, snap); err != nil && !apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.Internal, "delete member MiroirSnapshot: %v", err)
 		}

--- a/internal/csi/groupcontroller_test.go
+++ b/internal/csi/groupcontroller_test.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +39,7 @@ const groupGsnap1 = "gsnap-1"
 
 func replicatedVol(name string, nodes ...string) *miroirv1alpha1.MiroirVolume {
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			DRBD:      &miroirv1alpha1.DRBDSpec{Port: 7000},
@@ -154,8 +153,8 @@ func TestCreateVolumeGroupSnapshotIdempotent(t *testing.T) {
 func TestCreateVolumeGroupSnapshotMismatchCreatesNothing(t *testing.T) {
 	s := newScheme(t)
 	existing := &miroirv1alpha1.MiroirSnapshotGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{groupGsnap1 + "-" + volNew}},
+		Name: groupGsnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{groupGsnap1 + "-" + volNew}},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(replicatedVol(volSrc, nodeA), existing).
@@ -185,8 +184,8 @@ func TestCreateVolumeGroupSnapshotMismatchCreatesNothing(t *testing.T) {
 func TestCreateVolumeGroupSnapshotConflictCleansStrayMembers(t *testing.T) {
 	s := newScheme(t)
 	winner := &miroirv1alpha1.MiroirSnapshotGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{groupGsnap1 + "-" + volSrc}},
+		Name: groupGsnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{groupGsnap1 + "-" + volSrc}},
 	}
 	groupGets := 0
 	cl := fake.NewClientBuilder().WithScheme(s).
@@ -283,7 +282,7 @@ func TestCreateVolumeGroupSnapshotPartialFailureCleansMembers(t *testing.T) {
 func TestCreateVolumeGroupSnapshotRejectsUnreplicated(t *testing.T) {
 	s := newScheme(t)
 	plain := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 5 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendZFS}},
@@ -323,14 +322,14 @@ func TestCreateVolumeGroupSnapshotMissingVolume(t *testing.T) {
 func TestGetVolumeGroupSnapshotReportsReadiness(t *testing.T) {
 	s := newScheme(t)
 	member := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1 + "-" + volSrc},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
-		Status:     miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
+		Name:   groupGsnap1 + "-" + volSrc,
+		Spec:   miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
+		Status: miroirv1alpha1.MiroirSnapshotStatus{ReadyToUse: true, SizeBytes: 5 << 30},
 	}
 	grp := &miroirv1alpha1.MiroirSnapshotGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{member.Name}},
-		Status:     miroirv1alpha1.MiroirSnapshotGroupStatus{ReadyToUse: true},
+		Name:   groupGsnap1,
+		Spec:   miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{member.Name}},
+		Status: miroirv1alpha1.MiroirSnapshotGroupStatus{ReadyToUse: true},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(member, grp).
 		WithStatusSubresource(&miroirv1alpha1.MiroirSnapshot{}, &miroirv1alpha1.MiroirSnapshotGroup{}).
@@ -365,12 +364,12 @@ func TestGetVolumeGroupSnapshotReportsReadiness(t *testing.T) {
 func TestDeleteVolumeGroupSnapshotDeletesMembersAndGroup(t *testing.T) {
 	s := newScheme(t)
 	m1 := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1 + "-" + volSrc},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
+		Name: groupGsnap1 + "-" + volSrc,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
 	}
 	grp := &miroirv1alpha1.MiroirSnapshotGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{m1.Name}},
+		Name: groupGsnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{m1.Name}},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(m1, grp).Build()
 	c := &Controller{Client: cl}
@@ -403,12 +402,12 @@ func TestDeleteVolumeGroupSnapshotDeletesMembersAndGroup(t *testing.T) {
 func TestDeleteVolumeGroupSnapshotDeletesGroupFirst(t *testing.T) {
 	s := newScheme(t)
 	m1 := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1 + "-" + volSrc},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
+		Name: groupGsnap1 + "-" + volSrc,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
 	}
 	grp := &miroirv1alpha1.MiroirSnapshotGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: groupGsnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{m1.Name}},
+		Name: groupGsnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotGroupSpec{SnapshotNames: []string{m1.Name}},
 	}
 	var deletes []string
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(m1, grp).
@@ -439,8 +438,8 @@ func TestDeleteVolumeGroupSnapshotDeletesGroupFirst(t *testing.T) {
 func TestDeleteVolumeGroupSnapshotRejectsForeignMember(t *testing.T) {
 	s := newScheme(t)
 	foreign := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: "other-group"},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: "other-group"},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(foreign).Build()
 	c := &Controller{Client: cl}
@@ -459,8 +458,8 @@ func TestDeleteVolumeGroupSnapshotRejectsForeignMember(t *testing.T) {
 func TestDeleteSnapshotRefusesGroupMember(t *testing.T) {
 	s := newScheme(t)
 	member := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: snapSnap1},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
+		Name: snapSnap1,
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volSrc, Group: groupGsnap1},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(member).Build()
 	c := &Controller{Client: cl}

--- a/internal/csi/health_test.go
+++ b/internal/csi/health_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
@@ -30,8 +29,8 @@ import (
 
 func volWithStatus(name string, phase miroirv1alpha1.VolumePhase, perNode map[string]miroirv1alpha1.ReplicaStatus) *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Status:     miroirv1alpha1.MiroirVolumeStatus{Phase: phase, PerNode: perNode},
+		Name:   name,
+		Status: miroirv1alpha1.MiroirVolumeStatus{Phase: phase, PerNode: perNode},
 	}
 }
 

--- a/internal/csi/node_test.go
+++ b/internal/csi/node_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	mount "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
@@ -56,7 +55,7 @@ func (f fakeDRBDStatus) Status(context.Context, string) (drbd.Status, error) {
 // has already created the local DRBD device.
 func stagedVolume() *miroirv1alpha1.MiroirVolume {
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			DRBD:      &miroirv1alpha1.DRBDSpec{Port: 7000},
@@ -234,8 +233,8 @@ func TestDevicePathActivatedIgnoresSplitSlot(t *testing.T) {
 // Service has a ClusterIP.
 func exportVolume(address string) *miroirv1alpha1.MiroirVolume {
 	v := &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
-		Spec:       miroirv1alpha1.MiroirVolumeSpec{Export: &miroirv1alpha1.ExportSpec{FSType: "ext4"}},
+		Name: volPvc1,
+		Spec: miroirv1alpha1.MiroirVolumeSpec{Export: &miroirv1alpha1.ExportSpec{FSType: "ext4"}},
 	}
 	if address != "" {
 		v.Status.Export = &miroirv1alpha1.ExportStatus{Address: address}
@@ -295,7 +294,7 @@ func TestDevicePathRefusesForeignNode(t *testing.T) {
 // allowed; this node (node-a) holds no replica.
 func remoteVolume() *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volPvc1},
+		Name: volPvc1,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:         1 << 30,
 			DRBD:              &miroirv1alpha1.DRBDSpec{Port: 7000},

--- a/internal/csi/placement_test.go
+++ b/internal/csi/placement_test.go
@@ -42,7 +42,7 @@ const gib = 1 << 30
 func miroirNodeObj(name string, capacity, allocated int64) *miroirv1alpha1.MiroirNode {
 	now := metav1.Now()
 	return &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Status: miroirv1alpha1.MiroirNodeStatus{
 			Pools: []miroirv1alpha1.MiroirNodePoolStatus{{
 				Name: poolDefault, CapacityBytes: capacity, AllocatedBytes: allocated,
@@ -55,7 +55,7 @@ func miroirNodeObj(name string, capacity, allocated int64) *miroirv1alpha1.Miroi
 // volOn builds a MiroirVolume placing one replica of the given size on node.
 func volOn(name, node string, sizeBytes int64) *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: sizeBytes,
 			Replicas:  []miroirv1alpha1.Replica{{Node: node, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -364,8 +364,8 @@ func multiPoolNodes() nodemap.Map {
 func miroirNodePools(name string, pools ...miroirv1alpha1.MiroirNodePoolStatus) *miroirv1alpha1.MiroirNode {
 	now := metav1.Now()
 	return &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Status:     miroirv1alpha1.MiroirNodeStatus{Pools: pools, ObservedAt: &now},
+		Name:   name,
+		Status: miroirv1alpha1.MiroirNodeStatus{Pools: pools, ObservedAt: &now},
 	}
 }
 
@@ -884,7 +884,7 @@ func TestPlaceBurstSpreadsSecondReplicas(t *testing.T) {
 		}
 		seconds = append(seconds, got[1].Node)
 		vol := &miroirv1alpha1.MiroirVolume{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Name: name,
 			Spec: miroirv1alpha1.MiroirVolumeSpec{
 				SizeBytes: 5 * gib,
 				Replicas:  []miroirv1alpha1.Replica{{Node: got[0].Node}, {Node: got[1].Node}},

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -23,7 +23,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -51,7 +50,7 @@ func exportVolume(name string, nodes ...string) *miroirv1alpha1.MiroirVolume {
 		reps[i] = miroirv1alpha1.Replica{Node: n, NodeID: int32(i)}
 	}
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID("uid-" + name)},
+		Name: name, UID: types.UID("uid-" + name),
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			Replicas:  reps,
@@ -77,7 +76,7 @@ func newReconciler(objs ...client.Object) (*Reconciler, client.Client) {
 
 func reconcile(t *testing.T, r *Reconciler, name string) {
 	t.Helper()
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{Name: name}); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
 }

--- a/internal/export/workloads.go
+++ b/internal/export/workloads.go
@@ -80,7 +80,7 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 	labels := shareLabels(vol.Name)
 	privileged := true
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: shareName(vol.Name), Namespace: namespace, Labels: labels},
+		Name: shareName(vol.Name), Namespace: namespace, Labels: labels,
 		Spec: appsv1.DeploymentSpec{
 			Replicas:             ptr.To[int32](1),
 			Strategy:             appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
@@ -127,9 +127,7 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 							},
 						},
 						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(nfsPort)},
-							},
+							TCPSocket:           &corev1.TCPSocketAction{Port: intstr.FromInt32(nfsPort)},
 							InitialDelaySeconds: 5,
 							PeriodSeconds:       10,
 						},
@@ -139,19 +137,15 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 						// while the gateway is still staging — a failover wait must
 						// not be liveness-killed — so no InitialDelay is needed.
 						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromInt32(httpPort)},
-							},
+							HTTPGet:          &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromInt32(httpPort)},
 							PeriodSeconds:    20,
 							TimeoutSeconds:   10,
 							FailureThreshold: 3,
 						},
 					}},
 					Volumes: []corev1.Volume{{
-						Name: "dev",
-						VolumeSource: corev1.VolumeSource{
-							HostPath: &corev1.HostPathVolumeSource{Path: "/dev", Type: ptr.To(corev1.HostPathDirectory)},
-						},
+						Name:     "dev",
+						HostPath: &corev1.HostPathVolumeSource{Path: "/dev", Type: ptr.To(corev1.HostPathDirectory)},
 					}},
 				},
 			},
@@ -166,7 +160,7 @@ func buildDeployment(vol *miroirv1alpha1.MiroirVolume, namespace, image, service
 func buildService(vol *miroirv1alpha1.MiroirVolume, namespace string) *corev1.Service {
 	labels := shareLabels(vol.Name)
 	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: shareName(vol.Name), Namespace: namespace, Labels: labels},
+		Name: shareName(vol.Name), Namespace: namespace, Labels: labels,
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
 			Selector: labels,

--- a/internal/membership/autodiskful_test.go
+++ b/internal/membership/autodiskful_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -50,7 +49,7 @@ func clientVol(age time.Duration) *miroirv1alpha1.MiroirVolume {
 func freshStats(free int64) *miroirv1alpha1.MiroirNode {
 	now := metav1.Now()
 	return &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeC},
+		Name: nodeC,
 		Status: miroirv1alpha1.MiroirNodeStatus{
 			Pools: []miroirv1alpha1.MiroirNodePoolStatus{{
 				Name: poolDefault, CapacityBytes: 100 << 30, AllocatedBytes: 100<<30 - free,
@@ -64,7 +63,7 @@ func freshStats(free int64) *miroirv1alpha1.MiroirNode {
 func reconcileAD(t *testing.T, r *AutoDiskfulReconciler, name string) ctrl.Result {
 	t.Helper()
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: name}})
+		ctrl.Request{Name: name})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/membership/autoevict_test.go
+++ b/internal/membership/autoevict_test.go
@@ -25,7 +25,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -47,7 +46,7 @@ const (
 func minAt(name string, age time.Duration, free int64) *miroirv1alpha1.MiroirNode {
 	at := metav1.NewTime(time.Now().Add(-age))
 	return &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: miroirv1alpha1.MiroirNodeSpec{
 			Pools: []miroirv1alpha1.MiroirNodePool{{
 				Name: poolDefault, ZFS: &miroirv1alpha1.ZFSPool{},
@@ -77,7 +76,7 @@ func evictVol() *miroirv1alpha1.MiroirVolume {
 func reconcileAE(t *testing.T, r *AutoEvictReconciler, name string) ctrl.Result {
 	t.Helper()
 	res, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: name}})
+		ctrl.Request{Name: name})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,8 +226,8 @@ func TestAutoEvictStandsDownWhenPeerConnected(t *testing.T) {
 // their CoW state, so eviction waits until they are gone.
 func TestAutoEvictBlocksOnSnapshot(t *testing.T) {
 	snap := &miroirv1alpha1.MiroirSnapshot{
-		ObjectMeta: metav1.ObjectMeta{Name: "snap-1"},
-		Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volPvc1},
+		Name: "snap-1",
+		Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: volPvc1},
 	}
 	r := newAE(t, evictVol(), snap,
 		minAt(nodeB, 2*time.Hour, 50<<30),
@@ -391,7 +390,7 @@ func TestAutoEvictValveIgnoresOptedOutNodes(t *testing.T) {
 // client — severed while the node is alive and doing IO.
 func TestAutoEvictStandsDownWhenNodeReady(t *testing.T) {
 	kubeletAlive := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeB},
+		Name: nodeB,
 		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
 			{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
 		}},
@@ -418,7 +417,7 @@ func TestAutoEvictStandsDownWhenNodeReady(t *testing.T) {
 // node the reconciler exists for.
 func TestAutoEvictProceedsWhenNodeNotReady(t *testing.T) {
 	kubeletDead := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeB},
+		Name: nodeB,
 		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
 			{Type: corev1.NodeReady, Status: corev1.ConditionUnknown},
 		}},

--- a/internal/membership/reconciler.go
+++ b/internal/membership/reconciler.go
@@ -332,7 +332,7 @@ func enqueueAllVolumes(c client.Client) handler.EventHandler {
 		reqs := make([]ctrl.Request, 0, len(list.Items))
 		for i := range list.Items {
 			reqs = append(reqs, ctrl.Request{
-				NamespacedName: types.NamespacedName{Name: list.Items[i].Name},
+				Name: list.Items[i].Name,
 			})
 		}
 		return reqs

--- a/internal/membership/reconciler_test.go
+++ b/internal/membership/reconciler_test.go
@@ -71,7 +71,7 @@ func newScheme(t *testing.T) *runtime.Scheme {
 //nolint:unparam // future tests will vary the name
 func node(name, ip string) *corev1.Node {
 	return &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
 			{Type: corev1.NodeInternalIP, Address: ip},
 		}},
@@ -82,12 +82,10 @@ func node(name, ip string) *corev1.Node {
 // operator-added node-c entry awaiting completion.
 func replicatedVol() *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pvc-1",
-			Finalizers: []string{
-				constants.FinalizerPrefix + "node-a",
-				constants.FinalizerPrefix + "node-b",
-			},
+		Name: "pvc-1",
+		Finalizers: []string{
+			constants.FinalizerPrefix + "node-a",
+			constants.FinalizerPrefix + "node-b",
 		},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
@@ -105,7 +103,7 @@ func replicatedVol() *miroirv1alpha1.MiroirVolume {
 func reconcile(t *testing.T, r *Reconciler, name string) {
 	t.Helper()
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		ctrl.Request{Name: name}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -306,7 +304,7 @@ func TestConflictedNodeStopsWithoutRequeue(t *testing.T) {
 	}}
 
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volPvc1}}); err != nil {
+		ctrl.Request{Name: volPvc1}); err != nil {
 		t.Fatalf("an address conflict must not requeue with backoff, got %v", err)
 	}
 	if got := get(t, r, volPvc1).Spec.Replicas[2]; got.Address != "" {
@@ -337,7 +335,7 @@ func TestRequeuesWhenNodeNotReady(t *testing.T) {
 			}}
 
 			if _, err := r.Reconcile(t.Context(),
-				ctrl.Request{NamespacedName: types.NamespacedName{Name: "pvc-1"}}); err == nil {
+				ctrl.Request{Name: "pvc-1"}); err == nil {
 				t.Fatal("transient completion failure must return an error to requeue")
 			}
 			if got := get(t, r, "pvc-1").Spec.Replicas[2]; got.Address != "" {
@@ -435,7 +433,7 @@ func TestCompletesReplicaAndClientWithDistinctIDs(t *testing.T) {
 // name, bound to a claim.
 func boundPV(volName, ns, claim string) *corev1.PersistentVolume {
 	return &corev1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: volName},
+		Name: volName,
 		Spec: corev1.PersistentVolumeSpec{
 			ClaimRef: &corev1.ObjectReference{Namespace: ns, Name: claim},
 			PersistentVolumeSource: corev1.PersistentVolumeSource{

--- a/internal/membership/tiebreaker_test.go
+++ b/internal/membership/tiebreaker_test.go
@@ -20,8 +20,6 @@ import (
 	"slices"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -43,12 +41,10 @@ const (
 // shape the tie-breaker reconciler retrofits.
 func freezeVol() *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: volTB,
-			Finalizers: []string{
-				constants.FinalizerPrefix + nodeA,
-				constants.FinalizerPrefix + nodeB,
-			},
+		Name: volTB,
+		Finalizers: []string{
+			constants.FinalizerPrefix + nodeA,
+			constants.FinalizerPrefix + nodeB,
 		},
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes:    1 << 30,
@@ -65,7 +61,7 @@ func freezeVol() *miroirv1alpha1.MiroirVolume {
 func tbReconcile(t *testing.T, r *TieBreakerReconciler) {
 	t.Helper()
 	if _, err := r.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volTB}}); err != nil {
+		ctrl.Request{Name: volTB}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -132,7 +128,7 @@ func TestTieBreakerWaitsForInFlightRemoval(t *testing.T) {
 	}}
 
 	res, err := tb.Reconcile(t.Context(),
-		ctrl.Request{NamespacedName: types.NamespacedName{Name: volTB}})
+		ctrl.Request{Name: volTB})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/nodemap/nodemap_test.go
+++ b/internal/nodemap/nodemap_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +43,7 @@ const (
 )
 
 func miroirNode(name string, spec miroirv1alpha1.MiroirNodeSpec) miroirv1alpha1.MiroirNode {
-	return miroirv1alpha1.MiroirNode{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: spec}
+	return miroirv1alpha1.MiroirNode{Name: name, Spec: spec}
 }
 
 func TestFromSpecFlattensBackendBlocks(t *testing.T) {
@@ -285,7 +284,7 @@ func TestReplicationAddress(t *testing.T) {
 	}
 	internalIP := func(name, ip string) *corev1.Node {
 		return &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Name: name,
 			Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
 				{Type: corev1.NodeInternalIP, Address: ip},
 			}},
@@ -309,7 +308,7 @@ func TestReplicationAddress(t *testing.T) {
 		},
 		"node without InternalIP errors": {
 			m:       Map{nodeA: {}},
-			client:  withNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeA}}),
+			client:  withNode(&corev1.Node{Name: nodeA}),
 			wantErr: true,
 		},
 		"absent node errors": {

--- a/internal/stage/stage_test.go
+++ b/internal/stage/stage_test.go
@@ -24,7 +24,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
@@ -53,7 +52,7 @@ func (r *restartingDRBD) Restart(_ context.Context, name string) error {
 
 func replicatedVolume() *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1"},
+		Name: "pvc-1",
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			DRBD: &miroirv1alpha1.DRBDSpec{Port: 7000},
 		},

--- a/internal/topology/conflict.go
+++ b/internal/topology/conflict.go
@@ -30,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -150,7 +149,7 @@ func (r *ConflictReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("topologyconflict").
 		Watches(&miroirv1alpha1.MiroirNode{}, handler.EnqueueRequestsFromMapFunc(
 			func(context.Context, client.Object) []ctrl.Request {
-				return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: topologyRequestKey}}}
+				return []ctrl.Request{{Name: topologyRequestKey}}
 			}), builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/topology/conflict_test.go
+++ b/internal/topology/conflict_test.go
@@ -58,7 +58,7 @@ func newClient(t *testing.T, objs ...client.Object) client.WithWatch {
 
 func addrNode(name, addr string) *miroirv1alpha1.MiroirNode {
 	return &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: miroirv1alpha1.MiroirNodeSpec{
 			Address: addr,
 			Pools: []miroirv1alpha1.MiroirNodePool{{
@@ -73,7 +73,7 @@ func reconcile(t *testing.T, c client.Client, name string) *miroirv1alpha1.Miroi
 	t.Helper()
 	r := &ConflictReconciler{Client: c}
 	if _, err := r.Reconcile(t.Context(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: name},
+		Name: name,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestConflictSinglePassCoversAllNodes(t *testing.T) {
 		addrNode(nodeC, "10.0.100.3"))
 	r := &ConflictReconciler{Client: c}
 	if _, err := r.Reconcile(t.Context(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: topologyRequestKey},
+		Name: topologyRequestKey,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestConflictOneBadNodeDoesNotBlockTheFleet(t *testing.T) {
 	})
 
 	r := &ConflictReconciler{Client: c}
-	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: topologyRequestKey}})
+	_, err := r.Reconcile(t.Context(), ctrl.Request{Name: topologyRequestKey})
 	if err == nil || !strings.Contains(err.Error(), nodeA) {
 		t.Fatalf("the per-node failure must surface with the node named, got %v", err)
 	}
@@ -220,7 +220,7 @@ func TestConflictEventFiresOncePerFreshConflict(t *testing.T) {
 	c := newClient(t, addrNode(nodeA, "10.0.100.1"), addrNode(nodeB, "10.0.100.1"))
 	rec := events.NewFakeRecorder(8)
 	r := &ConflictReconciler{Client: c, Recorder: rec}
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: topologyRequestKey}}
+	req := ctrl.Request{Name: topologyRequestKey}
 
 	if _, err := r.Reconcile(t.Context(), req); err != nil {
 		t.Fatal(err)

--- a/internal/topology/nodegroup.go
+++ b/internal/topology/nodegroup.go
@@ -142,11 +142,9 @@ func (r *NodeGroupReconciler) materialize(ctx context.Context, group *miroirv1al
 	desired := r.desiredSpec(group, node)
 	if current == nil {
 		mn := &miroirv1alpha1.MiroirNode{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   node.Name,
-				Labels: map[string]string{miroirv1alpha1.NodeGroupLabel: group.Name},
-			},
-			Spec: desired,
+			Name:   node.Name,
+			Labels: map[string]string{miroirv1alpha1.NodeGroupLabel: group.Name},
+			Spec:   desired,
 		}
 		// AlreadyExists is cache lag (often our own creation from the
 		// previous pass): surfacing it requeues, and the next pass

--- a/internal/topology/nodegroup_test.go
+++ b/internal/topology/nodegroup_test.go
@@ -42,14 +42,13 @@ const (
 )
 
 func k8sNode(name string, labels map[string]string, annotations map[string]string) *corev1.Node {
-	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{
-		Name: name, Labels: labels, Annotations: annotations,
-	}}
+	return &corev1.Node{
+		Name: name, Labels: labels, Annotations: annotations}
 }
 
 func nvmeGroup() *miroirv1alpha1.MiroirNodeGroup {
 	return &miroirv1alpha1.MiroirNodeGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: classNVMe},
+		Name: classNVMe,
 		Spec: miroirv1alpha1.MiroirNodeGroupSpec{
 			NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{classLabel: classNVMe}},
 			Template: miroirv1alpha1.MiroirNodeSpec{
@@ -66,7 +65,7 @@ func reconcileGroup(t *testing.T, c client.Client, name string) *miroirv1alpha1.
 	t.Helper()
 	r := &NodeGroupReconciler{Client: c}
 	if _, err := r.Reconcile(t.Context(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: name},
+		Name: name,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +143,7 @@ func TestNodeGroupRevertsManagedDrift(t *testing.T) {
 // reports the conflict.
 func TestNodeGroupSkipsDirectMiroirNode(t *testing.T) {
 	direct := &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeA}, // no provenance label
+		Name: nodeA, // no provenance label
 		Spec: miroirv1alpha1.MiroirNodeSpec{
 			Pools: []miroirv1alpha1.MiroirNodePool{{Name: poolDefault, ZFS: &miroirv1alpha1.ZFSPool{Dataset: "tank/miroir"}}},
 		},
@@ -247,7 +246,7 @@ func TestNodeGroupOneBadNodeDoesNotBlockTheFleet(t *testing.T) {
 	})
 
 	r := &NodeGroupReconciler{Client: c}
-	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: classNVMe}})
+	_, err := r.Reconcile(t.Context(), ctrl.Request{Name: classNVMe})
 	if err == nil || !strings.Contains(err.Error(), nodeB) {
 		t.Fatalf("the per-node failure must surface with the node named, got %v", err)
 	}
@@ -274,7 +273,7 @@ func TestNodeGroupOneBadNodeDoesNotBlockTheFleet(t *testing.T) {
 // conflicted node to a group: the next pass must take it over.
 func TestNodeGroupTakesOverAfterDirectDelete(t *testing.T) {
 	direct := &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeA},
+		Name: nodeA,
 		Spec: miroirv1alpha1.MiroirNodeSpec{
 			Pools: []miroirv1alpha1.MiroirNodePool{{Name: poolDefault, ZFS: &miroirv1alpha1.ZFSPool{Dataset: "tank/miroir"}}},
 		},

--- a/test/integration/crd_validation_test.go
+++ b/test/integration/crd_validation_test.go
@@ -45,7 +45,7 @@ const (
 // unreplicatedVolume is the minimal valid single-replica volume.
 func unreplicatedVolume(name string) *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			Replicas:  []miroirv1alpha1.Replica{{Node: nodeA, Backend: miroirv1alpha1.BackendLVMThin}},
@@ -58,7 +58,7 @@ func unreplicatedVolume(name string) *miroirv1alpha1.MiroirVolume {
 // rules must be tested in isolation.
 func replicatedVolume(name string) *miroirv1alpha1.MiroirVolume {
 	return &miroirv1alpha1.MiroirVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: miroirv1alpha1.MiroirVolumeSpec{
 			SizeBytes: 1 << 30,
 			Replicas: []miroirv1alpha1.Replica{
@@ -258,8 +258,8 @@ var _ = Describe("MiroirVolume CEL validation", func() {
 var _ = Describe("MiroirSnapshot CEL validation", func() {
 	It("rejects retargeting volumeName", func() {
 		snap := &miroirv1alpha1.MiroirSnapshot{
-			ObjectMeta: metav1.ObjectMeta{Name: "snap-retarget"},
-			Spec:       miroirv1alpha1.MiroirSnapshotSpec{VolumeName: "pvc-a"},
+			Name: "snap-retarget",
+			Spec: miroirv1alpha1.MiroirSnapshotSpec{VolumeName: "pvc-a"},
 		}
 		Expect(k8sClient.Create(ctx, snap)).To(Succeed())
 		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, snap)).To(Succeed()) })
@@ -274,8 +274,8 @@ var _ = Describe("MiroirSnapshot CEL validation", func() {
 // minimalNode is a valid single-pool MiroirNode for the CEL cases below.
 func minimalNode(name string, pool miroirv1alpha1.MiroirNodePool) *miroirv1alpha1.MiroirNode {
 	return &miroirv1alpha1.MiroirNode{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec:       miroirv1alpha1.MiroirNodeSpec{Pools: []miroirv1alpha1.MiroirNodePool{pool}},
+		Name: name,
+		Spec: miroirv1alpha1.MiroirNodeSpec{Pools: []miroirv1alpha1.MiroirNodePool{pool}},
 	}
 }
 
@@ -289,7 +289,7 @@ func lvmthinPool(name string) miroirv1alpha1.MiroirNodePool {
 var _ = Describe("MiroirNode CEL validation", func() {
 	It("accepts each backend with its own block and applies the zfs defaults", func() {
 		node := &miroirv1alpha1.MiroirNode{
-			ObjectMeta: metav1.ObjectMeta{Name: "min-valid"},
+			Name: "min-valid",
 			Spec: miroirv1alpha1.MiroirNodeSpec{
 				Zone:    "rack-1",
 				Address: "10.0.100.11",
@@ -388,7 +388,7 @@ var _ = Describe("MiroirNode CEL validation", func() {
 
 	It("rejects two pools sharing a backing", func() {
 		node := &miroirv1alpha1.MiroirNode{
-			ObjectMeta: metav1.ObjectMeta{Name: "min-shared-backing"},
+			Name: "min-shared-backing",
 			Spec: miroirv1alpha1.MiroirNodeSpec{Pools: []miroirv1alpha1.MiroirNodePool{
 				lvmthinPool("a"),
 				lvmthinPool("b"),
@@ -432,7 +432,7 @@ var _ = Describe("MiroirNode CEL validation", func() {
 	})
 
 	It("requires at least one pool", func() {
-		node := &miroirv1alpha1.MiroirNode{ObjectMeta: metav1.ObjectMeta{Name: "min-no-pools"}}
+		node := &miroirv1alpha1.MiroirNode{Name: "min-no-pools"}
 		Expect(apierrors.IsInvalid(k8sClient.Create(ctx, node))).To(BeTrue())
 	})
 })
@@ -440,7 +440,7 @@ var _ = Describe("MiroirNode CEL validation", func() {
 var _ = Describe("MiroirNodeGroup CEL rules", func() {
 	It("rejects an address in the template — it is a per-node fact", func() {
 		group := &miroirv1alpha1.MiroirNodeGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: "grp-addr"},
+			Name: "grp-addr",
 			Spec: miroirv1alpha1.MiroirNodeGroupSpec{
 				NodeSelector: metav1.LabelSelector{},
 				Template: miroirv1alpha1.MiroirNodeSpec{
@@ -456,7 +456,7 @@ var _ = Describe("MiroirNodeGroup CEL rules", func() {
 
 	It("accepts a template with pools and an empty selector, and validates the pool oneOf", func() {
 		group := &miroirv1alpha1.MiroirNodeGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: "grp-valid"},
+			Name: "grp-valid",
 			Spec: miroirv1alpha1.MiroirNodeGroupSpec{
 				NodeSelector: metav1.LabelSelector{},
 				Template: miroirv1alpha1.MiroirNodeSpec{
@@ -468,7 +468,7 @@ var _ = Describe("MiroirNodeGroup CEL rules", func() {
 		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, group)).To(Succeed()) })
 
 		blockless := &miroirv1alpha1.MiroirNodeGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: "grp-blockless"},
+			Name: "grp-blockless",
 			Spec: miroirv1alpha1.MiroirNodeGroupSpec{
 				NodeSelector: metav1.LabelSelector{},
 				Template: miroirv1alpha1.MiroirNodeSpec{
@@ -482,7 +482,7 @@ var _ = Describe("MiroirNodeGroup CEL rules", func() {
 
 	It("rejects a selector expression the reconciler could not compile", func() {
 		group := &miroirv1alpha1.MiroirNodeGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: "grp-badexpr"},
+			Name: "grp-badexpr",
 			Spec: miroirv1alpha1.MiroirNodeGroupSpec{
 				NodeSelector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      "storage.miroir.home-operations.com/class",
@@ -501,7 +501,7 @@ var _ = Describe("MiroirNodeGroup CEL rules", func() {
 
 	It("rejects a name longer than a label value — it becomes the provenance label", func() {
 		group := &miroirv1alpha1.MiroirNodeGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("g", 64)},
+			Name: strings.Repeat("g", 64),
 			Spec: miroirv1alpha1.MiroirNodeGroupSpec{
 				NodeSelector: metav1.LabelSelector{},
 				Template: miroirv1alpha1.MiroirNodeSpec{


### PR DESCRIPTION
Updates the toolchain to Go 1.27.0 and runs the `go fix` modernizers. Same rollout as echo#84, gatus-sidecar#177, containers#1777, external-dns-unifi-webhook#313, and chaski#129.

- Bump `go` to 1.27.0 in mise and go.mod, lockfile regenerated.
- Bump golangci-lint 2.12.2 → 2.13.0: 2.12.2 is built with go1.26 and refuses a 1.27 language target; 2.13.0 is built with go1.27.0.
- Apply the `embedlit` fixer from `go fix` (new 1.27 language feature: promoted fields of embedded structs as struct-literal keys), flattening `ObjectMeta: metav1.ObjectMeta{...}` wrappers across 30 files. The fix pass was run with `GOOS=linux` so the linux-only `internal/stage` and `internal/agent` packages are covered. No generated files (deepcopy/applyconfiguration) are touched.

Verified: `GOOS=linux go build ./...` + `go vet ./...`, `gofmt -l` (clean), `GOOS=linux golangci-lint run` (0 issues), the full unit-test suite in a linux `golang:1.27.0` container (all packages pass, including stage/agent), and `GOOS=linux govulncheck` (clean). Integration/e2e left to CI as usual.