### PR TITLE
chore(mise): wait for code generation before fmt and vet

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -38,10 +38,14 @@ run = [
 
 [tasks.fmt]
 description = "Run go fmt against code"
+# generate rewrites the tracked Go sources under api/; when both are scheduled
+# (test, build, ...) a concurrent reader can catch a half-written file.
+wait_for = ["generate"]
 run = "go fmt ./..."
 
 [tasks.vet]
 description = "Run go vet against code"
+wait_for = ["generate", "fmt"]
 run = "go vet ./..."
 
 [tasks.vulncheck]


### PR DESCRIPTION
`test`, `test-integration`, `build`, and `run-controller` list `generate`, `fmt`, and `vet` as parallel `depends`. `generate` rewrites the tracked Go sources under `api/` on every run, so `go vet` can open one of those files while `controller-gen` has truncated it and fail with `expected 'package', found 'EOF'`, as the `Go Test` job did on #452 (run 33063227021).

This adds `wait_for = ["generate"]` to `fmt` and `wait_for = ["generate", "fmt"]` to `vet`. `wait_for` only orders tasks that are already scheduled, so `mise run vet` / `mise run fmt` on their own do not pick up `generate`.

`mise tasks deps test` after the change:

```
test
├── vet
│   ├── fmt
│   │   └── generate
│   └── generate
├── fmt
│   └── generate
├── generate
└── manifests
```

`mise run test` now starts `fmt` only after `generate` finishes and `vet` after `fmt`; `manifests` still runs alongside `generate`.
