### PR TITLE
fix(agent): self-heal a Primary-side stale out-of-sync bitmap after failover

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,8 @@
   `out-of-sync` bits toward a peer with no resync draining them. With the
   connection `Connected` and both disks `UpToDate`, this is one of two
   things. A _stale bitmap_ — bits stranded by a refused clear during peer
-  teardown, or a resync DRBD armed and abandoned after a rapid
+  teardown, left on a newly promoted Primary toward a Secondary after a
+  failover, or a resync DRBD armed and abandoned after a rapid
   promote/demote — is detected and self-healed: the agent cycles the
   affected peer connection within a couple of poll cycles and emits a
   `StuckResyncRecovered` event; the re-run handshake discards the bitmap

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -854,9 +854,11 @@ func peerReportedSplitBrain(vol *miroirv1alpha1.MiroirVolume, self string) bool 
 //     reply the peer already discarded (issue #397). Both wear
 //     StuckResyncPeers.
 //   - Bits stranded by a bitmap clear the kernel refused mid peer-teardown
-//     ("bitmap locked", issue #389), everything otherwise healthy
-//     (StaleBitmapPeers, behind staleBitmapActionable's gates — the same
-//     kernel shape is a verify finding, which stays manual).
+//     ("bitmap locked", issue #389), or left on a freshly promoted Primary
+//     toward a Secondary after a failover (issue #469), everything
+//     otherwise healthy (StaleBitmapPeers, behind staleBitmapActionable's
+//     gates — the same kernel shape is a verify finding, which stays
+//     manual).
 //
 // Neither drains in place: the kernel only reconciles a dirty bitmap on a
 // connection transition (its missed-end-of-resync rescue runs at connect),
@@ -929,16 +931,19 @@ func (r *VolumeReconciler) recoverStuckResync(ctx context.Context, vol *miroirv1
 }
 
 // staleBitmapActionable reports whether the stale-bitmap candidates in
