### PR TITLE
fix(export): patch replicas on scale-down and drop the redundant deletion predicate

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,8 +54,13 @@
   class naming the same pool, per
   [Stage kopiur backups unreplicated](quickstart.md#stage-kopiur-backups-unreplicated).
 - **RWX `MiroirVolume` stuck deleting, `Device is held open`**: a
-  still-running gateway is the live opener. Check
-  `kubectl get deploy -n miroir-system miroir-share-<volume>`; if it
-  is at 1 replica, scale it to zero (or delete it) so the agent's
-  teardown finalizer can finish. See
+  still-running gateway is the live opener. The controller scales the
+  share Deployment to zero itself when the volume is deleted, so check
+  `kubectl get deploy -n miroir-system miroir-share-<volume>` first. If
+  it is still at 1 replica (controller not running, or a release from
+  before it did this), scale it to zero or delete it so the agent's
+  teardown finalizer can finish. If it is already at 0 but the gateway
+  pod stays `Terminating`, the pod is wedged on the device itself and
+  the Deployment is no longer the lever: inspect the DRBD resource on
+  that node as for a stuck RWO volume. See
   [ReadWriteMany (RWX)](rwx.md).

--- a/internal/export/reconciler.go
+++ b/internal/export/reconciler.go
@@ -39,7 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
@@ -85,11 +84,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// finalizer waits for the gateway, owner-ref GC waits for the
 	// finalizer, and the gateway waits for GC.
 	if !vol.DeletionTimestamp.IsZero() {
-		if err := r.scaleDown(ctx, vol); err != nil {
-			return ctrl.Result{}, err
-		}
+		// Drop the gauge before the write: a stale 1 would mask the
+		// teardown for as long as the scale-down keeps failing.
 		dropExportMetrics(vol.Name)
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, r.scaleDown(ctx, vol)
 	}
 
 	available, err := r.ensureDeployment(ctx, vol)
@@ -180,8 +178,12 @@ func (r *Reconciler) publishAddress(ctx context.Context, vol *miroirv1alpha1.Mir
 // scaleDown zeroes the gateway Deployment's replicas so the pod exits and
 // releases the DRBD device, unblocking the agent's teardown finalizer. The
 // Deployment itself stays (owned by the volume, collected by GC once the
-// finalizer drops). A missing or unowned Deployment is a no-op.
+// finalizer drops). A missing Deployment is a no-op; one controlled by
+// another owner (a volume recreated under the same name) is left alone
+// and logged, since it is the only export-side clue why the teardown
+// stays parked.
 func (r *Reconciler) scaleDown(ctx context.Context, vol *miroirv1alpha1.MiroirVolume) error {
+	log := ctrl.LoggerFrom(ctx)
 	dep := &appsv1.Deployment{}
 	dep.Name = shareName(vol.Name)
 	dep.Namespace = r.Namespace
@@ -189,42 +191,40 @@ func (r *Reconciler) scaleDown(ctx context.Context, vol *miroirv1alpha1.MiroirVo
 		return client.IgnoreNotFound(err)
 	}
 	if !metav1.IsControlledBy(dep, vol) {
+		log.Info("RWX gateway is not controlled by this volume, leaving it running",
+			"volume", vol.Name, "volumeUID", vol.UID, "controller", metav1.GetControllerOf(dep))
 		return nil
 	}
 	if dep.Spec.Replicas != nil && *dep.Spec.Replicas == 0 {
 		return nil
 	}
-	ctrl.LoggerFrom(ctx).Info("scaling RWX gateway to zero", "volume", vol.Name)
+	// A merge patch of just replicas carries no resourceVersion, so a
+	// cache lagging the deployment controller's status writes (likely
+	// while the pod churns) cannot turn this into a conflict.
+	base := dep.DeepCopy()
 	dep.Spec.Replicas = ptr.To[int32](0)
-	return r.Update(ctx, dep)
+	if err := r.Patch(ctx, dep, client.MergeFrom(base)); err != nil {
+		return err
+	}
+	log.Info("scaled RWX gateway to zero", "volume", vol.Name)
+	return nil
 }
 
 // SetupWithManager registers the reconciler. The volume watch passes
 // generation changes (status churn from agents carries nothing this
-// reconciler reads), label changes (the PVC-ref backfill is a label-only
-// patch, and without it an existing RWX volume's miroir_export_ready
-// series would keep its fallback pvc label until an unrelated workload
-// event), and deletionTimestamp (a metadata-only update that generation
-// and label predicates miss; without it a deleting volume's gateway is
-// never scaled down). It owns its Deployment/Service so drift on those
-// heals.
+// reconciler reads; deletion arrives this way too, because the apiserver
+// bumps generation when it first sets deletionTimestamp on an object
+// with finalizers) and label changes (the PVC-ref backfill is a
+// label-only patch, and without it an existing RWX volume's
+// miroir_export_ready series would keep its fallback pvc label until an
+// unrelated workload event). It owns its Deployment/Service so drift on
+// those heals.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
-	deleting := predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew != nil && !e.ObjectNew.GetDeletionTimestamp().IsZero()
-		},
-		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object != nil && !e.Object.GetDeletionTimestamp().IsZero()
-		},
-		DeleteFunc:  func(event.DeleteEvent) bool { return false },
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&miroirv1alpha1.MiroirVolume{},
 			builder.WithPredicates(predicate.Or[client.Object](
 				predicate.GenerationChangedPredicate{},
-				predicate.LabelChangedPredicate{},
-				deleting))).
+				predicate.LabelChangedPredicate{}))).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Named("export").

