### PR TITLE
fix(export): scale down gateway on volume deletion to break teardown deadlock

### DIFF
--- a/docs/rwx.md
+++ b/docs/rwx.md
@@ -73,3 +73,7 @@ Things worth knowing:
   `.ganesha-recovery` directory at the root of the exported
   filesystem so locks survive failover; it is visible to consumers.
   Leave it alone.
+- **Deletion scales the gateway to zero first.** The gateway is the
+  device's only writer, so the share Deployment is scaled to zero when
+  the volume is deleted. Otherwise teardown waits forever for an
+  opener that will not leave.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,3 +53,9 @@
   cycle. Point `spec.staging.storageClassName` at a `replicas: "1"`
   class naming the same pool, per
   [Stage kopiur backups unreplicated](quickstart.md#stage-kopiur-backups-unreplicated).
+- **RWX `MiroirVolume` stuck deleting, `Device is held open`**: a
+  still-running gateway is the live opener. Check
+  `kubectl get deploy -n miroir-system miroir-share-<volume>`; if it
+  is at 1 replica, scale it to zero (or delete it) so the agent's
+  teardown finalizer can finish. See
+  [ReadWriteMany (RWX)](rwx.md).

--- a/internal/export/reconciler.go
+++ b/internal/export/reconciler.go
@@ -19,9 +19,11 @@ limitations under the License.
 // reconciler maintains a per-volume Deployment (the NFS-Ganesha share
 // manager, pinned to the volume's diskful replica nodes) and a ClusterIP
 // Service fronting it, and publishes the Service's address on
-// status.export.address for the CSI node service to mount. Both workloads
-// are owned by the MiroirVolume, so deleting the volume garbage-collects
-// them.
+// status.export.address for the CSI node service to mount. Workloads are
+// owner-ref'd to the volume, but on deletion this reconciler scales the
+// gateway to zero itself: the gateway stages the device, so owner-ref GC
+// (which waits for the object to vanish) deadlocks against the agent's
+// teardown finalizer (which waits for the gateway to release the device).
 package export
 
 import (
@@ -31,10 +33,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
@@ -57,8 +62,9 @@ type Reconciler struct {
 }
 
 // Reconcile ensures the gateway Deployment and Service exist for an RWX
-// volume and records the Service address. Owned workloads are garbage
-// collected when the volume is deleted, so a missing volume is a no-op.
+// volume and records the Service address. A deleting volume's gateway is
+// scaled to zero here so the pod releases the device; a missing volume is
+// a no-op.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -70,9 +76,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		return ctrl.Result{}, err
 	}
-	// Only RWX volumes have a gateway; a volume being deleted keeps its
-	// workloads until GC removes them with the owner.
-	if vol.Spec.Export == nil || !vol.DeletionTimestamp.IsZero() {
+	if vol.Spec.Export == nil {
+		dropExportMetrics(vol.Name)
+		return ctrl.Result{}, nil
+	}
+	// The gateway is the live opener of the device. Scale it to zero
+	// before the agent tries drbdsetup down; otherwise the teardown
+	// finalizer waits for the gateway, owner-ref GC waits for the
+	// finalizer, and the gateway waits for GC.
+	if !vol.DeletionTimestamp.IsZero() {
+		if err := r.scaleDown(ctx, vol); err != nil {
+			return ctrl.Result{}, err
+		}
 		dropExportMetrics(vol.Name)
 		return ctrl.Result{}, nil
 	}
@@ -162,19 +177,54 @@ func (r *Reconciler) publishAddress(ctx context.Context, vol *miroirv1alpha1.Mir
 	return r.Status().Patch(ctx, vol, client.MergeFrom(base))
 }
 
+// scaleDown zeroes the gateway Deployment's replicas so the pod exits and
+// releases the DRBD device, unblocking the agent's teardown finalizer. The
+// Deployment itself stays (owned by the volume, collected by GC once the
+// finalizer drops). A missing or unowned Deployment is a no-op.
+func (r *Reconciler) scaleDown(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) error {
+	dep := &appsv1.Deployment{}
+	dep.Name = shareName(vol.Name)
+	dep.Namespace = r.Namespace
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), dep); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !metav1.IsControlledBy(dep, vol) {
+		return nil
+	}
+	if dep.Spec.Replicas != nil && *dep.Spec.Replicas == 0 {
+		return nil
+	}
+	ctrl.LoggerFrom(ctx).Info("scaling RWX gateway to zero", "volume", vol.Name)
+	dep.Spec.Replicas = ptr.To[int32](0)
+	return r.Update(ctx, dep)
+}
+
 // SetupWithManager registers the reconciler. The volume watch passes
 // generation changes (status churn from agents carries nothing this
