### PR TITLE
fix(backend): reactivate restore clones with the activation-skip override

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -109,8 +109,10 @@ func TestLVMThinCreateIdempotent(t *testing.T) {
 	}
 	fe.notCalledWith(t, "lvcreate")
 	// Existing LVs are activated: Talos does not run vgchange -ay at boot,
-	// so post-reboot the LV has no device node until activated.
-	fe.calledWith(t, "lvchange --activate y vg-miroir/pvc-1")
+	// so post-reboot the LV has no device node until activated. Restore
+	// clones recover through this path and carry the activation-skip
+	// flag, so the override must be present (#490).
+	fe.calledWith(t, "lvchange --activate y --ignoreactivationskip vg-miroir/pvc-1")
 }
 
 // A misaligned size still reaching the backend (a CR spec from before the
@@ -408,8 +410,10 @@ func TestZFSCreateFromSnapshot(t *testing.T) {
 }
 
 func TestLVMThinCloneReactivates(t *testing.T) {
-	// Existing clone (post-reboot reconcile) must be re-activated: Talos
-	// does not activate foreign LVs at boot.
+	// An existing clone must be re-activated with the activation-skip
+	// override. The reconciler recovers existing clones through Create
+	// (see TestLVMThinCreateIdempotent); this branch remains for
+	// direct callers.
 	fe := &fakeExec{}
 	b := newLVMThin(cfg, fe.run)
 

--- a/internal/backend/lvmthin.go
+++ b/internal/backend/lvmthin.go
@@ -206,9 +206,13 @@ func (l *lvmThin) Create(ctx context.Context, vol string, sizeBytes int64) (stri
 	}
 	// Talos does not activate foreign LVs at boot, so an LV surviving a
 	// node reboot exists in metadata but has no device node until
-	// activated. Idempotent on an already-active LV.
+	// activated. Idempotent on an already-active LV. Restore clones
+	// recover through here too (realizeBacking skips CreateFromSnapshot
+	// once the LV exists) and, being thin snapshots, carry the
+	// activation-skip flag that a plain activate silently honours; the
+	// override is a no-op on LVs born without it.
 	if _, err := l.lvm(ctx, "lvchange", "--activate", "y",
-		l.ref(vol)); err != nil {
+		"--ignoreactivationskip", l.ref(vol)); err != nil {
 		return "", fmt.Errorf("activate %s: %w", vol, err)
 	}
 	return l.ensureDevice(ctx, vol)


### PR DESCRIPTION
## Summary

Fixes #490.

A clone restored from a `MiroirSnapshot` is a thin snapshot of the snapshot LV, so LVM flags it activation-skip by default (`auto_set_activation_skip=1`). `CreateFromSnapshot` activates it with `--ignoreactivationskip`, but since #322 `realizeBacking` routes every reconcile after the first through `finishClone` → `Create`, whose plain `lvchange -ay` LVM silently skips on a flagged LV (exit 0, no activation). After a node reboot the clone never comes back and `ensureDevice` fails on every reconcile.

`Create`'s reactivation now passes `--ignoreactivationskip` too. Every caller of `Create` passes a volume name, never a `miroir-` snapshot LV, so snapshots parked with the flag on purpose (#276) stay parked. Clones already stuck in the field recover on their next reconcile without the manual `lvchange` workaround.

## Notes

- The trigger is a node reboot rather than an agent restart: LV activation is kernel state and the agent never deactivates a volume LV. The reporter's timestamps (clone at 18:38Z, API loss at 18:40Z) fit a reboot.
- `TestLVMThinCloneReactivates` still exercises the `CreateFromSnapshot` branch, which the reconciler no longer takes for an existing LV; its comment now says so. `TestLVMThinCreateIdempotent` is the regression test.

## Testing

- `mise run test`, `mise run lint`, `mise run vet` pass.