-// StaleBitmapPeers are safe to cycle (issue #389). Their kernel shape is
-// indistinguishable from a verify finding, so everything else must read
-// healthy — a Secondary leg with an UpToDate disk and quorum, every
-// diskful peer connected and UpToDate, no resync, verify, or split-brain
-// in flight — and the coordinator's last recorded verify must not have
-// findings outstanding: auto-resyncing a real finding would destroy the
-// evidence of which leg was wrong, so that case stays manual (the record
-// clears once a later verify reports 0 after the operator's own cycle).
+// StaleBitmapPeers are safe to cycle (issues #389 and #469). Their kernel
+// shape is indistinguishable from a verify finding, so everything else
+// must read healthy — an UpToDate disk with quorum, every diskful peer
+// connected and UpToDate, no resync, verify, or split-brain in flight —
+// and the coordinator's last recorded verify must not have findings
+// outstanding: auto-resyncing a real finding would destroy the evidence
+// of which leg was wrong, so that case stays manual (the record clears
+// once a later verify reports 0 after the operator's own cycle). The leg's
+// own role is not a gate: the parser only nominates pairs with exactly one
+// Primary, and an UpToDate Primary always sources the re-handshake, so
+// the direction is settled whichever side holds the bits.
 func (r *VolumeReconciler) staleBitmapActionable(vol *miroirv1alpha1.MiroirVolume, st drbd.Status) bool {
-	if len(st.StaleBitmapPeers) == 0 || st.Primary || st.DiskState != drbd.DiskUpToDate ||
+	if len(st.StaleBitmapPeers) == 0 || st.DiskState != drbd.DiskUpToDate ||
 		!st.Quorum || st.Resyncing || st.SplitBrain {
 		return false
 	}

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -3594,6 +3594,45 @@ func TestReconcileStaleBitmapCyclesAfterConfirmation(t *testing.T) {
 	fe.calledWith(t, "drbdsetup connect pvc-1 1")
 }
 
+// The inverse shape (issue #469): after a failover the new Primary holds
+// a one-sided bitmap toward a healthy Secondary, which reads zero on the
+// same connection. The Primary is the only leg that can see it, and it
+// sources the re-handshake, so it cycles the peer after the confirmation
+// window just like the Secondary-side case.
+func TestReconcileStaleBitmapPrimaryLegCyclesAfterConfirmation(t *testing.T) {
+	r, fe := stuckResyncSetup(t)
+	fe.statusJSON = `[{"name":"pvc-1","role":"Primary",
+		"devices":[{"disk-state":"UpToDate","quorum":true}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected","peer-role":"Secondary",
+			"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":392}]}]}]`
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdsetup disconnect")
+	backdateStuck(t, r)
+	reconcile(t, r, volPvc1)
+	fe.calledWith(t, "drbdsetup disconnect pvc-1 1")
+	fe.calledWith(t, "drbdsetup connect pvc-1 1")
+}
+
+// A Secondary/Secondary pair has no Primary to source the re-handshake, so
+// the same bits toward a Secondary peer stay unflagged: nothing arms and
+// nothing is cycled.
+func TestReconcileStaleBitmapSecondaryPairStaysManual(t *testing.T) {
+	r, fe := stuckResyncSetup(t)
+	fe.statusJSON = `[{"name":"pvc-1","role":"Secondary",
+		"devices":[{"disk-state":"UpToDate","quorum":true}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected","peer-role":"Secondary",
+			"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":392}]}]}]`
+	reconcile(t, r, volPvc1)
+	reconcile(t, r, volPvc1)
+	fe.notCalledWith(t, "drbdsetup disconnect")
+	r.recoveryMu.Lock()
+	_, armed := r.stuckSince[volPvc1]
+	r.recoveryMu.Unlock()
+	if armed {
+		t.Fatal("a Secondary/Secondary pair must keep the confirmation clock unarmed")
+	}
+}
+
 // The same kernel shape with a verify finding on record is a genuine
 // data-difference report, not a stale bitmap: auto-resyncing it would
 // destroy the evidence of which leg was wrong, so it stays manual — the

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -1296,17 +1296,19 @@ type Status struct {
 	// bitmap sees it — the peer still reads this node as UpToDate — so at
 	// most one node acts on it. Nil when no peer is stuck.
 	StuckResyncPeers map[int32]bool
-	// StaleBitmapPeers holds the DRBD node ids of Primary peers this leg
-	// carries a one-sided out-of-sync bitmap toward while everything
-	// reads healthy: connection Connected, replication Established,
-	// peer-disk UpToDate, out-of-sync above zero. Bits stranded by a
-	// bitmap clear the kernel refused mid peer-teardown ("bitmap locked")
-	// never drain on their own — DRBD only reconciles a dirty bitmap on a
-	// connection transition (issue #389). The same kernel shape is also a
-	// verify finding, which must stay manual — the agent gates on the
-	// recorded verify outcome before acting. Restricted to Primary peers
-	// so the resync direction at the re-handshake is unambiguous. Nil
-	// when none.
+	// StaleBitmapPeers holds the DRBD node ids of peers this leg carries
+	// a one-sided out-of-sync bitmap toward while everything reads
+	// healthy: connection Connected, replication Established, peer-disk
+	// UpToDate, out-of-sync above zero. Bits stranded by a bitmap clear
+	// the kernel refused mid peer-teardown ("bitmap locked") never drain
+	// on their own — DRBD only reconciles a dirty bitmap on a connection
+	// transition (issue #389). The same kernel shape is also a verify
+	// finding, which must stay manual — the agent gates on the recorded
+	// verify outcome before acting. Restricted to pairs with exactly one
+	// Primary — a Secondary leg toward a Primary peer (#389) or a Primary
+	// leg toward a Secondary peer (issue #469) — so the resync direction
+	// at the re-handshake is unambiguous: the Primary sources. Nil when
+	// none.
 	StaleBitmapPeers map[int32]bool
 }
 
@@ -1424,12 +1426,14 @@ func (d *Driver) Status(ctx context.Context, name string) (Status, error) {
 				}
 				s.StuckResyncPeers[c.PeerNodeID] = true
 			}