--- a/internal/export/reconciler_test.go
+++ b/internal/export/reconciler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package export
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -30,9 +31,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	miroirv1alpha1 "github.com/home-operations/miroir/api/v1alpha1"
+	"github.com/home-operations/miroir/internal/constants"
 )
 
 const (
@@ -42,7 +45,7 @@ const (
 	nodeC  = "node-c"
 
 	testClusterIP = "10.96.1.5"
-	testFinalizer = "miroir.home-operations.com/teardown-node-a"
+	testFinalizer = constants.FinalizerPrefix + nodeA
 )
 
 // exportVolume is an RWX volume with a data replica on each named node.
@@ -62,12 +65,16 @@ func exportVolume(name string, nodes ...string) *miroirv1alpha1.MiroirVolume {
 }
 
 func newReconciler(objs ...client.Object) (*Reconciler, client.Client) {
+	return newReconcilerWithInterceptor(interceptor.Funcs{}, objs...)
+}
+
+func newReconcilerWithInterceptor(fns interceptor.Funcs, objs ...client.Object) (*Reconciler, client.Client) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = miroirv1alpha1.AddToScheme(scheme)
 	cl := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
-		WithObjects(objs...).Build()
+		WithObjects(objs...).WithInterceptorFuncs(fns).Build()
 	return &Reconciler{
 		Client:         cl,
 		Namespace:      testNS,
@@ -353,6 +360,60 @@ func TestReconcileAlreadyDeletingVolumeScalesExistingGateway(t *testing.T) {
 	dep := getDeployment(t, cl, "pvc-stuck")
 	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 0 {
 		t.Fatalf("already-deleting volume must scale the gateway to 0, got replicas=%v", dep.Spec.Replicas)
+	}
+}
+
+// A gateway Deployment controlled by a different owner (a volume
+// recreated under the same name) is not this volume's to scale.
+func TestReconcileDeletingVolumeLeavesUnownedGateway(t *testing.T) {
+	vol := exportVolume("pvc-foreign", nodeA, nodeB)
+	vol.Finalizers = []string{testFinalizer}
+	now := metav1.Now()
+	vol.DeletionTimestamp = &now
+	previous := exportVolume("pvc-foreign", nodeA, nodeB)
+	previous.UID = "uid-previous-incarnation"
+	existing := buildDeployment(vol, testNS, "ghcr.io/home-operations/miroir-gateway:test", "miroir-gateway")
+	existing.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(previous, miroirv1alpha1.GroupVersion.WithKind("MiroirVolume")),
+	}
+	r, cl := newReconciler(vol, existing)
+
+	reconcile(t, r, "pvc-foreign")
+
+	dep := getDeployment(t, cl, "pvc-foreign")
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 1 {
+		t.Fatalf("gateway owned by another volume must be left alone, got replicas=%v", dep.Spec.Replicas)
+	}
+}
+
+// A failed scale-down surfaces as a reconcile error for retry, but the
+// ready gauge is dropped regardless: a stale 1 would mask the teardown.
+func TestReconcileDeletingVolumeDropsMetricWhenScaleDownFails(t *testing.T) {
+	vol := exportVolume("pvc-patchfail", nodeA, nodeB)
+	vol.Finalizers = []string{testFinalizer}
+	patchErr := apierrors.NewConflict(appsv1.Resource("deployments"), shareName("pvc-patchfail"), nil)
+	r, cl := newReconcilerWithInterceptor(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if _, ok := obj.(*appsv1.Deployment); ok {
+				return patchErr
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	}, vol)
+	reconcile(t, r, "pvc-patchfail")
+	if _, ok := exportReadyGauge(t, "pvc-patchfail"); !ok {
+		t.Fatal("live reconcile must record the gauge")
+	}
+
+	if err := cl.Delete(t.Context(), vol); err != nil {
+		t.Fatal(err)
+	}
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "pvc-patchfail"}})
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("reconcile must return the scale-down error, got %v", err)
+	}
+	if _, ok := exportReadyGauge(t, "pvc-patchfail"); ok {
+		t.Fatal("gauge series must be dropped even when the scale-down fails")
 	}
 }
 

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -250,8 +250,9 @@ kubectl exec -n "$NS" rwx-a -- grep -q after-failover /data/shared \
     || die "post-failover write not visible on $node"
 ok "RWX survived gateway reschedule and stayed writable"
 
