### PR TITLE
fix(agent): forget-peer legs dropped by adjust so a removed client cannot phantom-vote

### DIFF
--- a/docs/remote-consumers.md
+++ b/docs/remote-consumers.md
@@ -32,8 +32,11 @@ Trade-offs to understand:
 - **An attached client does not vote in quorum.** Client legs are
   configured with DRBD's `tiebreaker no` (one of the reasons for the
   9.3.1 module floor), so attaching and detaching consumers never moves the
-  majority threshold, and a dead consumer node leaves no phantom vote
-  behind.
+  majority threshold. Once a client leg is removed, the agent also runs
+  `drbdsetup forget-peer` for its node-id on every leg: DRBD keeps a
+  removed peer's metadata slot otherwise and counts it as a missing
+  tiebreaker, which on a 2-replica volume would let a single replica loss
+  drop quorum with the real tie-breaker still connected.
 - **Trims from consumers reach the real backings.** A client leg's
   device advertises the diskful legs' probed discard granularity
   (DRBD's diskless default is a 512-byte fiction dm-thin would

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -630,12 +630,13 @@ func TestReconcilePaddedRestoreGrowsCloneBeforeCreateMD(t *testing.T) {
 	fb := newFakeBackend()
 	v := paddedRestoreVol()
 	stateDir := t.TempDir()
-	// The leading not-in-kernel read is probeMetadata's: the fresh clone must
-	// not read as adopted metadata, or create-md never runs.
+	// The leading not-in-kernel reads are Apply's peer snapshot and
+	// probeMetadata's: the fresh clone must not read as adopted metadata,
+	// or create-md never runs.
 	up := `[{"name":"` + volPvc1 + `",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
-	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, up, up, up, up}}
+	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, statusNotInKernel, up, up, up, up}}
 	fb.seq = &fe.calls // interleave the backing resize into the DRBD call log
 
 	c := fake.NewClientBuilder().WithScheme(s).
@@ -771,7 +772,7 @@ func TestReconcilePaddedRestoreSeedMintsGeneration(t *testing.T) {
 	inc := `[{"name":"` + volPvc1 + `",
 		"devices":[{"disk-state":"` + diskStateInconsistent + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
-	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, inc, inc, inc, inc}}
+	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, statusNotInKernel, inc, inc, inc, inc}}
 
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snapObj(snapSnap1, "src-vol")).
@@ -807,7 +808,7 @@ func TestReconcilePaddedRestoreSeedMintRefusesWhenPeerHasData(t *testing.T) {
 	inc := `[{"name":"` + volPvc1 + `",
 		"devices":[{"disk-state":"` + diskStateInconsistent + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
-	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, inc, inc, inc, inc}}
+	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, statusNotInKernel, inc, inc, inc, inc}}
 
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snapObj(snapSnap1, "src-vol")).
@@ -837,7 +838,7 @@ func TestReconcilePaddedRestoreSeedDemotesInterruptedMint(t *testing.T) {
 	up := `[{"name":"` + volPvc1 + `","role":"Primary",
 		"devices":[{"disk-state":"` + diskStateUpToDate + `"}],
 		"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
-	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, up, up, up, up}}
+	fe := &fakeDRBDExec{statusSeq: []string{statusNotInKernel, statusNotInKernel, up, up, up, up}}
 
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(v, snapObj(snapSnap1, "src-vol")).
@@ -2272,12 +2273,13 @@ func TestReconcileWipedNodeForcesFullSync(t *testing.T) {
 		WithStatusSubresource(&miroirv1alpha1.MiroirVolume{}).
 		Build()
 
-	// The kernel probe finds nothing (fresh boot, resource never
+	// The kernel reads before adjust (Apply's peer snapshot, then the
+	// metadata probe) find nothing (fresh boot, resource never
 	// configured); the post-Apply --json status still answers.
 	fe := &fakeDRBDExec{
 		statusJSON: `[{"name":"` + volPvc1 + `","role":"Secondary",
 		"devices":[{"disk-state":"Inconsistent"}],"connections":[]}]`,
-		statusSeq: []string{statusNotInKernel},
+		statusSeq: []string{statusNotInKernel, statusNotInKernel},
 	}
 	fb := newFakeBackend() // Exists() == false: the wipe took the device
 	r := &VolumeReconciler{
@@ -3721,11 +3723,11 @@ func birthSetup(t *testing.T, nodeName string, peerNodeID int, statusSeq ...stri
 	}
 	fe := &fakeDRBDExec{}
 	if len(statusSeq) > 0 {
-		// The leading not-in-kernel read is probeMetadata's: a fresh volume
-		// must take the create-md path, not read the kernel view as adopted
-		// metadata.
-		seq := make([]string, 0, 1+len(statusSeq))
-		seq = append(seq, statusNotInKernel)
+		// The leading not-in-kernel reads are Apply's peer snapshot and
+		// probeMetadata's: a fresh volume must take the create-md path, not
+		// read the kernel view as adopted metadata.
+		seq := make([]string, 0, 2+len(statusSeq))
+		seq = append(seq, statusNotInKernel, statusNotInKernel)
 		for _, tmpl := range statusSeq {
 			seq = append(seq, fmt.Sprintf(tmpl, peerNodeID))
 		}
@@ -3892,6 +3894,7 @@ func TestFastPathMissesOnPeerDiskStateChange(t *testing.T) {
 	// The peer's disk turns Inconsistent; everything else is unchanged.
 	fe.statusSeq = []string{
 		fmt.Sprintf(birthReadyJSON, 1), // fastPath live check → fingerprint miss
+		fmt.Sprintf(birthReadyJSON, 1), // Apply's peer snapshot
 		fmt.Sprintf(birthReadyJSON, 1), // probeMetadata → attached, adopt
 		fmt.Sprintf(birthReadyJSON, 1), // pipeline status → trigger fires
 		fmt.Sprintf(birthDoneJSON, 1),  // post-mint re-read

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -1097,6 +1097,10 @@ func (f *fakeDRBDExec) run(_ context.Context, name string, args ...string) (stri
 		return out, nil
 	}
 	if strings.HasPrefix(line, "drbdsetup status") {
+		if f.statusJSON == "" {
+			// Nothing in the kernel by default: --json prints an empty list.
+			return "[]", nil
+		}
 		return f.statusJSON, nil
 	}
 	for key, out := range f.responses {

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -95,6 +96,20 @@ func (d *Driver) ensureMarkedMetadata(ctx context.Context, r Resource) error {
 // ensureMetadata for how the birth generation lands), bring the resource
 // up / adjust.
 func (d *Driver) Apply(ctx context.Context, r Resource) error {
+	// The kernel's peer set before the config changes, so the peers adjust
+	// drops below can have their metadata slots forgotten afterwards (see
+	// forgetRemovedPeers). Read from the kernel rather than the previous
+	// .res so a failed adjust retries the forget on the next pass; a
+	// resource that is not up yet answers with an error, which just means
+	// there is nothing to forget.
+	var kernelPeers []int32
+	if parsed, err := d.listStatus(ctx, r.Name); err == nil {
+		for _, res := range parsed {
+			if res.Name == r.Name {
+				kernelPeers = res.peerIDs()
+			}
+		}
+	}
 	if err := d.writeConfig(r); err != nil {
 		return err
 	}
@@ -137,7 +152,7 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 				return mdErr
 			}
 			if _, err = d.adm(ctx, "adjust", r.Name); err == nil {
-				return d.ensureDeviceNode(r.Minor)
+				return d.finishApply(ctx, r, kernelPeers)
 			}
 		}
 		if !strings.Contains(err.Error(), "Unknown resource") {
@@ -148,10 +163,39 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 		}
 	}
 
+	return d.finishApply(ctx, r, kernelPeers)
+}
+
+// finishApply is the tail of Apply once adjust has succeeded.
+func (d *Driver) finishApply(ctx context.Context, r Resource, kernelPeers []int32) error {
+	if err := d.forgetRemovedPeers(ctx, r, kernelPeers); err != nil {
+		return err
+	}
 	// No udev runs on Talos, so DRBD's rules never create the device
 	// node. Without it, the first open(2) would create a regular file
 	// under /dev and mkfs would silently write into tmpfs.
 	return d.ensureDeviceNode(r.Minor)
+}
+
+// forgetRemovedPeers clears the metadata slot of every peer adjust just
+// dropped from the resource. del-peer leaves MDF_NODE_EXISTS behind in
+// each diskful leg's metadata, and DRBD's quorum code counts an
+// unconfigured slot wearing it as a missing diskless tiebreaker: on a
+// 2-replica freeze volume that phantom doubles the tiebreaker electorate,
+// so the next single diskful loss drops quorum with the real tiebreaker
+// still connected (issue #478). Only forget-peer clears the slot. It
+// requires the peer to be unconfigured, hence after adjust, and is a
+// no-op on a diskless leg, which has no metadata to hold the flag.
+func (d *Driver) forgetRemovedPeers(ctx context.Context, r Resource, before []int32) error {
+	for _, id := range before {
+		if slices.ContainsFunc(r.Peers, func(p Peer) bool { return p.NodeID == id }) {
+			continue
+		}
+		if _, err := d.Exec(ctx, "drbdsetup", "forget-peer", r.Name, strconv.Itoa(int(id))); err != nil {
+			return fmt.Errorf("forget-peer %s %d: %w", r.Name, id, err)
+		}
+	}
+	return nil
 }
 
 // ensureMetadata creates the backing metadata, surviving a crash at any

--- a/internal/drbd/drbd.go
+++ b/internal/drbd/drbd.go
@@ -96,19 +96,18 @@ func (d *Driver) ensureMarkedMetadata(ctx context.Context, r Resource) error {
 // ensureMetadata for how the birth generation lands), bring the resource
 // up / adjust.
 func (d *Driver) Apply(ctx context.Context, r Resource) error {
-	// The kernel's peer set before the config changes, so the peers adjust
-	// drops below can have their metadata slots forgotten afterwards (see
-	// forgetRemovedPeers). Read from the kernel rather than the previous
-	// .res so a failed adjust retries the forget on the next pass; a
-	// resource that is not up yet answers with an error, which just means
-	// there is nothing to forget.
-	var kernelPeers []int32
-	if parsed, err := d.listStatus(ctx, r.Name); err == nil {
-		for _, res := range parsed {
-			if res.Name == r.Name {
-				kernelPeers = res.peerIDs()
-			}
-		}
+	// The peers adjust is about to drop, recorded before the kernel forgets
+	// them so their metadata slots can be cleared afterwards (see
+	// forgetRemovedPeers). The kernel view rather than the previous .res
+	// is the source, so a failed adjust retries on the next pass; the
+	// marker keeps the set across a failed forget, when the kernel no
+	// longer knows the peer either.
+	removed, err := d.removedPeers(ctx, r)
+	if err != nil {
+		return err
+	}
+	if err := d.writePendingForgets(r.Name, removed); err != nil {
+		return err
 	}
 	if err := d.writeConfig(r); err != nil {
 		return err
@@ -152,7 +151,7 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 				return mdErr
 			}
 			if _, err = d.adm(ctx, "adjust", r.Name); err == nil {
-				return d.finishApply(ctx, r, kernelPeers)
+				return d.finishApply(ctx, r, removed)
 			}
 		}
 		if !strings.Contains(err.Error(), "Unknown resource") {
@@ -163,12 +162,12 @@ func (d *Driver) Apply(ctx context.Context, r Resource) error {
 		}
 	}
 
-	return d.finishApply(ctx, r, kernelPeers)
+	return d.finishApply(ctx, r, removed)
 }
 
 // finishApply is the tail of Apply once adjust has succeeded.
-func (d *Driver) finishApply(ctx context.Context, r Resource, kernelPeers []int32) error {
-	if err := d.forgetRemovedPeers(ctx, r, kernelPeers); err != nil {
+func (d *Driver) finishApply(ctx context.Context, r Resource, removed []int32) error {
+	if err := d.forgetRemovedPeers(ctx, r, removed); err != nil {
 		return err
 	}
 	// No udev runs on Talos, so DRBD's rules never create the device
@@ -177,7 +176,82 @@ func (d *Driver) finishApply(ctx context.Context, r Resource, kernelPeers []int3
 	return d.ensureDeviceNode(r.Minor)
 }
 
-// forgetRemovedPeers clears the metadata slot of every peer adjust just
+// pendingForgetSuffix names the marker listing node-ids whose forget-peer
+// is still owed, one per line. It is written before adjust drops them from
+// the kernel and removed once every forget succeeds: after a failed
+// forget the kernel view no longer knows the peer, so the marker is the
+// only record that a slot still needs clearing.
+const pendingForgetSuffix = ".forget-pending"
+
+// removedPeers is the set of node-ids the rendered config no longer lists
+// but that still need a forget-peer: the kernel's current peers plus any
+// left pending by an earlier failed forget. A node-id back in the config
+// (a consumer returning to the same node) drops out of the set; it is
+// live again and gets re-snapshotted when it leaves. A resource that is
+// not up answers "No such resource", which means the kernel holds no
+// peers; any other status failure aborts the apply, since going on would
+// drop peers with no record of them.
+func (d *Driver) removedPeers(ctx context.Context, r Resource) ([]int32, error) {
+	pending, err := d.readPendingForgets(r.Name)
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := d.listStatus(ctx, r.Name)
+	if err != nil && !strings.Contains(err.Error(), "No such resource") {
+		return nil, fmt.Errorf("apply %s: %w", r.Name, err)
+	}
+	for _, res := range parsed {
+		if res.Name == r.Name {
+			pending = append(pending, res.peerIDs()...)
+		}
+	}
+	removed := slices.DeleteFunc(pending, func(id int32) bool {
+		return slices.ContainsFunc(r.Peers, func(p Peer) bool { return p.NodeID == id })
+	})
+	slices.Sort(removed)
+	return slices.Compact(removed), nil
+}
+
+func (d *Driver) readPendingForgets(name string) ([]int32, error) {
+	data, err := os.ReadFile(d.path(name + pendingForgetSuffix))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var ids []int32
+	for field := range strings.FieldsSeq(string(data)) {
+		id, err := strconv.ParseInt(field, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("pending forgets %s: %w", name, err)
+		}
+		ids = append(ids, int32(id))
+	}
+	return ids, nil
+}
+
+// writePendingForgets records ids as owed forgets; an empty set removes
+// the marker.
+func (d *Driver) writePendingForgets(name string, ids []int32) error {
+	path := d.path(name + pendingForgetSuffix)
+	if len(ids) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	var b strings.Builder
+	for _, id := range ids {
+		fmt.Fprintf(&b, "%d\n", id)
+	}
+	if err := os.MkdirAll(d.StateDir, 0o750); err != nil {
+		return err
+	}
+	return writeFileAtomic(path, []byte(b.String()), 0o640)
+}
+
+// forgetRemovedPeers clears the metadata slot of every peer adjust
 // dropped from the resource. del-peer leaves MDF_NODE_EXISTS behind in
 // each diskful leg's metadata, and DRBD's quorum code counts an
 // unconfigured slot wearing it as a missing diskless tiebreaker: on a
@@ -185,17 +259,15 @@ func (d *Driver) finishApply(ctx context.Context, r Resource, kernelPeers []int3
 // so the next single diskful loss drops quorum with the real tiebreaker
 // still connected (issue #478). Only forget-peer clears the slot. It
 // requires the peer to be unconfigured, hence after adjust, and is a
-// no-op on a diskless leg, which has no metadata to hold the flag.
-func (d *Driver) forgetRemovedPeers(ctx context.Context, r Resource, before []int32) error {
-	for _, id := range before {
-		if slices.ContainsFunc(r.Peers, func(p Peer) bool { return p.NodeID == id }) {
-			continue
-		}
+// no-op on a diskless leg, which has no metadata to hold the flag. The
+// pending marker is cleared only once every forget has succeeded.
+func (d *Driver) forgetRemovedPeers(ctx context.Context, r Resource, removed []int32) error {
+	for _, id := range removed {
 		if _, err := d.Exec(ctx, "drbdsetup", "forget-peer", r.Name, strconv.Itoa(int(id))); err != nil {
 			return fmt.Errorf("forget-peer %s %d: %w", r.Name, id, err)
 		}
 	}
-	return nil
+	return d.writePendingForgets(r.Name, nil)
 }
 
 // ensureMetadata creates the backing metadata, surviving a crash at any
@@ -402,7 +474,7 @@ func virginMetadata(dump, name string) bool {
 // stateSuffixes are the per-resource files in StateDir that teardown
 // removes — keep in sync with everything Apply, ensureMetadata, and
 // WipeForeignMetadata write.
-var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted", ".md-wiped"}
+var stateSuffixes = []string{".res", ".md-created", ".md-seeding", ".md-adopted", ".md-wiped", pendingForgetSuffix}
 
 // removeStateFiles deletes the resource's rendered config and markers.
 func (d *Driver) removeStateFiles(name string) error {

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -277,6 +277,10 @@ func (f *fakeExec) run(_ context.Context, name string, args ...string) (string, 
 		// Fresh backing device by default.
 		return "", errors.New("Exclusive open failed. no valid meta data")
 	}
+	if strings.HasPrefix(line, cmdDrbdsetupStatus) {
+		// Nothing in the kernel by default: --json prints an empty list.
+		return "[]", nil
+	}
 	return "", nil
 }
 
@@ -636,16 +640,74 @@ func TestApplyForgetsRemovedPeers(t *testing.T) {
 		fe.notCalledWith(t, "forget-peer")
 	})
 
-	t.Run("a failed forget fails the apply", func(t *testing.T) {
+	t.Run("a failed forget fails the apply and is retried", func(t *testing.T) {
 		fe := &fakeExec{
 			responses: map[string]string{cmdDrbdsetupStatus: status},
-			errOn:     map[string]error{"forget-peer": errors.New("exit status 1")},
+			errOnce:   map[string]error{"forget-peer": errors.New("exit status 1")},
 		}
 		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
 
 		if err := d.Apply(t.Context(), testResource(nodeA)); err == nil {
 			t.Fatal("a failed forget-peer must surface so the next pass retries it")
 		}
+		if _, err := os.Stat(d.path(volPvc1 + pendingForgetSuffix)); err != nil {
+			t.Fatalf("a failed forget must leave the pending marker: %v", err)
+		}
+		// adjust already dropped the peer: the kernel view no longer lists
+		// it, so only the marker can carry it to this pass.
+		fe.responses[cmdDrbdsetupStatus] = `[{"name":"` + volPvc1 + `","role":"Secondary",
+			"devices":[{"disk-state":"` + DiskUpToDate + `"}],
+			"connections":[{"peer-node-id":1,"connection-state":"Connected"}]}]`
+		fe.calls = nil
+		if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
+			t.Fatal(err)
+		}
+		fe.calledWith(t, "drbdsetup forget-peer pvc-1 3")
+		if _, err := os.Stat(d.path(volPvc1 + pendingForgetSuffix)); !os.IsNotExist(err) {
+			t.Fatal("a completed forget must clear the pending marker")
+		}
+	})
+
+	t.Run("a pending peer back in the config is dropped without a forget", func(t *testing.T) {
+		fe := &fakeExec{responses: map[string]string{cmdDrbdsetupStatus: status}}
+		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+		if err := d.writePendingForgets(volPvc1, []int32{3}); err != nil {
+			t.Fatal(err)
+		}
+		r := testResource(nodeA)
+		r.Peers = append(r.Peers, Peer{Node: nodeWorker1, NodeID: 3, Address: addrC, Diskless: true, Client: true})
+
+		if err := d.Apply(t.Context(), r); err != nil {
+			t.Fatal(err)
+		}
+		fe.notCalledWith(t, "forget-peer")
+		if _, err := os.Stat(d.path(volPvc1 + pendingForgetSuffix)); !os.IsNotExist(err) {
+			t.Fatal("a re-configured peer must leave the pending marker")
+		}
+	})
+
+	t.Run("a resource not in the kernel has nothing to forget", func(t *testing.T) {
+		fe := &fakeExec{errOn: map[string]error{
+			cmdDrbdsetupStatus: errors.New("exit status 10: pvc-1: No such resource"),
+		}}
+		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+		if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
+			t.Fatal(err)
+		}
+		fe.notCalledWith(t, "forget-peer")
+	})
+
+	t.Run("any other status failure fails the apply", func(t *testing.T) {
+		fe := &fakeExec{errOn: map[string]error{
+			cmdDrbdsetupStatus: errors.New("exit status 20: Failed to modprobe drbd"),
+		}}
+		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+		if err := d.Apply(t.Context(), testResource(nodeA)); err == nil {
+			t.Fatal("an unreadable kernel view must not let adjust drop peers unrecorded")
+		}
+		fe.notCalledWith(t, "drbdadm adjust")
 	})
 }
 

--- a/internal/drbd/drbd_test.go
+++ b/internal/drbd/drbd_test.go
@@ -313,6 +313,7 @@ func TestApplyFreshResource(t *testing.T) {
 	// manufactured per node.
 	fe.notCalledWith(t, "new-current-uuid")
 	fe.calledWith(t, "drbdadm adjust pvc-1")
+	fe.notCalledWith(t, "forget-peer")
 
 	if _, err := os.Stat(filepath.Join(d.StateDir, "pvc-1.res")); err != nil {
 		t.Fatal("res file not written")
@@ -594,6 +595,58 @@ func TestApplyIdempotent(t *testing.T) {
 		}
 	}
 	fe.calledWith(t, "drbdadm adjust pvc-1")
+}
+
+// A peer adjust drops (del-peer) keeps its MDF_NODE_EXISTS metadata slot,
+// which DRBD's quorum code counts as a missing diskless tiebreaker (issue
+// #478). Apply must forget-peer every node-id the kernel had before the
+// config change and the new config no longer lists — after adjust, since
+// forget-peer refuses a still-configured peer — and only those.
+func TestApplyForgetsRemovedPeers(t *testing.T) {
+	status := `[{"name":"` + volPvc1 + `","role":"Secondary",
+		"devices":[{"disk-state":"` + DiskUpToDate + `"}],
+		"connections":[{"peer-node-id":1,"connection-state":"Connected"},
+		{"peer-node-id":3,"connection-state":"Connected"}]}]`
+
+	t.Run("forgets the dropped peer only", func(t *testing.T) {
+		fe := &fakeExec{responses: map[string]string{cmdDrbdsetupStatus: status}}
+		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+		if err := d.Apply(t.Context(), testResource(nodeA)); err != nil {
+			t.Fatal(err)
+		}
+		fe.calledWith(t, "drbdsetup forget-peer pvc-1 3")
+		fe.notCalledWith(t, "forget-peer pvc-1 1")
+		adjust := slices.Index(fe.calls, "drbdadm adjust pvc-1")
+		forget := slices.Index(fe.calls, "drbdsetup forget-peer pvc-1 3")
+		if adjust < 0 || forget < adjust {
+			t.Fatalf("forget-peer must follow adjust: %v", fe.calls)
+		}
+	})
+
+	t.Run("nothing to forget when the peer set is unchanged", func(t *testing.T) {
+		fe := &fakeExec{responses: map[string]string{cmdDrbdsetupStatus: status}}
+		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+		r := testResource(nodeA)
+		r.Peers = append(r.Peers, Peer{Node: nodeWorker1, NodeID: 3, Address: addrC, Diskless: true, Client: true})
+
+		if err := d.Apply(t.Context(), r); err != nil {
+			t.Fatal(err)
+		}
+		fe.notCalledWith(t, "forget-peer")
+	})
+
+	t.Run("a failed forget fails the apply", func(t *testing.T) {
+		fe := &fakeExec{
+			responses: map[string]string{cmdDrbdsetupStatus: status},
+			errOn:     map[string]error{"forget-peer": errors.New("exit status 1")},
+		}
+		d := &Driver{StateDir: t.TempDir(), Exec: fe.run, Mknod: fakeMknod}
+
+		if err := d.Apply(t.Context(), testResource(nodeA)); err == nil {
+			t.Fatal("a failed forget-peer must surface so the next pass retries it")
+		}
+	})
 }
 
 func TestApplyRetriesAfterCreateMDCrash(t *testing.T) {


### PR DESCRIPTION
Fixes #478.

\`drbdsetup del-peer\` (what \`drbdadm adjust\` issues for a peer dropped from the config) leaves \`MDF_NODE_EXISTS\` in every diskful leg's on-disk metadata. DRBD's quorum code (\`__calc_quorum_with_disk\`) treats an unconfigured slot carrying that flag as a missing diskless tiebreaker, so on a 2-replica \`freeze\` volume the tiebreaker majority becomes 2 of {1 live, 1 phantom} and the real tiebreaker can no longer carry the vote: the next single diskful loss drops quorum, \`on-no-quorum io-error\` fires, and the Primary's filesystem goes read-only. Only \`forget-peer\` clears the slot; nothing in the tree called it.

## Change

- \`Apply\` snapshots the kernel's configured peer set (\`drbdsetup status --json\`) before writing the new config, and after a successful adjust runs \`drbdsetup forget-peer <res> <node-id>\` for every node-id that is no longer in the rendered peers. Sourcing the "before" set from the kernel rather than the previous \`.res\` means a failed adjust retries the forget on the next pass.
- \`forget-peer\` requires the peer to be unconfigured, hence after adjust. It is a kernel-side no-op on a diskless leg (no metadata to hold the flag), so it runs unconditionally on every leg. A failure surfaces as an \`Apply\` error so the reconcile retries.
- The same path covers a relocated tiebreaker or an evicted replica, since any dropped peer goes through adjust.
- Docs: the remote-consumers "no phantom vote" claim now describes the forget-peer step.

## Tests

- \`TestApplyForgetsRemovedPeers\`: forgets only the dropped node-id, after adjust; nothing when the peer set is unchanged; a failed forget fails the apply.
- Agent reconciler fixtures that script \`drbdsetup status\` answers gain one leading not-in-kernel entry for the new pre-adjust read.
- \`mise run test\`, \`mise run lint\`, \`mise run vet\`, \`gofmt -s -l\` clean.

## Not covered

A diskful leg that was down while the client leg was removed never issues the del-peer itself, so it never sees the peer in its kernel view and keeps the stale slot. Clearing that needs metadata-level visibility (\`drbdmeta\`) that \`Apply\` does not have today.