-			// A one-sided bitmap toward a healthy Primary peer with no
-			// resync running: stale bits from a refused clear (issue
-			// #389) — or a verify finding, which the agent's gates keep
-			// manual. The peer-role restriction keeps the resync
-			// direction at the re-handshake unambiguous.
-			if c.ConnectionState == connConnected && c.PeerRole == rolePrimary &&
+			// A one-sided bitmap toward a healthy peer with no resync
+			// running: stale bits from a refused clear (issue #389, held
+			// by a Secondary toward the Primary; issue #469, held by the
+			// Primary toward a Secondary) — or a verify finding, which
+			// the agent's gates keep manual. Exactly one Primary in the
+			// pair keeps the resync direction at the re-handshake
+			// unambiguous; Secondary/Secondary stays excluded.
+			if c.ConnectionState == connConnected && (c.PeerRole == rolePrimary) != s.Primary &&
 				pd.ReplicationState == replEstablished &&
 				pd.PeerDiskState == DiskUpToDate && pd.OutOfSyncKiB > 0 {
 				if s.StaleBitmapPeers == nil {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -1690,6 +1690,32 @@ func TestStatusStaleBitmapPeers(t *testing.T) {
 	}
 }
 
+// The inverse pair (issue #469): a Primary leg holding a one-sided bitmap
+// toward a healthy Secondary peer is flagged too — the Primary sources the
+// re-handshake, so the direction is just as settled. A Primary peer of a
+// Primary leg (dual-primary, no unambiguous source) stays unflagged.
+func TestStatusStaleBitmapPeersPrimaryLeg(t *testing.T) {
+	fe := &fakeExec{responses: map[string]string{
+		cmdDrbdsetupStatus: `[{"name":"` + volPvc1 + `","role":"Primary",
+			"devices":[{"disk-state":"UpToDate","quorum":true}],
+			"connections":[
+				{"peer-node-id":1,"connection-state":"Connected","peer-role":"Secondary",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":392}]},
+				{"peer-node-id":2,"connection-state":"Connected","peer-role":"Secondary",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":0}]},
+				{"peer-node-id":3,"connection-state":"Connected","peer-role":"Primary",
+					"peer_devices":[{"replication-state":"Established","peer-disk-state":"UpToDate","out-of-sync":4096}]}]}]`,
+	}}
+	d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+	s, err := d.Status(t.Context(), volPvc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.StaleBitmapPeers) != 1 || !s.StaleBitmapPeers[1] {
+		t.Fatalf("want only peer 1 flagged stale, got %v", s.StaleBitmapPeers)
+	}
+}
+
 // A healthy volume reports no stuck peers — nil, so fingerprint comparison
 // via maps.Equal treats it the same as an empty map.
 func TestStatusStuckResyncPeersNilWhenHealthy(t *testing.T) {


### PR DESCRIPTION
Fixes #469

## Problem

#469: during a sequential node upgrade, the workload's volumes failed over to a new Primary, and that Primary came up holding a small one-sided `out-of-sync` bitmap toward one Secondary. Everything read `Connected` / `Established` / `UpToDate` with quorum, no resync or verify in flight, and the Secondary reported 0 on the same connection. Nothing drains a dirty bitmap without a connection transition, so `MiroirVolumeOutOfSync` fired indefinitely until a manual `drbdadm disconnect` on the Primary cleared it on the handshake.

This is the inverse of the shape #392 self-heals. #392's parser only nominates a peer when that **peer** is Primary, and `staleBitmapActionable` additionally refuses to act from a Primary leg. Both checks encode the same intent, "act from a Secondary toward a Primary", so a bitmap held by the Primary can never qualify, and only the holder can see it.

## Fix

Nominate pairs with **exactly one Primary** instead of requiring the peer to be the Primary:

- **Parser** (`Status.StaleBitmapPeers`): `(peer is Primary) != (this leg is Primary)`. A Secondary leg toward a Primary peer (#389) and a Primary leg toward a Secondary peer (#469) both qualify; Secondary/Secondary stays excluded because nothing settles the source, and a Primary/Primary pair is excluded for the same reason.
- **Agent gate** (`staleBitmapActionable`): drop the local-role check. Every other gate is unchanged: disk `UpToDate`, quorum, every diskful peer connected and `UpToDate`, no resync/verify/split-brain in flight, and no verify finding recorded on the coordinator (that gate is per volume, so it protects the Primary-side case as-is).

The safety argument is the one #392 already relies on. The direction restriction exists so the re-handshake has an unambiguous SyncSource, and an UpToDate Primary is always the source against a Secondary, so the local-Primary case is just as settled as the peer-Primary case. A disconnect drops the connection for both ends whichever side issues it, so cycling from the Primary adds no quorum or I/O exposure over the existing Secondary-side cycle. Identical data reconciles with zero movement; real divergence resyncs from the Primary.

Same confirmation window, per-peer `drbdsetup disconnect`/`connect`, and `StuckResyncRecovered` event as before. The troubleshooting entry now names the failover shape among what self-heals.

## Verified

- Parser: a Primary leg flags only its out-of-sync Secondary peer, not a clean peer or a Primary peer; the existing Secondary-leg test still holds.
- Reconciler: a Primary-role status cycles the peer after the confirmation window; a Secondary/Secondary pair never arms the clock.
- `mise run test`, `mise run lint`, `mise run vet` green.