-# Clean up the RWX resources so the teardown check below stays about the
-# RWO PVs it already tracks.
+# Release the RWX consumers here; the PVC delete below only waits for the
+# claim object, so the RWX volume's own teardown is verified alongside the
+# RWO ones in the final step.
 kubectl delete pod -n "$NS" rwx-a rwx-b --wait
 kubectl delete pvc -n "$NS" rwx-data --wait
 
@@ -260,14 +261,14 @@ pv2=$(kubectl get pvc -n "$NS" smoke-restore -o jsonpath='{.spec.volumeName}')
 kubectl delete namespace "$NS" --wait=true --timeout=120s
 trap - EXIT
 deadline=$((SECONDS + 120))
-while kubectl get miroirvolume "$pv" "$pv2" 2>/dev/null | grep -q pvc-; do
+while kubectl get miroirvolume "$pv" "$pv2" "$rwx_pv" 2>/dev/null | grep -q pvc-; do
     [ "$SECONDS" -lt "$deadline" ] || die "miroirvolumes not cleaned up"
     sleep 5
 done
 for n in $node $other; do
     pod=$(agent_pod "$n")
     leftovers=$(kubectl exec -n miroir-system "$pod" -c agent -- sh -c \
-        "drbdsetup status 2>/dev/null | grep -cE '^($pv|$pv2)'" || true)
+        "drbdsetup status 2>/dev/null | grep -cE '^($pv|$pv2|$rwx_pv)'" || true)
     [ "${leftovers:-0}" = 0 ] || die "DRBD resource leftover on $n"
 done
 ok "volumes, DRBD resources and backing devices cleaned up"

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -265,11 +265,13 @@ while kubectl get miroirvolume "$pv" "$pv2" "$rwx_pv" 2>/dev/null | grep -q pvc-
     [ "$SECONDS" -lt "$deadline" ] || die "miroirvolumes not cleaned up"
     sleep 5
 done
-for n in $node $other; do
-    pod=$(agent_pod "$n")
+# Replica placement is the controller's choice, so a leg can sit on any
+# storage node, not only the two the consumer pods ran on.
+for pod in $(kubectl get pods -n miroir-system -l app.kubernetes.io/component=agent \
+    -o jsonpath='{.items[*].metadata.name}'); do
     leftovers=$(kubectl exec -n miroir-system "$pod" -c agent -- sh -c \
         "drbdsetup status 2>/dev/null | grep -cE '^($pv|$pv2|$rwx_pv)'" || true)
-    [ "${leftovers:-0}" = 0 ] || die "DRBD resource leftover on $n"
+    [ "${leftovers:-0}" = 0 ] || die "DRBD resource leftover in $pod"
 done
 ok "volumes, DRBD resources and backing devices cleaned up"
 


### PR DESCRIPTION
Follow-ups to #451 from its review.

- `scaleDown` sends a merge patch of `spec.replicas` (no resourceVersion precondition) instead of a full `Update`, so a cache lagging the deployment controller's status writes cannot 409 the teardown; the log line moves after the successful write.
- `dropExportMetrics` runs before the scale-down so a failed write never leaves a stale `miroir_export_ready=1`.
- The `deleting` predicate is removed: the apiserver bumps `metadata.generation` when it first sets `deletionTimestamp` on an object with finalizers (`k8s.io/apiserver` `registry/generic/registry/store.go` and `registry/rest/delete.go`), so `GenerationChangedPredicate` already delivers deletion; the extra predicate re-ran the reconciler on every status write of a deleting volume.
- A Deployment controlled by a different owner is logged when left alone.
- Tests: unowned-gateway and failed-scale-down cases; `testFinalizer` built from `constants.FinalizerPrefix`.
- `test/smoke/smoke.sh` tracks the RWX volume in the "nothing left behind" checks so a stuck RWX teardown fails the run.
- `docs/troubleshooting.md` scopes the entry to when a human still needs to act.

`mise run vet`, `mise run lint`, `mise run test` pass.