-// reconciler reads) and label changes — the PVC-ref backfill is a
-// label-only patch, and without it an existing RWX volume's
-// miroir_export_ready series would keep its fallback pvc label until an
-// unrelated workload event. It owns its Deployment/Service so drift on
-// those heals.
+// reconciler reads), label changes (the PVC-ref backfill is a label-only
+// patch, and without it an existing RWX volume's miroir_export_ready
+// series would keep its fallback pvc label until an unrelated workload
+// event), and deletionTimestamp (a metadata-only update that generation
+// and label predicates miss; without it a deleting volume's gateway is
+// never scaled down). It owns its Deployment/Service so drift on those
+// heals.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	deleting := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew != nil && !e.ObjectNew.GetDeletionTimestamp().IsZero()
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object != nil && !e.Object.GetDeletionTimestamp().IsZero()
+		},
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&miroirv1alpha1.MiroirVolume{},
 			builder.WithPredicates(predicate.Or[client.Object](
 				predicate.GenerationChangedPredicate{},
-				predicate.LabelChangedPredicate{}))).
+				predicate.LabelChangedPredicate{},
+				deleting))).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Named("export").

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -42,6 +42,7 @@ const (
 	nodeC  = "node-c"
 
 	testClusterIP = "10.96.1.5"
+	testFinalizer = "miroir.home-operations.com/teardown-node-a"
 )
 
 // exportVolume is an RWX volume with a data replica on each named node.
@@ -281,12 +282,12 @@ func affinityNodes(t *testing.T, dep *appsv1.Deployment) []string {
 	return terms[0].MatchExpressions[0].Values
 }
 
