### PR TITLE
fix(csi): never let staging reformat a device that carries a filesystem

### DIFF
--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -24,6 +24,7 @@ package stage
 
 import (
 	"context"
+	"errors"
 	"os"
 	"slices"
 	"strings"
@@ -33,6 +34,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	mount "k8s.io/mount-utils"
+	utilexec "k8s.io/utils/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
@@ -213,27 +215,42 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 				return status.Errorf(codes.DataLoss,
 					"volume %s was formatted before but %s reads blank — refusing to reformat", vol.Name, dev)
 			}
+			// Genuinely never formatted: FormatAndMount's mkfs-if-blank is
+			// safe here, its worst case is formatting a device that holds no
+			// data.
+			if err := d.Mounter.FormatAndMount(dev, target, fsType, xfsCloneMountFlags(vol, format, flags)); err != nil {
+				if rerr := recoverFrozenBdev(ctx, d, vol, dev, err); rerr != nil {
+					return rerr
+				}
+				return status.Errorf(codes.Internal, "format/mount %s: %v", dev, err)
+			}
+			// First mkfs. A failed patch fails the stage; the retry lands in
+			// the mount branch below and records it then.
+			if err := MarkFormatted(ctx, d.Client, vol); err != nil {
+				return status.Errorf(codes.Internal, "record formatted flag: %v", err)
+			}
 		} else {
+			// This probe is the format decision. FormatAndMount re-probes
+			// internally and answers a blank read with mkfs, and blkid cannot
+			// tell a blank device from one that is momentarily unreadable
+			// (exit status 2 either way) — under a DRBD peer-teardown storm
+			// that combination reformatted healthy replicas (issue #444). A
+			// device known to carry a filesystem is mounted without ever
+			// re-entering a path that can format.
+			//
 			// Record before mounting so a clone that arrived with a
 			// filesystem is protected from then on.
 			if err := MarkFormatted(ctx, d.Client, vol); err != nil {
 				return status.Errorf(codes.Internal, "record formatted flag: %v", err)
 			}
-		}
-
-		// FormatAndMount formats only when the device has no filesystem —
-		// the mkfs-if-blank step.
-		if err := d.Mounter.FormatAndMount(dev, target, fsType, xfsCloneMountFlags(vol, format, flags)); err != nil {
-			if rerr := recoverFrozenBdev(ctx, d, vol, dev, err); rerr != nil {
-				return rerr
+			if err := checkAndRepair(d, dev); err != nil {
+				return err
 			}
-			return status.Errorf(codes.Internal, "format/mount %s: %v", dev, err)
-		}
-		if format == "" {
-			// First mkfs. A failed patch fails the stage; the retry lands in
-			// the format != "" path above and records it then.
-			if err := MarkFormatted(ctx, d.Client, vol); err != nil {
-				return status.Errorf(codes.Internal, "record formatted flag: %v", err)
+			if err := d.Mounter.Mount(dev, target, fsType, xfsCloneMountFlags(vol, format, flags)); err != nil {
+				if rerr := recoverFrozenBdev(ctx, d, vol, dev, err); rerr != nil {
+					return rerr
+				}
+				return status.Errorf(codes.Internal, "mount %s: %v", dev, err)
 			}
 		}
 	} else {
@@ -266,6 +283,27 @@ func EnsureFilesystem(ctx context.Context, d Deps, vol *miroirv1alpha1.MiroirVol
 	// auto-recovery.
 	if err := MarkActivated(ctx, d.Client, vol); err != nil {
 		return status.Errorf(codes.Internal, "record activated flag: %v", err)
+	}
+	return nil
+}
+
+// fsckErrorsUncorrected is fsck's exit status for errors it found but
+// could not fix (mount-utils keeps the same constant unexported).
+const fsckErrorsUncorrected = 4
+
+// checkAndRepair is the pre-mount fsck FormatAndMount would have run on a
+// device that already carries a filesystem; it exists because the mount
+// branch above must bypass FormatAndMount (issue #444). Repairable issues
+// are fixed in place; only damage fsck reports as uncorrectable fails the
+// stage, and every other outcome (fsck missing, unsupported filesystem)
+// falls through to the mount, matching mount-utils' tolerances.
+func checkAndRepair(d Deps, dev string) error {
+	out, err := d.Mounter.Exec.Command("fsck", "-a", dev).CombinedOutput()
+	if err != nil {
+		if ee, ok := errors.AsType[utilexec.ExitError](err); ok && ee.ExitStatus() == fsckErrorsUncorrected {
+			return status.Errorf(codes.Internal,
+				"fsck found errors on %s it could not correct: %s", dev, out)
+		}
 	}
 	return nil
 }

--- a/internal/stage/stage_test.go
+++ b/internal/stage/stage_test.go
@@ -19,13 +19,21 @@ package stage
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	mount "k8s.io/mount-utils"
+	utilexec "k8s.io/utils/exec"
+	fakeexec "k8s.io/utils/exec/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
 	"github.com/home-operations/miroir/internal/drbd"
@@ -196,6 +204,164 @@ func TestFormattedBeforeRefusesToGuessOnAReadFailure(t *testing.T) {
 	_, err := formattedBefore(t.Context(), Deps{Reader: r}, restoredVolume())
 	if status.Code(err) != codes.Unavailable {
 		t.Fatalf("an unreadable flag must hand kubelet a retry, got %v", err)
+	}
+}
+
+// scriptedExec answers each command, in order, from script.
+func scriptedExec(script []fakeexec.FakeAction) *fakeexec.FakeExec {
+	fcmd := &fakeexec.FakeCmd{CombinedOutputScript: script}
+	fe := &fakeexec.FakeExec{}
+	for range script {
+		fe.CommandScript = append(fe.CommandScript,
+			func(cmd string, args ...string) utilexec.Cmd {
+				return fakeexec.InitFakeCmd(fcmd, cmd, args...)
+			})
+	}
+	return fe
+}
+
+func execOut(s string) fakeexec.FakeAction {
+	return func() ([]byte, []byte, error) { return []byte(s), nil, nil }
+}
+
+func execExit(code int) fakeexec.FakeAction {
+	return func() ([]byte, []byte, error) { return nil, nil, fakeexec.FakeExitError{Status: code} }
+}
+
+// ensureDeps builds Deps around a fake mounter, a scripted exec, and a
+// fake client holding vol.
+func ensureDeps(t *testing.T, vol *miroirv1alpha1.MiroirVolume, fm *mount.FakeMounter, fe *fakeexec.FakeExec) Deps {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := miroirv1alpha1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
+		WithObjects(vol).Build()
+	return Deps{Client: c, NodeName: "node-a", DRBD: statusOnlyDRBD{},
+		Mounter: mount.NewSafeFormatAndMount(fm, fe)}
+}
+
+// tempDev stands in for the block device: EnsureFilesystem's write probe
+// only needs something openable O_RDWR.
+func tempDev(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
+}
+
+// EnsureFilesystem's own probe is the format decision: a device that reads
+// a filesystem is mounted without re-entering FormatAndMount, whose internal
+// re-probe answers a momentarily unreadable device with mkfs (issue #444).
+// The bait entries would satisfy exactly that re-probe and mkfs; the stage
+// must never reach them.
+func TestEnsureFilesystemNeverReformatsAFormattedDevice(t *testing.T) {
+	vol := replicatedVolume()
+	fm := mount.NewFakeMounter(nil)
+	fe := scriptedExec([]fakeexec.FakeAction{
+		execOut("TYPE=ext4\n"), // blkid: the device carries a filesystem
+		execOut(""),            // fsck -a: clean
+		execOut("1\n"),         // blockdev --getro: read-only skips the resize path
+		execExit(2),            // bait: a re-probe reading the device blank
+		execOut(""),            // bait: the mkfs that must never run
+	})
+	d := ensureDeps(t, vol, fm, fe)
+	if err := EnsureFilesystem(t.Context(), d, vol, tempDev(t),
+		filepath.Join(t.TempDir(), "staging"), "ext4", nil); err != nil {
+		t.Fatal(err)
+	}
+	if fe.CommandCalls != 3 {
+		t.Fatalf("exec ran %d commands, want 3 (blkid, fsck, blockdev) and no mkfs", fe.CommandCalls)
+	}
+	log := fm.GetLog()
+	if len(log) != 1 || log[0].Action != mount.FakeActionMount {
+		t.Fatalf("expected exactly one mount, got %+v", log)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := d.Client.Get(t.Context(), types.NamespacedName{Name: vol.Name}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.Formatted || !got.Status.Activated {
+		t.Fatalf("flags must latch: formatted=%v activated=%v",
+			got.Status.Formatted, got.Status.Activated)
+	}
+}
+
+// A blank probe on a volume that ever carried a filesystem is refused, not
+// formatted — blkid cannot tell blank from unreadable.
+func TestEnsureFilesystemRefusesBlankFormattedVolume(t *testing.T) {
+	vol := replicatedVolume()
+	vol.Status.Formatted = true
+	fm := mount.NewFakeMounter(nil)
+	fe := scriptedExec([]fakeexec.FakeAction{
+		execExit(2), // blkid: blank (or unreadable — indistinguishable)
+		execOut(""), // bait: the mkfs that must never run
+	})
+	err := EnsureFilesystem(t.Context(), ensureDeps(t, vol, fm, fe), vol, tempDev(t),
+		filepath.Join(t.TempDir(), "staging"), "ext4", nil)
+	if status.Code(err) != codes.DataLoss {
+		t.Fatalf("a formatted volume reading blank must refuse with DataLoss, got %v", err)
+	}
+	if fe.CommandCalls != 1 {
+		t.Fatalf("exec ran %d commands, want 1 (blkid only)", fe.CommandCalls)
+	}
+	if log := fm.GetLog(); len(log) != 0 {
+		t.Fatalf("nothing may be mounted: %+v", log)
+	}
+}
+
+// A volume that never carried a filesystem still gets its one mkfs.
+func TestEnsureFilesystemFormatsNeverFormattedVolume(t *testing.T) {
+	vol := replicatedVolume()
+	fm := mount.NewFakeMounter(nil)
+	fe := scriptedExec([]fakeexec.FakeAction{
+		execExit(2),    // blkid: blank
+		execExit(2),    // FormatAndMount's internal blkid: still blank
+		execOut(""),    // mkfs.ext4
+		execOut("1\n"), // blockdev --getro: read-only skips the resize path
+	})
+	d := ensureDeps(t, vol, fm, fe)
+	if err := EnsureFilesystem(t.Context(), d, vol, tempDev(t),
+		filepath.Join(t.TempDir(), "staging"), "ext4", nil); err != nil {
+		t.Fatal(err)
+	}
+	log := fm.GetLog()
+	if len(log) != 1 || log[0].Action != mount.FakeActionMount {
+		t.Fatalf("expected exactly one mount, got %+v", log)
+	}
+	got := &miroirv1alpha1.MiroirVolume{}
+	if err := d.Client.Get(t.Context(), types.NamespacedName{Name: vol.Name}, got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Status.Formatted || !got.Status.Activated {
+		t.Fatalf("flags must latch after first mkfs: formatted=%v activated=%v",
+			got.Status.Formatted, got.Status.Activated)
+	}
+}
+
+// Damage fsck cannot correct fails the stage before anything is mounted,
+// matching FormatAndMount's refusal.
+func TestEnsureFilesystemFailsStageOnUncorrectableFsck(t *testing.T) {
+	vol := replicatedVolume()
+	fm := mount.NewFakeMounter(nil)
+	fe := scriptedExec([]fakeexec.FakeAction{
+		execOut("TYPE=ext4\n"),
+		execExit(4), // fsck: errors left uncorrected
+	})
+	err := EnsureFilesystem(t.Context(), ensureDeps(t, vol, fm, fe), vol, tempDev(t),
+		filepath.Join(t.TempDir(), "staging"), "ext4", nil)
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("uncorrectable fsck errors must fail the stage, got %v", err)
+	}
+	if log := fm.GetLog(); len(log) != 0 {
+		t.Fatalf("nothing may be mounted: %+v", log)
 	}
 }
 


### PR DESCRIPTION
## Problem

Two production volumes were destroyed by `mkfs.ext4 -F` during `NodeStageVolume` even though their local DRBD replicas were `UpToDate` and `MiroirVolume.status.formatted` was `true` (#444). The `formattedBefore` gate added in #373 was active in both incidents — it guards miroir's own `GetDiskFormat` probe, but `EnsureFilesystem` then handed the device to mount-utils' `FormatAndMount`, which **re-probes internally and formats whenever its own probe reads blank**, with no way to intercept the decision.

`blkid` exits 2 both when no signature exists and when it is "impossible to gather any information about the device content", and mount-utils maps exit 2 to "unformatted". So a device made momentarily unreadable by the DRBD peer-teardown storm visible in the incident logs is indistinguishable from a blank one, and the second (ungated) probe converted that transient window into a replicated, permanent wipe.

## Fix

Make the staging probe authoritative in `EnsureFilesystem`:

- A device whose probe reads a filesystem is fsck'd (preserving the pre-mount check `FormatAndMount` used to run) and mounted directly — it never re-enters any path that can format. A transiently unreadable device on a formatted volume keeps failing loudly with `DataLoss` and kubelet retries.
- `FormatAndMount` now runs only for a volume that has never been formatted, where the worst case of its internal re-probe is formatting a device that holds no data.

## Tests

New table-level tests drive `EnsureFilesystem` with a scripted exec: the key one baits the script with the exact re-probe-blank + mkfs sequence from the incident and asserts staging never reaches it; others cover the `DataLoss` refusal, the legitimate first mkfs, and the uncorrectable-fsck failure. `mise run fmt`, `vet`, `lint`, and `test` all pass.

Follow-ups deliberately not in this PR: gating staging on DRBD quorum / peer-set stability (suggested fix 3 in the issue), and the snapshot-barrier stall on a read-only filesystem noted as the secondary observation.

Fixes #444