-// A volume being deleted keeps its gateway workloads (GC removes them
-// with the owner) but its ready gauge is dropped — a stale 1 would mask
-// the teardown.
-func TestReconcileDeletingVolumeKeepsWorkloadsDropsMetric(t *testing.T) {
+// A volume being deleted has its gateway scaled to zero (so the pod
+// releases the DRBD device for the agent's teardown) but the Deployment
+// itself stays for GC. The ready gauge is dropped.
+func TestReconcileDeletingVolumeScalesDownDropsMetric(t *testing.T) {
 	vol := exportVolume("pvc-deleting", nodeA, nodeB)
-	vol.Finalizers = []string{"miroir.home-operations.com/teardown-node-a"}
+	vol.Finalizers = []string{testFinalizer}
 	r, cl := newReconciler(vol)
 	reconcile(t, r, "pvc-deleting")
 	getDeployment(t, cl, "pvc-deleting") // created
@@ -297,8 +298,77 @@ func TestReconcileDeletingVolumeKeepsWorkloadsDropsMetric(t *testing.T) {
 	}
 	reconcile(t, r, "pvc-deleting")
 
-	getDeployment(t, cl, "pvc-deleting") // deliberately retained for GC
+	dep := getDeployment(t, cl, "pvc-deleting") // retained for GC
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 0 {
+		t.Fatalf("deleting volume must scale the gateway to 0, got replicas=%v", dep.Spec.Replicas)
+	}
 	if _, ok := exportReadyGauge(t, "pvc-deleting"); ok {
 		t.Fatal("gauge series must be dropped while the volume is deleting")
+	}
+}
+
+// Reconciling a deleting volume whose Deployment is already scaled to
+// zero is a no-op (idempotent).
+func TestReconcileDeletingVolumeScaleDownIdempotent(t *testing.T) {
+	vol := exportVolume("pvc-idem", nodeA, nodeB)
+	vol.Finalizers = []string{testFinalizer}
+	r, cl := newReconciler(vol)
+	reconcile(t, r, "pvc-idem")
+
+	if err := cl.Delete(t.Context(), vol); err != nil {
+		t.Fatal(err)
+	}
+	// First reconcile scales down.
+	reconcile(t, r, "pvc-idem")
+	dep := getDeployment(t, cl, "pvc-idem")
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 0 {
+		t.Fatalf("first reconcile must scale to 0, got %v", dep.Spec.Replicas)
+	}
+	rv := dep.ResourceVersion
+
+	// Second reconcile is a no-op (no update, same RV).
+	reconcile(t, r, "pvc-idem")
+	dep = getDeployment(t, cl, "pvc-idem")
+	if dep.ResourceVersion != rv {
+		t.Fatal("idempotent reconcile must not update the Deployment again")
+	}
+}
+
+// An already-deleting volume (the production stuck case: gateway still
+// at replicas=1, teardown finalizer held) must scale the existing
+// gateway down on first sight, without a prior live reconcile.
+func TestReconcileAlreadyDeletingVolumeScalesExistingGateway(t *testing.T) {
+	vol := exportVolume("pvc-stuck", nodeA, nodeB)
+	vol.Finalizers = []string{testFinalizer}
+	now := metav1.Now()
+	vol.DeletionTimestamp = &now
+	existing := buildDeployment(vol, testNS, "ghcr.io/home-operations/miroir-gateway:test", "miroir-gateway")
+	existing.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(vol, miroirv1alpha1.GroupVersion.WithKind("MiroirVolume")),
+	}
+	r, cl := newReconciler(vol, existing)
+
+	reconcile(t, r, "pvc-stuck")
+
+	dep := getDeployment(t, cl, "pvc-stuck")
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 0 {
+		t.Fatalf("already-deleting volume must scale the gateway to 0, got replicas=%v", dep.Spec.Replicas)
+	}
+}
+
+// A deleting volume with no gateway Deployment is a no-op.
+func TestReconcileDeletingVolumeWithoutDeployment(t *testing.T) {
+	vol := exportVolume("pvc-none", nodeA, nodeB)
+	vol.Finalizers = []string{testFinalizer}
+	now := metav1.Now()
+	vol.DeletionTimestamp = &now
+	r, cl := newReconciler(vol)
+
+	reconcile(t, r, "pvc-none")
+
+	dep := &appsv1.Deployment{}
+	err := cl.Get(t.Context(), types.NamespacedName{Name: shareName("pvc-none"), Namespace: testNS}, dep)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("must not create a gateway for a deleting volume, got err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

RWX volume deletions deadlock permanently: the export reconciler returned
early for deleting volumes (relying on owner-ref GC), but GC waits for the
volume object to disappear, the object waits for the teardown finalizer,
and the finalizer waits for the gateway pod to release the DRBD device. No
party yields, and the volume stays Terminating forever.

This PR:

- Splits the early-return condition so `DeletionTimestamp` is handled
  separately from `Export == nil`.
- Scales the gateway Deployment to zero replicas when a volume is
  deleting, unblocking `drbdsetup down` in the agent's teardown
  finalizer.
- Adds a `deletionTimestamp` predicate to `SetupWithManager` so the
  metadata-only deletion update (which generation and label predicates
  miss) triggers the reconciler.
- Updates `docs/rwx.md` and `docs/troubleshooting.md` with the
  behaviour change and a workaround for stuck volumes on older versions.
- Adds four unit tests covering scale-down, idempotency, the
  already-stuck case, and missing-deployment no-op.

## Reproduction

Every RWX `MiroirVolume` deletion on 0.11.23 (and likely earlier) is
affected. In the reporter's cluster 19 of 19 RWX volumes were stuck
Terminating while all 8 RWO volumes deleted cleanly.

## Test plan

- [x] `go test ./internal/export/...` passes locally (four new tests,
  one renamed).
- [x] Built image, deployed to a live cluster with 19 stuck RWX volumes;
  all cleared within seconds of the patched controller starting.
- [ ] CI (`go test -race ./...`, golangci-lint, govulncheck) passes.


Made with [Cursor](https://cursor.com)